### PR TITLE
Machinery emp tweak

### DIFF
--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -136,8 +136,12 @@
 		if (prob(100 / severity) && istype(wires))
 			if (prob(20))
 				wires.RandomCut()
+				visible_message(SPAN_DANGER("A shower of sparks sprays out of \the [src]'s wiring panel!"))
+				sparks(3, 0, get_turf(src))
 			else
 				wires.RandomPulse()
+				visible_message(SPAN_WARNING("Something sparks inside \the [src]'s wiring panel!"))
+				new /obj/effect/sparks(get_turf(src))
 
 	..()
 

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -143,7 +143,7 @@
 				visible_message(SPAN_WARNING("Something sparks inside \the [src]'s wiring panel!"))
 				new /obj/effect/sparks(get_turf(src))
 
-	..()
+		..()
 
 /obj/machinery/ex_act(severity)
 	..()

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -121,7 +121,7 @@
 	return PROCESS_KILL // Only process if you need to.
 
 /obj/machinery/emp_act(severity)
-	if(use_power && stat == EMPTY_BITFIELD)
+	if(use_power && operable())
 		use_power_oneoff(7500/severity)
 
 		var/obj/effect/overlay/pulse2 = new /obj/effect/overlay(loc)


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: EMPs will no longer pulse wiring in broken machinery.
rscadd: Machinery whos wiring is affected by EMPs will now spark and display a visible message indicating something in the wiring panel is damaged.
tweak: Standardized EMP damage now only effects machinery that is turned on and functional.
/:cl: