### PR TITLE
`attackby()` to `use_*()` - Machinery

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -31,6 +31,7 @@
 #include "code\__defines\armor.dm"
 #include "code\__defines\atmos.dm"
 #include "code\__defines\atmospherics.dm"
+#include "code\__defines\atom_interactions.dm"
 #include "code\__defines\chemistry.dm"
 #include "code\__defines\client.dm"
 #include "code\__defines\colors.dm"

--- a/code/__defines/atom_interactions.dm
+++ b/code/__defines/atom_interactions.dm
@@ -1,0 +1,9 @@
+// Macros to attempt chains of `use_*` procs independently of `resolve_attackby())`.
+/// Attempt use procs in this order: use_tool > attackby
+#define TRY_USE_TOOL(SRC, TOOL, USER, CLICKPARAM) (SRC.use_tool(TOOL, USER, CLICKPARAM) || SRC.attackby(TOOL, USER, CLICKPARAM))
+
+/// Attempt use procs in this order: use_grab > use_tool > attackby
+#define TRY_USE_GRAB(SRC, GRAB, USER, CLICKPARAM) (SRC.use_grab(GRAB, CLICKPARAM) || TRY_USE_TOOL(SRC, GRAB, USER, CLICKPARAM))
+
+/// Attempt use procs in this order: use_weapon > use_tool > attackby
+#define TRY_USE_WEAPON(SRC, WEAPON, USER, CLICKPARAM) (SRC.use_weapon(WEAPON, USER, CLICKPARAM) || TRY_USE_TOOL(SRC, WEAPON, USER, CLICKPARAM))

--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -315,3 +315,7 @@
 #define ATOM_FLOURESCENCE_NONE 0 // Not flourescent
 #define ATOM_FLOURESCENCE_INACTIVE 1 // Flourescent but not actively lit
 #define ATOM_FLOURESCENCE_ACTVE 2 // Flourescent and actively lit. Helps prevent repeated processing on a flourescent atom by multiple UV lights
+
+
+/// Generates a string that can be used in displayed text for IDs that may be contained in another atom. Generally paired with the result of GetIdCard()
+#define GET_ID_CARD_NAME(ATOM, ID) (ID == ATOM ? "\the [ID]" : "\the [ID] in \the [ATOM]")

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -63,6 +63,43 @@ avoid code duplication. This includes items that may sometimes act as a standard
 
 
 /**
+ * Verifies the target can still be interacted with after, e.g. a do_after timer or input dialog, or other proc calls that sleep.
+ *
+ * **Parameters**:
+ * - `target` - The atom that was clicked on.
+ * - `item` (Optional) - The atom being used. This will be compared against active hand.
+ * - `silent` (Booleant, default `FALSE`) - If set, `src` will not be sent feedback messages on failure.
+ *
+ * Returns boolean.
+ */
+/mob/proc/use_sanity_check(atom/target, atom/item = null, silent = FALSE)
+	SHOULD_CALL_PARENT(TRUE)
+
+	if (QDELETED(target))
+		if (!silent)
+			to_chat(src, SPAN_WARNING("The item you were interacting with no longer exists."))
+		return FALSE
+
+	if (!target.Adjacent(src))
+		if (!silent)
+			to_chat(src, SPAN_WARNING("You must remain next to \the [target] to complete that action."))
+		return FALSE
+
+	if (!isnull(item))
+		if (QDELETED(item))
+			if (!silent)
+				to_chat(src, SPAN_WARNING("The item you were using no longer exists."))
+			return FALSE
+
+		if (get_active_hand() != item)
+			if (!silent)
+				to_chat(src, SPAN_WARNING("\The [item] must remain in your active hand to complete that action."))
+			return FALSE
+
+	return TRUE
+
+
+/**
  * Interaction handler for using an item on yourself. This is called and the result checked before the other `use_*`
  * interaction procs are called, regardless of user intent.
  *

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -35,6 +35,9 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /**
  * Called when the item is in the active hand and another atom is clicked. This is generally called by `ClickOn()`.
  *
+ * This passes down to `attack()`, `use_user()`, `use_grab()`, `use_weapon()`, `use_tool()`, and `attackby()`, in that order, depending on item
+ * flags and user's intent.
+ *
  * **Parameters**:
  * - `A` - The atom that was clicked.
  * - `user` - The mob using the item.
@@ -47,10 +50,133 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		add_fingerprint(user)
 	if ((item_flags & ITEM_FLAG_TRY_ATTACK) && attack(A, user))
 		return TRUE
-	return A.attackby(src, user, click_params)
+	if (A == user)
+		. = user.use_user(src, click_params)
+	if (!. && istype(src, /obj/item/grab))
+		. = A.use_grab(src, click_params)
+	if (!. && user.a_intent == I_HURT)
+		. = A.use_weapon(src, user, click_params)
+	if (!.)
+		. = A.use_tool(src, user, click_params)
+	if (!.)
+		return A.attackby(src, user, click_params)
 
 
 /**
+ * Interaction handler for using an item on yourself. This is called and the result checked before the other `use_*`
+ * interaction procs are called, regardless of user intent.
+ *
+ * **Parameters**:
+ * - `tool` - The item being used by the mob.
+ * - `click_params` - List of click parameters.
+ *
+ * Returns boolean to indicate whether the attack call was handled or not. If `FALSE`, the next `use_*` proc in the
+ * resolve chain will be called.
+ */
+/mob/proc/use_user(obj/item/tool, list/click_params = list())
+	SHOULD_CALL_PARENT(TRUE)
+	return FALSE
+
+
+/mob/living/carbon/human/use_user(obj/item/tool, list/click_params)
+	// Devouring
+	if (zone_sel.selecting == BP_MOUTH && can_devour(tool, silent = TRUE))
+		var/obj/item/blocked = check_mouth_coverage()
+		if (blocked)
+			to_chat(src, SPAN_WARNING("\The [blocked] is in the way!"))
+			return TRUE
+		if (devour(tool))
+			return TRUE
+
+	return ..()
+
+
+/**
+ * Interaction handler for being clicked on with a grab. This is called regardless of user intent.
+ *
+ * **Parameters**:
+ * - `grab` - The grab item being used.
+ * - `click_params` - List of click parameters.
+ *
+ * Returns boolean to indicate whether the attack call was handled or not. If `FALSE`, the next `use_*` proc in the
+ * resolve chain will be called.
+ */
+/atom/proc/use_grab(obj/item/grab/grab, list/click_params)
+	return FALSE
+
+
+/**
+ * Interaction handler for using an item on this atom with harm intent. Generally, this is for attacking the atom.
+ *
+ * **Parameters**:
+ * - `weapon` - The item being used on this atom.
+ * - `user` - The mob interacting with this atom.
+ * - `click_params` - List of click parameters.
+ *
+ * Returns boolean to indicate whether the attack call was handled or not. If `FALSE`, the next `use_*` proc in the
+ * resolve chain will be called.
+ */
+/atom/proc/use_weapon(obj/item/weapon, mob/user, list/click_params = list())
+	SHOULD_CALL_PARENT(TRUE)
+	// Standardized damage
+	if (user.a_intent == I_HURT && weapon.force > 0 && get_max_health() && !HAS_FLAGS(weapon.item_flags, ITEM_FLAG_NO_BLUDGEON))
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.do_attack_animation(src)
+		var/damage_flags = weapon.damage_flags()
+		if (!can_damage_health(weapon.force, weapon.damtype, damage_flags))
+			playsound(src, damage_hitsound, 50)
+			user.visible_message(
+				SPAN_WARNING("\The [user] hits \the [src] with \a [weapon], but it bounces off!"),
+				SPAN_WARNING("You hit \the [src] with \the [weapon], but it bounces off!")
+			)
+			return TRUE
+		playsound(src, damage_hitsound, 75)
+		user.visible_message(
+			SPAN_DANGER("\The [user] hits \the [src] with \a [weapon]!"),
+			SPAN_DANGER("You hit \the [src] with \the [weapon]!")
+		)
+		damage_health(weapon.force, weapon.damtype, damage_flags, skip_can_damage_check = TRUE)
+		return TRUE
+
+	return FALSE
+
+
+/mob/living/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	// Legacy mob attack code is handled by the weapon
+	if (weapon.attack(src, user, user.zone_sel ? user.zone_sel.selecting : ran_zone()))
+		return TRUE
+
+	return ..()
+
+
+/**
+ * Interaction handler for using an item on this atom with a non-harm intent, or if `use_weapon()` did not resolve an
+ * action. Generally, this is for any standard interactions with items.
+ *
+ * **Parameters**:
+ * - `tool` - The item being used on this atom.
+ * - `user` - The mob interacting with this atom.
+ * - `click_params` - List of click parameters.
+ *
+ * Returns boolean to indicate whether the attack call was handled or not. If `FALSE`, the next `use_*` proc in the
+ * resolve chain will be called.
+ */
+/atom/proc/use_tool(obj/item/tool, mob/user, list/click_params = list())
+	SHOULD_CALL_PARENT(TRUE)
+	return FALSE
+
+
+/mob/living/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Surgery is handled by the tool
+	if (can_operate(src, user) && tool.do_surgery(src, user))
+		return TRUE
+
+	return ..()
+
+
+/**
+ * DEPRECATED - USE THE `use_*()` PROCS INSTEAD.
+ *
  * Called when this atom is clicked on while another item is in the active hand. This is generally called by this item's `resolve_attackby()` proc.
  *
  * **Parameters**:
@@ -61,44 +187,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
  * Returns boolean to indicate whether the attack call was handled or not.
  */
 /atom/proc/attackby(obj/item/W, mob/user, click_params)
-	if (user.a_intent == I_HURT && get_max_health() && !(W.item_flags & ITEM_FLAG_NO_BLUDGEON))
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		user.do_attack_animation(src)
-		var/damage_flags = W.damage_flags()
-		if (!can_damage_health(W.force, W.damtype, damage_flags))
-			playsound(src, damage_hitsound, 50)
-			user.visible_message(
-				SPAN_WARNING("\The [user] hits \the [src] with \a [W], but it bounces off!"),
-				SPAN_WARNING("You hit \the [src] with \the [W], but it bounces off!")
-			)
-			return
-		playsound(src, damage_hitsound, 75)
-		user.visible_message(
-			SPAN_DANGER("\The [user] hits \the [src] with \a [W]!"),
-			SPAN_DANGER("You hit \the [src] with \the [W]!")
-		)
-		damage_health(W.force, W.damtype, damage_flags, skip_can_damage_check = TRUE)
-		return TRUE
 	return FALSE
-
-
-/mob/living/attackby(obj/item/I, mob/user)
-	if(!ismob(user))
-		return 0
-	if(can_operate(src,user) && I.do_surgery(src,user)) //Surgery
-		return 1
-	return I.attack(src, user, user.zone_sel ? user.zone_sel.selecting : ran_zone())
-
-
-/mob/living/carbon/human/attackby(obj/item/I, mob/user)
-	if(user == src && zone_sel.selecting == BP_MOUTH && can_devour(I, silent = TRUE))
-		var/obj/item/blocked = src.check_mouth_coverage()
-		if(blocked)
-			to_chat(user, SPAN_WARNING("\The [blocked] is in the way!"))
-			return TRUE
-		if(devour(I))
-			return TRUE
-	return ..()
 
 
 /**

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -56,14 +56,15 @@
 			if (prob(25))
 				src.set_density(0)
 
-/obj/machinery/optable/attackby(obj/item/O, mob/user)
-	if (istype(O, /obj/item/grab))
-		var/obj/item/grab/G = O
-		if(iscarbon(G.affecting) && check_table(G.affecting))
-			take_victim(G.affecting,usr)
-			qdel(O)
-			return
+
+/obj/machinery/optable/use_grab(obj/item/grab/grab, list/click_params)
+	if (check_table(grab.affecting))
+		take_victim(grab.affecting, grab.assailant)
+		qdel(grab)
+		return TRUE
+
 	return ..()
+
 
 /obj/machinery/optable/state_transition(singleton/machine_construction/default/new_state)
 	. = ..()

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -245,8 +245,8 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 	for(var/obj/item/stock_parts/part in component_parts)
 		if(!components_are_accessible(part.type))
 			continue
-		if((. = part.attackby(I, user)))
-			return
+		if (TRY_USE_TOOL(part, I, user, null))
+			return TRUE
 	return construct_state && construct_state.attackby(I, user, src)
 
 /// Passes `attack_hand()` calls through to components within the machine, if they are accessible.

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -235,10 +235,14 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 /// Called whenever an attached component updates it's status. Override to handle updates to the machine.
 /obj/machinery/proc/component_stat_change(obj/item/stock_parts/part, old_stat, flag)
 
-/obj/machinery/attackby(obj/item/I, mob/user)
-	if(component_attackby(I, user))
+
+/obj/machinery/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Components - Pass through to individual stock parts
+	if (component_attackby(tool, user))
 		return TRUE
+
 	return ..()
+
 
 /// Passes `attackby()` calls through to components within the machine, if they are accessible.
 /obj/machinery/proc/component_attackby(obj/item/I, mob/user)

--- a/code/game/machinery/bluespace_drive.dm
+++ b/code/game/machinery/bluespace_drive.dm
@@ -95,24 +95,30 @@
 	update_icon()
 
 
-/obj/machinery/bluespacedrive/attackby(obj/item/item, mob/user)
-	if (istype(item, /obj/item/grab))
-		var/obj/item/grab/grab = item
-		to_chat(user, SPAN_WARNING("\The [src] pulls at \the [grab.affecting] but they're too heavy."))
-		return
-	if (issilicon(user) || !user.unEquip(item, src))
-		to_chat(user, SPAN_WARNING("\The [src] pulls at \the [item] but it's attached to you."))
-		return
+/obj/machinery/bluespacedrive/use_grab(obj/item/grab/grab, list/click_params)
+	to_chat(grab.assailant, SPAN_WARNING("\The [src] pulls at \the [grab.affecting], but they're too heavy."))
+	return TRUE
+
+
+/obj/machinery/bluespacedrive/use_tool(obj/item/tool, mob/user, list/click_params)
+	SHOULD_CALL_PARENT(FALSE) // Consumes everything, no point.
+
+	if (!user.unEquip(tool, src))
+		to_chat(user, SPAN_WARNING("\The [src] pulls at \the [tool], but it's attached to you."))
+		return TRUE
+
 	user.visible_message(
-		SPAN_WARNING("\The [user] reaches out \a [item] to \the [src], warping briefly as it disappears in a flash of blue light, scintillating motes left behind."),
-		SPAN_DANGER("You touch \the [src] with \the [item], the field buckling around it before retracting with a crackle as it leaves small, blue scintillas on your hand as you flinch away."),
+		SPAN_WARNING("\The [user] reaches out \a [tool] to \the [src], warping briefly as it disappears in a flash of blue light, scintillating motes left behind."),
+		SPAN_DANGER("You touch \the [src] with \the [tool], the field buckling around it before retracting with a crackle as it leaves small, blue scintillas on your hand as you flinch away."),
 		SPAN_WARNING("You hear an otherwordly crackle, followed by humming.")
 	)
-	qdel(item)
+	qdel(tool)
 	if (prob(5))
-		playsound(loc, 'sound/items/eatfood.ogg', 40)		//Yum
+		playsound(src, 'sound/items/eatfood.ogg', 40)		//Yum
 	else
-		playsound(loc, 'sound/machines/BSD_interact.ogg', 40)
+		playsound(src, 'sound/machines/BSD_interact.ogg', 40)
+
+	return TRUE
 
 
 /obj/machinery/bluespacedrive/examine_damage_state(mob/user)

--- a/code/game/machinery/bodyscanner.dm
+++ b/code/game/machinery/bodyscanner.dm
@@ -90,15 +90,17 @@
 	if(istype(new_state))
 		updateUsrDialog()
 
-/obj/machinery/bodyscanner/attackby(obj/item/grab/normal/G, mob/user)
-	if(istype(G))
-		var/mob/M = G.affecting
-		if(!user_can_move_target_inside(M, user))
-			return
-		move_target_inside(M,user)
-		qdel(G)
+
+/obj/machinery/bodyscanner/use_grab(obj/item/grab/grab, list/click_params)
+	if (!user_can_move_target_inside(grab.affecting, grab.assailant))
 		return TRUE
-	return ..()
+	move_target_inside(grab.affecting, grab.assailant)
+	grab.assailant.visible_message(
+		SPAN_NOTICE("\The [grab.assailant] places \the [grab.affecting] into \the [src]."),
+		SPAN_NOTICE("You place \the [grab.affecting] into \the [src].")
+	)
+	qdel(grab)
+	return TRUE
 
 /obj/machinery/bodyscanner/proc/user_can_move_target_inside(mob/target, mob/user)
 	if(!istype(user) || !istype(target))

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -25,8 +25,11 @@
 	. = ..()
 	update_icon()
 
-/obj/machinery/button/attackby(obj/item/W, mob/user as mob)
+
+/obj/machinery/button/use_tool(obj/item/tool, mob/user, list/click_params)
+	SHOULD_CALL_PARENT(FALSE) // Passes through to attack_hand
 	return attack_hand(user)
+
 
 /obj/machinery/button/interface_interact(user)
 	if(!CanInteract(user, DefaultTopicState()))

--- a/code/game/machinery/cracker.dm
+++ b/code/game/machinery/cracker.dm
@@ -31,19 +31,25 @@
 	update_icon()
 	return TRUE
 
-/obj/machinery/portable_atmospherics/cracker/attackby(obj/item/thing, mob/user)
-	// remove deuterium as a reagent
-	if(thing.is_open_container() && thing.reagents)
-		if(!reagent_buffer[MATERIAL_DEUTERIUM] || reagent_buffer[MATERIAL_DEUTERIUM] <= 0)
-			to_chat(user, SPAN_WARNING("There is no deuterium stored in \the [src]."))
-			return
-		var/transfer_amt = min(thing.reagents.maximum_volume, reagent_buffer[MATERIAL_DEUTERIUM])
-		thing.reagents.add_reagent(MATERIAL_DEUTERIUM, transfer_amt)
-		thing.update_icon()
-		reagent_buffer[MATERIAL_DEUTERIUM] -= transfer_amt
-		user.visible_message(SPAN_NOTICE("\The [user] siphons [transfer_amt] unit\s of deuterium from \the [src] into \the [thing]."))
-		return
-	. = ..()
+
+/obj/machinery/portable_atmospherics/cracker/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Open Containers - Remove deuterium from reagent buffer
+	if (tool.is_open_container() && tool.reagents)
+		if (!reagent_buffer[MATERIAL_DEUTERIUM] || reagent_buffer[MATERIAL_DEUTERIUM] <= 0)
+			to_chat(user, SPAN_WARNING("There is no deuterium stored in \the [src] to siphon."))
+			return TRUE
+		var/transfer_amount = min(tool.reagents.maximum_volume, reagent_buffer[MATERIAL_DEUTERIUM])
+		tool.reagents.add_reagent(MATERIAL_DEUTERIUM, transfer_amount)
+		tool.update_icon()
+		reagent_buffer[MATERIAL_DEUTERIUM] -= transfer_amount
+		user.visible_message(
+			SPAN_NOTICE("\The [user] siphons some deuterium from \the [src] into \a [tool]."),
+			SPAN_NOTICE("You siphon [transfer_amount] unit\s of deuterium from \the [src] into \the [tool].")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/machinery/portable_atmospherics/cracker/power_change()
 	. = ..()

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -197,28 +197,38 @@
 	if(istype(new_state))
 		updateUsrDialog()
 
-/obj/machinery/atmospherics/unary/cryo_cell/attackby(obj/G, mob/user as mob)
-	if(component_attackby(G, user))
+
+/obj/machinery/atmospherics/unary/cryo_cell/use_grab(obj/item/grab/grab, list/click_params)
+	if (put_mob(grab.affecting))
+		grab.assailant.visible_message(
+			SPAN_NOTICE("\The [grab.assailant] places \the [grab.affecting] into \the [src]."),
+			SPAN_NOTICE("You place \the [grab.affecting] into \the [src].")
+		)
+		qdel(grab)
+	return TRUE
+
+
+/obj/machinery/atmospherics/unary/cryo_cell/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Component and construct state passthrough check
+	. = ..()
+	if (.)
+		return
+
+	// Glass Container - Load 'beaker'
+	if (istype(tool, /obj/item/reagent_containers/glass))
+		if (beaker)
+			to_chat(user, SPAN_WARNING("\The [src] already has \a [beaker] loaded."))
+			return TRUE
+		if (!user.unEquip(tool, src))
+			to_chat(user, SPAN_WARNING("You can't drop \the [tool]."))
+			return TRUE
+		beaker = tool
+		user.visible_message(
+			SPAN_NOTICE("\The [user] inserts \a [tool] into \the [src]."),
+			SPAN_NOTICE("You inster \the [tool] into \the [src].")
+		)
 		return TRUE
-	if(istype(G, /obj/item/reagent_containers/glass))
-		if(beaker)
-			to_chat(user, SPAN_WARNING("A beaker is already loaded into the machine."))
-			return
-		if(!user.unEquip(G, src))
-			return // Temperature will be adjusted on Entered()
-		beaker =  G
-		user.visible_message("[user] adds \a [G] to \the [src]!", "You add \a [G] to \the [src]!")
-	else if(istype(G, /obj/item/grab))
-		var/obj/item/grab/grab = G
-		if(!ismob(grab.affecting))
-			return
-		for(var/mob/living/carbon/slime/M in range(1,grab.affecting))
-			if(M.Victim == grab.affecting)
-				to_chat(user, "[grab.affecting.name] will not fit into the cryo because they have a slime latched onto their head.")
-				return
-		if(put_mob(grab.affecting))
-			qdel(G)
-	return
+
 
 /obj/machinery/atmospherics/unary/cryo_cell/on_update_icon()
 	overlays.Cut()

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -5,7 +5,7 @@ var/global/list/doppler_arrays = list()
 	desc = "A highly precise directional sensor array which measures the release of quants from decaying tachyons. The doppler shifting of the mirror-image formed by these quants can reveal the size, location and temporal affects of energetic disturbances within a large radius ahead of the array."
 	icon = 'icons/obj/machines/research.dmi'
 	icon_state = "tdoppler"
-	obj_flags = OBJ_FLAG_ROTATABLE
+	obj_flags = OBJ_FLAG_ROTATABLE | OBJ_FLAG_ANCHORABLE
 	construct_state = /singleton/machine_construction/default/panel_closed
 	var/currentlyfacing
 	var/direct
@@ -51,14 +51,6 @@ var/global/list/doppler_arrays = list()
 	if(inoperable())
 		icon_state = "[initial(icon_state)]-off"
 
-/obj/machinery/doppler_array/attackby(obj/item/W, mob/user)
-	if(component_attackby(W, user))
-		return TRUE
-	else if(isWrench(W))
-		anchored = !anchored
-		to_chat(user, SPAN_NOTICE("You wrench the stabilising bolts [anchored ? "into place" : "loose"]."))
-		playsound(loc, 'sound/items/Ratchet.ogg', 40)
-		update_icon()
 
 /obj/machinery/doppler_array/proc/getcurrentdirection()
 	switch(direct)

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -32,17 +32,19 @@
 		icon_state = "[base_state]1-p"
 //		src.sd_SetLuminosity(0)
 
-//Don't want to render prison breaks impossible
-/obj/machinery/flasher/attackby(obj/item/W as obj, mob/user as mob)
-	if(isWirecutter(W))
-		add_fingerprint(user, 0, W)
-		src.disable = !src.disable
-		if (src.disable)
-			user.visible_message(SPAN_WARNING("[user] has disconnected the [src]'s flashbulb!"), SPAN_WARNING("You disconnect the [src]'s flashbulb!"))
-		if (!src.disable)
-			user.visible_message(SPAN_WARNING("[user] has connected the [src]'s flashbulb!"), SPAN_WARNING("You connect the [src]'s flashbulb!"))
-	else
-		..()
+
+/obj/machinery/flasher/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Wirecutters - Toggle the flashbulb
+	if (isWirecutter(tool))
+		disable = !disable
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [disable ? "disconnects" : "connects"] \the [src]'s flashbulb with \a [tool]."),
+			SPAN_NOTICE("You [disable ? "disconnect" : "connect"] \the [src]'s flashbulb with \the [tool].")
+		)
+		return TRUE
+
+	return ..()
+
 
 //Let the AI trigger them directly.
 /obj/machinery/flasher/attack_ai()
@@ -106,6 +108,7 @@
 	anchored = FALSE
 	base_state = "pflash"
 	density = TRUE
+	obj_flags = OBJ_FLAG_ANCHORABLE
 
 /obj/machinery/flasher/portable/HasProximity(atom/movable/AM as mob|obj)
 	if(!anchored || disable || last_flash && world.time < last_flash + 150)
@@ -119,18 +122,13 @@
 	if(isanimal(AM))
 		flash()
 
-/obj/machinery/flasher/portable/attackby(obj/item/W as obj, mob/user as mob)
-	if(isWrench(W))
-		add_fingerprint(user)
-		src.anchored = !src.anchored
 
-		if (!src.anchored)
-			user.show_message(text(SPAN_WARNING("[src] can now be moved.")))
-			src.overlays.Cut()
+/obj/machinery/flasher/portable/on_update_icon()
+	overlays.Cut()
+	. = ..()
+	if (anchored)
+		overlays += "[base_state]-s"
 
-		else if (src.anchored)
-			user.show_message(text(SPAN_WARNING("[src] is now secured.")))
-			src.overlays += "[base_state]-s"
 
 /obj/machinery/button/flasher
 	name = "flasher button"

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -104,17 +104,20 @@
 		icon_state = "migniter-p"
 //		src.sd_SetLuminosity(0)
 
-/obj/machinery/sparker/attackby(obj/item/W as obj, mob/user as mob)
-	if(isScrewdriver(W))
-		add_fingerprint(user)
+
+/obj/machinery/sparker/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Screwdriver - Enable/disable
+	if (isScrewdriver(tool))
 		disable = !disable
-		if(disable)
-			user.visible_message(SPAN_WARNING("[user] has disabled the [src]!"), SPAN_WARNING("You disable the connection to the [src]."))
-		else if(!disable)
-			user.visible_message(SPAN_WARNING("[user] has reconnected the [src]!"), SPAN_WARNING("You fix the connection to the [src]."))
 		update_icon()
-	else
-		..()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [disable ? "disables" : "enables"] \the [src] with \a [tool]."),
+			SPAN_NOTICE("You [disable ? "disable" : "enable"] \the [src] with \a [tool].")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/machinery/sparker/attack_ai()
 	if (anchored)

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -10,6 +10,7 @@
 	active_power_usage = 100
 	clicksound = 'sound/machines/buttonbeep.ogg'
 	pixel_x = -8
+	obj_flags = OBJ_FLAG_ANCHORABLE
 
 	var/jukebox/jukebox
 
@@ -59,13 +60,9 @@
 	return TRUE
 
 
-/obj/machinery/jukebox/attackby(obj/item/I, mob/user)
-	if (isWrench(I))
-		add_fingerprint(user)
-		wrench_floor_bolts(user, 0)
-		power_change()
-		return
-	return ..()
+/obj/machinery/jukebox/wrench_floor_bolts(mob/user, delay)
+	. = ..()
+	power_change()
 
 
 

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -66,10 +66,19 @@
 		set_state(!on)
 		return TRUE
 
-/obj/machinery/light_switch/attackby(obj/item/tool as obj, mob/user as mob)
-	if(istype(tool, /obj/item/screwdriver))
-		new /obj/item/frame/light_switch(user.loc, 1)
+
+/obj/machinery/light_switch/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Screwdriver - Detach from wal
+	if (isScrewdriver(tool))
+		new /obj/item/frame/light_switch(get_turf(src))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] removes \the [src] from the wall with \a [tool]."),
+			SPAN_NOTICE("You remove \the [src] from the wall with \the [tool].")
+		)
 		qdel(src)
+		return TRUE
+
+	return ..()
 
 
 /obj/machinery/light_switch/powered()

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -727,26 +727,46 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 			src.updateUsrDialog()
 
 
+/obj/machinery/newscaster/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	SHOULD_CALL_PARENT(FALSE) // Self contained until it uses standardized health
 
-/obj/machinery/newscaster/attackby(obj/item/I, mob/user)
-	if (user.a_intent == I_HURT)
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		if (I.force < 15)
-			visible_message(SPAN_WARNING("\The [user] uselessly bops \the [src] with \an [I]."))
-		else if (MACHINE_IS_BROKEN(src))
-			visible_message(SPAN_WARNING("\The [user] further abuses the shattered [name]."))
-			playsound(src, 'sound/effects/hit_on_shattered_glass.ogg', 100, 1)
-		else if (++hitstaken < 3)
-			visible_message(SPAN_DANGER("\The [user] slams \the [src] with \an [I], cracking it!"))
-			playsound(src, 'sound/effects/Glassbr3.ogg', 100, 1)
-		else
-			visible_message(SPAN_DANGER("\The [user] smashes \the [src] with \an [I]!"))
-			playsound(src, 'sound/effects/Glasshit.ogg', 100, 1)
-			set_broken(TRUE)
-			update_icon()
+	user.do_attack_animation(src)
+	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+
+	if (MACHINE_IS_BROKEN(src))
+		playsound(src, 'sound/effects/hit_on_shattered_glass.ogg', 100, 1)
+		user.visible_message(
+			SPAN_WARNING("\The [user] further abuses the shattered [name] with \a [weapon]."),
+			SPAN_WARNING("You further abuse the shattered [name] with \the [weapon].")
+		)
 		return TRUE
-	else
-		. = ..()
+
+	if (weapon.force < 15)
+		playsound(src, 'sound/weapons/genhit.ogg', 50, 1)
+		user.visible_message(
+			SPAN_WARNING("\The [user] uselessly bops \the [src] with \a [weapon]."),
+			SPAN_WARNING("You uselessly bop \the [src] with \the [weapon].")
+		)
+		return TRUE
+
+	if (hitstaken >= 3)
+		playsound(src, 'sound/effects/Glasshit.ogg', 100, 1)
+		set_broken(TRUE)
+		update_icon()
+		user.visible_message(
+			SPAN_WARNING("\The [user] smashes \the [src] with \a [weapon]!"),
+			SPAN_DANGER("You smash \the [src] with \the [weapon]!")
+		)
+		return TRUE
+
+	hitstaken++
+	playsound(src, 'sound/effects/Glassbr3.ogg', 100, 1)
+	user.visible_message(
+		SPAN_WARNING("\The [user] slams \the [src] with \a [weapon], cracking it!"),
+		SPAN_DANGER("You smash \the [src] with \the [weapon], cracking it!")
+	)
+	return TRUE
+
 
 /datum/news_photo
 	var/is_synth = 0

--- a/code/game/machinery/pager.dm
+++ b/code/game/machinery/pager.dm
@@ -16,8 +16,11 @@
 		var/area/A = get_area(src)
 		location = A.name
 
-/obj/machinery/pager/attackby(obj/item/W, mob/user as mob)
-	return attack_hand(user)
+
+/obj/machinery/pager/use_tool(obj/item/tool, mob/user, list/click_params)
+	SHOULD_CALL_PARENT(FALSE) // Passthrough to attack_hand
+	return attack_hand()
+
 
 /obj/machinery/pager/interface_interact(mob/living/user)
 	if(!CanInteract(user, GLOB.default_state))

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -146,6 +146,31 @@
 	setWelding(!welding, usr)
 	return
 
+/**
+ * Checks if the welding tool can be used for an interaction requiring the given amount of fuel.
+ *
+ * **Parameters**:
+ * - `user` - The mob attempting the interaction. Targeted by feedback messages.
+ * - `amount` (Integer, default `1`) - The amount of fuel needed.
+ * - `silent` (Boolean, default `FALSE`) - If set, `user` is not sent feedback messages.
+ *
+ * Returns boolean.
+ */
+/obj/item/weldingtool/proc/can_use(mob/user, amount = 1, silent = FALSE)
+	SHOULD_CALL_PARENT(TRUE)
+
+	if (!isOn())
+		if (!silent)
+			to_chat(user, SPAN_WARNING("\The [src] must be turned on first."))
+		return FALSE
+
+	if (get_fuel() < amount)
+		if (!silent)
+			to_chat(user, SPAN_WARNING("\The [src] doesn't have enough fuel. You need at least [amount] unit\s."))
+		return FALSE
+
+	return TRUE
+
 //Returns the amount of fuel in the welder
 /obj/item/weldingtool/proc/get_fuel()
 	return tank ? tank.reagents.get_reagent_amount(/datum/reagent/fuel) : 0

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -124,13 +124,16 @@
 		if (damtype == DAMAGE_BURN)
 			. |= DAMAGE_FLAG_LASER
 
-/obj/attackby(obj/item/O, mob/user)
-	if(obj_flags & OBJ_FLAG_ANCHORABLE)
-		if(isWrench(O))
-			wrench_floor_bolts(user)
-			update_icon()
-			return
+
+/obj/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Wrench - Toggle anchoring
+	if (HAS_FLAGS(obj_flags, OBJ_FLAG_ANCHORABLE) && isWrench(tool))
+		wrench_floor_bolts(user)
+		update_icon()
+		return TRUE
+
 	return ..()
+
 
 /obj/proc/wrench_floor_bolts(mob/user, delay=20)
 	playsound(loc, 'sound/items/Ratchet.ogg', 100, 1)


### PR DESCRIPTION
Depends on #32919

Codexifying all the interactions will be in a separate PR once the codex framework is merged.

## Changelog
:cl: SierraKomodo
tweak: Machinery now has consistent failure state feedback messages and visible messages for various tool and item interactions.
tweak: Repairing barriers with a welding tool now consumes 5 units of fuel.
tweak: Portable flashers can now be disabled with wirecutters, just like non-portable flashers.
/:cl:

## Other Changes
- Added `GET_ID_CARD_NAME()` macro to create consistent `\the [id]` / `\the [id] in \the [loc]` messages for ID cards fetched via `GetIdCard()`.
- Added `can_use()` proc to welding tools for consistent checking of if a welding tool is usable with the requested amount of fuel.
- Added `use_sanity_check()` proc to mobs for common validity checks after do_after, input, etc.
- Added `TRY_USE_*` macros, used in certain places where `attackby()` was called directly instead of routing through `resolve_attackby()`.
- Replaces `/obj/attackby()` with `/obj/use_tool()` to prevent any potential order of operations issues with wrenching anchoring bolts.
- Replaces `attackby()` overrides with `use_*()` overrides in the following type groups:
  - `/obj/machinery`
- Applies the following generalizations/standardizations to the above override updates:
  - Each interaction item is prefaced by a comment naming the item and it's interaction.
  - Added user feedback messages to all failure states.
  - Added visible messages to most interactions, skipping those that would be considered stealthy/hard to spot, with the general format of `USER ACTIONS TARGET WITH TOOL`
  - Updated any ID checks to use `tool.GetIdCard()` and the access list from that ID, instead of checking if tool itself is an id and/or calling access checks on the mob.
  - Sorted interactions to be in alphabetical order by tool name, as provided in the preface comments.
  - Added unequip checks to interactions that involve deleting or removing items from the mob.
  - Standardized spawning of all dropped items from interactions on the target's turf.
  - All `playsound()` calls originate directly from `src`.
  - Replaced instances of magic values used in attackby with constants or defines where appropriate.
  - Replaced hardcoded anchoring interactions with the `OBJ_FLAG_ANCHORABLE` flag.
  - Moved icon, overlay, and underlay operations to `on_update_icon()`

## Todo
- [ ] `/obj/machinery` (In progress)
- [ ] `/obj/item/stock_parts`