### PR TITLE
Adjacent fire damage

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -16,7 +16,6 @@
 	var/damaged_reinf = FALSE
 	var/init_material = MATERIAL_GLASS
 	var/init_reinf_material = null
-	var/damage_per_fire_tick = 2 		// Amount of damage per fire tick. Regular windows are not fireproof so they might as well break quickly.
 	var/construction_state = 2
 	var/id
 	var/polarized = 0
@@ -609,7 +608,7 @@
 	if(reinf_material)
 		melting_point += 0.25*reinf_material.melting_point
 	if (exposed_temperature > melting_point)
-		damage_health(damage_per_fire_tick, DAMAGE_FIRE)
+		..()
 
 /obj/structure/window/basic
 	icon_state = "window"

--- a/code/game/turfs/simulated/floor_acts.dm
+++ b/code/game/turfs/simulated/floor_acts.dm
@@ -40,6 +40,26 @@
 /turf/simulated/floor/adjacent_fire_act(turf/simulated/floor/adj_turf, datum/gas_mixture/adj_air, adj_temp, adj_volume)
 	var/dir_to = get_dir(src, adj_turf)
 
-	for(var/obj/structure/window/W in src)
-		if(W.dir == dir_to || W.is_fulltile()) //Same direction or diagonal (full tile)
-			W.fire_act(adj_air, adj_temp, adj_volume)
+	for (var/atom/movable/A as anything in src)
+		// Windows first - Directional windows don't pass the below atmos checks.
+		if (istype(A, /obj/structure/window))
+			var/obj/structure/window/W = A
+			if (W.dir == dir_to || W.is_fulltile()) //Same direction or diagonal (full tile)
+				W.fire_act(adj_air, adj_temp, adj_volume)
+			continue
+
+		// Only effect atoms that block air and fire.
+		var/canpass
+		switch (A.atmos_canpass)
+			if (CANPASS_ALWAYS)
+				canpass = TRUE
+			if (CANPASS_DENSITY)
+				canpass = !density
+			if (CANPASS_PROC)
+				canpass = !A.c_airblock(adj_turf)
+			if (CANPASS_NEVER)
+				canpass = FALSE
+		if (canpass)
+			continue
+
+		A.fire_act(adj_air, adj_temp, adj_volume)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -180,13 +180,11 @@
 
 /turf/simulated/wall/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)//Doesn't fucking work because walls don't interact with air
 	burn(exposed_temperature)
+	if (exposed_temperature > material.melting_point)
+		..()
 
 /turf/simulated/wall/adjacent_fire_act(turf/simulated/floor/adj_turf, datum/gas_mixture/adj_air, adj_temp, adj_volume)
-	burn(adj_temp)
-	if(adj_temp > material.melting_point)
-		damage_health(log(Frand(0.9, 1.1) * (adj_temp - material.melting_point)), DAMAGE_BURN)
-
-	return ..()
+	fire_act(adj_air, adj_temp, adj_volume)
 
 /turf/simulated/wall/proc/dismantle_wall(devastated, no_product)
 

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -259,13 +259,14 @@
 
 /turf/simulated/wall/proc/burn(temperature)
 	if(material.combustion_effect(src, temperature, 0.7))
-		spawn(2)
-			new /obj/structure/girder(src)
-			src.ChangeTurf(/turf/simulated/floor)
-			for(var/turf/simulated/wall/W in range(3,src))
-				W.burn((temperature/4))
-			for(var/obj/machinery/door/airlock/phoron/D in range(3,src))
-				D.ignite(temperature/4)
+		addtimer(CALLBACK(src, .proc/burn_adjacent, temperature), 2, TIMER_UNIQUE)
+
+/turf/simulated/wall/proc/burn_adjacent(temperature)
+	for (var/turf/simulated/wall/W in range(3,src))
+		W.burn((temperature/4))
+	for (var/obj/machinery/door/airlock/phoron/D in range(3,src))
+		D.ignite(temperature/4)
+	kill_health()
 
 /turf/simulated/wall/get_color()
 	return paint_color

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -210,7 +210,7 @@ var/global/const/enterloopsanity = 100
 						thing.HasProximity(A)
 	return
 
-/turf/proc/adjacent_fire_act(turf/simulated/floor/source, exposed_temperature, exposed_volume)
+/turf/proc/adjacent_fire_act(turf/simulated/floor/adj_turf, datum/gas_mixture/adj_air, adj_temp, adj_volume)
 	return
 
 /turf/proc/is_plating()

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -44,7 +44,7 @@ exactly 25 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 5 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 355 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 354 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 0 "anchored = 0/1" 'anchored\s*=\s*\d' -P
 exactly 2 "density = 0/1" 'density\s*=\s*\d' -P


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Adjacent fires are more effective against windows and walls and can effect some other atoms that would otherwise block airflow and fire. Doors are currently exempt.
/:cl: