### PR TITLE
Lowers mutineer/loyalist slots, adjusts TC

### DIFF
--- a/code/game/antagonist/station/loyalist.dm
+++ b/code/game/antagonist/station/loyalist.dm
@@ -13,10 +13,10 @@ GLOBAL_DATUM_INIT(loyalists, /datum/antagonist/loyalists, new)
 	antaghud_indicator = "hud_loyal"
 	flags = 0
 
-	hard_cap = 2
-	hard_cap_round = 4
-	initial_spawn_req = 2
-	initial_spawn_target = 4
+	hard_cap = 1
+	hard_cap_round = 2
+	initial_spawn_req = 1
+	initial_spawn_target = 2
 
 	// Inround loyalists.
 	faction_role_text = "Loyalist"
@@ -46,3 +46,12 @@ GLOBAL_DATUM_INIT(loyalists, /datum/antagonist/loyalists, new)
 		loyal_obj.target = player.mind
 		loyal_obj.explanation_text = "Protect [player.real_name], the [player.mind.assigned_role]."
 		global_objectives += loyal_obj
+
+/datum/antagonist/loyalists/equip(mob/living/carbon/human/loyalists_mob)
+	spawn_uplink(loyalists_mob)
+	. = ..()
+	if(!.)
+		return
+
+/datum/antagonist/loyalists/proc/spawn_uplink(mob/living/carbon/human/loyalists_mob)
+	setup_uplink_source(loyalists_mob, 60)

--- a/code/game/antagonist/station/revolutionary.dm
+++ b/code/game/antagonist/station/revolutionary.dm
@@ -15,10 +15,10 @@ GLOBAL_DATUM_INIT(revs, /datum/antagonist/revolutionary, new)
 	antaghud_indicator = "hud_rev"
 	skill_setter = /datum/antag_skill_setter/station
 
-	hard_cap = 2
-	hard_cap_round = 4
-	initial_spawn_req = 2
-	initial_spawn_target = 4
+	hard_cap = 1
+	hard_cap_round = 2
+	initial_spawn_req = 1
+	initial_spawn_target = 2
 
 	//Inround revs.
 	faction_role_text = "Revolutionary"
@@ -53,4 +53,4 @@ GLOBAL_DATUM_INIT(revs, /datum/antagonist/revolutionary, new)
 		return
 
 /datum/antagonist/revolutionary/proc/spawn_uplink(mob/living/carbon/human/revolutionary_mob)
-	setup_uplink_source(revolutionary_mob, DEFAULT_TELECRYSTAL_AMOUNT)
+	setup_uplink_source(revolutionary_mob, 80)


### PR DESCRIPTION
:cl: Singing Spock
tweak: Lowered Head Loyalist and Head Mutineer slots to 2 each
tweak: Lowered Head Mutineer starting TC to 80
tweak: Gave Head Loyalist an uplink with 60 TC
/:cl:

In a recent Mutiny round we wound up with the game assigning 3 headrevs and 0 headloyals. Admins assigned someone to be a headloyal, but they were outnumber 3-1 and got steamrollled. Looking at the code, as far as I can tell the game checks if there's enough players with the correct antags selected to fill the required slots, then assigns all antags of one kind and then all of the other, which is what led to this (I am guessing that not everybody had both roles readied up). While I would like to code a more elegant and complete solution, this should help in the short-term, lowering the max number on each side to 2. It is still possible for the stars to align poorly and for it to be 2-1 or even 2-0, but those are problems far easier to solve in-round than it being 3-0 or 3-1.

Additionally, the fact that one side gets TC and the other doesn't creates additional imbalance. The Loyalists definitely do not get the full support of the ship unless they take it by force, but a lot of ship resources do get put into play more often than not on these rounds. Therefore I have given headrevs and headloyals 80 and 60 TC respectively.

I am not entirely sure I did the Loyalist's upload properly, I don't entirely understand how the code works since I copy/pasted it from revs. If someone more knowledgeable could look over it, I'd appreciate it.