### PR TITLE
Runtime batch 2022 12 26

### DIFF
--- a/code/controllers/subsystems/zcopy.dm
+++ b/code/controllers/subsystems/zcopy.dm
@@ -191,6 +191,11 @@ SUBSYSTEM_DEF(zcopy)
 		while (Td.below)
 			Td = Td.below
 
+		// Debug checking for #32286 - https://github.com/Baystation12/Baystation12/issues/32286
+		if (Td.z > length(zlev_maximums))
+			crash_with("zcopy hit a z-level not included in zlev_maximums: [Td.z] - Maximum z-level: [length(zlev_maximums)] - Source turf: [Td] ([Td.type]) in [get_area(Td)] ([Td.x], [Td.y], [Td.z]).")
+			continue // Prevents the subsystem from halting on the next line
+
 		// Depth must be the depth of the *visible* turf, not self.
 		var/turf_depth
 		turf_depth = T.z_depth = zlev_maximums[Td.z] - Td.z

--- a/code/datums/trading/unique.dm
+++ b/code/datums/trading/unique.dm
@@ -23,7 +23,7 @@
 	return --duration_of_stay > 0
 
 /datum/trader/ship/unique/what_do_you_want()
-	return get_response(TRADER_WHAT_WANT, "I don't want anything!")
+	return make_response(TRADER_WHAT_WANT, "I don't want anything!", 0, FALSE)
 
 /datum/trader/ship/unique/severance
 	name = "Unknown"

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -36,7 +36,7 @@
 
 /atom/movable/Destroy()
 	if(!(atom_flags & ATOM_FLAG_INITIALIZED))
-		crash_with("Was deleted before initalization")
+		crash_with("\A [src] was deleted before initalization")
 	walk(src, 0)
 	for(var/A in src)
 		qdel(A)

--- a/code/modules/mining/machinery/mineral_console.dm
+++ b/code/modules/mining/machinery/mineral_console.dm
@@ -11,6 +11,9 @@
 	return TRUE
 
 /obj/machinery/computer/mining/interact(mob/user)
+	if (!connected)
+		to_chat(user, SPAN_WARNING("\The [src] is not connected to a processing machine. <a href='?src=\ref[src];scan_for_machine=1'>Scan</a>"))
+		return
 	var/datum/browser/popup = new(user, "mining-[name]", "[src] Control Panel")
 	popup.set_content(jointext(connected.get_console_data(), "<br>"))
 	popup.open()

--- a/code/modules/organs/internal/species/ipc.dm
+++ b/code/modules/organs/internal/species/ipc.dm
@@ -310,7 +310,8 @@
 	if (self && self.mind)
 		self.visible_message("\The [self] unceremoniously falls lifeless.")
 		var/mob/observer/ghost/G = self.ghostize(FALSE)
-		G.timeofdeath = world.time
+		if (G) // In case of aghosts or keyless mobs
+			G.timeofdeath = world.time
 
 /*
 	This is for law stuff directly. This is how a human mob will be able to communicate with the posi_brainmob in the

--- a/code/modules/species/species_random.dm
+++ b/code/modules/species/species_random.dm
@@ -4,7 +4,8 @@
 	if(!(appearance_flags & Z) || !random_##Y.len){\
 		return;\
 	}\
-	var/singleton/color_generator/CG = GET_SINGLETON(pickweight(random_##Y));\
+	var/selection = pickweight(random_##Y);\
+	var/singleton/color_generator/CG = GET_SINGLETON(selection);\
 	return CG && CG.GenerateRGB();\
 }
 

--- a/maps/away/casino/casino.dm
+++ b/maps/away/casino/casino.dm
@@ -154,6 +154,12 @@
 /obj/structure/casino/craps/craps_down
 	icon_state = "craps_down"
 
+/obj/structure/casino/pod_controller
+	name = "escape pod controller"
+	desc = "An escape pod controller. This one seems to have crashed and doesn't respond to commands."
+	icon = 'icons/obj/airlock_machines.dmi'
+	icon_state = "airlock_control_off"
+
 //========================used bullet casings=======================
 /obj/item/ammo_casing/rifle/used/Initialize()
 	. = ..()

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -4747,12 +4747,9 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{
-	frequency = 1380;
-	id_tag = "Casino_escape_pod_3";
+/obj/structure/casino/pod_controller{
 	name = "Casino escape pod Three controller";
-	pixel_x = 24;
-	tag_door = "Casino escape_pod_3_hatch"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
 /area/casino/casino_bow)
@@ -4761,12 +4758,9 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{
-	frequency = 1380;
-	id_tag = "Casino_escape_pod_2";
+/obj/structure/casino/pod_controller{
 	name = "Casino escape pod Two controller";
-	pixel_x = 24;
-	tag_door = "Casino escape_pod_2_hatch"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
 /area/casino/casino_bow)
@@ -4775,12 +4769,9 @@
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
-/obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod{
-	frequency = 1380;
-	id_tag = "Casino_escape_pod_1";
+/obj/structure/casino/pod_controller{
 	name = "Casino escape pod One controller";
-	pixel_x = 24;
-	tag_door = "escape_pod_17_hatch"
+	pixel_x = 24
 	},
 /turf/simulated/floor/plating,
 /area/casino/casino_bow)


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Certain trader types should no longer break when asking them what they want.
bugfix: The Randomize button in character setup will no longer randomly break/crash.
bugfix: Ore processing consoles that are not connected to valid machinery now display a prompt to scan for adjacent machinery instead of crashing.
/:cl:

NUFC:
- 'Was deleted before initialization' runtime message now includes the name of the atom.
- Turfs queued for zcopy that are on a z-level exceeding the subsystem's current maximum z-level should now cleanly runtime and skip to the next item, instead of crashing the process loop. The root cause of this is most likely z-level manipulation that doesn't call the required `calculate_zstack_limits()` proc when they're done, possibly adminbus related.

Issue fixes:
- Fixes #31613
- Fixes #32732
- Fixes #32707
- Fixes #32448
- Closes #32755
- Fixes #24216
- Fixes #28868
- Closes #32286

Notes:
- I have no idea how the species_random.dm change fixes the issue, but it does after spending a full minute just spamming the button. I also have no idea what caused the result to randomly be null prior to the change, but I was able to consistantly cause it to happen by spamming the button pre-change. I'm going to assume it's something to do with the define stacking.
- #24216 was fixed by adding a new static object to replace the escape pod controllers present in the Casino map. Those aren't intended to launch or be used as real escape pods, so they don't need the real controllers.