### PR TITLE
Runtime batch 2023 01 16

### DIFF
--- a/code/_helpers/matrices.dm
+++ b/code/_helpers/matrices.dm
@@ -90,7 +90,7 @@ var/global/list/delta_index = list(
 
 //Exxagerates or removes brightness
 /proc/color_contrast(value)
-	value = clamp(value, -100, 100)
+	value = round(clamp(value, -100, 100))
 	if(value == 0)
 		return color_identity()
 

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -142,9 +142,10 @@
 			to_chat(user, SPAN_WARNING("You waste some [name] and fail to build \the [recipe.display_name()]!"))
 			return
 		var/atom/O = recipe.spawn_result(user, user.loc, produced)
-		O.add_fingerprint(user)
-
-		user.put_in_hands(O)
+		// Stack recipes will delete the created item if it merges with a stack already in hand.
+		if (!QDELETED(O))
+			O.add_fingerprint(user)
+			user.put_in_hands(O)
 
 /obj/item/stack/Topic(href, href_list)
 	..()

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -134,7 +134,7 @@
 
 	if (recipe.time)
 		to_chat(user, SPAN_NOTICE("Building [recipe.display_name()] ..."))
-		if (!user.do_skilled(recipe.time, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT))
+		if (!user.do_skilled(recipe.time, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT | DO_BAR_OVER_USER))
 			return
 
 	if (use(required))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2096,25 +2096,27 @@
 				log_and_message_admins("has forced [last_ckey]/([M]) to ghost and deactivate.")
 				return
 
-			var/obj/machinery/cryopod/C
-			if (isrobot(M))
-				for (var/obj/machinery/cryopod/robot/CP in SSmachines.machinery)
-					if (CP.occupant || !(CP.z in GLOB.using_map.station_levels))
-						continue
-					C = CP
-			else
-				for (var/obj/machinery/cryopod/CP in SSmachines.machinery)
-					if (CP.occupant || !(CP.z in GLOB.using_map.station_levels))
-						continue
-					C = CP
+			if (!istype(M.loc, /obj/machinery/cryopod))
+				var/obj/machinery/cryopod/C
+				if (isrobot(M))
+					for (var/obj/machinery/cryopod/robot/CP in SSmachines.machinery)
+						if (CP.occupant || !(CP.z in GLOB.using_map.station_levels))
+							continue
+						C = CP
+				else
+					for (var/obj/machinery/cryopod/CP in SSmachines.machinery)
+						if (CP.occupant || !(CP.z in GLOB.using_map.station_levels))
+							continue
+						C = CP
 
-			if (!C || C.occupant)
-				to_chat(usr, SPAN_WARNING("Could not find an empty cryopod!"))
-				return
+				if (!C || C.occupant)
+					to_chat(usr, SPAN_WARNING("Could not find an empty cryopod!"))
+					return
+
+				C.set_occupant(M)
 
 			log_and_message_admins("has put [last_ckey]/([M]) into a cryopod and ghosted them.")
 
-			C.set_occupant(M)
 			var/ghost = M.ghostize(FALSE)
 			if (ghost)
 				show_player_panel(M)

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -27,6 +27,15 @@
 		attach_accessory(null, new path (src))
 
 
+/obj/item/clothing/Destroy()
+	for (var/obj/item/clothing/accessory/A as anything in accessories)
+		remove_accessory(null, A)
+		qdel(A)
+	accessories.Cut()
+	accessories = null
+	. = ..()
+
+
 // Updates the icons of the mob wearing the clothing item, if any.
 /obj/item/clothing/proc/update_clothing_icon()
 	return


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Progress bars now appear when creating items from stacks of materials.
bugfix: Stacks with an amount of 0 will no longer appear when crafting stacks from materials when you already have a stack in your other hand or you spam-click.
bugfix: Force-cryoing mobs that are already in cryopods no longer forcemoves them into another cryopod and breaks the original pod.
/:cl:

## Other Changes
- `color_contrast()` now rounds `value` before applying it against the matrix list, as a failsafe for proccalls feeding it decimals.
- Fixes accessories not being properly cleaned up from clothing when destroyed.

## Bug Fixes
- Fixes #32614
- Fixes #32799