### PR TITLE
Fixes syringes not working on carp meat

### DIFF
--- a/code/modules/reagents/reagent_containers/food/fish.dm
+++ b/code/modules/reagents/reagent_containers/food/fish.dm
@@ -19,7 +19,7 @@
 
 
 /obj/item/reagent_containers/food/snacks/fish/attackby(obj/item/item, mob/living/user)
-	if (!item.sharp)
+	if (istype(item, /obj/item/reagent_containers/syringe) || !item.sharp)
 		return ..()
 	var/turf/turf = get_turf(src)
 	if (turf != loc || !(locate(/obj/structure/table) in turf))
@@ -70,7 +70,7 @@
 
 /obj/item/reagent_containers/food/snacks/fish/space_pike/Initialize()
 	. = ..()
-	reagents.add_reagent(/datum/reagent/toxin/carpotoxin, 6)
+	reagents.add_reagent(/datum/reagent/toxin/carpotoxin, 11)
 
 
 /obj/item/reagent_containers/food/snacks/fish/space_shark


### PR DESCRIPTION
🆑 Taza, gy1ta23
bugfix: syringes no longer turn fish fillet into sashimi. 
bugfix: you can now extract carpotoxin from carp meat with syringes
tweak: pike meat now has a bit more carpotoxin in it than carp meat
/🆑

I was trying to test extracting carpotoxin from meat and I kept making delicious food. 

As hilarious as that is, this fixes that. 