### PR TITLE
Runtime batch 2023-01-18

### DIFF
--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -222,7 +222,7 @@
 	var/size
 
 	var/result = cmd_admin_narrate_helper(src, style, size)
-	if (!result)
+	if (!result || !M)
 		return
 
 	to_chat(M, result[1])

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -105,6 +105,10 @@ var/global/list/holder_mob_icon_cache = list()
 	overlays |= M.overlays
 	var/mob/living/carbon/human/H = loc
 	last_holder = H
+	if (M.pulledby)
+		if (M.pulledby.pulling == src)
+			M.pulledby.pulling = null
+		M.pulledby = null
 	register_all_movement(H, M)
 
 	update_held_icon()

--- a/code/modules/psionics/interface/ui_hub.dm
+++ b/code/modules/psionics/interface/ui_hub.dm
@@ -12,8 +12,8 @@
 	. = ..()
 	on_cooldown = image(icon, "cooldown")
 	components = list(
-		new /obj/screen/psi/armour(loc),
-		new /obj/screen/psi/toggle_psi_menu(loc, src)
+		new /obj/screen/psi/armour(owner),
+		new /obj/screen/psi/toggle_psi_menu(owner, src)
 	)
 	START_PROCESSING(SSprocessing, src)
 


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Psionic shielding HUD icon now displays and can be toggled once more.
/:cl:

## Other Changes
- Fixes direct narrate crashing if the mob is deleted while typing the narration text.

## Bugfixes
- Fixes #32945
- Fixes #32946
- Fixes #31896
- Fixes #32949