### PR TITLE
adds punctuation to seen flare message/changes font

### DIFF
--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -73,7 +73,7 @@
 		for(var/mob/living/mob in GLOB.alive_mobs)
 			var/turf/T = get_turf(mob)
 			if(T && (T != TO) && (TO.z == T.z) && !mob.blinded)
-				to_chat(mob, SPAN_NOTICE("You see a bright light to \the [dir2text(get_dir(T,TO))]"))
+				to_chat(mob, SPAN_DANGER("You see a bright light to \the [dir2text(get_dir(T,TO))]!"))
 			CHECK_TICK
 
 /obj/item/projectile/energy/electrode	//has more pain than a beam because it's harder to hit


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
🆑 gy1ta23
tweak: fired flares are more textually visible
/🆑

I was fiddling about, as some say, on a private server, and I came upon a most horrid and prominent discovery;  the message given when you see a flare fired by a flare gun is lacking punctuation, and is quite hard to spot as well! I nearly missed it myself, and my eyes are quite sharp. As such, I have given it a more proper exclamation mark and changed the font tag to DANGER. The latter gives it a good bit of pop in the chat box, which is more representative of how optically striking and visible flares are (as designed). Danger often follows signals of distress.

![PR OLD NEW](https://user-images.githubusercontent.com/44277885/212595003-8934b375-7649-438d-aa63-227938409ac1.png)
