### PR TITLE
Change Trainee Roles Description

### DIFF
--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -162,7 +162,7 @@
 							 /datum/computer_file/program/shields_monitor)
 
 /datum/job/engineer_trainee/get_description_blurb()
-	return "You are an Engineer Trainee. You are learning how to operate the various onboard engineering systems from senior engineering staff. You are subordinate to all of the other engineers aboard."
+	return "You are an Engineer Trainee. You are learning how to operate the various onboard engineering systems from senior engineering staff. You are subordinate to all of the other engineers aboard. The role is only for players new to the engineering system and department."
 
 /datum/job/roboticist
 	title = "Roboticist"

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -178,7 +178,7 @@
 							 /datum/computer_file/program/camera_monitor)
 
 /datum/job/medical_trainee/get_description_blurb()
-	return "You are a Trainee Medical Technician. You are learning how to treat and recover wounded crew from the more experienced medical personnel aboard. You are subordinate to the rest of the medical team."
+	return "You are a Trainee Medical Technician. You are learning how to treat and recover wounded crew from the more experienced medical personnel aboard. You are subordinate to the rest of the medical team. The role is only for players new to the medical system and department."
 
 /datum/job/chemist
 	title = "Pharmacist"


### PR DESCRIPTION
:cl: Ryan180602
tweak: Specify in role description for Engi/MT Trainee roles that the role is for new players.
/:cl:

should hopefully avoid ahelps concerning old people using trainee slots (considering how low in numbers they are).

should also ideally be reflected in the wiki (but i lost my password and have to recover my account).