### PR TITLE
add node make-suid tool and /proc/is_suid

### DIFF
--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -669,3 +669,11 @@
 			return "Northwest"
 		if(337)
 			return "North-Northwest"
+
+
+/// Check if thing is an SUID. If other is supplied, check if other matches thing.
+/proc/is_suid(thing, other)
+	var/static/regex/suid_check = regex(@"^~[0-9a-zA-Z]{15}$")
+	if (other && other != thing)
+		return FALSE
+	return findtext(thing, suid_check)

--- a/tools/make-suid/index.js
+++ b/tools/make-suid/index.js
@@ -1,0 +1,17 @@
+import { randomInt } from 'node:crypto'
+let results = parseInt(process.argv[2])
+if (typeof results !== 'number')
+  results = 1
+else if (!Number.isSafeInteger(results))
+  results = 1
+else if (results < 1)
+  results = 1
+else if (results > 100)
+  results = 100
+const symbols = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+for (let result = 0; result < results; ++result) {
+  const suid = Array.from({ length: 15 })
+  for (let index = 0; index < suid.length; ++index)
+    suid[index] = symbols[randomInt(symbols.length)]
+  console.log(`~${suid.join('')}`)
+}

--- a/tools/make-suid/package.json
+++ b/tools/make-suid/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "make-suid",
+  "description": "Creates ~ prefixed 62^15 space unique IDs on demand.",
+  "version": "1.0.0",
+  "type":"module",
+  "contributors": [
+      "spookerton <spkrtn@pm.me> (https://github.com/spookerton)"
+  ]
+}


### PR DESCRIPTION
ID strings provide resistance to save data against refactors and other
changes; you can change a preference's path, name, etc and retain the
ID so that existing saves are not affected.

SUIDs are much better for ID strings than relying on authors to hand
write unique IDs and have the side benefit of being shorter than paths
and names, which are currently frequently used despite being brittle.

make-suid produces 16 byte strings that are safe from RFC 3986 mangling
with a leading ~ for duck typing and 62^15 randomness, which provides
quite a large approximate rounds to collision. is_suid can check if
something is an SUID, or if two things match and are SUIDs.

Does not actually use them anywhere yet; that will be a lot of work.