### PR TITLE
Supermatter fire containment

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -484,10 +484,11 @@
  * - `exposed_volume` - The volume of the air for the fire affecting the atom. Usually, this is `air.volume`.
  */
 /atom/proc/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if (get_max_health())
+	var/melting_point = get_material_melting_point()
+	if (get_max_health() && exposed_temperature > melting_point)
 		// No hitsound here to avoid noise spam.
-		// 1 point of damage for every 100 kelvin above 300 (~27 C).
-		damage_health(round(max(exposed_temperature - 300, 0) / 100), DAMAGE_FIRE)
+		// 1 point of damage for every 100 kelvin above 300 (~27 C), minimum of 1.
+		damage_health(max(round((exposed_temperature - melting_point) / 100), 1), DAMAGE_FIRE)
 
 /**
  * Handler for melting from heat or other sources. Called by terrain generation and some instances of `fire_act()` or

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -145,9 +145,8 @@
 	else
 		overlays += "can-o3"
 
-/obj/machinery/portable_atmospherics/canister/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if (exposed_temperature > temperature_resistance)
-		..()
+/obj/machinery/portable_atmospherics/canister/get_material_melting_point()
+	return temperature_resistance
 
 /obj/machinery/portable_atmospherics/canister/on_death()
 	var/atom/location = loc

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -246,6 +246,9 @@
 	spark_system.start()
 	playsound(loc, "sparks", 50, 1)
 
+/obj/machinery/camera/get_material()
+	return SSmaterials.get_material_by_name(MATERIAL_PLASTEEL)
+
 /obj/machinery/camera/can_damage_health(damage, damage_type)
 	if (invuln)
 		return FALSE

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1421,13 +1421,10 @@ About the new airlock wires panel:
 		src.lock()
 	return
 
-/obj/machinery/door/airlock/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	var/material/material = get_material()
-	var/melting_point = material.melting_point
+/obj/machinery/door/airlock/get_material_melting_point()
+	. = ..()
 	if (window_material)
-		melting_point = round((melting_point + window_material.melting_point) / 2)
-	if (exposed_temperature > melting_point)
-		..()
+		. = round((. + window_material.melting_point) / 2)
 
 // Braces can act as an extra layer of armor - they will take damage first.
 /obj/machinery/door/airlock/damage_health(damage, damage_type, damage_flags, severity, skip_can_damage_check)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1421,6 +1421,14 @@ About the new airlock wires panel:
 		src.lock()
 	return
 
+/obj/machinery/door/airlock/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	var/material/material = get_material()
+	var/melting_point = material.melting_point
+	if (window_material)
+		melting_point = round((melting_point + window_material.melting_point) / 2)
+	if (exposed_temperature > melting_point)
+		..()
+
 // Braces can act as an extra layer of armor - they will take damage first.
 /obj/machinery/door/airlock/damage_health(damage, damage_type, damage_flags, severity, skip_can_damage_check)
 	if (brace)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -508,6 +508,11 @@
 		toggle()
 	return TRUE
 
+/obj/machinery/door/get_material_melting_point()
+	. = ..()
+	if (heat_proof)
+		. += 4000
+
 // Public access
 
 /singleton/public_access/public_method/open_door

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -88,7 +88,7 @@
 	. = ..()
 
 /obj/machinery/door/firedoor/get_material()
-	return SSmaterials.get_material_by_name(MATERIAL_STEEL)
+	return SSmaterials.get_material_by_name(MATERIAL_PLASTEEL)
 
 /obj/machinery/door/firedoor/examine(mob/user, distance)
 	. = ..()

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -224,11 +224,6 @@
 			return 0
 	return 0
 
-/obj/structure/grille/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	if (!is_broken() && exposed_temperature > material.melting_point)
-		damage_health(1, DAMAGE_BURN)
-	..()
-
 /obj/structure/grille/cult
 	name = "cult grille"
 	desc = "A matrice built out of an unknown material, with some sort of force field blocking air around it."

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -571,12 +571,10 @@
 	D.alpha = damage_alpha
 	overlays += D
 
-/obj/structure/window/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
-	var/melting_point = material.melting_point
-	if(reinf_material)
-		melting_point += 0.25*reinf_material.melting_point
-	if (exposed_temperature > melting_point)
-		..()
+/obj/structure/window/get_material_melting_point()
+	. = ..()
+	if (reinf_material)
+		. += 0.25 * reinf_material.melting_point
 
 /obj/structure/window/basic
 	icon_state = "window"

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -171,12 +171,14 @@
 	dismantle_wall(TRUE)
 
 /turf/simulated/wall/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)//Doesn't fucking work because walls don't interact with air
+	burn(exposed_temperature)
+	..()
+
+/turf/simulated/wall/get_material_melting_point()
 	var/melting_point = material.melting_point
 	if (reinf_material)
 		melting_point += reinf_material.melting_point
-	burn(exposed_temperature)
-	if (exposed_temperature > melting_point)
-		..()
+	return melting_point
 
 /turf/simulated/wall/adjacent_fire_act(turf/simulated/floor/adj_turf, datum/gas_mixture/adj_air, adj_temp, adj_volume)
 	fire_act(adj_air, adj_temp, adj_volume)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -171,8 +171,11 @@
 	dismantle_wall(TRUE)
 
 /turf/simulated/wall/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)//Doesn't fucking work because walls don't interact with air
+	var/melting_point = material.melting_point
+	if (reinf_material)
+		melting_point += reinf_material.melting_point
 	burn(exposed_temperature)
-	if (exposed_temperature > material.melting_point)
+	if (exposed_temperature > melting_point)
 		..()
 
 /turf/simulated/wall/adjacent_fire_act(turf/simulated/floor/adj_turf, datum/gas_mixture/adj_air, adj_temp, adj_volume)

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -40,6 +40,19 @@
 	if (material)
 		return material.display_name
 
+/**
+ * Returns the material's melting point, or `T100C` if there is no material. Overrideable for special cases, such as
+ * atoms that allow material reinforcement or that by nature should have a higher or lower melting point.
+ */
+/atom/proc/get_material_melting_point()
+	return T100C
+
+/obj/get_material_melting_point()
+	. = ..()
+	var/material/material = get_material()
+	if (material)
+		. = material.melting_point
+
 // Material definition and procs follow.
 /material
 	var/name	                          // Unique name for use in indexing the list.

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -235,6 +235,12 @@
 	name = "\improper TRAINED PERSONNEL OPERATION ONLY";
 	pixel_y = -32
 	},
+/obj/machinery/button/blast_door{
+	desc = "A switch made to open the engine access hatch.";
+	id_tag = "EngineAccess";
+	name = "Engine Access Hatch";
+	pixel_x = -36
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/engine_monitoring)
 "au" = (
@@ -6027,14 +6033,6 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/obj/machinery/button/alternate/door/bolts{
-	desc = "A remote control-switch for the engine core airlock hatch bolts.";
-	id_tag = "engine_access_hatch";
-	name = "Engine Hatch Bolt Control";
-	pixel_x = 24;
-	pixel_y = 8;
-	req_access = list("ACCESS_ENGINEERING")
-	},
 /obj/machinery/rotating_alarm/supermatter{
 	dir = 8
 	},
@@ -7374,10 +7372,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/obj/machinery/door/airlock/hatch{
-	icon_state = "closed";
-	id_tag = "engine_access_hatch";
-	locked = 1
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "EngineAccess";
+	name = "Engine Access Hatch"
 	},
 /turf/simulated/floor/reinforced/airless,
 /area/engineering/engine_room)
@@ -17788,10 +17786,10 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "Xo" = (
-/obj/machinery/door/airlock/hatch{
-	icon_state = "closed";
-	id_tag = "engine_access_hatch";
-	locked = 1
+/obj/machinery/door/blast/regular{
+	dir = 4;
+	id_tag = "EngineAccess";
+	name = "Engine Access Hatch"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Walls and doors now properly respect their material's melting points during fire damage checks.
bugfix: Grilles no longer receive damage twice from fires.
balance: Fire doors and cameras now use plasteel's heat resistance value (~6,000 kelvin). Up from steel (~1,800).
balance: Fire damage is now reduced by the atom's melting point value. By default, this is 100C (373K).
maptweak: Replaced the engine hatch doors with blast doors labelled as 'Engine Access Hatch'. These doors can be toggled by a new button located in the engine monitoring room, next to all the other emergency buttons (It's the far left one).
/:cl:

NUFC:
- Added `/atom/proc/get_material_melting_point()`, used during `fire_act()` to compare against `exposed_temperature` to determine whether or not damage should occur.
- Applied the `/obj/machinery/door/heat_proof` var to melting point calculations, increasing the melting point by 4,000 if set.