### PR TITLE
no tmp vars

### DIFF
--- a/code/controllers/subsystems/airflow.dm
+++ b/code/controllers/subsystems/airflow.dm
@@ -106,11 +106,11 @@ SUBSYSTEM_DEF(airflow)
 #undef CLEAR_OBJECT
 
 
-/atom/movable/var/tmp/airflow_xo
-/atom/movable/var/tmp/airflow_yo
-/atom/movable/var/tmp/airflow_od
-/atom/movable/var/tmp/airflow_process_delay
-/atom/movable/var/tmp/airflow_skip_speedcheck
+/atom/movable/var/airflow_xo
+/atom/movable/var/airflow_yo
+/atom/movable/var/airflow_od
+/atom/movable/var/airflow_process_delay
+/atom/movable/var/airflow_skip_speedcheck
 
 
 /atom/movable/proc/prepare_airflow(strength)

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -1,11 +1,11 @@
 /datum
-	var/tmp/gc_destroyed //Time when this object was destroyed.
-	var/tmp/is_processing = FALSE
+	var/gc_destroyed //Time when this object was destroyed.
+	var/is_processing = FALSE
 	var/list/active_timers  //for SStimer
 
 #ifdef TESTING
-	var/tmp/running_find_references
-	var/tmp/last_find_references = 0
+	var/running_find_references
+	var/last_find_references = 0
 #endif
 
 

--- a/code/datums/weakref.dm
+++ b/code/datums/weakref.dm
@@ -1,5 +1,5 @@
 /datum
-	var/tmp/weakref/weakref
+	var/weakref/weakref
 
 //obtain a weak reference to a datum
 /proc/weakref(datum/D)
@@ -17,8 +17,8 @@
 	var/ref
 
 	// Handy info for debugging
-	var/tmp/ref_name
-	var/tmp/ref_type
+	var/ref_name
+	var/ref_type
 
 /weakref/New(datum/D)
 	ref = "\ref[D]"

--- a/code/game/machinery/cracker.dm
+++ b/code/game/machinery/cracker.dm
@@ -13,11 +13,11 @@
 	active_power_usage = 10000
 
 	var/list/reagent_buffer = list()
-	var/tmp/fluid_consumption_per_tick = 100
-	var/tmp/gas_generated_per_tick = 1
-	var/tmp/max_reagents = 100
-	var/tmp/deuterium_generation_chance = 10
-	var/tmp/deuterium_generation_amount = 1
+	var/fluid_consumption_per_tick = 100
+	var/gas_generated_per_tick = 1
+	var/max_reagents = 100
+	var/deuterium_generation_chance = 10
+	var/deuterium_generation_amount = 1
 
 /obj/machinery/portable_atmospherics/cracker/on_update_icon()
 	icon_state = (use_power == POWER_USE_ACTIVE) ? "cracker_on" : "cracker"

--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -7,7 +7,7 @@
 	name="beam"
 	icon='icons/effects/beam.dmi'
 	icon_state= "b_beam"
-	var/tmp/atom/BeamSource
+	var/atom/BeamSource
 
 /obj/effect/overlay/beam/New()
 	..()

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -34,7 +34,7 @@
 	var/height = 0 // Determines if fluids can overflow onto next turf
 	var/footstep_type
 
-	var/tmp/changing_turf
+	var/changing_turf
 
 	/// List of 'dangerous' objs that the turf holds that can cause something bad to happen when stepped on, used for AI mobs.
 	var/list/dangerous_objects

--- a/code/game/turfs/turf_ao.dm
+++ b/code/game/turfs/turf_ao.dm
@@ -3,10 +3,10 @@
 
 /turf/var/permit_ao = TRUE
 /// Current ambient occlusion overlays. Tracked so we can reverse them without dropping all priority overlays.
-/turf/var/tmp/list/ao_overlays
-/turf/var/tmp/ao_neighbors
-/turf/var/tmp/list/ao_overlays_mimic
-/turf/var/tmp/ao_neighbors_mimic
+/turf/var/list/ao_overlays
+/turf/var/ao_neighbors
+/turf/var/list/ao_overlays_mimic
+/turf/var/ao_neighbors_mimic
 /turf/var/ao_queued = AO_UPDATE_NONE
 
 /turf/proc/regenerate_ao()

--- a/code/modules/ZAS/Airflow.dm
+++ b/code/modules/ZAS/Airflow.dm
@@ -2,7 +2,7 @@
 Contains helper procs for airflow, handled in /connection_group.
 */
 
-/mob/var/tmp/last_airflow_stun = 0
+/mob/var/last_airflow_stun = 0
 /mob/proc/airflow_stun()
 	if(stat == 2)
 		return 0
@@ -66,11 +66,11 @@ Contains helper procs for airflow, handled in /connection_group.
 	return ..()
 
 
-/atom/movable/var/tmp/turf/airflow_dest
-/atom/movable/var/tmp/airflow_speed = 0
-/atom/movable/var/tmp/airflow_time = 0
-/atom/movable/var/tmp/last_airflow = 0
-/atom/movable/var/tmp/airborne_acceleration = 0
+/atom/movable/var/turf/airflow_dest
+/atom/movable/var/airflow_speed = 0
+/atom/movable/var/airflow_time = 0
+/atom/movable/var/last_airflow = 0
+/atom/movable/var/airborne_acceleration = 0
 
 /atom/movable/proc/AirflowCanMove(n)
 	return 1

--- a/code/modules/ZAS/ConnectionManager.dm
+++ b/code/modules/ZAS/ConnectionManager.dm
@@ -34,7 +34,7 @@ Macros:
 // macro-ized to cut down on proc calls
 #define check(c) (c && c.valid())
 
-/turf/var/tmp/connection_manager/connections
+/turf/var/connection_manager/connections
 
 /connection_manager/var/connection/N
 /connection_manager/var/connection/S

--- a/code/modules/ZAS/Debug.dm
+++ b/code/modules/ZAS/Debug.dm
@@ -9,7 +9,7 @@ var/global/image/mark = image('icons/Testing/Zone.dmi', icon_state = "mark")
 
 /connection_edge/var/dbg_out = 0
 
-/turf/var/tmp/dbg_img
+/turf/var/dbg_img
 /turf/proc/dbg(image/img, d = 0)
 	if(d > 0) img.dir = d
 	overlays -= dbg_img

--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -3,7 +3,7 @@ For the main html chat area
 *********************************/
 
 /// Cache of icons for the browser output
-GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/tmp/iconCache.sav"))
+GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav"))
 
 
 /// Should match the value set in the browser js

--- a/code/modules/lighting/lighting_source.dm
+++ b/code/modules/lighting/lighting_source.dm
@@ -19,9 +19,9 @@ var/global/total_lighting_sources = 0
 	var/lum_b
 
 	// The lumcount values used to apply the light.
-	var/tmp/applied_lum_r
-	var/tmp/applied_lum_g
-	var/tmp/applied_lum_b
+	var/applied_lum_r
+	var/applied_lum_g
+	var/applied_lum_b
 
 	var/list/datum/lighting_corner/effect_str     // List used to store how much we're affecting corners.
 	var/list/turf/affecting_turfs

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -2,13 +2,13 @@
 /turf/var/dynamic_lighting = TRUE
 /turf/luminosity           = 1
 
-/turf/var/tmp/lighting_corners_initialised = FALSE
+/turf/var/lighting_corners_initialised = FALSE
 
 /// List of light sources affecting this turf.
-/turf/var/tmp/list/datum/light_source/affecting_lights
+/turf/var/list/datum/light_source/affecting_lights
 /// Our lighting overlay.
-/turf/var/tmp/atom/movable/lighting_overlay/lighting_overlay
-/turf/var/tmp/list/datum/lighting_corner/corners
+/turf/var/atom/movable/lighting_overlay/lighting_overlay
+/turf/var/list/datum/lighting_corner/corners
 /turf/var/opaque_counter
 
 /turf/set_opacity(new_opacity)

--- a/code/modules/mob/living/carbon/alien/diona/_nymph.dm
+++ b/code/modules/mob/living/carbon/alien/diona/_nymph.dm
@@ -39,9 +39,9 @@
 	var/obj/item/holding_item
 	var/mob/living/carbon/alien/diona/next_nymph
 	var/mob/living/carbon/alien/diona/previous_nymph
-	var/tmp/image/flower
-	var/tmp/image/eyes
-	var/tmp/last_glow
+	var/image/flower
+	var/image/eyes
+	var/last_glow
 
 /mob/living/carbon/alien/diona/get_jump_distance()
 	return 3

--- a/code/modules/mob/living/carbon/alien/diona/gestalt/_gestalt.dm
+++ b/code/modules/mob/living/carbon/alien/diona/gestalt/_gestalt.dm
@@ -12,8 +12,8 @@
 	var/list/nymphs                  = list()
 	var/list/valid_things_to_roll_up = list(/mob/living/carbon/alien/diona = TRUE, /mob/living/carbon/alien/diona/sterile = TRUE)
 	var/list/democracy_bucket        = list("Change to a humanoid form." = /datum/gestalt_vote/form_change_humanoid)
-	var/tmp/image/eyes_overlay
-	var/tmp/datum/gestalt_vote/current_vote
+	var/image/eyes_overlay
+	var/datum/gestalt_vote/current_vote
 
 /obj/structure/diona_gestalt/mob_breakout(mob/living/escapee)
 	. = ..()

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -1,6 +1,6 @@
 /atom/movable
 	/// The mimic (if any) that's *directly* copying us.
-	var/tmp/atom/movable/openspace/mimic/bound_overlay
+	var/atom/movable/openspace/mimic/bound_overlay
 	/// If TRUE, this atom is ignored by Z-Mimic.
 	var/no_z_overlay
 

--- a/code/modules/multiz/zmimic/mimic_turf.dm
+++ b/code/modules/multiz/zmimic/mimic_turf.dm
@@ -1,23 +1,23 @@
 /// Reference to any open turf that might be above us to speed up atom Entered() updates.
-/turf/var/tmp/turf/above
-/turf/var/tmp/turf/below
+/turf/var/turf/above
+/turf/var/turf/below
 /// If we're a non-overwrite z-turf, this holds the appearance of the bottom-most Z-turf in the z-stack.
-/turf/var/tmp/atom/movable/openspace/turf_proxy/mimic_proxy
+/turf/var/atom/movable/openspace/turf_proxy/mimic_proxy
 /// Overlay used to multiply color of all OO overlays at once.
-/turf/var/tmp/atom/movable/openspace/multiplier/shadower
+/turf/var/atom/movable/openspace/multiplier/shadower
 /// If this is a delegate (non-overwrite) Z-turf with a z-turf above, this is the delegate copy that's copying us.
-/turf/var/tmp/atom/movable/openspace/turf_mimic/mimic_above_copy
+/turf/var/atom/movable/openspace/turf_mimic/mimic_above_copy
 /// If we're at the bottom of the stack, a proxy used to fake a below space turf.
-/turf/var/tmp/atom/movable/openspace/turf_proxy/mimic_underlay
+/turf/var/atom/movable/openspace/turf_proxy/mimic_underlay
 /// How many times this turf is currently queued - multiple queue occurrences are allowed to ensure update consistency.
-/turf/var/tmp/z_queued = 0
+/turf/var/z_queued = 0
 /// If this Z-turf leads to space, uninterrupted.
-/turf/var/tmp/z_eventually_space = FALSE
+/turf/var/z_eventually_space = FALSE
 /turf/var/z_flags = 0
 
 // debug
-/turf/var/tmp/z_depth
-/turf/var/tmp/z_generation = 0
+/turf/var/z_depth
+/turf/var/z_generation = 0
 
 /turf/Entered(atom/movable/thing, turf/oldLoc)
 	. = ..()

--- a/code/modules/organs/external/wounds/wound.dm
+++ b/code/modules/organs/external/wounds/wound.dm
@@ -26,9 +26,9 @@
 	var/autoheal_cutoff = 15   // the maximum amount of damage that this wound can have and still autoheal
 
 	// helper lists
-	var/tmp/list/embedded_objects
-	var/tmp/list/desc_list = list()
-	var/tmp/list/damage_list = list()
+	var/list/embedded_objects
+	var/list/desc_list = list()
+	var/list/damage_list = list()
 
 /datum/wound/New(damage, obj/item/organ/external/organ = null)
 

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -13,8 +13,8 @@
 	max_damage = 45
 	var/eye_icon = 'icons/mob/human_races/species/default_eyes.dmi'
 	var/apply_eye_colour = TRUE
-	var/tmp/last_cached_eye_colour
-	var/tmp/last_eye_cache_key
+	var/last_cached_eye_colour
+	var/last_eye_cache_key
 	var/flash_mod
 	var/darksight_range
 	var/darksight_tint

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -7,7 +7,7 @@
 	var/pulse = PULSE_NORM
 	var/heartbeat = 0
 	var/beat_sound = 'sound/effects/singlebeat.ogg'
-	var/tmp/next_blood_squirt = 0
+	var/next_blood_squirt = 0
 	damage_reduction = 0.7
 	relative_size = 5
 	max_damage = 45

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -93,11 +93,11 @@
 	var/keep_aim = 1 	//1 for keep shooting until aim is lowered
 						//0 for one bullet after tarrget moves and aim is lowered
 	var/multi_aim = 0 //Used to determine if you can target multiple people.
-	var/tmp/list/mob/living/aim_targets //List of who yer targeting.
-	var/tmp/mob/living/last_moved_mob //Used to fire faster at more than one person.
-	var/tmp/told_cant_shoot = 0 //So that it doesn't spam them with the fact they cannot hit them.
-	var/tmp/lock_time = -100
-	var/tmp/last_safety_check = -INFINITY
+	var/list/mob/living/aim_targets //List of who yer targeting.
+	var/mob/living/last_moved_mob //Used to fire faster at more than one person.
+	var/told_cant_shoot = 0 //So that it doesn't spam them with the fact they cannot hit them.
+	var/lock_time = -100
+	var/last_safety_check = -INFINITY
 	var/safety_state = 1
 	var/has_safety = TRUE
 	var/safety_icon 	   //overlay to apply to gun based on safety state, if any

--- a/code/modules/turbolift/turbolift.dm
+++ b/code/modules/turbolift/turbolift.dm
@@ -10,7 +10,7 @@
 	var/obj/structure/lift/panel/control_panel_interior // Lift control panel.
 	var/doors_closing = 0								// Whether doors are in the process of closing
 
-	var/tmp/moving_upwards
+	var/moving_upwards
 	var/busy_state                                      // Used for controller processing.
 	var/next_process
 

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -51,6 +51,7 @@ exactly 2 "density = 0/1" 'density\s*=\s*\d' -P
 exactly 0 "emagged = 0/1" 'emagged\s*=\s*\d' -P
 exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
+exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 num=`find ./html/changelogs -not -name "*.yml" | wc -l`


### PR DESCRIPTION
The issaved proc is true or false depending on whether a var will be stored if its owner is written to a savefile. It is false for const/global/static/tmp. This is useful for determining if a var is static or const at runtime but tmp creates false negatives. We don't use savefiles for storing datum states so the behavior is valueless to us anyway- so no tmp vars.