### PR TITLE
Fix bad door opening calls

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -172,6 +172,9 @@
 	return ..()
 
 
+/obj/machinery/door/blast/allowed(mob/M)
+	return FALSE // Blast doors can only be opened remotely, or with a crowbar when broken/unpowered.
+
 
 // Proc: open()
 // Parameters: None

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -171,10 +171,13 @@
 			do_animate("deny")
 	return
 
-// This is legacy code that should be revisited, probably by moving the bulk of the logic into here.
-/obj/machinery/door/interface_interact(user)
-	if(CanInteract(user, DefaultTopicState()))
-		return attackby(user = user)
+/obj/machinery/door/attack_hand(mob/user)
+	..()
+	if (allowed(user) && operable())
+		if (density)
+			open()
+		else
+			close()
 
 /obj/machinery/door/attackby(obj/item/I as obj, mob/user as mob)
 	src.add_fingerprint(user, 0, I)


### PR DESCRIPTION
who did this to me. why do this to me. you pain me so.

:cl: SierraKomodo
bugfix: Blast doors no longer open when clicked on.
/:cl:

Alternative to #32882 that doesn't break attack interactions.

Bug fixes:
- Fixes #32881
- Closes #32882 