### PR TITLE
More damage sources

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -10,10 +10,10 @@
  * - `armorcheck` (string) - TODO: Unused. Remove.
  * - `dam_flags` (bitfield, any of `DAMAGE_FLAG_*`) - Damage flags associated with the attack.
  *
- * Returns boolean. TODO: Return value is unused. Remove.
+ * Returns boolean.
  */
 /atom/proc/attack_generic(mob/user, damage, attack_verb = "hits", wallbreaker = FALSE, damtype = DAMAGE_BRUTE, armorcheck = "melee", dam_flags = EMPTY_BITFIELD)
-	return FALSE
+	return
 
 
 /*

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -13,7 +13,30 @@
  * Returns boolean.
  */
 /atom/proc/attack_generic(mob/user, damage, attack_verb = "hits", wallbreaker = FALSE, damtype = DAMAGE_BRUTE, armorcheck = "melee", dam_flags = EMPTY_BITFIELD)
-	return
+	if (damage && get_max_health())
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.do_attack_animation(src)
+		if (!can_damage_health(damage, damtype))
+			playsound(src, damage_hitsound, 50)
+			user.visible_message(
+				SPAN_WARNING("\The [user] bonks \the [src] harmlessly!"),
+				SPAN_WARNING("You bonk \the [src] harmlessly!")
+			)
+			return
+		var/damage_flags = EMPTY_BITFIELD
+		if (wallbreaker)
+			SET_FLAGS(damage_flags, DAMAGE_FLAG_TURF_BREAKER)
+		playsound(src, damage_hitsound, 75)
+		if (damage_health(damage, damtype, damage_flags, skip_can_damage_check = TRUE))
+			user.visible_message(
+				SPAN_DANGER("\The [user] smashes through \the [src]!"),
+				SPAN_DANGER("You smash through \the [src]!")
+			)
+		else
+			user.visible_message(
+				SPAN_DANGER("\The [user] [attack_verb] \the [src]!"),
+				SPAN_DANGER("You [attack_verb] \the [src]!")
+			)
 
 
 /*

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -486,9 +486,28 @@
  * - `TT` - The thrownthing datum associated with the impact.
  */
 /atom/proc/hitby(atom/movable/AM, datum/thrownthing/TT)//already handled by throw impact
-	if(isliving(AM))
+	if(isliving(AM) && !isturf(src)) // See `/turf/hitby()` for turf handling of mob impacts
 		var/mob/living/M = AM
 		M.apply_damage(TT.speed * 5, DAMAGE_BRUTE)
+
+	if (get_max_health())
+		var/damage = 0
+		var/damage_type = DAMAGE_BRUTE
+		var/damage_flags = EMPTY_BITFIELD
+		if (isobj(AM))
+			var/obj/O = AM
+			damage = O.throwforce
+			damage_type = O.damtype
+		else if (ismob(AM))
+			var/mob/M = AM
+			damage = M.mob_size
+		damage = damage * (TT.speed / THROWFORCE_SPEED_DIVISOR)
+		if (!can_damage_health(damage, damage_type))
+			playsound(src, damage_hitsound, 50)
+			AM.visible_message(SPAN_NOTICE("\The [AM] bounces off \the [src] harmlessly."))
+			return
+		damage_health(damage, damage_type, damage_flags, skip_can_damage_check = TRUE)
+		AM.visible_message(SPAN_WARNING("\The [AM] impacts \the [src], causing damage!"))
 
 
 /**

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -13,15 +13,12 @@
 	var/footstep_type
 	var/mob_offset = 0 //used for on_structure_offset mob animation
 
-/obj/structure/attack_generic(mob/user, damage, attack_verb, wallbreaker)
-	if(wallbreaker && damage && breakable)
-		visible_message(SPAN_DANGER("\The [user] smashes \the [src] to pieces!"))
-		attack_animation(user)
-		qdel(src)
-		return
-	visible_message(SPAN_DANGER("\The [user] [attack_verb] \the [src]!"))
-	attack_animation(user)
-	damage_health(damage, DAMAGE_BRUTE)
+/obj/structure/damage_health(damage, damage_type, damage_flags, severity, skip_can_damage_check)
+	if (damage && HAS_FLAGS(damage_flags, DAMAGE_FLAG_TURF_BREAKER))
+		if (breakable)
+			return kill_health()
+		damage = max(damage, 10)
+	..()
 
 /obj/structure/proc/mob_breakout(mob/living/escapee)
 	set waitfor = FALSE

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -18,11 +18,10 @@
 		visible_message(SPAN_DANGER("\The [user] smashes \the [src] to pieces!"))
 		attack_animation(user)
 		qdel(src)
-		return 1
+		return
 	visible_message(SPAN_DANGER("\The [user] [attack_verb] \the [src]!"))
 	attack_animation(user)
 	damage_health(damage, DAMAGE_BRUTE)
-	return 1
 
 /obj/structure/proc/mob_breakout(mob/living/escapee)
 	set waitfor = FALSE

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -84,10 +84,6 @@
 	for (var/mob/M in src)
 		shatter(M)
 
-/obj/structure/closet/statue/attack_generic(mob/user, damage, attacktext, environment_smash)
-	if(damage && environment_smash)
-		kill_health()
-
 /obj/structure/closet/statue/MouseDrop_T()
 	return
 

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -20,17 +20,6 @@
 	health_max = 50
 	cover = 25
 
-/obj/structure/girder/attack_generic(mob/user, damage, attack_message = "smashes apart", wallbreaker)
-	if(!damage)
-		return
-	attack_animation(user)
-	playsound(loc, 'sound/weapons/tablehit1.ogg', 40, 1)
-	visible_message(SPAN_DANGER("[user] [attack_message] [src]!"))
-	if(wallbreaker)
-		kill_health()
-	else
-		damage_health(damage, DAMAGE_BRUTE)
-
 /obj/structure/girder/bullet_act(obj/item/projectile/Proj)
 	//Girders only provide partial cover. There's a chance that the projectiles will just pass through. (unless you are trying to shoot the girder)
 	if(Proj.original != src && !prob(cover))

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -22,7 +22,7 @@
 
 /obj/structure/girder/attack_generic(mob/user, damage, attack_message = "smashes apart", wallbreaker)
 	if(!damage)
-		return 0
+		return
 	attack_animation(user)
 	playsound(loc, 'sound/weapons/tablehit1.ogg', 40, 1)
 	visible_message(SPAN_DANGER("[user] [attack_message] [src]!"))
@@ -30,7 +30,6 @@
 		kill_health()
 	else
 		damage_health(damage, DAMAGE_BRUTE)
-	return 1
 
 /obj/structure/girder/bullet_act(obj/item/projectile/Proj)
 	//Girders only provide partial cover. There's a chance that the projectiles will just pass through. (unless you are trying to shoot the girder)

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -202,7 +202,6 @@
 		user.visible_message(SPAN_DANGER("[user] [attack_verb] open the [src]!"))
 	else
 		user.visible_message(SPAN_DANGER("[user] [attack_verb] at [src]!"))
-	return 1
 
 /obj/structure/inflatable/CanFluidPass(coming_from)
 	return !density

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -196,13 +196,6 @@
 	deflate()
 	return TRUE
 
-/obj/structure/inflatable/attack_generic(mob/user, damage, attack_verb)
-	attack_animation(user)
-	if (damage_health(damage))
-		user.visible_message(SPAN_DANGER("[user] [attack_verb] open the [src]!"))
-	else
-		user.visible_message(SPAN_DANGER("[user] [attack_verb] at [src]!"))
-
 /obj/structure/inflatable/CanFluidPass(coming_from)
 	return !density
 

--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -151,19 +151,6 @@
 			paint_color = adjust_brightness(paint_color, bleach_factor)
 		update_icon()
 
-/obj/structure/wall_frame/hitby(AM as mob|obj, datum/thrownthing/TT)
-	..()
-	var/tforce = 0
-	if(ismob(AM)) // All mobs have a multiplier and a size according to mob_defines.dm
-		var/mob/I = AM
-		tforce = I.mob_size * (TT.speed/THROWFORCE_SPEED_DIVISOR)
-	else
-		var/obj/O = AM
-		tforce = O.throwforce * (TT.speed/THROWFORCE_SPEED_DIVISOR)
-	if (tforce < 15)
-		return
-	damage_health(tforce, DAMAGE_BRUTE)
-
 /obj/structure/wall_frame/on_death()
 	dismantle()
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -214,21 +214,6 @@
 		return 0
 	return 1
 
-/obj/structure/window/hitby(atom/movable/AM, datum/thrownthing/TT)
-	..()
-	visible_message(SPAN_DANGER("[src] was hit by [AM]."))
-	var/tforce = 0
-	if(ismob(AM)) // All mobs have a multiplier and a size according to mob_defines.dm
-		var/mob/I = AM
-		tforce = I.mob_size * (TT.speed/THROWFORCE_SPEED_DIVISOR)
-	else if(isobj(AM))
-		var/obj/item/I = AM
-		tforce = I.throwforce * (TT.speed/THROWFORCE_SPEED_DIVISOR)
-	if(reinf_material) tforce *= 0.25
-	playsound(loc, 'sound/effects/Glasshit.ogg', 100, 1)
-	damage_health(tforce, DAMAGE_BRUTE)
-	deanchor(AM)
-
 /obj/structure/window/attack_hand(mob/user as mob)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if(MUTATION_HULK in user.mutations)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -260,22 +260,6 @@
 							"You hear a knocking sound.")
 	return
 
-/obj/structure/window/attack_generic(mob/user, damage, attack_verb, environment_smash)
-	if(environment_smash >= 1)
-		damage = max(damage, 10)
-
-	if(istype(user))
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		user.do_attack_animation(src)
-	if(!damage)
-		return
-	if(can_damage_health(damage, DAMAGE_BRUTE))
-		visible_message(SPAN_DANGER("[user] [attack_verb] into [src]!"))
-		playsound(loc, 'sound/effects/Glasshit.ogg', 100, 1)
-		damage_health(damage, DAMAGE_BRUTE, skip_can_damage_check = TRUE)
-	else
-		visible_message(SPAN_NOTICE("\The [user] bonks \the [src] harmlessly."))
-
 /obj/structure/window/do_simple_ranged_interaction(mob/user)
 	visible_message(SPAN_NOTICE("Something knocks on \the [src]."))
 	playsound(loc, 'sound/effects/Glasshit.ogg', 50, 1)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -275,7 +275,6 @@
 		damage_health(damage, DAMAGE_BRUTE, skip_can_damage_check = TRUE)
 	else
 		visible_message(SPAN_NOTICE("\The [user] bonks \the [src] harmlessly."))
-	return 1
 
 /obj/structure/window/do_simple_ranged_interaction(mob/user)
 	visible_message(SPAN_NOTICE("Something knocks on \the [src]."))

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -143,10 +143,12 @@
 
 	if(reinf_material)
 		if(damage >= max(material.hardness,reinf_material.hardness))
-			return success_smash(user)
+			success_smash(user)
+			return
 	else if(wallbreaker == 2 || damage >= material.hardness)
-		return success_smash(user)
-	return fail_smash(user)
+		success_smash(user)
+		return
+	fail_smash(user)
 
 /turf/simulated/wall/attackby(obj/item/W, mob/user)
 

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -106,14 +106,6 @@
 
 	..()
 
-/turf/simulated/wall/hitby(AM as mob|obj, datum/thrownthing/TT)
-	if(!ismob(AM))
-		var/obj/O = AM
-		var/tforce = O.throwforce * (TT.speed/THROWFORCE_SPEED_DIVISOR)
-		playsound(src, hitsound, tforce >= 15? 60 : 25, TRUE)
-		damage_health(tforce, O.damtype)
-	..()
-
 /turf/simulated/wall/proc/clear_plants()
 	for(var/obj/effect/overlay/wallrot/WR in src)
 		qdel(WR)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -317,6 +317,8 @@ var/global/const/enterloopsanity = 100
 		spawn(2)
 			step(AM, turn(intial_dir, 180))
 
+	..()
+
 /turf/proc/can_engrave()
 	return FALSE
 

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -17,7 +17,10 @@
 	manual_unbuckle(user)
 
 /obj/effect/vine/attack_generic(mob/user)
-	manual_unbuckle(user)
+	if (buckled_mob == user)
+		manual_unbuckle(user)
+		return
+	..()
 
 /obj/effect/vine/Crossed(atom/movable/O)
 	if(isliving(O))

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -531,11 +531,6 @@
 		playsound(loc, SOUNDS_BULLET_METAL, 100, 1)
 	..()
 
-/obj/item/device/electronic_assembly/attack_generic(mob/user, damage)
-	user.visible_message(SPAN_WARNING("\The [user] smashes \the [src]!"), SPAN_WARNING("You smash \the [src]!"))
-	attack_animation(user)
-	damage_health(damage)
-
 /obj/item/device/electronic_assembly/emp_act(severity)
 	for(var/I in src)
 		var/atom/movable/AM = I

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -186,7 +186,8 @@
 		return attack_self(user)
 	else if(adj)
 		setClickCooldown(arms ? arms.action_delay : 15)
-		return A.attack_generic(src, arms.melee_damage, "attacked")
+		A.attack_generic(src, arms.melee_damage, "attacked")
+		return
 	return
 
 /mob/living/exosuit/proc/set_hardpoint(hardpoint_tag)
@@ -467,7 +468,7 @@
 	return
 
 /mob/living/exosuit/attack_generic(mob/user, damage, attack_message = "smashes into")
-	if(..())
+	if(damage)
 		playsound(loc, arms.mech_punch_sound, 40, 1)
 
 /mob/living/exosuit/proc/attack_self(mob/user)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -270,7 +270,6 @@
 	var/obj/item/organ/external/affecting = get_organ(ran_zone(dam_zone))
 	apply_damage(damage, damtype, affecting, dam_flags)
 	updatehealth()
-	return 1
 
 //Breaks all grips and pulls that the mob currently has.
 /mob/living/carbon/human/proc/break_all_grabs(mob/living/carbon/user)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -239,8 +239,6 @@
 	if (ai_holder)
 		ai_holder.react_to_attack(user)
 
-	return TRUE
-
 /mob/living/proc/IgniteMob()
 	if(fire_stacks > 0 && !on_fire)
 		on_fire = 1

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -698,7 +698,7 @@
 
 //Robots take half damage from basic attacks.
 /mob/living/silicon/robot/attack_generic(mob/user, damage, attack_message)
-	return ..(user,Floor(damage/2),attack_message)
+	..(user,Floor(damage/2),attack_message)
 
 /mob/living/silicon/robot/get_req_access()
 	return req_access

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -758,22 +758,18 @@
 	speech_buffer.Add(message)
 
 /mob/living/simple_animal/hostile/retaliate/parrot/attack_generic(mob/user, damage, attack_message)
-
-	var/success = ..()
-
 	if(client)
-		return success
+		return
 
 	if(parrot_state == PARROT_PERCH)
 		parrot_sleep_dur = parrot_sleep_max //Reset it's sleep timer if it was perched
 
-	if(!success)
-		return 0
+	if(!damage)
+		return
 
 	parrot_interest = user
 	parrot_state = PARROT_SWOOP | PARROT_ATTACK //Attack other animals regardless
 	icon_state = "[icon_set]_fly"
-	return success
 
 /mob/living/simple_animal/hostile/retaliate/parrot/proc/can_pick_up(obj/item/I)
 	. = (Adjacent(I) && I.w_class <= parrot_isize && !I.anchored)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -339,7 +339,6 @@
 	)
 	attack_animation(user)
 	broken()
-	return TRUE
 
 /// Set's the lights `current_mode`. `new_mode` should be one of `LIGHTMODE_*`.
 /obj/machinery/light/proc/set_mode(new_mode)

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -48,23 +48,6 @@
 	visible_message(SPAN_NOTICE("\The [src] dissipates!"))
 	qdel(src)
 
-/obj/machinery/shield/hitby(AM as mob|obj, datum/thrownthing/TT)
-	//Let everyone know we've been hit!
-	visible_message(SPAN_NOTICE("<B>\The [src] was hit by [AM].</B>"))
-
-	//Super realistic, resource-intensive, real-time damage calculations.
-	var/tforce = 0
-
-	if(ismob(AM)) // All mobs have a multiplier and a size according to mob_defines.dm
-		var/mob/I = AM
-		tforce = I.mob_size * (TT.speed/THROWFORCE_SPEED_DIVISOR)
-	else
-		var/obj/O = AM
-		tforce = O.throwforce * (TT.speed/THROWFORCE_SPEED_DIVISOR)
-
-	damage_health(tforce)
-
-	..()
 /obj/machinery/shieldgen
 	name = "Emergency shield projector"
 	desc = "Used to seal minor hull breaches."

--- a/code/modules/turbolift/turbolift_console.dm
+++ b/code/modules/turbolift/turbolift_console.dm
@@ -37,7 +37,7 @@
 	return attack_hand(user)
 
 /obj/structure/lift/attack_generic(mob/user)
-	return attack_hand(user)
+	attack_hand(user)
 
 /obj/structure/lift/attack_hand(mob/user)
 	return interact(user)


### PR DESCRIPTION
:cl: SierraKomodo
refactor: Generic mob attacks and thrown item/mob impacts now apply standardized damage. 
/:cl:

NUFC:
- Removed the unused return value from `attack_generic()` and its overrides.

NOTE:
- This does not cover hitby and attack_generic overrides for atoms added to standardized health in #32826