### PR TITLE
fixes alert light position in bridge saferoom

### DIFF
--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -12150,9 +12150,6 @@
 	start_pressure = 450
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/rotating_alarm/security_alarm{
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/bridge)
 "IG" = (
@@ -14582,6 +14579,9 @@
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 8
+	},
+/obj/machinery/rotating_alarm/security_alarm{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/bridge)


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/44277885/209647041-9552280d-7d01-4058-82d1-7342a6ed06c0.png)
⠀
⠀
⠀
Here it is. The security level signal was floating, I moved it so it is not. In addition to that, I moved it from being behind an air tank in the corner of the room to being in the center; this has the minor effect that as a ghost the flag/banner in the SEA's office will be over it, but I think that this tradeoff is acceptable given the much better positioning for people that matter (players).

I hope I'm making you proud, air-war-man
⠀
⠀
⠀

![pr1 fucked bridge light exp2](https://user-images.githubusercontent.com/44277885/209647031-cd22e529-6379-40d4-9fa3-26af3a42f55e.png)

![pr2 fucked bridge light exp2](https://user-images.githubusercontent.com/44277885/209646896-a8c921a9-ed98-41f8-b999-18197d60ad04.png)
