### PR TITLE
Make bed deploying instant

### DIFF
--- a/code/game/objects/structures/roller_bed.dm
+++ b/code/game/objects/structures/roller_bed.dm
@@ -399,8 +399,6 @@
 			SPAN_ITALIC("You start setting up \the [src]."),
 			range = 5
 		)
-		if (!do_after(user, 2 SECONDS, src, do_flags = DO_PUBLIC_UNIQUE | DO_BAR_OVER_USER))
-			return
 	var/obj/structure/roller_bed/roller = new (target)
 	if (user)
 		roller.add_fingerprint(user)


### PR DESCRIPTION
:cl: Ryan180602
tweak: Beds now deploy instant. but need time to pick back up.
/:cl:

few rounds of feedback suggested that bed deploy timer was a bit unneeded and hampered medical efforts in not an entirely fun way. 