### PR TITLE
Runtime batch fix 2023 01 02

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -411,6 +411,8 @@
  * If you're expecting to be calling a lot of icon updates at once, use `queue_icon_update()` instead.
  */
 /atom/proc/update_icon()
+	if (QDELETED(src))
+		return
 	on_update_icon(arglist(args))
 
 /**

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -591,6 +591,10 @@ var/global/list/tank_gauge_cache = list()
 	var/obj/item/device/assembly_holder/assembly = null
 
 /obj/item/device/tankassemblyproxy/receive_signal()	//This is mainly called by the sensor through sense() to the holder, and from the holder to here.
+	if (!tank || !assembly)
+		log_debug(append_admin_tools("A tank assembly received a signal but lacks a valid assembly holder.", usr, get_turf(src)))
+		to_chat(usr, SPAN_DEBUG("A tank assembly associated with you attempted to ignite but failed because it lacks a valid assembly holder. Please ahelp this bug to be investigated in-round."))
+		return
 	tank.ignite()	//boom (or not boom if you made shijwtty mix)
 
 /obj/item/tank/proc/assemble_bomb(W,user)	//Bomb assembly proc. This turns assembly+tank into a bomb

--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -96,8 +96,7 @@
 
 	if(get_damage_value() != 0)
 		var/overlay = round((get_damage_percentage() / 100) * damage_overlays.len) + 1
-		if(overlay > damage_overlays.len)
-			overlay = damage_overlays.len
+		overlay = clamp(overlay, 1, damage_overlays.len)
 
 		overlays += damage_overlays[overlay]
 	return

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -640,8 +640,8 @@
 	var/list/valid_things = list()
 	if(isweakref(I.data))
 		var/atom/A = I.data.resolve()
-		var/desired_type = A.type
-		if(desired_type)
+		if (A)
+			var/desired_type = A.type
 			for(var/i in nearby_things)
 				var/atom/thing = i
 				if(ismob(thing) && !isliving(thing))

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -54,8 +54,8 @@
 				for(var/datum/robot_component/org in damaged)
 					var/message = "\t [capitalize(org.name)]: "
 					message += (org.installed == -1) ? SPAN_COLOR("red", "<b>DESTROYED</b> ") : ""
-					message += (org.electronics_damage > 0) ? SPAN_COLOR("#ffa500", org.electronics_damage) : 0
-					message += (org.brute_damage > 0) ? SPAN_COLOR("red", org.brute_damage) : 0
+					message += (org.electronics_damage > 0) ? SPAN_COLOR("#ffa500", org.electronics_damage) : "0"
+					message += (org.brute_damage > 0) ? SPAN_COLOR("red", org.brute_damage) : "0"
 					message += org.toggled ? "Toggled ON" : SPAN_COLOR("red", "Toggled OFF")
 					message += org.powered ? "Power ON" : SPAN_COLOR("red", "Power OFF")
 					user.show_message(SPAN_NOTICE(message), VISIBLE_MESSAGE)

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -96,7 +96,10 @@
 			for(var/obj/effect/landmark/start/sloc in landmarks_list)
 				if (sloc.name == "AI")
 					loc_landmark = sloc
-		O.forceMove(loc_landmark.loc)
+		if (!loc_landmark)
+			to_chat(O, SPAN_DEBUG("We still failed to find a AI spawn location. Where you're standing is now you're new home."))
+		else
+			O.forceMove(loc_landmark.loc)
 		O.on_mob_init()
 
 	O.add_ai_verbs()

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -25,7 +25,7 @@
 	var/graffiti_style
 
 /obj/item/organ/external/head/proc/get_eye_overlay()
-	if(glowing_eyes)
+	if(glowing_eyes && owner)
 		var/obj/item/organ/internal/eyes/eyes = owner.internal_organs_by_name[owner.species.vision_organ ? owner.species.vision_organ : BP_EYES]
 		if(eyes)
 			return eyes.get_special_overlay()

--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -126,7 +126,7 @@
 
 /obj/item/organ/internal/mmi_holder/Process()
 	..()
-	if(owner.is_asystole())
+	if(owner?.is_asystole())
 		take_internal_damage(0.5)
 
 /obj/item/organ/internal/mmi_holder/handle_regeneration() // MMI will regenerate from small amounts of damage, e.g. damage that might occur when swapping a power cell

--- a/code/modules/projectiles/guns/projectile/flaregun.dm
+++ b/code/modules/projectiles/guns/projectile/flaregun.dm
@@ -29,7 +29,7 @@
 /obj/item/gun/projectile/flare/special_check()
 	if(length(loaded))
 		var/obj/item/ammo_casing/casing = loaded[1]
-		if(istype(casing) && !istype(casing, /obj/item/ammo_casing/shotgun/flash))
+		if(istype(casing) && istype(casing.BB) && !istype(casing, /obj/item/ammo_casing/shotgun/flash))
 			var/damage = casing.BB.get_structure_damage()
 			if(istype(casing.BB, /obj/item/projectile/bullet/pellet))
 				var/obj/item/projectile/bullet/pellet/PP = casing.BB

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -523,8 +523,8 @@
 		SPAN_WARNING("For a brief moment, you hear an oppressive, unnatural silence.")
 	)
 
-	user.drop_from_inventory(W)
-	Consume(W)
+	if (user.drop_from_inventory(W))
+		Consume(W)
 
 	user.apply_damage(150, DAMAGE_RADIATION, damage_flags = DAMAGE_FLAG_DISPERSED)
 


### PR DESCRIPTION
NUFC:
- Provides clean error handling for #32847 alongside debug logs and an error message to the user. This should be looked into more closely if it happens on server.
- Prevents qdeleted atoms from processing icon updates.
- Prevents supermatter from deleting items that couldn't be dropped in attackby.

Bug Fixes:
- Fixes #23037
- Fixes #31698
- Fixes #29127
- Fixes #25488
- Closes #28098
- Fixes #32463
- Fixes #32852
- Fixes #32755
- Fixes #29031