### PR TITLE
Fix AEGs missing safety icon

### DIFF
--- a/code/modules/projectiles/guns/energy/nuclear.dm
+++ b/code/modules/projectiles/guns/energy/nuclear.dm
@@ -120,10 +120,13 @@
 		if("kill") return "nucgun-kill"
 
 /obj/item/gun/energy/gun/nuclear/on_update_icon()
-	var/list/new_overlays = list()
+	overlays.Cut()
+	overlays += get_charge_overlay()
+	overlays += get_reactor_overlay()
+	overlays += get_mode_overlay()
 
-	new_overlays += get_charge_overlay()
-	new_overlays += get_reactor_overlay()
-	new_overlays += get_mode_overlay()
-
-	overlays = new_overlays
+	// Safety
+	if (ismob(loc))
+		var/mob/M = loc
+		if (M.skill_check(SKILL_WEAPONS, SKILL_BASIC))
+			overlays += image('icons/obj/guns/gui.dmi', "safety[safety()]")


### PR DESCRIPTION
Technically a bandaid fix because, really, this should be able to just call parent. However, parent works off actual multiple versions of the same sprite, while the AEG uses overlays. This pains me.

## Changelog
:cl: SierraKomodo
bugfix: Advanced Energy Guns now have a working safety indicator icon.
/:cl:

## Bug Fixes
- Fixes #32928