### PR TITLE
Set canisters to physical damage resistance

### DIFF
--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -7,6 +7,7 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	w_class = ITEM_SIZE_GARGANTUAN
 	construct_state = null
+	health_resistances = DAMAGE_RESIST_PHYSICAL
 
 	var/valve_open = 0
 	var/release_pressure = ONE_ATMOSPHERE


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Canisters no longer take damage from EMPs, and are now set to be damaged by physical damage sources instead of electrical.
/:cl: