### PR TITLE
fix blastdoors opening when interacted with

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -169,8 +169,6 @@
 			to_chat(user, SPAN_WARNING("You must remain still while working on \the [src]."))
 		return
 
-	return ..()
-
 
 
 // Proc: open()


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed blast doors opening when interacted with.
/:cl: