### PR TITLE
potted plants; our trimmable friends

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -929,6 +929,7 @@
 #include "code\game\objects\items\crayons.dm"
 #include "code\game\objects\items\cryobag.dm"
 #include "code\game\objects\items\documents.dm"
+#include "code\game\objects\items\flora.dm"
 #include "code\game\objects\items\glassjar.dm"
 #include "code\game\objects\items\holosign_creator.dm"
 #include "code\game\objects\items\instruments.dm"

--- a/code/datums/supplypacks/hydroponics.dm
+++ b/code/datums/supplypacks/hydroponics.dm
@@ -106,7 +106,6 @@
 					/obj/structure/flora/pottedplant/tall,
 					/obj/structure/flora/pottedplant/sticky,
 					/obj/structure/flora/pottedplant/smelly,
-					/obj/structure/flora/pottedplant/small,
 					/obj/structure/flora/pottedplant/aquatic,
 					/obj/structure/flora/pottedplant/shoot,
 					/obj/structure/flora/pottedplant/flower,
@@ -117,7 +116,10 @@
 					/obj/structure/flora/pottedplant/drooping,
 					/obj/structure/flora/pottedplant/tropical,
 					/obj/structure/flora/pottedplant/dead,
-					/obj/structure/flora/pottedplant/decorative)
+					/obj/structure/flora/pottedplant/decorative,
+					/obj/item/flora/pottedplantsmall,
+					/obj/item/flora/pottedplantsmall/leaf,
+					/obj/item/flora/pottedplantsmall/fern)
 	cost = 8
 	containertype = /obj/structure/closet/crate/large/hydroponics
 	containername = "potted plant crate"

--- a/code/game/objects/items/flora.dm
+++ b/code/game/objects/items/flora.dm
@@ -1,0 +1,50 @@
+/obj/item/flora/pottedplantsmall
+	name = "small potted plant"
+	desc = "This is a pot of assorted small flora. Some look familiar."
+	icon = 'icons/obj/plants.dmi'
+	icon_state = "plant-15"
+	item_state = "plant-15"
+	w_class = ITEM_SIZE_LARGE
+
+/obj/item/flora/pottedplantsmall/leaf
+	name = "fancy leafy potted desk plant"
+	desc = "A tiny waxy leafed plant specimen."
+	icon_state = "plant-29"
+	item_state = "plant-29"
+
+/obj/item/flora/pottedplantsmall/fern
+	name = "fancy ferny potted plant"
+	desc = "This leafy desk fern could do with a trim."
+	icon_state = "plant-27"
+	item_state = "plant-27"
+	var/trimmed = FALSE
+
+/obj/item/flora/pottedplantsmall/fern/attackby(obj/item/S, mob/user)
+	if (!isWirecutter(S))
+		return ..()
+	else
+		playsound(src.loc, 'sound/items/Wirecutter.ogg', 50, 1)
+		visible_message(SPAN_NOTICE("\The [user] starts trimming the [src] with \the [S]."))
+		if (do_after(user, 6 SECONDS, src, DO_PUBLIC_UNIQUE))
+			playsound(src.loc, 'sound/items/Wirecutter.ogg', 50, 1)
+			to_chat (user, SPAN_NOTICE("You trim \the [src] with \the [S]. You probably should've used a pair of scissors."))
+			trimmed = TRUE
+			addtimer(CALLBACK(src, .proc/grow), 90 MINUTES, TIMER_UNIQUE|TIMER_OVERRIDE)
+			update_icon()
+
+/obj/item/flora/pottedplantsmall/fern/on_update_icon()
+	. = ..()
+	if (trimmed)
+		name = "fancy trimmed ferny potted plant"
+		desc = "This leafy desk fern seems to have been trimmed too much."
+		icon_state = "plant-30"
+		item_state = "plant-30"
+	else
+		name = "fancy ferny potted plant"
+		desc = "This leafy desk fern could do with a trim."
+		icon_state = "plant-27"
+		item_state = "plant-27"
+
+/obj/item/flora/pottedplantsmall/fern/proc/grow()
+	trimmed = FALSE
+	update_icon()

--- a/code/game/objects/structures/flora.dm
+++ b/code/game/objects/structures/flora.dm
@@ -33,7 +33,6 @@
 	..()
 	icon_state = "tree_[rand(1, 6)]"
 
-
 //grass
 /obj/structure/flora/grass
 	name = "grass"
@@ -46,7 +45,6 @@
 /obj/structure/flora/grass/brown/New()
 	..()
 	icon_state = "snowgrass[rand(1, 3)]bb"
-
 
 /obj/structure/flora/grass/green
 	icon_state = "snowgrass1gb"
@@ -61,7 +59,6 @@
 /obj/structure/flora/grass/both/New()
 	..()
 	icon_state = "snowgrassall[rand(1, 3)]"
-
 
 //bushes
 /obj/structure/flora/bush
@@ -81,7 +78,6 @@
 	layer = ABOVE_HUMAN_LAYER
 
 //newbushes
-
 /obj/structure/flora/ausbushes
 	name = "bush"
 	icon = 'icons/obj/flora/ausflora.dmi'
@@ -197,7 +193,6 @@
 	..()
 	icon_state = "fullgrass_[rand(1, 3)]"
 
-
 //potted plants credit: Flashkirby
 //potted plants 27-30: Cajoes
 /obj/structure/flora/pottedplant
@@ -276,11 +271,6 @@
 	desc = "This is some kind of tropical plant. It reeks of rotten eggs."
 	icon_state = "plant-14"
 
-/obj/structure/flora/pottedplant/small
-	name = "small potted plant"
-	desc = "This is a pot of assorted small flora. Some look familiar."
-	icon_state = "plant-15"
-
 /obj/structure/flora/pottedplant/aquatic
 	name = "aquatic potted plant"
 	desc = "This is apparently an aquatic plant. It's probably fake."
@@ -345,22 +335,7 @@
 	desc = "This is a decorative shrub. It's been trimmed into the shape of an apple."
 	icon_state = "applebush"
 
-/obj/structure/flora/pottedplant/deskfern
-	name = "fancy ferny potted plant"
-	desc = "This leafy desk fern could do with a trim."
-	icon_state = "plant-27"
-
 /obj/structure/flora/pottedplant/floorleaf
 	name = "fancy leafy floor plant"
 	desc = "This plant has remarkably waxy leaves."
 	icon_state = "plant-28"
-
-/obj/structure/flora/pottedplant/deskleaf
-	name = "fancy leafy potted desk plant"
-	desc = "A tiny waxy leafed plant specimen."
-	icon_state = "plant-29"
-
-/obj/structure/flora/pottedplant/deskferntrim
-	name = "fancy trimmed ferny potted plant"
-	desc = "This leafy desk fern seems to have been trimmed too much."
-	icon_state = "plant-30"

--- a/maps/away/meatstation/meatstation.dmm
+++ b/maps/away/meatstation/meatstation.dmm
@@ -4663,7 +4663,7 @@
 /area/space)
 "kS" = (
 /obj/structure/table/woodentable/ebony,
-/obj/structure/flora/pottedplant/deskferntrim,
+/obj/item/flora/pottedplantsmall/fern,
 /turf/simulated/floor/carpet/blue2,
 /area/meatstation/dorm)
 "kT" = (

--- a/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
@@ -2173,11 +2173,11 @@
 /turf/simulated/floor/tiled/skrell/green,
 /area/ship/skrellscoutship/command/armory)
 "gQ" = (
-/obj/structure/flora/pottedplant/deskferntrim,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
 /obj/structure/window/reinforced,
+/obj/item/flora/pottedplantsmall/fern,
 /turf/simulated/floor/carpet/magenta,
 /area/ship/skrellscoutship/wings/starboard)
 "gS" = (

--- a/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
@@ -3114,7 +3114,7 @@
 /area/map_template/oldlab2/recandlockers)
 "rl" = (
 /obj/structure/table/steel_reinforced,
-/obj/structure/flora/pottedplant/deskleaf{
+/obj/item/flora/pottedplantsmall/leaf{
 	pixel_y = 5
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -12084,7 +12084,7 @@
 /area/security/hangcheck)
 "OZ" = (
 /obj/structure/table/marble,
-/obj/structure/flora/pottedplant/deskferntrim{
+/obj/item/flora/pottedplantsmall/fern{
 	pixel_y = 4
 	},
 /turf/simulated/floor/lino,

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -6524,9 +6524,6 @@
 /area/maintenance/thirddeck/aftstarboard)
 "nI" = (
 /obj/structure/table/steel,
-/obj/structure/flora/pottedplant/small{
-	pixel_y = 13
-	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Security";
@@ -6538,6 +6535,9 @@
 	},
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 1
+	},
+/obj/item/flora/pottedplantsmall{
+	pixel_y = 13
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/habcheck)
@@ -12821,7 +12821,7 @@
 /area/maintenance/thirddeck/aftport)
 "Fn" = (
 /obj/structure/table/woodentable/walnut,
-/obj/structure/flora/pottedplant/deskleaf,
+/obj/item/flora/pottedplantsmall/leaf,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/observation)
 "Fo" = (
@@ -16999,6 +16999,10 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/habcheck)
+"QG" = (
+/obj/structure/table/woodentable/walnut,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/crew_quarters/observation)
 "QH" = (
 /obj/structure/bed/chair/office/dark{
 	dir = 8
@@ -28406,7 +28410,7 @@ aa
 Di
 Di
 BQ
-Fn
+QG
 YB
 nw
 Xq

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -16656,9 +16656,6 @@
 "evb" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/standard,
-/obj/structure/flora/pottedplant/small{
-	pixel_y = 10
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -16667,6 +16664,9 @@
 /obj/structure/cable/green{
 	d2 = 4;
 	icon_state = "0-4"
+	},
+/obj/item/flora/pottedplantsmall{
+	pixel_y = 10
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/foyer/storeroom)

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -2184,13 +2184,13 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
 	},
-/obj/structure/flora/pottedplant/deskleaf{
-	desc = "A tiny waxy leafed plant specimen. It has 'Green's replacement' scribbled into the pot."
-	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/item/flora/pottedplantsmall/leaf{
+	desc = "A tiny waxy leafed plant specimen. It has 'Green's replacement' scribbled onto the pot."
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
@@ -10861,6 +10861,8 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/device/multitool,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/device/destTagger,
+/obj/item/stack/package_wrap/twenty_five,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "Dw" = (
@@ -12235,13 +12237,12 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
 	},
-/obj/item/device/destTagger,
-/obj/item/stack/package_wrap/twenty_five,
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/item/flora/pottedplantsmall/fern,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "Jc" = (


### PR DESCRIPTION
🆑 gy1ta23, Taza
tweak: smaller potted plants are now objects. you can pick them up. rejoice
rscadd: small potted ferns are trimmable with wirecutters. the bridge now has a fern
/🆑

_Taza did the trimming code and sanitization for this._

Potted plants. My scourge. My bane. My ruination. These god-damnable little things, staring at me from their cathedras upon my desk. They know if they fall I have no chance of returning them to their proper place, no recourse. Before the smooth white polymer shell I stand a frail and broken man. My mind whimpers at their sight. I think I no longer possess the proper lucidity today to truly express what they have done to me, not anymore. How can a broken mind self-diagnose?

I do this for you, not for myself. I think I am, as I type this, beyond saving. The text on my monitor degenerates into the ramblings of a madman as my fingers move upon the keys. In these lines of code, I defenestrate these entities of unspeakable origin from their posts above us. They will go where we please, now, carryable as one desires (within the bounds of a large object.) Such power is not to be held lightly, but in these darkened times it is the only course of action available.

Trim them. Those terrible ferns hold things beyond words, beyond our coil. You **must** trim them. Wirecutters (or any object derived from such) will have to do, given the lack of scissors. Too much is better than too little. The Torch must be saved, and I no longer hold the capacity. I have enclosed further visual instructions, if such is necessary. Heed my warnings or find yourself knelt beside me.

![hedgetrim](https://user-images.githubusercontent.com/44277885/210124339-a4b3421f-b9f7-4caf-a0c7-22f01aaa95e2.gif)

My time runs short. Remember these words.
