### PR TITLE
Plasma cutter QoL tweaks

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -160,8 +160,15 @@
 	if(isWirecutter(W))
 		if(!shock(user, 100))
 			playsound(loc, 'sound/items/Wirecutter.ogg', 100, 1)
-			new /obj/item/stack/material/rods(get_turf(src), is_broken() ? 1 : 2, material.name)
-			qdel(src)
+			dismantle()
+		return
+
+	if(istype(W, /obj/item/gun/energy/plasmacutter)) // Plasma cutter shouldn't need to touch the grille to cut it, so no shock check.
+		var/obj/item/gun/energy/plasmacutter/cutter = W
+		if(!cutter.slice(user))
+			return
+		playsound(loc, 'sound/items/Welder.ogg', 80, 1)
+		dismantle()
 		return
 
 	if((isScrewdriver(W)) && (istype(loc, /turf/simulated) || anchored))
@@ -185,6 +192,10 @@
 
 	if (!(W.obj_flags & OBJ_FLAG_CONDUCTIBLE) || !shock(user, 70))
 		..()
+
+/obj/structure/grille/proc/dismantle()
+	new /obj/item/stack/material/rods(get_turf(src), is_broken() ? 1 : 2, material.name)
+	qdel(src)
 
 /obj/structure/grille/on_death(new_death_state)
 	visible_message(SPAN_WARNING("\The [src] falls to pieces!"))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -294,7 +294,10 @@
 			to_chat(user, SPAN_NOTICE("You're not sure how to dismantle \the [src] properly."))
 		else
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-			user.visible_message(SPAN_WARNING("[user] dismantles \the [src]."), SPAN_NOTICE("You dismantle \the [src]."))
+			user.visible_message(
+				SPAN_WARNING("[user] dismantles \the [src]."),
+				SPAN_NOTICE("You dismantle \the [src].")
+			)
 			dismantle()
 		return
 
@@ -343,9 +346,15 @@
 		if(!cutter.slice(user))
 			return
 		playsound(src, 'sound/items/Welder.ogg', 80, 1)
-		user.visible_message(SPAN_WARNING("[user] has started slicing \the [src] apart!"),SPAN_NOTICE("You start slicing \the [src] apart."))
+		user.visible_message(
+			SPAN_WARNING("[user] has started slicing \the [src] apart!"),
+			SPAN_NOTICE("You start slicing \the [src] apart.")
+		)
 		if(do_after(user, 2 SECONDS, src, DO_PUBLIC_UNIQUE))
-			user.visible_message(SPAN_WARNING("[user] slices \the [src] into sheets!"),SPAN_NOTICE("You slice \the [src] into sheets."))
+			user.visible_message(
+				SPAN_WARNING("[user] slices \the [src] into sheets!"),
+				SPAN_NOTICE("You slice \the [src] into sheets.")
+			)
 			playsound(src, 'sound/items/Welder.ogg', 80, 1)
 			dismantle()
 		return

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -294,13 +294,8 @@
 			to_chat(user, SPAN_NOTICE("You're not sure how to dismantle \the [src] properly."))
 		else
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-			visible_message(SPAN_NOTICE("[user] dismantles \the [src]."))
-			var/obj/item/stack/material/S = material.place_sheet(loc, is_fulltile() ? 4 : 1)
-			if(S && reinf_material)
-				S.reinf_material = reinf_material
-				S.update_strings()
-				S.update_icon()
-			qdel(src)
+			user.visible_message(SPAN_WARNING("[user] dismantles \the [src]."), SPAN_NOTICE("You dismantle \the [src]."))
+			dismantle()
 		return
 
 	if (isCoil(W) && is_fulltile())
@@ -343,17 +338,16 @@
 			to_chat(user, SPAN_NOTICE("The new ID of \the [src] is [id]."))
 		return
 
-	if (istype(W, /obj/item/gun/energy/plasmacutter) && anchored)
+	if (istype(W, /obj/item/gun/energy/plasmacutter))
 		var/obj/item/gun/energy/plasmacutter/cutter = W
 		if(!cutter.slice(user))
 			return
 		playsound(src, 'sound/items/Welder.ogg', 80, 1)
-		visible_message(SPAN_NOTICE("[user] has started slicing through the window's frame!"))
+		user.visible_message(SPAN_WARNING("[user] has started slicing \the [src] apart!"),SPAN_NOTICE("You start slicing \the [src] apart."))
 		if(do_after(user, 2 SECONDS, src, DO_PUBLIC_UNIQUE))
-			visible_message(SPAN_WARNING("[user] has sliced through the window's frame!"))
+			user.visible_message(SPAN_WARNING("[user] slices \the [src] into sheets!"),SPAN_NOTICE("You slice \the [src] into sheets."))
 			playsound(src, 'sound/items/Welder.ogg', 80, 1)
-			construction_state = 0
-			set_anchored(0)
+			dismantle()
 		return
 
 	if (istype(W, /obj/item/stack/material))
@@ -412,6 +406,14 @@
 		return
 
 	..()
+
+/obj/structure/window/proc/dismantle()
+	var/obj/item/stack/material/S = material.place_sheet(loc, is_fulltile() ? 4 : 1)
+	if(S && reinf_material)
+		S.reinf_material = reinf_material
+		S.update_strings()
+		S.update_icon()
+	qdel(src)
 
 /obj/structure/window/grab_attack(obj/item/grab/G)
 	if (G.assailant.a_intent != I_HURT)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -101,8 +101,11 @@
 	var/safety_state = 1
 	var/has_safety = TRUE
 	var/safety_icon 	   //overlay to apply to gun based on safety state, if any
-	var/gun_skill = SKILL_WEAPONS	// What skill governs this gun's training. Basic training with this skill is required to see the safety icon.
-	var/safety_skill = SKILL_EXPERT // What skill level covers safely handling this gun. Anything less and accidents can occur.
+
+	/// What skill governs safe handling of this gun. Basic skill level and higher will also show the safety overlay to the player.
+	var/gun_skill = SKILL_WEAPONS
+	/// What skill level is needed in the gun's skill to completely negate the chance of an accident.
+	var/safety_skill = SKILL_EXPERT
 
 /obj/item/gun/Initialize()
 	. = ..()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -101,6 +101,8 @@
 	var/safety_state = 1
 	var/has_safety = TRUE
 	var/safety_icon 	   //overlay to apply to gun based on safety state, if any
+	var/gun_skill = SKILL_WEAPONS	// What skill governs this gun's training. Basic training with this skill is required to see the safety icon.
+	var/safety_skill = SKILL_EXPERT // What skill level covers safely handling this gun. Anything less and accidents can occur.
 
 /obj/item/gun/Initialize()
 	. = ..()
@@ -129,7 +131,7 @@
 			else
 				item_state_slots[slot_l_hand_str] = initial(item_state)
 				item_state_slots[slot_r_hand_str] = initial(item_state)
-		if(M.skill_check(SKILL_WEAPONS,SKILL_BASIC))
+		if(M.skill_check(gun_skill,SKILL_BASIC))
 			overlays += image('icons/obj/guns/gui.dmi',"safety[safety()]")
 	if(safety_icon)
 		overlays += image(icon,"[safety_icon][safety()]")
@@ -636,7 +638,7 @@
 /obj/item/gun/proc/can_autofire()
 	return (can_autofire && world.time >= next_fire_time)
 
-/obj/item/gun/proc/check_accidents(mob/living/user, message = "[user] fumbles with the [src] and it goes off!",skill_path = SKILL_WEAPONS, fail_chance = 20, no_more_fail = SKILL_EXPERT, factor = 2)
+/obj/item/gun/proc/check_accidents(mob/living/user, message = "[user] fumbles with \the [src] and it goes off!",skill_path = gun_skill, fail_chance = 20, no_more_fail = safety_skill, factor = 2)
 	if(istype(user))
 		if(!safety() && user.skill_fail_prob(skill_path, fail_chance, no_more_fail, factor) && special_check(user))
 			user.visible_message(SPAN_WARNING(message))

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -142,7 +142,7 @@
 
 /obj/item/gun/energy/plasmacutter
 	name = "plasma cutter"
-	desc = "A mining tool capable of expelling concentrated plasma bursts. You could use it to cut limbs off of xenos! Or, you know, mine stuff."
+	desc = "An industrial tool that expels focused plasma bursts for deconstruction and mining."
 	charge_meter = 0
 	icon = 'icons/obj/guns/plasmacutter.dmi'
 	icon_state = "plasmacutter"
@@ -157,6 +157,10 @@
 	max_shots = 10
 	self_recharge = 1
 	var/datum/effect/effect/system/spark_spread/spark_system
+
+	// As an industrial tool the plasma cutter's safety training falls under construction.
+	gun_skill = SKILL_CONSTRUCTION
+	safety_skill = SKILL_ADEPT
 
 /obj/item/gun/energy/plasmacutter/mounted
 	name = "mounted plasma cutter"
@@ -178,7 +182,7 @@
 	if(!safety())
 		if(M)
 			M.welding_eyecheck()//Welding tool eye check
-			if(check_accidents(M, "[M] loses grip on [src] from its sudden recoil!",SKILL_CONSTRUCTION, 60, SKILL_ADEPT))
+			if(check_accidents(M, "[M] loses grip on \the [src] from its sudden recoil!",gun_skill, 60, safety_skill))
 				return 0
 		spark_system.start()
 		return 1


### PR DESCRIPTION
The main feature of this PR is that plasma cutters now slice windows into sheets instead of just unanchoring them. The former behavior was inconsistent with how plasma cutters cut through structures. They also now cut through grilles because there was no reason they couldn't have before.

Additionally, handheld plasma cutters currently do handling safety/accident checks using weapons expertise instead of construction due to an oversight. I've added two new variables for guns that declare their required skill type and skill level for safe handling.
Industrial tools are often designed with great emphasis on safety so the plasma cutter only requires adept skill for complete safety, instead of experienced. The safety overlay for plasma cutters is also now shown for players with at least basic construction instead of basic weapons expertise, since I've changed the display to show up based off the new gun skill type variable too.

Lastly I fixed some "the"s into "\the"s so we don't see lines like "Ulric McSecurity fumbles with the the plasma cutter and it goes off!" and I updated some visible messages so the user gets first person messages instead of third.

:cl: Nerezza
rscadd: Plasma cutters can now slice through metal grilles.
tweak: Plasma cutters now actually cut through windows instead of just unanchoring them.
tweak: Plasma cutters now use construction skill instead of weapons expertise for safely handling them.
tweak: Plasma cutter safety overlays are shown for users with construction skill instead of weapons expertise.
spellcheck: You will now no longer fumble "the the compact smartgun" when you have a firearms accident.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->