### PR TITLE
Species-based footwear footprints

### DIFF
--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -279,6 +279,13 @@
 
 	/// An associative list of /singleton/trait and trait level - See individual traits for valid levels
 	var/list/traits = list()
+
+	/**
+	* Allows a species to override footprints on worn clothing. Used by get_move_trail.
+	* Uses istype() so child objects should be first in the list relative to parent objects.
+	* For universally overriding footprints on all footwear, use obj/item/clothing instead of /obj/item/clothing/shoes since suit layer clothing that covers the feet (space suits) are a thing.
+	*/
+	var/list/footwear_trail_overrides
 /*
 These are all the things that can be adjusted for equipping stuff and
 each one can be in the NORTH, SOUTH, EAST, and WEST direction. Specify
@@ -629,6 +636,10 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 		return /obj/effect/decal/cleanable/blood/tracks/body
 	if(H.shoes || (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)))
 		var/obj/item/clothing/shoes = (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) ? H.wear_suit : H.shoes // suits take priority over shoes
+		if(footwear_trail_overrides)
+			for (var/key in footwear_trail_overrides)
+				if (istype(shoes, key))
+					return footwear_trail_overrides[key]
 		return shoes.move_trail
 	else
 		return move_trail

--- a/code/modules/species/station/lizard.dm
+++ b/code/modules/species/station/lizard.dm
@@ -159,6 +159,10 @@
 		/singleton/trait/malus/sugar = TRAIT_LEVEL_MAJOR
 	)
 
+	footwear_trail_overrides = list(
+		/obj/item/clothing = /obj/effect/decal/cleanable/blood/tracks/claw // Needs to apply to both shoes and space suits.
+	)
+
 /datum/species/unathi/equip_survival_gear(mob/living/carbon/human/H)
 	..()
 	H.equip_to_slot_or_del(new /obj/item/clothing/shoes/sandal(H),slot_shoes)


### PR DESCRIPTION
https://github.com/Baystation12/Baystation12/pull/32941 but with Spookerton's suggested implementation.

Current implementation overrides on all footwear and space suits that Unathi can wear. Currently the only shoes with unique footprints only fit on Human and IPC body types. This set up allows for, as an example, Unathi-only traitor shoes that makes their footprints look human to be implemented by adding those shoes to the footwear_trail_overrides list.

/obj/item/clothing needs to be the blanket object for overwriting footwear footprints instead of /obj/item/clothing/shoes or wearing space suits will give the species the default footprints for clothing.

![image](https://user-images.githubusercontent.com/1986009/213885769-be8d2bc5-8f5f-4993-ae1f-ae81c4cbbfcb.png)

:cl: Nerezza
rscadd: Unathi now leave their unique clawprints even while wearing footwear.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->