### PR TITLE
Species specific footprints for footwear/clothing

### DIFF
--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -17,7 +17,10 @@
 	var/volume_multiplier = 1
 
 	var/move_trail = /obj/effect/decal/cleanable/blood/tracks/footprints // if this item covers the feet, the footprints it should leave
-
+	var/list/species_trails = list(
+		"Default" = /obj/effect/decal/cleanable/blood/tracks/footprints,
+		SPECIES_UNATHI = /obj/effect/decal/cleanable/blood/tracks/claw
+	)
 
 /obj/item/clothing/Initialize()
 	. = ..()
@@ -98,9 +101,22 @@
 	return 1
 
 /obj/item/clothing/equipped(mob/user)
+	species_tracks(user)
 	if(needs_vision_update())
 		update_vision()
 	return ..()
+
+/obj/item/clothing/proc/species_tracks(mob/user)
+	//Change the tracks decal according to species.
+	var/bodytype = "Default"
+	var/mob/living/carbon/human/H
+	if(ishuman(user))
+		H = user
+		bodytype = H.species.get_bodytype()
+	if(!species_trails[bodytype])
+		move_trail = species_trails["Default"]
+	else
+		move_trail = species_trails[bodytype]
 
 /obj/item/clothing/proc/refit_for_species(target_species)
 	if(!species_restricted)

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -16,14 +16,23 @@
 	var/smell_state = SMELL_DEFAULT
 	var/volume_multiplier = 1
 
-	// The footprints left by items covering the feet (space suits and shoes) chosen by wearer bodytype (NOT SPECIES).
-	// "Default" is used if the wearer's bodytype isn't in the list.
-	// Change species_trails to give custom footprints, move_trail doesn't need to be changed..
+	/**
+	* The footprints decal left by items covering the feet. This includes space suits, not just footwear.
+	* This is called by species_tracks() to select the correct decal by wearer body type which is not the same as their species.
+	* Calling get_bodytype() on SPECIES_YEOSA returns SPECIES_UNATHI as an example.
+	*
+	* '"Default"' - Always include this. This can be the only value in the list if every species should use the specified footprint decals.
+	* If the wearer's body type doesn't match any of the specified body types, this is the value the proc uses by default.
+	*
+	* 'SPECIES_UNATHI' - An example of a valid body type. Assign any body types a custom footprint decal and the proc will use the specified decal instead of the default.
+	* Multiple body types can have specified footprint decals in the list.
+	*/
 	var/list/species_trails = list(
 		"Default" = /obj/effect/decal/cleanable/blood/tracks/footprints,
 		SPECIES_UNATHI = /obj/effect/decal/cleanable/blood/tracks/claw
 	)
-	var/move_trail = /obj/effect/decal/cleanable/blood/tracks/footprints // Default value set since there's no real reason for this to be null.
+	/// Use species_trails instead. This variable is now only used to store the footprint decals chosen when someone equips a clothing item.
+	var/move_trail = /obj/effect/decal/cleanable/blood/tracks/footprints // Default value set since there's no reason for this to be null.
 
 
 /obj/item/clothing/Initialize()
@@ -110,9 +119,9 @@
 		update_vision()
 	return ..()
 
+/// This proc is called when a clothing item is equipped to determine what footprints it gives the wearer. See species_trails for details on how to set this up.
 /obj/item/clothing/proc/species_tracks(mob/user)
-	//Change the tracks decal according to species.
-	var/bodytype = "Default"
+	var/bodytype = "Default"					// Should never try to find a null bodytype.
 	var/mob/living/carbon/human/H
 	if(ishuman(user))
 		H = user

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -16,11 +16,15 @@
 	var/smell_state = SMELL_DEFAULT
 	var/volume_multiplier = 1
 
-	var/move_trail = /obj/effect/decal/cleanable/blood/tracks/footprints // if this item covers the feet, the footprints it should leave
+	// The footprints left by items covering the feet (space suits and shoes) chosen by wearer bodytype (NOT SPECIES).
+	// "Default" is used if the wearer's bodytype isn't in the list.
+	// Change species_trails to give custom footprints, move_trail doesn't need to be changed..
 	var/list/species_trails = list(
 		"Default" = /obj/effect/decal/cleanable/blood/tracks/footprints,
 		SPECIES_UNATHI = /obj/effect/decal/cleanable/blood/tracks/claw
 	)
+	var/move_trail = /obj/effect/decal/cleanable/blood/tracks/footprints // Default value set since there's no real reason for this to be null.
+
 
 /obj/item/clothing/Initialize()
 	. = ..()
@@ -112,10 +116,10 @@
 	var/mob/living/carbon/human/H
 	if(ishuman(user))
 		H = user
-		bodytype = H.species.get_bodytype()
-	if(!species_trails[bodytype])
+		bodytype = H.species.get_bodytype()		// Gets the species bodytype, this is NOT the user's species.
+	if(!species_trails[bodytype])				// If the species bodytype isn't assigned a specific footprint, use the assigned default.
 		move_trail = species_trails["Default"]
-	else
+	else										// Otherwise use the footprint assigned to the bodytype.
 		move_trail = species_trails[bodytype]
 
 /obj/item/clothing/proc/refit_for_species(target_species)

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -230,7 +230,6 @@
 /obj/item/clothing/shoes/laceup/sneakies
 	desc = "The height of fashion, and they're pre-polished. Upon further inspection, the soles appear to be on backwards. They look uncomfortable."
 	species_restricted = list(SPECIES_HUMAN, SPECIES_IPC)
-	move_trail = /obj/effect/decal/cleanable/blood/tracks/footprints/reversed
 	species_trails = list(
 		"Default" = /obj/effect/decal/cleanable/blood/tracks/footprints/reversed
 	)

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -231,6 +231,9 @@
 	desc = "The height of fashion, and they're pre-polished. Upon further inspection, the soles appear to be on backwards. They look uncomfortable."
 	species_restricted = list(SPECIES_HUMAN, SPECIES_IPC)
 	move_trail = /obj/effect/decal/cleanable/blood/tracks/footprints/reversed
+	species_trails = list(
+		"Default" = /obj/effect/decal/cleanable/blood/tracks/footprints/reversed
+	)
 	item_flags = ITEM_FLAG_SILENT
 
 /obj/item/clothing/shoes/heels


### PR DESCRIPTION
Unathi footwear is usually depicted as fitting around their digitigrade feet and the large claws on them, however even with their claws usually poking out of their footwear they've still left human-shaped footprints behind.

This PR implements a feature for species-specific footprints for footwear. Hardsuit boots on a human or skrell leaves human-shaped footprints, while hardsuit boots on an Unathi leaves Unathi-shaped footprints. This also works for magboots, and Unathi footwear.

Only one item exists that has unique footprint decals. It has been updated to work with the new proc.

The new proc is hooked in for use by all clothing instead of just footwear because footprints are also taken from space suits too, since they also cover the feet.

Testing image below, the same pair of magboots were passed between a Human and an Unathi repeatedly to make sure the correct footprints were chosen every time. Not pictured is the HCM test (passed) and making sure the footwear with unique footprints still worked correctly (passed).
![image](https://user-images.githubusercontent.com/1986009/212843410-fc9a86cc-3d1b-4e98-afc4-376f2e497b7d.png)
No maintenance drones were harmed in the making of this PR.

:cl: Nerezza
rscadd: Unathi now leave their unique clawprints even while wearing footwear.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->