### PR TITLE
Eggcluster spiderling death

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -54,6 +54,13 @@
 		O.implants -= src
 	. = ..()
 
+/obj/effect/spider/eggcluster/on_death()
+	if (isturf(loc))
+		var/amount_to_spawn = round(spiders_max * amount_grown / 100)
+		for (var/count = 1 to amount_to_spawn)
+			new spider_type(loc, src)
+	. = ..()
+
 /obj/effect/spider/eggcluster/Process()
 	if(prob(70))
 		amount_grown += rand(0,2)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -168,7 +168,7 @@
 		..()
 
 /obj/effect/spider/spiderling/on_death()
-	visible_message(SPAN_CLASS("alert", "\The [src] dies!"))
+	visible_message(SPAN_WARNING("\The [src] dies!"))
 	new /obj/effect/decal/cleanable/spiderling_remains(loc)
 	qdel(src)
 

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -7,6 +7,10 @@
 	density = FALSE
 	health_max = 15
 
+/obj/effect/spider/on_death()
+	visible_message(SPAN_WARNING("\The [src] breaks apart!"))
+	qdel(src)
+
 /obj/effect/spider/stickyweb
 	icon_state = "stickyweb1"
 


### PR DESCRIPTION
Depends on #32858 

:cl: SierraKomodo
rscadd: Eggclusters now release some spiderlings when they are broken. The number of spiderlings released depends on how mature the egg cluster was.
/:cl: