### PR TITLE
Runtime batch 2023 01 15

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -242,14 +242,12 @@
 
 
 	// Try to find all the players who can hear the message
-	for(var/i = 1; i <= GLOB.player_list.len; i++)
-		var/mob/M = GLOB.player_list[i]
-		if(M)
-			var/turf/ear = get_turf(M)
-			if(ear)
-				// Ghostship is magic: Ghosts can hear radio chatter from anywhere
-				if(speaker_coverage[ear] || (isghost(M) && M.get_preference_value(/datum/client_preference/ghost_radio) == GLOB.PREF_ALL_CHATTER))
-					. |= M		// Since we're already looping through mobs, why bother using |= ? This only slows things down.
+	for (var/mob/M in GLOB.player_list)
+		var/turf/ear = get_turf(M)
+		if(ear)
+			// Ghostship is magic: Ghosts can hear radio chatter from anywhere
+			if(speaker_coverage[ear] || (isghost(M) && M.get_preference_value(/datum/client_preference/ghost_radio) == GLOB.PREF_ALL_CHATTER))
+				. |= M		// Since we're already looping through mobs, why bother using |= ? This only slows things down.
 	return .
 
 /proc/get_mobs_and_objs_in_view_fast(turf/T, range, list/mobs, list/objs, checkghosts = null)

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -138,6 +138,8 @@
 
 #define QDEL_NULL_LIST(x) if(x) { for(var/y in x) { qdel(y) }}; if(x) {x.Cut(); x = null; } // Second x check to handle items that LAZYREMOVE on qdel.
 
+#define QDEL_NULL_ASSOC_LIST(x) if(x) { for(var/y in x) { qdel(x[y]) }}; if(x) {x.Cut(); x = null; }
+
 #define QDEL_NULL(x) if(x) { qdel(x) ; x = null }
 
 #define QDEL_IN(item, time) addtimer(new Callback(item, /datum/proc/qdel_self), time, TIMER_STOPPABLE)

--- a/code/datums/callbacks.dm
+++ b/code/datums/callbacks.dm
@@ -74,7 +74,9 @@ var/global/const/Callback = /datum/callback
 	else if (QDELETED(target))
 		return
 	else if (istype(target))
-		var/list/params = list(target.target, target.callable) + target.params
+		var/list/params = list(target.target, target.callable)
+		if (LAZYLEN(target.params))
+			params += target.params
 		if (length(args) > 1)
 			params += args.Copy(2)
 		return invoke(arglist(params))

--- a/code/datums/communication/pray.dm
+++ b/code/datums/communication/pray.dm
@@ -7,8 +7,7 @@
 
 /singleton/communication_channel/pray/do_communicate(mob/communicator, message, speech_method_type)
 	var/image/cross = image('icons/obj/storage.dmi',"bible")
-	for(var/m in GLOB.player_list)
-		var/mob/M = m
+	for(var/mob/M in GLOB.player_list)
 		if(!M.client)
 			continue
 		if(M.client.holder && M.client.get_preference_value(/datum/client_preference/staff/show_chat_prayers) == GLOB.PREF_SHOW)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -328,6 +328,8 @@
 // This function can not be undone; do not call this unless you are sure
 // Also make sure there is a valid control computer
 /obj/machinery/cryopod/proc/despawn_occupant()
+	SHOULD_NOT_SLEEP(TRUE) // Sleeping causes the double-despawn bug
+
 	if (QDELETED(occupant))
 		log_and_message_admins("A mob was deleted while in a cryopod, or the cryopod double-processed. This may cause errors!")
 		return
@@ -416,7 +418,7 @@
 	log_and_message_admins("[key_name(occupant)] ([role_alt_title]) entered cryostorage.")
 
 	if(announce_despawn)
-		announce.autosay("[occupant.real_name], [role_alt_title], [on_store_message]", "[on_store_name]")
+		invoke_async(announce, /obj/item/device/radio/proc/autosay, "[occupant.real_name], [role_alt_title], [on_store_message]", "[on_store_name]")
 
 	var/despawnmessage = replacetext(on_store_visible_message, "$occupant$", occupant.real_name)
 	visible_message(SPAN_NOTICE("\The [initial(name)] " + despawnmessage), range = 3)

--- a/code/game/objects/compass/compass_holder.dm
+++ b/code/game/objects/compass/compass_holder.dm
@@ -67,7 +67,7 @@ var/global/list/angle_step_to_dir = list(
 	return global.angle_step_to_dir[clamp(round(angle/45)+1, 1, length(global.angle_step_to_dir))]
 
 /obj/compass_holder/Destroy()
-	QDEL_NULL_LIST(compass_waypoints)
+	QDEL_NULL_ASSOC_LIST(compass_waypoints)
 	. = ..()
 
 /obj/compass_holder/proc/get_heading_strength()

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -66,8 +66,7 @@ GLOBAL_LIST_INIT(tray_hit_sound,list('sound/items/trayhit1.ogg', 'sound/items/tr
 	var/turf/turf_source = get_turf(source)
 
  	// Looping through the player list has the added bonus of working for mobs inside containers
-	for (var/P in GLOB.player_list)
-		var/mob/M = P
+	for (var/mob/M in GLOB.player_list)
 		if(!M || !M.client)
 			continue
 		if(get_dist(M, turf_source) <= (world.view + extrarange) * 2)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1330,7 +1330,7 @@ GLOBAL_VAR_INIT(skip_allow_lists, FALSE)
 		return
 
 	if(!M)
-		M = input("Select mob.", "Select mob.") as null|anything in GLOB.player_list
+		M = input("Select mob.", "Select mob.") as null|mob in GLOB.player_list
 	if(!istype(M))
 		return
 	var/datum/nano_module/skill_ui/NM = /datum/nano_module/skill_ui

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -912,7 +912,7 @@ Ccomp's first proc.
 			mode = 1
 	var/affected = 0
 	var/floored = 0
-	for (mob as anything in GLOB.player_list)
+	for (mob in GLOB.player_list)
 		var/living = isliving(mob)
 		if (!living && !isobserver(mob))
 			continue

--- a/code/modules/alarm/alarm_handler.dm
+++ b/code/modules/alarm/alarm_handler.dm
@@ -54,7 +54,7 @@
 	if(z_level)
 		. = list()
 		for(var/z in GetConnectedZlevels(z_level))
-			. += alarms_by_z["[z]"] || list()
+			. += SANITIZE_LIST(alarms_by_z["[z]"])
 	else
 		return alarms
 
@@ -76,7 +76,7 @@
 	if ((alarm.end_time && world.time > alarm.end_time) || !alarm.sources.len)
 		alarms -= alarm
 		alarms_assoc -= alarm.origin
-		alarms_by_z["[alarm.alarm_z()]"] -= alarm
+		LAZYREMOVE(alarms_by_z["[alarm.alarm_z()]"], alarm)
 		on_alarm_change(alarm, ALARM_CLEARED)
 		return 1
 	return 0

--- a/code/modules/events/exo_awakening/exo_awaken.dm
+++ b/code/modules/events/exo_awakening/exo_awaken.dm
@@ -76,10 +76,8 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 	var/list/players = list()
 
 	for (var/area/A in exoplanet_areas)
-		var/mob/M
-		for (var/i = length(GLOB.player_list) to 1 step -1)
-			M = GLOB.player_list[i]
-			if (M && M.stat != DEAD && (get_z(M) in GetConnectedZlevels(A.z)))
+		for (var/mob/M in GLOB.player_list)
+			if (M.stat != DEAD && (get_z(M) in GetConnectedZlevels(A.z)))
 				players += M
 
 				if (get_crewmember_record(M.real_name || M.name))

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/tunneler.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/tunneler.dm
@@ -60,6 +60,8 @@
 	// Telegraph to give a small window to dodge if really close.
 	do_windup_animation(A, tunnel_warning)
 	sleep(tunnel_warning) // For the telegraphing.
+	if (QDELETED(src))
+		return FALSE
 
 	// Do the dig!
 	visible_message(SPAN_DANGER("\The [src] tunnels towards \the [A]!"))

--- a/code/modules/psionics/interface/ui.dm
+++ b/code/modules/psionics/interface/ui.dm
@@ -3,10 +3,10 @@
 	var/mob/living/owner
 	var/hidden = TRUE
 
-/obj/screen/psi/Initialize(mapload, mob/living/_owner)
+/obj/screen/psi/Initialize(mapload)
 	. = ..()
+	owner = loc
 	loc = null
-	owner = _owner
 	update_icon()
 
 /obj/screen/psi/Destroy()

--- a/code/modules/psionics/interface/ui_hub.dm
+++ b/code/modules/psionics/interface/ui_hub.dm
@@ -8,13 +8,13 @@
 	var/image/on_cooldown
 	var/list/components
 
-/obj/screen/psi/hub/New(mob/living/_owner)
+/obj/screen/psi/hub/Initialize(mapload)
+	. = ..()
 	on_cooldown = image(icon, "cooldown")
 	components = list(
-		new /obj/screen/psi/armour(_owner),
-		new /obj/screen/psi/toggle_psi_menu(_owner, src)
-		)
-	..()
+		new /obj/screen/psi/armour(loc),
+		new /obj/screen/psi/toggle_psi_menu(loc, src)
+	)
 	START_PROCESSING(SSprocessing, src)
 
 /obj/screen/psi/hub/on_update_icon()

--- a/code/modules/psionics/interface/ui_toggles.dm
+++ b/code/modules/psionics/interface/ui_toggles.dm
@@ -26,9 +26,9 @@
 	icon_state = "arrow_left"
 	var/obj/screen/psi/hub/controller
 
-/obj/screen/psi/toggle_psi_menu/New(mob/living/_owner, obj/screen/psi/hub/_controller)
+/obj/screen/psi/toggle_psi_menu/Initialize(mapload, obj/screen/psi/hub/_controller)
+	. = ..()
 	controller = _controller
-	..(_owner)
 
 /obj/screen/psi/toggle_psi_menu/Click()
 	var/set_hidden = !hidden


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Psionics now work again.
bugfix: Cryopods will now longer occasionally announce a mob has been flushed twice.
bugfix: Custom email addresses in character setup should function again.
/:cl:

## Other Changes
- Added `QDEL_NULL_ASSOC_LIST` macro for ease of clearing the values of associative lists
- Moved `New()` calls in psionics to `Initialize()` - Somehow those got missed in #32885 and caused init order issues.
- `alarms_by_z`'s entries are now treated as lazy lists, since the entries themselves aren't guaranteed to exist and are added to using LAZY macros.
- `despawn_occupant()` for cryopods now has the should not sleep flag - Sleeping is what causes the double flushing bug. The specific culprit was `announce.autosay()` which is now run using `invoke_async()` instead of directly.
- Tuneler spiders now check if the spider has been qdeleted after the sleep in their special action proc. Really, this shouldn't be sleeping at all because the AI system expects a return value, but that's a refactor for another day.
- All for loops referencing `GLOB.player_list` now type check, as a bandaid fix for null entries in the list.

## Bug Fixes
- Fixes #32867
- Fixes #32912
- Fixes #32913
- Fixes #32914
- Fixes #32917
- Fixes #20558
- Fixes #20215
- Fixes #32916
- Fixes #19499
- Closes #26018
- Fixes #32925