### PR TITLE
Timer deletion fixes

### DIFF
--- a/code/__defines/MC.dm
+++ b/code/__defines/MC.dm
@@ -186,9 +186,6 @@ if(Datum.is_processing) {\
 /// Repeat the timer until it's deleted or the parent is destroyed.
 #define TIMER_LOOP FLAG(5)
 
-///Delete the timer on parent datum Destroy() and when deltimer'd
-#define TIMER_DELETE_ME FLAG(6)
-
 /// The default timer ID.
 #define TIMER_ID_NULL -1
 

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -148,7 +148,7 @@ var/global/const/NEGATIVE_INFINITY = -1#INF // win: -1.#INF, lin: -inf
 
 #define QDEL_NULL(x) if(x) { qdel(x) ; x = null }
 
-#define QDEL_IN(item, time) addtimer(CALLBACK(GLOBAL_PROC, .proc/qdel, item), time, TIMER_STOPPABLE)
+#define QDEL_IN(item, time) addtimer(CALLBACK(item, /datum/proc/qdel_self), time, TIMER_STOPPABLE)
 
 #define DROP_NULL(x) if(x) { x.dropInto(loc); x = null; }
 

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -639,7 +639,7 @@ SUBSYSTEM_DEF(timer)
 	timer_subsystem = timer_subsystem || SStimer
 	//id is string
 	var/datum/timedevent/timer = timer_subsystem.timer_id_dict[id]
-	if (timer && (!timer.spent || timer.flags & TIMER_DELETE_ME))
+	if (timer && !timer.spent)
 		qdel(timer)
 		return TRUE
 	return FALSE

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -23,7 +23,7 @@
 	var/list/timers = active_timers
 	active_timers = null
 	for(var/datum/timedevent/timer as anything in timers)
-		if (timer.spent && !(timer.flags & TIMER_DELETE_ME))
+		if (timer.spent)
 			continue
 		qdel(timer)
 

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -119,7 +119,7 @@
 		pulse2.anchored = TRUE
 		pulse2.set_dir(pick(GLOB.cardinal))
 
-		addtimer(CALLBACK(GLOBAL_PROC, /proc/qdel, pulse2), 1 SECOND)
+		QDEL_IN(pulse2, 1 SECOND)
 	..()
 
 /obj/machinery/ex_act(severity)

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -21,7 +21,7 @@
 
 /obj/effect/decal/cleanable/greenglow/Initialize()
 	. = ..()
-	addtimer(CALLBACK(src, /datum/proc/qdel_self), 2 MINUTES)
+	QDEL_IN(src, 2 MINUTES)
 
 /obj/effect/decal/cleanable/dirt
 	name = "dirt"

--- a/code/game/objects/effects/decals/misc.dm
+++ b/code/game/objects/effects/decals/misc.dm
@@ -9,7 +9,7 @@
 
 /obj/effect/decal/point/Initialize()
 	. = ..()
-	addtimer(CALLBACK(null, /proc/qdel, src), 2 SECONDS)
+	QDEL_IN(src, 2 SECONDS)
 
 // Used for spray that you spray at walls, tables, hydrovats etc
 /obj/effect/decal/spraystill

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -179,12 +179,12 @@
 			deltimer(destruction_timer)
 			destruction_timer = null
 	else if (!destruction_timer)
-		destruction_timer = addtimer(CALLBACK(src, /datum/.proc/qdel_self), 10 SECONDS, TIMER_STOPPABLE)
+		destruction_timer = QDEL_IN(src, 10 SECONDS)
 
 // Called when the turf we're on is deleted/changed.
 /atom/movable/openspace/mimic/proc/owning_turf_changed()
 	if (!destruction_timer)
-		destruction_timer = addtimer(CALLBACK(src, /datum/.proc/qdel_self), 10 SECONDS, TIMER_STOPPABLE)
+		destruction_timer = QDEL_IN(src, 10 SECONDS)
 
 // -- TURF PROXY --
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -35,7 +35,7 @@
 	energy = starting_energy
 
 	if (temp)
-		addtimer(CALLBACK(null, /proc/qdel, src), temp)
+		QDEL_IN(src, temp)
 
 	..()
 	START_PROCESSING(SSobj, src)


### PR DESCRIPTION
NUFC:
- Removes the unused `TIMER_DELETE_ME` flag, which should result in timers being deleted by default when their parent datum is destroyed.
- `QDEL_IN()` has been updated to call `qdel_self()` on the target datum, instead of the global `qdel()`. This allows for the timer to be cancelled if the datum is deleted before the timer expires.

Bug fixes:
- Fixes #32614
- Closes #25664 (Fixes some causes of this, but there may be other cases)