### PR TITLE
Include Temperatures in Chemistry Recipe Codex

### DIFF
--- a/code/__defines/math_physics.dm
+++ b/code/__defines/math_physics.dm
@@ -22,6 +22,8 @@
 
 #define CELSIUS + T0C
 
+#define KELVIN_TO_CELSIUS(X) ((X) - T0C)
+
 #define ATMOS_PRECISION 0.0001
 #define QUANTIZE(variable) (round(variable, ATMOS_PRECISION))
 

--- a/code/modules/codex/categories/category_reagents.dm
+++ b/code/modules/codex/categories/category_reagents.dm
@@ -41,6 +41,11 @@
 			else
 				production_strings += "- [jointext(reactant_values, " + ")]: [reaction.result_amount]u [lowertext(initial(result.name))]"
 
+			if (reaction.maximum_temperature < INFINITY)
+				production_strings += "- Maximum temperature: [KELVIN_TO_CELSIUS(reaction.maximum_temperature)]C ([reaction.maximum_temperature]K)"
+			if (reaction.minimum_temperature > 0)
+				production_strings += "- Minimum temperature: [KELVIN_TO_CELSIUS(reaction.minimum_temperature)]C ([reaction.minimum_temperature]K)"
+
 		if(production_strings.len)
 			if(!entry.mechanics_text)
 				entry.mechanics_text = "It can be produced as follows:<br>"


### PR DESCRIPTION
Azzy mentioned the codex for recipes doesn't include temperatures. This fixes that.

## Changelog
:cl: SierraKomodo
rscadd: Codex entries for chemistry recipes now include the minimum and maximum temperatures.
/:cl:

## Other Changes
- Adds a `KELVIN_TO_CELSIUS()` helper macro.