### PR TITLE
Table health tweaks

### DIFF
--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -37,10 +37,14 @@
 	if(!material)
 		new_health = 10
 		damage_hitsound = initial(damage_hitsound)
+		health_min_damage = 0
 	else
 		new_health = material.integrity / 2
+		health_min_damage = material.hardness
 		if(reinforced)
 			new_health += reinforced.integrity / 2
+			health_min_damage += reinforced.hardness
+		health_min_damage = round(health_min_damage / 10)
 		damage_hitsound = material.hitsound
 	set_max_health(new_health)
 

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -36,10 +36,12 @@
 	var/new_health = 0
 	if(!material)
 		new_health = 10
+		damage_hitsound = initial(damage_hitsound)
 	else
 		new_health = material.integrity / 2
 		if(reinforced)
 			new_health += reinforced.integrity / 2
+		damage_hitsound = material.hitsound
 	set_max_health(new_health)
 
 /obj/structure/table/damage_health(damage, damage_type, damage_flags = EMPTY_BITFIELD, severity, skip_can_damage_check = FALSE)


### PR DESCRIPTION
:cl: SierraKomodo
rscadd: Tables now use their material's hit sound when struck.
rscadd: Tables now have a minimum damage value needed to damage their health, derived from their material.
/:cl: