### PR TITLE
Give emergency adrenaline autoinjector the intended volume

### DIFF
--- a/code/game/objects/items/weapons/storage/med_pouch.dm
+++ b/code/game/objects/items/weapons/storage/med_pouch.dm
@@ -214,5 +214,6 @@ Single Use Emergency Pouches
 
 /obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/adrenaline
 	name = "emergency adrenaline autoinjector"
+	volume = 8
 	amount_per_transfer_from_this = 8
 	starts_with = list(/datum/reagent/adrenaline = 8)


### PR DESCRIPTION
:cl: Nerezza
bugfix: Emergency Adrenaline Autoinjectors now contain 8u of adrenaline as originally intended instead of just 5u. This means it is now possible for patients to reach medbay before the stabilizing effects of an adrenaline shot runs out.
/:cl:

The emergency adrenaline autoinjector was intended to have 8u of adrenaline, but its volume/capacity was left at the default 5u as an oversight causing it to only spawn in with and inject 5u. This PR adjusts the volume of the autoinjector so it contains and injects the correct amount, the reason for the increased volume is explained below.

~~Adrenaline's critical stabilizing effects only apply while someone has more than 4u of adrenaline in their bloodstream. Whoever set this autoinjector up intended them to inject twice that amount (8u) so the effects are guaranteed to last longer than a minute, however due to the missing custom volume the adrenaline instead injected 5u which often doesn't remain over the critical threshold for long enough to be useful. This fix effectively makes adrenaline autoinjectors as effective at temporarily stabilizing critically injured people as they were intended to be.~~

Apologies for the above, I'd misremembered the affect_blood proc for adrenaline and was corrected by qtslop in a few ways.

That said the increased dosage is still important because 4u of adrenaline is removed from the bloodstream if it does help in restarting a stopped heart. At 5u dose this would leave less than 1u remaining after doing so (a small amount of the total 5u is metabolized before the resuscitation is processed, so restarting the heart would never leave a full 1u behind), which would diminish the duration of its painkilling effects. A full 8u dose would permit 1 heart restart followed by the longest duration of painkilling effects without leaving enough adrenaline for a second resuscitation attempt.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->