### PR TITLE
Interaction fixes

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -23,7 +23,7 @@
 				SPAN_WARNING("You bonk \the [src] harmlessly!")
 			)
 			return
-		var/damage_flags = EMPTY_BITFIELD
+		var/damage_flags = dam_flags
 		if (wallbreaker)
 			SET_FLAGS(damage_flags, DAMAGE_FLAG_TURF_BREAKER)
 		playsound(src, damage_hitsound, 75)

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -35,7 +35,7 @@
 		else
 			user.visible_message(
 				SPAN_DANGER("\The [user] [attack_verb] \the [src]!"),
-				SPAN_DANGER("You [attack_verb] \the [src]!")
+				SPAN_DANGER("You attack \the [src]!")
 			)
 
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -179,6 +179,22 @@
 		else
 			close()
 
+/obj/machinery/door/attack_generic(mob/user, damage, attack_verb, wallbreaker, damtype, armorcheck, dam_flags)
+	if (can_open(TRUE))
+		user.visible_message(
+			SPAN_WARNING("\The [user] starts forcing \the [src] open!"),
+			SPAN_NOTICE("You start forcing \the [src] open!")
+		)
+		if (!do_after(user, 10 SECONDS, src, DO_PUBLIC_PROGRESS | DO_USER_UNIQUE_ACT) || !can_open(TRUE))
+			return
+		open(TRUE)
+		user.visible_message(
+			SPAN_WARNING("\The [user] forces \the [src] open!"),
+			SPAN_NOTICE("You force \the [src] open!")
+		)
+		return
+	..()
+
 /obj/machinery/door/attackby(obj/item/I as obj, mob/user as mob)
 	src.add_fingerprint(user, 0, I)
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -271,7 +271,7 @@
 	. = ..()
 	queue_icon_update()
 	if (health_mod < 0 && !health_dead)
-		var/initial_damage_percentage = round(((get_current_health() - health_mod) / get_max_health()) * 100)
+		var/initial_damage_percentage = 100 - round(((get_current_health() - health_mod) / get_max_health()) * 100)
 		var/damage_percentage = get_damage_percentage()
 		if (damage_percentage >= 75 && initial_damage_percentage < 75)
 			visible_message("\The [src] looks like it's about to break!" )

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -156,7 +156,7 @@
 	..()
 	update_icon()
 	if (health_mod < 0)
-		var/initial_damage_percentage = round(((get_current_health() - health_mod) / get_max_health()) * 100)
+		var/initial_damage_percentage = 100 - round(((get_current_health() - health_mod) / get_max_health()) * 100)
 		var/damage_percentage = get_damage_percentage()
 		if (damage_percentage >= 75 && initial_damage_percentage < 75)
 			visible_message(SPAN_DANGER("\The [src] looks like it's about to shatter!"))

--- a/code/modules/species/outsider/zombie.dm
+++ b/code/modules/species/outsider/zombie.dm
@@ -115,15 +115,15 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 	H.stat = CONSCIOUS
 
 	if (H.wear_id)
-		qdel(H.wear_id)
+		H.drop_from_inventory(H.wear_id)
 	if (H.gloves)
-		qdel(H.gloves)
+		H.drop_from_inventory(H.gloves)
 	if (H.head)
-		qdel(H.head) //Remove helmet so headshots aren't impossible
+		H.drop_from_inventory(H.head) //Remove helmet so headshots aren't impossible
 	if (H.glasses)
-		qdel(H.glasses)
+		H.drop_from_inventory(H.glasses)
 	if (H.wear_mask)
-		qdel(H.wear_mask)
+		H.drop_from_inventory(H.wear_mask)
 	..()
 
 /datum/species/zombie/handle_environment_special(mob/living/carbon/human/H)

--- a/code/modules/xenoarcheaology/artifacts/artifact.dm
+++ b/code/modules/xenoarcheaology/artifacts/artifact.dm
@@ -208,7 +208,7 @@
 	..()
 	queue_icon_update()
 	if (health_mod < 0)
-		var/initial_damage_percentage = round(((get_current_health() - health_mod) / get_max_health()) * 100)
+		var/initial_damage_percentage = 100 - round(((get_current_health() - health_mod) / get_max_health()) * 100)
 		var/damage_percentage = get_damage_percentage()
 		if (damage_percentage >= 75 && initial_damage_percentage < 75)
 			visible_message("\The [src] looks like it's about to break!")


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
tweak: Mobs will now drop equipment instead of deleting it when zombified.
bugfix: Damage state warnings no longer spam chat with every attack.
bugfix: Generic attacks now show 'You hit' instead of 'You hits', 'You smashes', etc messages to the user.
tweak: Generic attacks will now force open closed and broken doors. This means zombies and simple mobs will be able to open broken doors once again.
/:cl:


## NUFC
- Fixes `attack_generic()` not passing `dam_flags` on to `damage_health()`.


## Bug Fixes
- Fixes #32890


## TODO
- [ ] Fix undamaged doors opening and being forced open at the same time when clicked as a zombie or other mob.
- [ ] Test AI mob interactions with doors.
- [ ] Contemplate purging the existing attack_* proc chains.