### PR TITLE
Emergency adrenaline autoinjector cleanup

### DIFF
--- a/code/game/objects/items/weapons/storage/med_pouch.dm
+++ b/code/game/objects/items/weapons/storage/med_pouch.dm
@@ -214,5 +214,4 @@ Single Use Emergency Pouches
 
 /obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/adrenaline
 	name = "emergency adrenaline autoinjector"
-	amount_per_transfer_from_this = 8
-	starts_with = list(/datum/reagent/adrenaline = 8)
+	starts_with = list(/datum/reagent/adrenaline = 5)


### PR DESCRIPTION
Having been informed the 5u adrenaline autoinjector has since been intentionally balanced around and the wrong dosage size oversight had been intentionally left in, I've created a PR to correct the leftover discrepancy from the oversight from 5y ago. Now you'll not risk having another scamp like me coming along trying to "fix" the discrepancy/"bug" here. No changelog since this has no user-facing effect on gameplay p:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->