### PR TITLE
Shotgun Rebalanced and Rebranded

### DIFF
--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -1,10 +1,11 @@
 /obj/item/gun/projectile/shotgun/pump
 	name = "shotgun"
-	desc = "The mass-produced W-T Remmington 29x shotgun is a favourite of police and security forces on many worlds. Useful for sweeping alleys or ship corridors."
+	desc = "A mass-produced shotgun by Mars Security Industries. The rugged ZX-870 'Bulldog' is durable and common throughout most frontier worlds. Useful for sweeping alleys or ship corridors."
 	icon = 'icons/obj/guns/shotguns.dmi'
 	icon_state = "shotgun"
 	item_state = "shotgun"
-	max_shells = 4
+	max_shells = 6
+	// A non-sawned off shotgun should probably have some sort of advantage to its mutilated counterpart. Behold: an extension tube!
 	w_class = ITEM_SIZE_HUGE
 	force = 10
 	obj_flags =  OBJ_FLAG_CONDUCTIBLE
@@ -125,7 +126,7 @@
 
 /obj/item/gun/projectile/shotgun/pump/sawn
 	name = "riot shotgun"
-	desc = "The mass-produced W-T Remmington 29x shotgun is a favourite of police and security forces on many worlds. Useful for sweeping alleys or ship corridors. This one's had it's stock cut off."
+	desc = "A mass-produced shotgun by Mars Security Industries. The rugged ZX-870 'Bulldog' is durable and common throughout most frontier worlds. This one's had it's stock cut off, shortening the magazine tube.."
 	icon = 'icons/obj/guns/shotguns.dmi'
 	icon_state = "rshotgun"
 	item_state = "rshotgun"

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -126,7 +126,7 @@
 
 /obj/item/gun/projectile/shotgun/pump/sawn
 	name = "riot shotgun"
-	desc = "A mass-produced shotgun by Mars Security Industries. The rugged ZX-870 'Bulldog' is durable and common throughout most frontier worlds. This one's had it's stock cut off, shortening the magazine tube.."
+	desc = "A mass-produced shotgun by Mars Security Industries. The rugged ZX-870 'Bulldog' is durable and common throughout most frontier worlds. This one has had it's stock cut off, shortening the magazine tube."
 	icon = 'icons/obj/guns/shotguns.dmi'
 	icon_state = "rshotgun"
 	item_state = "rshotgun"


### PR DESCRIPTION
:cl:
tweak: Adjusted shotgun manufacturers to be more lore-friendly.
balance: Non-sawn off shotguns are now able to contain two more shells (6+1 total) than their half-intact cousins. 
/:cl:

## About The Pull Request

I've taken it upon myself to rebalance and rebrand the standard shotgun. Ballistic weapons tend to fall off severely and in my experience this is largely due to their bulkiness/amount of ammo. This PR aims to make one of the more common slug-throwers more viable, while still suffering from the same old drawbacks as before.

## Ammo

The way I see it, a non-sawed off shotgun should probably have some sort of advantage to its mutilated counterpart. The riot is smaller, easier to use and overall just better. This leaves the regular'ol shotty worthless in comparison. 

So: Behold! An extension tube! It's internal workings are in the stock, which connect to the receiver via complex engineering. No-longer will you be _completely_ outclassed in a duel!

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

