### PR TITLE
Fix airlocks damaging themselves when closing

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1280,11 +1280,15 @@ About the new airlock wires panel:
 					close_door_at = world.time + 6
 					return
 
+	var/crushed = FALSE
 	for(var/turf/turf in locs)
 		for(var/atom/movable/AM in turf)
-			if(AM.airlock_crush(door_crush_damage))
-				damage_health(door_crush_damage, DAMAGE_BRUTE)
-				use_power_oneoff(door_crush_damage * 100)		// Uses bunch extra power for crushing the target.
+			if (AM != src && AM.airlock_can_crush())
+				AM.airlock_crush(door_crush_damage)
+				crushed = TRUE
+	if (crushed)
+		damage_health(door_crush_damage, DAMAGE_BRUTE)
+		use_power_oneoff(door_crush_damage * 100)		// Uses bunch extra power for crushing the target.
 
 	use_power_oneoff(360)	//360 W seems much more appropriate for an actuator moving an industrial door capable of crushing people
 	if(arePowerSystemsOn())

--- a/code/game/machinery/doors/airlock_interactions.dm
+++ b/code/game/machinery/doors/airlock_interactions.dm
@@ -37,25 +37,41 @@
 #define AIRLOCK_CRUSH_INCREMENT 10 // Damage caused by airlock crushing a mob is split into multiple smaller hits. Makes door crushing behave more like a "slow" crushing effect rather than high-speed impacts.
 #define CYBORG_AIRLOCKCRUSH_RESISTANCE 2 // Damage caused to silicon mobs (usually cyborgs) from being crushed by airlocks is divided by this number. Unlike organics cyborgs don't have passive regeneration.
 
+/**
+ * Whether or not the atom can be crushed and damaged by a closing airlock.
+ */
+/atom/movable/proc/airlock_can_crush()
+	if (health_max)
+		return TRUE
+	return FALSE
+
+/**
+ * Handles being crushed by a closing airlock. Has no return value.
+ */
 /atom/movable/proc/airlock_crush(crush_damage)
 	damage_health(crush_damage, DAMAGE_BRUTE)
-	return TRUE
 
 /obj/structure/window/airlock_crush(crush_damage)
 	shatter(TRUE)
+
+/obj/effect/energy_field/airlock_can_crush()
 	return TRUE
 
 /obj/effect/energy_field/airlock_crush(crush_damage)
 	Stress(crush_damage)
-	return TRUE
 
 /obj/structure/closet/airlock_crush(crush_damage)
 	for(var/atom/movable/AM in src)
 		AM.airlock_crush(crush_damage)
-	. = ..()
+	..()
+
+/mob/living/airlock_can_crush()
+	if (status_flags & GODMODE)
+		return FALSE
+	return TRUE
 
 /mob/living/airlock_crush(crush_damage)
-	. = ..()
+	..()
 
 	for(var/i in 1 to round(crush_damage/AIRLOCK_CRUSH_INCREMENT, 1))
 		apply_damage(AIRLOCK_CRUSH_INCREMENT, DAMAGE_BRUTE)
@@ -81,18 +97,21 @@
 			return
 
 /mob/living/carbon/airlock_crush(crush_damage)
-	. = ..()
+	..()
 	if (can_feel_pain())
 		emote("scream")
 
 /mob/living/silicon/robot/airlock_crush(crush_damage)
-	return ..(round(crush_damage / CYBORG_AIRLOCKCRUSH_RESISTANCE)) //TODO implement robot melee armour and remove this.
+	..(round(crush_damage / CYBORG_AIRLOCKCRUSH_RESISTANCE)) //TODO implement robot melee armour and remove this.
 
-/obj/structure/disposalpipe/airlock_crush(crush_damage)
+/obj/structure/disposalpipe/airlock_can_crush()
 	return FALSE
 
-/obj/machinery/atmospherics/pipe/airlock_crush(crush_damage)
+/obj/machinery/atmospherics/pipe/airlock_can_crush()
 	return FALSE
 
-/obj/structure/cable/airlock_crush(crush_damage)
+/obj/structure/cable/airlock_can_crush()
 	return FALSE
+
+/obj/machinery/door/airlock_can_crush()
+	return FALSE // Shutters, firedoors, etc

--- a/code/game/objects/effects/fluids.dm
+++ b/code/game/objects/effects/fluids.dm
@@ -21,7 +21,6 @@
 
 /obj/effect/fluid/airlock_crush()
 	qdel(src)
-	return FALSE
 
 /obj/effect/fluid/Initialize()
 	. = ..()


### PR DESCRIPTION
Hotfix, fast merging. Thoroughly tested this resolves the bug.

:cl: SierraKomodo
bugfix: Airlocks no longer damage themselves when closing.
/:cl:

NUFC:
- Added an `airlock_can_crush()` proc to determine whether or not an atom can be damaged by a closing airlock.
- Removed the boolean return from `airlock_crush()` in favor of the above proc check.
- Adjusted the logic for airlock crushing - Airlocks only take damage and use power once per closing instead of once per item crushed now, and only if items were crushable.