### PR TITLE
Add debug logs to `explosion_rec()`

### DIFF
--- a/code/game/objects/explosion_recursive.dm
+++ b/code/game/objects/explosion_recursive.dm
@@ -8,16 +8,26 @@ var/global/explosion_in_progress = 0
 
 
 /proc/explosion_rec(turf/epicenter, power, shaped)
+	var/debug_coord = "\[[epicenter.x],[epicenter.y],[epicenter.z]\]"
+	log_debug(append_admin_tools("[debug_coord] RECURSIVE EXPLOSION: Starting. Power [power]."))
 	var/loopbreak = 0
 	while(explosion_in_progress)
-		if(loopbreak >= 15) return
+		log_debug("[debug_coord] RECURSIVE EXPLOSION: Explosion in progress, delaying. Loopbreak [loopbreak].")
+		if(loopbreak >= 15)
+			log_debug("[debug_coord] RECURSIVE EXPLOSION: Explosion still in progress. Exiting.")
+			return
 		sleep(10)
 		loopbreak++
 
-	if(power <= 0) return
+	if(power <= 0)
+		log_debug("[debug_coord] RECURSIVE EXPLOSION: Invalid power [power]. Exiting.")
+		return
 	epicenter = get_turf(epicenter)
-	if(!epicenter) return
+	if(!epicenter)
+		log_debug("[debug_coord] RECURSIVE EXPLOSION: Invalid or null turf. Exiting.")
+		return
 
+	log_debug("[debug_coord] RECURSIVE EXPLOSION: Setting explosion in progress.")
 	explosion_in_progress = 1
 	explosion_turfs = list()
 
@@ -67,6 +77,7 @@ var/global/explosion_in_progress = 0
 					addtimer(CALLBACK(AM, /atom/movable/.proc/throw_at, throw_target, 9/severity, 9/severity), 0)
 
 	explosion_turfs.Cut()
+	log_debug("[debug_coord] RECURSIVE EXPLOSION: Unsetting explosion in progress and exiting.")
 	explosion_in_progress = 0
 
 


### PR DESCRIPTION
NUFC

Logs are an attempt to track down what's causing the global `explosion_in_progress` var to become stuck.