### PR TITLE
Add `ci skip` flag to changelog compilation action

### DIFF
--- a/.github/workflows/changelog_generation.yml
+++ b/.github/workflows/changelog_generation.yml
@@ -37,5 +37,5 @@ jobs:
           git config --global user.email "${{ secrets.BOT_EMAIL }}"
           git config --global user.name "${{ secrets.BOT_NAME }}"
           git diff --quiet --exit-code && echo "No changes found, abort." && exit 0
-          git commit -m "Automatic changelog generation" -a
+          git commit -m "Automatic changelog generation [ci skip]" -a
           git push


### PR DESCRIPTION
There's nothing in the test suite that needs to run when changelogs update. This should help mitigate tests being cancelled by commits that don't actually run tests.

NUFC:
- Commits made during the `Compile changelogs` action now include the `[ci skip]` flag.