### PR TITLE
Fireproofing Fireproof Areas

### DIFF
--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -135,6 +135,9 @@
 /obj/machinery/door/blast/get_material()
 	return implicit_material
 
+/obj/machinery/door/blast/get_material_melting_point()
+	return 10000 // Blast doors are implicitly heavily fire resistant and are used for containing high-temperature areas like burn chambers.
+
 // Proc: attackby()
 // Parameters: 2 (C - Item this object was clicked with, user - Mob which clicked this object)
 // Description: If we are clicked with crowbar or wielded fire axe, try to manually open the door.

--- a/code/game/turfs/simulated/floor_acts.dm
+++ b/code/game/turfs/simulated/floor_acts.dm
@@ -40,15 +40,16 @@
 /turf/simulated/floor/adjacent_fire_act(turf/simulated/floor/adj_turf, datum/gas_mixture/adj_air, adj_temp, adj_volume)
 	var/dir_to = get_dir(src, adj_turf)
 
-	for (var/atom/movable/A as anything in src)
-		// Windows first - Directional windows don't pass the below atmos checks.
-		if (istype(A, /obj/structure/window))
-			var/obj/structure/window/W = A
-			if (W.dir == dir_to || W.is_fulltile()) //Same direction or diagonal (full tile)
-				W.fire_act(adj_air, adj_temp, adj_volume)
-			continue
+	// Check for and affect things in a certain order to accomodate atoms that should cover and protect other atoms, such as fire doors
+	// First, to avoid multiple type checked loops through source, build lists of the specific types of atoms
+	var/list/fire_doors = list()
+	var/list/other_doors = list()
+	var/list/blocking_windows = list()
 
-		// Only effect atoms that block air and fire.
+	var/list/blocking_atoms = list() // These atoms protect everything else on the turf from the fire
+	var/list/other_atoms = list() // These atoms do not protect anything else
+
+	for (var/atom/movable/A as anything in src)
 		var/canpass
 		switch (A.atmos_canpass)
 			if (CANPASS_ALWAYS)
@@ -62,4 +63,38 @@
 		if (canpass)
 			continue
 
-		A.fire_act(adj_air, adj_temp, adj_volume)
+		if (istype(A, /obj/machinery/door))
+			var/obj/machinery/door/door = A
+			if (istype(door, /obj/machinery/door/blast) || istype(door, /obj/machinery/door/firedoor))
+				fire_doors += door
+			else
+				other_doors += door
+			continue
+
+		if (istype(A, /obj/structure/window))
+			var/obj/structure/window/window = A
+			if (window.dir == dir_to || window.is_fulltile()) //Same direction or diagonal (full tile)
+				blocking_windows += window
+			else
+				other_atoms += window
+			continue
+
+		other_atoms += A
+
+	// These checks prevent null entries from showing up due to merging empty lists
+	if (length(fire_doors))
+		blocking_atoms |= fire_doors
+	if (length(other_doors))
+		blocking_atoms |= other_doors
+	if (length(blocking_windows))
+		blocking_atoms |= blocking_windows
+
+	// Blocking - Hit the first one then stop.
+	if (length(blocking_atoms))
+		var/atom/A = blocking_atoms[0]
+		A.fire_act(adj_turf, adj_air, adj_temp, adj_volume)
+		return
+
+	// Non-blocking - Hit everything
+	for (var/atom/A as anything in other_atoms)
+		A.fire_act(adj_turf, adj_air, adj_temp, adj_volume)

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -10480,11 +10480,19 @@
 /obj/machinery/button/blast_door{
 	id_tag = "disvent";
 	name = "Incinerator Vent Control";
+	pixel_x = 8;
 	pixel_y = -24
 	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
+	},
+/obj/machinery/button/blast_door{
+	desc = "A switch made to open the incinerator blast doors.";
+	id_tag = "IncineratorBlastDoors";
+	name = "Incinerator Blast Doors";
+	pixel_x = -8;
+	pixel_y = -24
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/incinerator)
@@ -10692,6 +10700,10 @@
 	id_tag = "incinerator_airlock_interior";
 	locked = 1;
 	name = "Mixing Room Interior Airlock"
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "IncineratorBlastDoors";
+	name = "Incinerator Blast Door"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/incinerator)
@@ -11137,6 +11149,10 @@
 	id_tag = "incinerator_airlock_exterior";
 	locked = 1;
 	name = "Mixing Room Exterior Airlock"
+	},
+/obj/machinery/door/blast/regular{
+	id_tag = "IncineratorBlastDoors";
+	name = "Incinerator Blast Door"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/incinerator)


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
tweak: Blast doors now have a much higher fire resistance of 10,000 kelvin. This should allow them to withstand the incinerator and nacelle burn chambers.
tweak: Certain atoms now protect other atoms on the same tile from taking fire damage, at least until they break. The atoms, in the order they are checked and affected, are: Closed blast and fire doors, closed doors, and windows.
maptweak: The incinerator now has blast doors added to cover the two airlocks, so your fires don't destroy them.
/:cl:

## Bug Fixes
- Fixes #32936
- Fixes #32937
