### PR TITLE
Add framework for interactions information to codex entries

### DIFF
--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -17,6 +17,75 @@
 		if(2) return "[input[1]][and_text][input[2]]"
 		else  return "[jointext(input, comma_text, 1, -1)][final_comma_text][and_text][input[input.len]]"
 
+/**
+ * Converts a list to an HTML formatted list, i.e.:
+ *
+ * ```dm
+ * list(
+ *     "Value1",
+ *     "Value2"
+ * )
+ * ```
+ *
+ * Becomes:
+ *
+ * ```html
+ * <ul>
+ *     <li>Value1</li>
+ *     <li>Value2</li>
+ * </ul>
+ * ```
+ *
+ * **Parameters**:
+ * - `input` - The list to convert to an HTML formatted list. Values must be convertable to string. List keys from associative lists are not used.
+ * - `numbered_list` (Boolean, default `FALSE`) - If set, the list will use `<ol>` instead of `<ul>` tags, generating a numbered list instead of bullets.
+ *
+ * Returns string, or null if `input` is empty.
+ */
+/proc/html_list(list/input, numbered_list = FALSE)
+	if (!length(input))
+		return
+	var/html_tag = numbered_list ? "ol" : "ul"
+	. = "<[html_tag]>"
+	for (var/key in input)
+		. += "<li>[input[key]]</li>"
+	. += "</[html_tag]>"
+
+/**
+ * Converts an associative list to an HTML formatted definition list, i.e.:
+ *
+ * ```dm
+ * list(
+ *     "Key1" = "Value1",
+ *     "Key2" = "Value2"
+ * )
+ * ```
+ *
+ * Becomes:
+ *
+ * ```html
+ * <dl>
+ *     <dt>Key1</dt>
+ *     <dd>Value1</dd>
+ *     <dt>Key2</dt>
+ *     <dd>Value2</dd>
+ *     ...
+ * </dl>
+ * ```
+ *
+ * **Parameters**:
+ * - `input` - The list to convert to an HTML formatted list. Both the key and value must be convertable to string.
+ *
+ * Returns string, or null if `input` is empty.
+ */
+/proc/html_list_dl(list/input)
+	if (!length(input))
+		return
+	. = "<dl>"
+	for (var/key in input)
+		. += "<dt>[key]</dt><dd>[input[key]]</dd>"
+	. += "</dl>"
+
 //Checks for specific types in a list
 /proc/is_type_in_list(atom/A, list/L)
 	for(var/type in L)

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -57,6 +57,13 @@ var/global/list/wireColours = list("red", "blue", "green", "darkred", "orange", 
 /datum/wires/proc/get_mechanics_info()
 	return
 
+/datum/wires/proc/get_interactions_info()
+	RETURN_TYPE(/list)
+	. = list()
+	.["Multitool"] = "<p>While the wire panel is accessible, allows pulsing wires by clicking the Pulse button in the panel UI.</p>"
+	.["Signaller"] = "<p>While the wire panel is accessible, can be attached to a wire by clicking the Attach Signaller button in the panel UI. An attached signaller will pulse the wire whenever it receives a signal.</p>"
+	.["Wirecutters"] = "<p>While the wire panel is accessible, allows cutting and mending wires by clicking the Cut and Mend buttons in the panel UI.</p>"
+
 /datum/wires/proc/GenerateWires()
 	var/list/colours_to_pick = wireColours.Copy() // Get a copy, not a reference.
 	var/list/indexes_to_pick = list()

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -445,6 +445,13 @@
 	if (wire_mechanics)
 		. += "<hr><h5>Wiring</h5>[wire_mechanics]"
 
+/obj/machinery/get_interactions_info()
+	. = ..()
+	var/wire_interactions = wires?.get_interactions_info()
+	if (wire_interactions)
+		for (var/key in wire_interactions)
+			.["[key]"] += "[wire_interactions[key]]"
+
 // This is really pretty crap and should be overridden for specific machines.
 /obj/machinery/water_act(depth)
 	..()

--- a/code/game/machinery/teleporter/beacon.dm
+++ b/code/game/machinery/teleporter/beacon.dm
@@ -181,9 +181,9 @@ var/global/const/TELEBEACON_WIRE_SIGNALLER = 4
 	.["Wrench"] += "<p>If the maintenance panel is closed, anchors/unanchors the beacon, allowing it to be moved. The beacon is not functional unless anchored.</p>"
 
 
-/obj/machinery/tele_beacon/get_antag_info()
+/obj/machinery/tele_beacon/get_antag_interactions_info()
 	. = ..()
-	. += "<p>If EMP'd, \the [src] will lose all established teleporter locks and will be disabled for up to 30 seconds.</p>"
+	.["EMP"] += "<p>Disables all established teleporter locks and disables the beacon for up to 30 seconds.</p>"
 
 
 /// Connects the beacon to a computer that's locking onto it. Returns TRUE on connection, FALSE if the connection fails.

--- a/code/game/machinery/teleporter/beacon.dm
+++ b/code/game/machinery/teleporter/beacon.dm
@@ -172,12 +172,13 @@ var/global/const/TELEBEACON_WIRE_SIGNALLER = 4
 /obj/machinery/tele_beacon/get_mechanics_info()
 	. = ..()
 	. += "<p>\The [src] can be targeted by teleporter control consoles to allow teleporter pads to send mobs and objects to this [src]'s location. \
-		It can only be targeted and used while \the [src] is powered and anchored (wrenched) to the floor.</p>\
-		<p>While the panel is closed:</p>\
-		<ul>\
-			<li>Use a Wrench to anchor/unanchor the beacon, allowing it to be moved. The beacon is not functional unless anchored.</li>\
-			<li>Use a Multitool to rename the beacon. The name will be displayed in teleport control consoles.</li>\
-		</ul>"
+		It can only be targeted and used while \the [src] is powered and anchored (wrenched) to the floor.</p>"
+
+
+/obj/machinery/tele_beacon/get_interactions_info()
+	. = ..()
+	.["Multitool"] += "<p>If the maintenance panel is closed, renames the beacon. The name will be displayed in teleport control consoles.</p>"
+	.["Wrench"] += "<p>If the maintenance panel is closed, anchors/unanchors the beacon, allowing it to be moved. The beacon is not functional unless anchored.</p>"
 
 
 /obj/machinery/tele_beacon/get_antag_info()

--- a/code/game/machinery/teleporter/beacon.dm
+++ b/code/game/machinery/teleporter/beacon.dm
@@ -183,7 +183,7 @@ var/global/const/TELEBEACON_WIRE_SIGNALLER = 4
 
 /obj/machinery/tele_beacon/get_antag_interactions_info()
 	. = ..()
-	.["EMP"] += "<p>Disables all established teleporter locks and disables the beacon for up to 30 seconds.</p>"
+	.[CODEX_INTERACTION_EMP] += "<p>Disables all established teleporter locks and disables the beacon for up to 30 seconds.</p>"
 
 
 /// Connects the beacon to a computer that's locking onto it. Returns TRUE on connection, FALSE if the connection fails.

--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -280,6 +280,15 @@
 				<li>Wrench to remove the frame from the wall</li>\
 			</ol>"
 
+/obj/item/device/radio/intercom/get_interactions_info()
+	. = ..()
+	.["Cable Coil"] += "<p>Used for construction. See construction steps.</p>"
+	.["Circuitboard"] += "<p>Used for construction. See construction steps.</p>"
+	.["Crowbar"] += "<p>Used for desconstruction. See deconstruction steps.</p>"
+	.["Screwdriver"] += "<p>Toggles the maintenance panel open and closed.</p>"
+	.["Wirecutters"] += "<p>Used for deconstruction. See deconstruction steps.</p>"
+	.["Wrench"] += "<p>Used for deconstruction. See deconstruction steps.</p>"
+
 /obj/item/device/radio/intercom/Process()
 	if (wiresexposed)
 		on = FALSE

--- a/code/game/objects/items/traitor_plush.dm
+++ b/code/game/objects/items/traitor_plush.dm
@@ -35,9 +35,9 @@
 	new spawned_mob(get_turf(src))
 	qdel(src)
 
-/obj/item/reagent_containers/food/snacks/dehydrated_carp/get_antag_info()
+/obj/item/reagent_containers/food/snacks/dehydrated_carp/get_antag_interactions_info()
 	. = ..()
-	. += "You can add water to this plushie to hydrate it, transforming it into a living space carp after a short delay. Be careful, as the carp will be hostile to you too!"
+	.["Water"] += "<p>Hydrates the plushie, transforming it into a living space carp after a short delay. Be careful, as the carp will be hostile to you too!</p>"
 
 /obj/item/plushbomb
 	name = "kitten plush"

--- a/code/game/objects/items/weapons/cane.dm
+++ b/code/game/objects/items/weapons/cane.dm
@@ -104,4 +104,8 @@
 
 /obj/item/gun/projectile/shotgun/cane/get_antag_info()
 	. = ..()
-	. += "<p>This cane conceals a single-shot shotgun! Ctrl-click the weapon to toggle the concealed trigger, acting in place of a safety. Inaccurate, so you'll want to be close to your victim.</p>"
+	. += "<p>This cane conceals a single-shot shotgun! Inaccurate, so you'll want to be close to your victim.</p>"
+
+/obj/item/gun/projectile/shotgun/cane/get_antag_interactions_info()
+	. = ..()
+	.["CTRL+CLICK"] = "<p>Toggles the concealed trigger, acting in place of a safety.</p>"

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -127,17 +127,6 @@
 			<li>Click on the HCM with an empty hand to remove it from your back.</li>
 		</ol>
 
-		<h4>TOOL INTERACTIONS</h4>
-		<ul>
-			<li>You can toggle the HCM's access panel lock by using an ID card with the required access on it.</li>
-			<li>You can open or close the HCM's maintenance panel by using a crowbar on it. The panel can only be opened if the HCM's access panel is unlocked.</li>
-			<li>You can remove modules or the oxygen tank by using a wrench on the HCM. You can only do this if the maintenance panel is open.</li>
-			<li>You can insert modules, power cells, oxygen tanks by using them on the HCM while its maintenance panel is open.</li>
-			<li>You can repair the HCM's internals by using nanopaste on it while the maintenance panel is open.</li>
-			<li>You can open or close the HCM's wire panel by using a screwdriver on it. This operates as a standard wire control panel, interactable with a multitool, wirecutters, signallers, etc. once open.</li>
-			<li>You can repair damage to the HCM's chest piece by using a stack of the relevant material or a welder on the HCM or the chest piece while the chest piece is deployed.</li>
-		</ul>
-
 		<h4>HARDSUIT INTERFACE</h4>
 		<p>The HCM's Hardsuit Interface can be accessed by using the <code>Open Hardsuit Interface</code> option under the <code>Hardsuit</code> tab in the top right, or using the <code>open-hardsuit-interface`</code>verb in the chat bar.</p>
 		<ul>
@@ -147,6 +136,18 @@
 			<li><b>Suit Pieces</b> displays the name and status of the major components of the hardsuit, and allows you to toggle the helmet on or off.</li>
 			<li>Additional HCM modules and their controls are displayed in the HCM's interface as well.</li>
 		</ul>
+	"}
+
+/obj/item/rig/get_interactions_info()
+	. = ..()
+	.["Crowbar"] += "<p>Toggles the maintenance panel open and closed if it is unlocked.</p>"
+	.["ID Card"] += "<p>Toggle the maintenance panel's access lock with an ID that has the required access. A locked panel cannot be crowbarred open.</p>"
+	.["Nanopaste"] += "<p>While the maintenance panel is open, repairs the HCM's internal components.</p>"
+	.["Screwdriver"] += "<p>Toggles the wiring panel open and closed.</p>"
+	.["Wrench"] += "<p>While the maintenance panel is open, allows you to remove specific components from the HCM, such as oxygen tanks, power cells, or HCM modules.</p>"
+	.["Miscellaneous"] += {"
+		<p>While the maintenance panel is open, oxygen tanks, power cells, and HCM modules can be inserted.</p>
+		<p>WYou can repair damage to the chest piece by using a stack of the relevant material or a welder on the HCM or the chest piece while the chest piece is deployed.</p>
 	"}
 
 /obj/item/rig/get_cell()

--- a/code/modules/codex/codex_atom.dm
+++ b/code/modules/codex/codex_atom.dm
@@ -39,6 +39,24 @@
 /atom/proc/get_mechanics_info()
 	return
 
+// Constants for use to describe special handlers in `get_interactions_info()`. These allow for consistant key names for overriding and stacking purposes.
+// Click handlers
+/atom/var/const/CODEX_INTERACTION_ALT_CLICK = "ALT+CLICK"
+/atom/var/const/CODEX_INTERACTION_ALT_SHIFT_CLICK = "ALT+SHIFT+CLICK"
+/atom/var/const/CODEX_INTERACTION_CTRL_CLICK = "CTRL+CLICK"
+/atom/var/const/CODEX_INTERACTION_CTRL_ALT_CLICK = "CTRL+ALT+CLICK"
+/atom/var/const/CODEX_INTERACTION_CTRL_ALT_SHIFT_CLICK = "CTRL+ALT+SHIFT+CLICK"
+/atom/var/const/CODEX_INTERACTION_CTRL_SHIFT_CLICK = "CTRL+SHIFT+CLICK"
+/atom/var/const/CODEX_INTERACTION_SHIFT_CLICK = "SHIFT+CLICK"
+
+// Use handlers
+/atom/var/const/CODEX_INTERACTION_USE_SELF = "Use On Self"
+/atom/var/const/CODEX_INTERACTION_HAND = "Empty Hand"
+
+// Other cases
+/atom/var/const/CODEX_INTERACTION_EMAG = "Cryptographic Sequencer (EMAG)"
+/atom/var/const/CODEX_INTERACTION_EMP = "EMP"
+
 /**
  * Handler for displaying information on tool interations in the Mechanics section of the atom's codex entry.
  *

--- a/code/modules/codex/codex_atom.dm
+++ b/code/modules/codex/codex_atom.dm
@@ -18,7 +18,13 @@
 
 	var/lore = get_lore_info()
 	var/mechanics = get_mechanics_info()
+	var/interactions = html_list_dl(get_interactions_info())
+	if (interactions)
+		mechanics += "<h4>Interactions</h4>[interactions]"
 	var/antag = get_antag_info()
+	interactions = html_list_dl(get_antag_interactions_info())
+	if (interactions)
+		antag += "<h4>Interactions</h4>[interactions]"
 	if(!lore && !mechanics && !antag)
 		return FALSE
 
@@ -34,12 +40,39 @@
 	return
 
 /**
+ * Handler for displaying information on tool interations in the Mechanics section of the atom's codex entry.
+ *
+ * Returns associative list of strings. Best practice is to append information to existing entries with `+=`, if present (This is null safe), i.e.:
+ * ```dm
+ * . = ..()
+ * .["Screwdriver"] += "<p>Toggles the maintenance panel open and closed.</p>"
+ * ```
+ */
+/atom/proc/get_interactions_info()
+	RETURN_TYPE(/list)
+	return list()
+
+/**
  * Handler for displaying information in the Antagonist section of the atom's codex entry.
  *
  * Returns string.
  */
 /atom/proc/get_antag_info()
 	return
+
+
+/**
+ * Handler for displaying information on tool interations in the Antagonist section of the atom's codex entry.
+ *
+ * Returns associative list of strings. Best practice is to append information to existing entries with `+=`, if present (This is null safe), i.e.:
+ * ```dm
+ * . = ..()
+ * .["Screwdriver"] += "<p>Toggles the maintenance panel open and closed.</p>"
+ * ```
+ */
+/atom/proc/get_antag_interactions_info()
+	RETURN_TYPE(/list)
+	return list()
 
 /**
  * Handler for displaying information in the Lore section of the atom's codex entry.

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -95,9 +95,12 @@ GLOBAL_LIST_EMPTY(admin_departments)
 /obj/machinery/photocopier/faxmachine/get_mechanics_info()
 	. = "<p>The fax machine can be used to transmit paper faxes to other fax machines on the map, or to off-ship organizations handled by server administration. To use the fax machine, you'll need to insert both a paper and your ID card, authenticate, select a destination, the transmit the fax.</p>"
 	. += "<p>You can also fax paper bundles, including photos, using this machine.</p>"
-	. += "<p>You can check the machine's department origin tag using a multitool.</p>"
-	. += "<p>You can link a PDA to it to receive notifications of inbound faxes by clicking on it with the PDA in hand.</p>"
 	. += ..()
+
+/obj/machinery/photocopier/faxmachine/get_interactions_info()
+	. = ..()
+	.["Multitool"] += "<p>Displays the fax machine's department origin tag.</p>"
+	.["PDA"] += "<p>Links the PDA to be notified of inbound faxes, or unlinks the PDA if it's currently linked.</p>"
 
 /obj/machinery/photocopier/faxmachine/get_antag_info()
 	. = "<p>If emagged with a cryptographic sequencer, the fax machine can then have it's origin department tag changed using a multitool. This allows you to send faxes pretending to be from somewhere else on the ship, or even an off-ship origin like EXCOMM.</p>"

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST_EMPTY(admin_departments)
 
 /obj/machinery/photocopier/faxmachine/get_antag_interactions_info()
 	. = ..()
-	.["Cryptographic Sequencer"] += "<p>Emags the fax machine, allowing its origin department tag to be modified using a multitool.</p>"
+	.[CODEX_INTERACTION_EMAG] += "<p>Emags the fax machine, allowing its origin department tag to be modified using a multitool.</p>"
 	.["Multitool"] += {"
 		<p>If emagged, allows changing the fax machine's origin department tag. This allows you to send faxes pretending to be from somewhere else on the ship, or even an off-ship origin like EXCOMM.<br />
 		<strong>NOTE</strong>: Any new department tags created in this way that do not already exist in the list of targets cannot receive faxes, as this does not add new departments to the list of valid fax targets.</p>

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -102,10 +102,13 @@ GLOBAL_LIST_EMPTY(admin_departments)
 	.["Multitool"] += "<p>Displays the fax machine's department origin tag.</p>"
 	.["PDA"] += "<p>Links the PDA to be notified of inbound faxes, or unlinks the PDA if it's currently linked.</p>"
 
-/obj/machinery/photocopier/faxmachine/get_antag_info()
-	. = "<p>If emagged with a cryptographic sequencer, the fax machine can then have it's origin department tag changed using a multitool. This allows you to send faxes pretending to be from somewhere else on the ship, or even an off-ship origin like EXCOMM.</p>"
-	. += "<p><strong>NOTE</strong>: Any new department tags created in this way that do not already exist in the list of targets cannot receive faxes, as this does not add new departments to the list of valid fax targets.</p>"
-	. += ..()
+/obj/machinery/photocopier/faxmachine/get_antag_interactions_info()
+	. = ..()
+	.["Cryptographic Sequencer"] += "<p>Emags the fax machine, allowing its origin department tag to be modified using a multitool.</p>"
+	.["Multitool"] += {"
+		<p>If emagged, allows changing the fax machine's origin department tag. This allows you to send faxes pretending to be from somewhere else on the ship, or even an off-ship origin like EXCOMM.<br />
+		<strong>NOTE</strong>: Any new department tags created in this way that do not already exist in the list of targets cannot receive faxes, as this does not add new departments to the list of valid fax targets.</p>
+	"}
 
 /obj/machinery/photocopier/faxmachine/emag_act(remaining_charges, mob/user, emag_source)
 	if (emagged)

--- a/html/browser/common.css
+++ b/html/browser/common.css
@@ -85,6 +85,10 @@ ul
 	list-style-type: none;
 }
 
+dl dt {
+    font-weight: bold;
+}
+
 li
 {
 	padding: 0 0 2px 0;

--- a/maps/torch/items/explo_shotgun.dm
+++ b/maps/torch/items/explo_shotgun.dm
@@ -17,9 +17,9 @@
 	. += "<br>This gun will be allowed to fire freely once off-ship, otherwise needs to be authorized by XO. \
 	<br>While you can load this gun with lethal ammo, there's a considerable risk of explosion when fired."
 
-/obj/item/gun/projectile/shotgun/pump/exploration/get_antag_info()
+/obj/item/gun/projectile/shotgun/pump/exploration/get_antag_interactions_info()
 	. = ..()
-	. += "<br>You can reinforce the barrel with a simple pipe, lowering chance of explosion to 1 in 10.<br>"
+	.["Pipe"] += "<p>Reinforces the barrel, lowering the chance of explosion to 1 in 10.</p>"
 
 /obj/item/gun/projectile/shotgun/pump/exploration/on_update_icon()
 	..()

--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -117,6 +117,10 @@ ul {
     list-style-type: none;
 }
 
+dl dt {
+    font-weight: bold;
+}
+
 li {
     padding: 0 0 2px 0;
 }


### PR DESCRIPTION
Some tweaking of codex in preparation of my upcoming slow-burn purge of `/attackby()` overrides. Since I plan to not only replace these with the `use_*()` procs added by #32919, but also to update them to current coding standards and best practices, this felt like a good oppurtunity to also update codex entries to include all interactions with various atoms. The interactions procs for the codex makes it, theoretically, easier to piece together these interactions between child and parent procs, while allowing those that fully override parent interactions to override the list accordingly.

![uyRFKg1QMY](https://user-images.githubusercontent.com/11140088/212612929-e3ae89a7-6856-4fa7-993a-70fd3c35e1b3.png)

## Changelog
:cl: SierraKomodo
rscadd: Codex entries can now include a list of various click and item interactions. These still have to be manually written, but are nicely formatted as a list and includes interactions provided by parent types. These can be found at the bottom of the OOC Information and Antagonist Information sections of any given item's codex entry, which in turn is accessed by clicking the codex link that appears when examining items, or searching through the Codex index found with the 'codex' verb.
/:cl:

## Other Changes
- Adds `html_list()` and `html_list_dl()` global procs for generating HTML formatted lists out of `/list` inputs.
- Adds `get_interactions_info()` and `get_antag_interactions_info()` procs to atoms, for generating lists of interactions for the codex.
- Adds `get_interactions_info()` to `/datum/wires` and uses the result of this in machinery's interactions lists.
- Transfers all existing interaction information from mechanics and antag information to their respecting interactions lists.
- Emboldens `<dt>` tags for HTML definition lists.
- Adds a series of `CODEX_INTERACTION_*` constants to serve as pre-defined keys for certain kinds of interactions, such as click handlers, use on self, empty hands, emagging, etc.