### PR TITLE
fixes the eldritch horror of challenge coin descriptions and also other stuff in places, again

### DIFF
--- a/code/game/objects/items/weapons/material/coins.dm
+++ b/code/game/objects/items/weapons/material/coins.dm
@@ -224,6 +224,7 @@
 
 /datum/gear/trinket/coin
 	display_name = "coin selection"
+	description = "A selection of coins, made of different materials."
 	path = /obj/item/material/coin
 	cost = 2
 

--- a/maps/torch/items/coins.dm
+++ b/maps/torch/items/coins.dm
@@ -3,115 +3,61 @@
 	icon = 'maps/torch/icons/obj/coins.dmi'
 	icon_state = "error"
 
-
 /obj/item/material/coin/challenge/sol/fleet
 	default_material = MATERIAL_BRONZE
 	name = "fleet challenge coin"
 	icon_state = "fleet"
-	desc = {"\
-		A challenge coin distributed by the SCG Fleet. On \
-		the front is the insignia of the Fleet, and on the back \
-		is the emblem of the SCG inscribed with various dates.\
-	"}
-
+	desc = "A challenge coin distributed by the SCG Fleet. On the front is the insignia of the Fleet, and on the back is the emblem of the SCG inscribed with various dates."
 
 /obj/item/material/coin/challenge/sol/army
 	default_material = MATERIAL_BRONZE
 	name = "army challenge coin"
 	icon_state = "army"
-	desc = {"\
-		A challenge coin distributed by the SCG Army. On the \
-		front is the insignia of the Army, and on the back is the \
-		emblem of the SCG inscribed with various dates.\
-	"}
-
+	desc = "A challenge coin distributed by the SCG Army. On the front is the insignia of the Army, and on the back is the emblem of the SCG inscribed with various dates."
 
 /obj/item/material/coin/challenge/sol/armsmen
 	default_material = MATERIAL_BRONZE
 	name = "armsmen challenge coin"
 	icon_state = "armsmen"
-	desc = {"\
-		A challenge coin distributed by the SCGF Naval \
-		Armsmen. On the front is an austere emblem of the Naval Armsmen, \
-		and on the back is a saluting naval armsman with the text, \
-		"WE GO WHERE WE'RE NEEDED.\
-	"}
-
+	desc = "A challenge coin distributed by the SCGF Naval Armsmen. On the front is an austere emblem of the Naval Armsmen, and on the back is a saluting naval armsman with the text, 'WE GO WHERE WE'RE NEEDED.'"
 
 /obj/item/material/coin/challenge/sol/gaia
 	default_material = MATERIAL_BRONZE
 	name = "gaia conflict challenge coin"
 	icon_state = "gaia"
-	desc = {"\
-		A challenge coin distributed by the SCG Defense Forces \
-		to commemorate the Gaia Conflict. On the front is the roman \
-		numeral IV in front of a roundel of Gaian national colors, \
-		and on the back is a dove with an olive branch.\
-	"}
-
-
+	desc = "A challenge coin distributed by the SCG Defense Forces to commemorate the Gaia Conflict. On the front is the roman numeral IV in front of a roundel of Gaian national colors, and on the back is a dove with an olive branch."
 
 /obj/item/material/coin/challenge/sol/observatory
 	default_material = MATERIAL_SILVER
 	name = "observatory challenge coin"
 	icon_state = "observatory"
-	desc = {"
-		A challenge coin distributed by the Expeditionary Corps \
-		for members of the Observatory Branch. On the front is a field \
-		of stars, and on the back is the insignia of the Expeditionary \
-		Corps on a large starship.\
-	"}
-
+	desc = "A challenge coin distributed by the Expeditionary Corps for members of the Observatory Branch. On the front is a field of stars, and on the back is the insignia of the Expeditionary Corps on a large starship."
 
 /obj/item/material/coin/challenge/sol/field_ops
 	default_material = MATERIAL_SILVER
 	name = "field operations challenge coin"
 	icon_state = "field-ops"
-	desc = {"\
-		A challenge coin distributed by the Expeditionary Corps \
-		for members of the Field Operations Branch. On the front is a \
-		compass above an alien planet, and on the back is the insignia \
-		of the Expeditionary Corps on a large starship.\
-	"}
-
+	desc = "A challenge coin distributed by the Expeditionary Corps for members of the Field Operations Branch. On the front is a compass above an alien planet, and on the back is the insignia of the Expeditionary Corps on a large starship."
 
 /obj/item/material/coin/challenge/sol/torch
 	default_material = MATERIAL_GOLD
 	name = "torch mission challenge coin"
 	icon_state = "torch"
-	desc = {"\
-		A challenge coin distributed by the Expeditionary Corps for those \
-		partaking in the Torch mission. On the front is the insignia of the \
-		SEV Torch, and on the back is a folksy frontiersman with the text, \
-		"PUSHING THE BOUNDARIES."\
-	"}
-
+	desc = "A challenge coin distributed by the Expeditionary Corps for those partaking in the Torch mission. On the front is the insignia of the SEV Torch, and on the back is a folksy frontiersman with the text, 'PUSHING THE BOUNDARIES.'"
 
 /obj/item/material/coin/challenge/misc
 	abstract_type = /obj/item/material/coin/challenge/misc
 	icon = 'maps/torch/icons/obj/coins.dmi'
 	icon_state = "error"
 
-
 /obj/item/material/coin/challenge/misc/pcrc
 	default_material = MATERIAL_GOLD
 	name = "pcrc challenge coin"
 	icon_state = "pcrc"
-	desc = {"\
-		A challenge coin issued by Proxima Centauri Risk Control \
-		to its operatives. On the front are the letters "PC" in the \
-		Greek alphabet against the PCRC corporate color scheme, and \
-		on the back is a Spartan shield with the motto, "IF NOT US, \
-		THEN WHO?"\
-	"}
-
+	desc = "A challenge coin issued by Proxima Centauri Risk Control to its operatives. On the front are the letters 'PC' in the Greek alphabet against the PCRC corporate color scheme, and on the back is a Spartan shield with the motto, 'IF NOT US, THEN WHO?'"
 
 /obj/item/material/coin/challenge/misc/saare
 	default_material = MATERIAL_SILVER
 	name = "saare challenge coin"
 	icon_state = "saare"
-	desc = {"\
-		A challenge coin issued by SAARE to its operatives. \
-		On the front is a golden scale of justice, and on the back \
-		is a stalwart SAARE operative standing guard.\
-	"}
+	desc = "A challenge coin issued by SAARE to its operatives. On the front is a golden scale of justice, and on the back is a stalwart SAARE operative standing guard."

--- a/maps/torch/loadout/loadout_misc.dm
+++ b/maps/torch/loadout/loadout_misc.dm
@@ -1,9 +1,8 @@
 /datum/gear/trinket/scg_challenge_coin
 	display_name = "sol challenge coin selection"
-	description = "A selection of challenge coins for identification, collection or simply bragging rights"
+	description = "A selection of Sol challenge coins for identification, collection or bragging rights."
 	path = /obj/item/material/coin/challenge/sol
 	cost = 1
-
 
 /datum/gear/trinket/scg_challenge_coin/New()
 	..()
@@ -17,13 +16,11 @@
 	options["torch"] = /obj/item/material/coin/challenge/sol/torch
 	gear_tweaks += new /datum/gear_tweak/path (options)
 
-
 /datum/gear/trinket/misc_challenge_coin
 	display_name = "misc challenge coin selection"
-	description = "A selection of challenge coins for identification, collection or simply bragging rights"
+	description = "A selection of challenge coins for identification, collection or bragging rights."
 	path = /obj/item/material/coin/challenge/misc
 	cost = 1
-
 
 /datum/gear/trinket/misc_challenge_coin/New()
 	..()
@@ -31,7 +28,6 @@
 	options["PCRC"] = /obj/item/material/coin/challenge/misc/pcrc
 	options["SAARE"] = /obj/item/material/coin/challenge/misc/saare
 	gear_tweaks += new /datum/gear_tweak/path (options)
-
 
 /datum/gear/trinket/gcc_challenge_coin/allowed_branches = list(
 	/datum/mil_branch/civilian,

--- a/packs/faction_iccgn/badges.dm
+++ b/packs/faction_iccgn/badges.dm
@@ -18,13 +18,13 @@
 
 /obj/item/clothing/accessory/iccgn_badge/enlisted
 	name = "pin badge, ICCGN Enlisted"
-	desc = "A shiny little pin badge denoting qualification as a confederation navy enlisted person."
+	desc = "A shiny little pin badge denoting that the holder is Confederation Navy enlisted personnel."
 	icon_state = "enlisted"
 	overlay_state = "enlisted_worn"
 
 
 /obj/item/clothing/accessory/iccgn_badge/officer
 	name = "pin badge, ICCGN Officer"
-	desc = "A shiny little pin badge denoting qualification as a confederation navy officer."
+	desc = "A shiny little pin badge denoting that the holder is a Confederation Navy officer."
 	icon_state = "officer"
 	overlay_state = "officer_worn"

--- a/packs/faction_iccgn/clothing.dm
+++ b/packs/faction_iccgn/clothing.dm
@@ -28,7 +28,7 @@
 
 /obj/item/clothing/under/iccgn/pt
 	name = "physical training uniform, ICCGN"
-	desc = "A comfortable set of clingy shorts and a t-shirt sporting the insigna of the confederation navy."
+	desc = "A comfortable set of clingy shorts and a t-shirt sporting the insigna of the Confederation Navy."
 	icon_state = "under_pt"
 	item_state_slots = list(
 		slot_l_hand_str = "under_pt_held_l",
@@ -39,7 +39,7 @@
 
 /obj/item/clothing/under/iccgn/utility
 	name = "utility uniform, ICCGN"
-	desc = "A comfortable black utility jumpsuit from a confederation navy uniform."
+	desc = "A comfortable black utility jumpsuit from a Confederation Navy uniform."
 	icon_state = "under_utility"
 	item_state_slots = list(
 		slot_l_hand_str = "under_utility_held_l",
@@ -50,7 +50,7 @@
 
 /obj/item/clothing/under/iccgn/service
 	name = "service uniform, ICCGN"
-	desc = "A smart service shirt and dress pants from a confederation navy uniform."
+	desc = "A smart service shirt and dress pants from a Confederation Navy uniform."
 	icon_state = "under_service"
 	item_state_slots = list(
 		slot_l_hand_str = "under_service_held_l",
@@ -61,7 +61,7 @@
 
 /obj/item/clothing/under/iccgn/service_command
 	name = "service uniform, ICCGN"
-	desc = "A smart senior officers' shirt and dress pants from a confederation navy uniform."
+	desc = "A smart senior officers' shirt and dress pants from a Confederation Navy uniform."
 	icon_state = "under_service_command"
 	item_state_slots = list(
 		slot_l_hand_str = "under_service_command_held_l",
@@ -93,7 +93,7 @@
 
 /obj/item/clothing/suit/iccgn/utility
 	name = "utility jacket, ICCGN"
-	desc = "A rugged utility jacket from a confederation navy uniform."
+	desc = "A rugged utility jacket from a Confederation Navy uniform."
 	icon_state = "suit_utility"
 	item_state_slots = list(
 		slot_l_hand_str = "suit_utility_held_l",
@@ -107,7 +107,7 @@
 
 /obj/item/clothing/suit/iccgn/service_enlisted
 	name = "service jacket, ICCGN"
-	desc = "A slick enlisted persons' service jacket from a confederation navy uniform."
+	desc = "A slick enlisted persons' service jacket from a Confederation Navy uniform."
 	icon_state = "suit_service"
 	item_state_slots = list(
 		slot_l_hand_str = "suit_service_held_l",
@@ -122,7 +122,7 @@
 
 /obj/item/clothing/suit/iccgn/service_officer
 	name = "service jacket, ICCGN"
-	desc = "A slick officers' service jacket from a confederation navy uniform."
+	desc = "A slick officers' service jacket from a Confederation Navy uniform."
 	icon_state = "suit_service"
 	item_state_slots = list(
 		slot_l_hand_str = "suit_service_held_l",
@@ -137,7 +137,7 @@
 
 /obj/item/clothing/suit/iccgn/service_command
 	name = "service jacket, ICCGN"
-	desc = "A slick senior officers' service jacket from a confederation navy uniform."
+	desc = "A slick senior officers' service jacket from a Confederation Navy uniform."
 	icon_state = "suit_service_command"
 	item_state_slots = list(
 		slot_l_hand_str = "suit_service_held_l",
@@ -152,7 +152,7 @@
 
 /obj/item/clothing/suit/iccgn/dress_enlisted
 	name = "dress cloak, ICCGN"
-	desc = "A stylish enlisted persons' dress cloak from a confederation navy uniform."
+	desc = "A stylish enlisted persons' dress cloak from a Confederation Navy uniform."
 	icon_state = "suit_dress_enlisted"
 	item_state_slots = list(
 		slot_l_hand_str = "suit_dress_enlisted_held_l",
@@ -167,7 +167,7 @@
 
 /obj/item/clothing/suit/iccgn/dress_officer
 	name = "dress cloak, ICCGN"
-	desc = "A stylish officers' dress cloak from a confederation navy uniform."
+	desc = "A stylish officers' dress cloak from a Confederation Navy uniform."
 	icon_state = "suit_dress_officer"
 	item_state_slots = list(
 		slot_l_hand_str = "suit_dress_officer_held_l",
@@ -182,7 +182,7 @@
 
 /obj/item/clothing/suit/iccgn/dress_command
 	name = "dress cloak, ICCGN"
-	desc = "A stylish senior officers' dress cloak from a confederation navy uniform."
+	desc = "A stylish senior officers' dress cloak from a Confederation Navy uniform."
 	icon_state = "suit_dress_command"
 	item_state_slots = list(
 		slot_l_hand_str = "suit_dress_command_held_l",
@@ -210,7 +210,7 @@
 
 /obj/item/clothing/gloves/iccgn/duty
 	name = "duty gloves, ICCGN"
-	desc = "Regal black utility gloves from a confederation navy uniform."
+	desc = "Regal black utility gloves from a Confederation Navy uniform."
 	icon_state = "gloves_utility"
 	item_state_slots = list(
 		slot_l_hand_str = "gloves_utility_held_l",
@@ -234,7 +234,7 @@
 
 /obj/item/clothing/shoes/iccgn/utility
 	name = "duty boots, ICCGN"
-	desc = "Spectacularly shiny utility boots from a confederation navy uniform."
+	desc = "Spectacularly shiny utility boots from a Confederation Navy uniform."
 	icon_state = "boots_utility"
 	item_state_slots = list(
 		slot_l_hand_str = "boots_utility_held_l",
@@ -245,7 +245,7 @@
 
 /obj/item/clothing/shoes/iccgn/service
 	name = "service boots, ICCGN"
-	desc = "Extra tall service boots from a confederation navy uniform."
+	desc = "Extra tall service boots from a Confederation Navy uniform."
 	icon_state = "boots_service"
 	item_state_slots = list(
 		slot_l_hand_str = "boots_service_held_l",
@@ -269,7 +269,7 @@
 
 /obj/item/clothing/head/iccgn/beret
 	name = "uniform beret, ICCGN"
-	desc = "A slick grey beret from a confederation navy uniform."
+	desc = "A slick grey beret from a Confederation Navy uniform."
 	icon_state = "hat_beret"
 	item_state_slots = list(
 		slot_l_hand_str = "hat_beret_held_l",
@@ -280,7 +280,7 @@
 
 /obj/item/clothing/head/iccgn/service
 	name = "service cover, ICCGN"
-	desc = "A peaked service cap from a confederation navy uniform."
+	desc = "A peaked service cap from a Confederation Navy uniform."
 	icon_state = "hat_service"
 	item_state_slots = list(
 		slot_l_hand_str = "hat_service_held_l",
@@ -291,7 +291,7 @@
 
 /obj/item/clothing/head/iccgn/service_command
 	name = "service cover, ICCGN"
-	desc = "A senior officers' peaked service cap from a confederation navy uniform."
+	desc = "A senior officers' peaked service cap from a Confederation Navy uniform."
 	icon_state = "hat_service_command"
 	item_state_slots = list(
 		slot_l_hand_str = "hat_service_command_held_l",

--- a/packs/faction_iccgn/coins.dm
+++ b/packs/faction_iccgn/coins.dm
@@ -3,63 +3,35 @@
 	icon = 'packs/faction_iccgn/coins.dmi'
 	icon_state = "error"
 
-
 /obj/item/material/coin/challenge/gcc/navy
 	default_material = MATERIAL_IRON
 	name = "confederation navy challenge coin"
 	icon_state = "navy"
-	desc = {"\
-		A challenge coin issued by the Confederation Navy. \
-		On the front is the insignia of the Navy, and on the back \
-		is a rendering of the late Admiral Yevgeny Novikov.\
-	"}
-
+	desc = "A challenge coin issued by the Confederation Navy. On the front is the insignia of the Navy, and on the back is a rendering of the late Admiral Yevgeny Novikov."
 
 /obj/item/material/coin/challenge/gcc/navy_old
 	default_material = MATERIAL_IRON
 	name = "old confederation navy challenge coin"
 	icon_state = "navy-old"
-	desc = {"\
-		A tarnished challenge coin once issued by the \
-		Confederation Navy. On the front is the insignia of the \
-		Navy, and on the back is an older model of cruiser with \
-		Pan-Slavic text written around it.\
-	"}
-
+	desc = "A tarnished challenge coin once issued by the Confederation Navy. On the front is the insignia of the Navy, and on the back is an older model of cruiser with Pan-Slavic text written around it."
 
 /obj/item/material/coin/challenge/gcc/guard
 	default_material = MATERIAL_IRON
 	name = "colonial guard challenge coin"
 	icon_state = "guard"
-	desc = {"\
-		A challenge coin issued by the Confederation Navy. \
-		On the front is the insignia of the Colonial Guard, and on \
-		the back is a smiling crewman in dress uniform holding an \
-		ancient ceremonial rifle.\
-	"}
-
+	desc = "A challenge coin issued by the Confederation Navy. On the front is the insignia of the Colonial Guard, and on the back is a smiling crewman in dress uniform holding an ancient ceremonial rifle."
 
 /obj/item/material/coin/challenge/gcc/surface
 	default_material = MATERIAL_IRON
 	name = "surface warfare challenge coin"
 	icon_state = "surface"
-	desc = {"\
-		A challenge coin issued by the Confederation Surface \
-		Warfare Corps. On the front is a mace against the Corps's \
-		parade colors, and on the back is an emboss of a bearded \
-		soldier giving a thumbs-up.\
-	"}
-
+	desc = "A challenge coin issued by the Confederation Surface Warfare Corps. On the front is a mace against the Corps' parade colors, and on the back is an emboss of a bearded soldier giving a thumbs-up."
 
 /datum/gear/trinket/gcc_challenge_coin
 	display_name = "confederation challenge coin selection"
-	description = {"\
-		A selection of challenge coins used by confederation military \
-		forces for identification, collection, or bragging rights.\
-	"}
+	description = "A selection of challenge coins used by Confederation military forces for identification, collection, or bragging rights."
 	path = /obj/item/material/coin/challenge/gcc
 	cost = 1
-
 
 /datum/gear/trinket/gcc_challenge_coin/New()
 	..()

--- a/packs/faction_iccgn/patches.dm
+++ b/packs/faction_iccgn/patches.dm
@@ -1,12 +1,11 @@
 /datum/gear/accessory/iccgn_patch
 	display_name = "ICCGN Patch Selection"
-	description = "Uniform patches of the confederation navy."
+	description = "A selection of Confederation Navy uniform patches."
 	path = /obj/item/clothing/accessory/iccgn_patch
 	flags = GEAR_HAS_SUBTYPE_SELECTION | GEAR_HAS_NO_CUSTOMIZATION
 	allowed_branches = list(
 		/datum/mil_branch/iccgn
 	)
-
 
 /obj/item/clothing/accessory/iccgn_patch
 	abstract_type = /obj/item/clothing/accessory/iccgn_patch
@@ -27,51 +26,44 @@
 /obj/item/clothing/accessory/iccgn_patch/get_fibers()
 	return null
 
-
 /obj/item/clothing/accessory/iccgn_patch/gilgamesh
 	name = "uniform patch, Gilgamesh Flotilla"
-	desc = "An embroidered patch with confederation navy iconography. This one indicates that its wearer is part of the Gilgamesh Flotilla."
+	desc = "An embroidered patch with Confederation Navy iconography. This one indicates that its wearer is part of the Gilgamesh Flotilla."
 	icon_state = "gilgamesh"
 	overlay_state = "gilgamesh_worn"
 
-
 /obj/item/clothing/accessory/iccgn_patch/sestris
 	name = "uniform patch, Sestris Flotilla"
-	desc = "An embroidered patch with confederation navy iconography. This one indicates that its wearer is part of the Sestris Flotilla."
+	desc = "An embroidered patch with Confederation Navy iconography. This one indicates that its wearer is part of the Sestris Flotilla."
 	icon_state = "sestris"
 	overlay_state = "sestris_worn"
 
-
 /obj/item/clothing/accessory/iccgn_patch/pioneer
 	name = "uniform patch, Pioneering Corps"
-	desc = "An embroidered patch with confederation navy iconography. This one indicates that its wearer is part of the Pioneering Corps."
+	desc = "An embroidered patch with Confederation Navy iconography. This one indicates that its wearer is part of the Pioneering Corps."
 	icon_state = "pioneer"
 	overlay_state = "pioneer_worn"
 
-
 /obj/item/clothing/accessory/iccgn_patch/ordnance
 	name = "uniform patch, Ordnance Corps"
-	desc = "An embroidered patch with confederation navy iconography. This one indicates that its wearer is part of the Ordnance Corps."
+	desc = "An embroidered patch with Confederation Navy iconography. This one indicates that its wearer is part of the Ordnance Corps."
 	icon_state = "ordnance"
 	overlay_state = "ordnance_worn"
 
-
 /obj/item/clothing/accessory/iccgn_patch/security
 	name = "uniform patch, Internal Security"
-	desc = "An embroidered patch with confederation navy iconography. This one indicates that its wearer is part of the Office of Internal Security."
+	desc = "An embroidered patch with Confederation Navy iconography. This one indicates that its wearer is part of the Office of Internal Security."
 	icon_state = "security"
 	overlay_state = "security_worn"
 
-
 /obj/item/clothing/accessory/iccgn_patch/research
 	name = "uniform patch, Defense Research"
-	desc = "An embroidered patch with confederation navy iconography. This one indicates that its wearer is part of the Office of Defense Research."
+	desc = "An embroidered patch with Confederation Navy iconography. This one indicates that its wearer is part of the Office of Defense Research."
 	icon_state = "research"
 	overlay_state = "research_worn"
 
-
 /obj/item/clothing/accessory/iccgn_patch/guard
 	name = "uniform patch, Colonial Guard"
-	desc = "An embroidered patch with confederation navy iconography. This one indicates that its wearer is part of the Colonial Guard."
+	desc = "An embroidered patch with Confederation Navy iconography. This one indicates that its wearer is part of the Colonial Guard."
 	icon_state = "guard"
 	overlay_state = "guard_worn"


### PR DESCRIPTION
🆑
tweak: text/typo fixes for loadout coins, confederate naval uniforms
/🆑

### LOOK AT THIS, AGAIN.
⠀
⠀
⠀
![download (1)](https://user-images.githubusercontent.com/44277885/207252005-705b5c32-a47d-4fcc-b225-0004605134eb.png)
⠀⠀

⠀
### THIS IS STILL IN MY JACKET EVERY ROUND, AND EVERY ROUND THE PAIN STILL STABS AT MY SOUL.
⠀
⠀
I once again made it standard. Not just for myself, but for all of you, again. Because still I love a̵l̵l̵ most of you. And, of course, I fixed the rest of the coins, too, again, as I would be a weak man otherwise - and since Confederate Navy seemed to be improperly capitalized in most of the coins and then pack-faction stuff, I got that too, because I had time, again, and then I fixed some other writing stuff there, again, and probably some other stuff I can't even remember, again. My soul is sustained by nothing but removing large swathes of this codebase, as always, and fixing small textual inanities seven steps down a file tree, repeatedly. I do (still) expect one of you to give me another idea for the former before April comes.

🙇‍♂️🙇‍♂️🙇‍♂️🙇‍♂️