### PR TITLE
Add a light to the kitchen counter

### DIFF
--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -4146,10 +4146,6 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
@@ -4160,6 +4156,9 @@
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
+	},
+/obj/machinery/light/spot{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
@@ -18055,6 +18054,10 @@
 	dir = 4
 	},
 /obj/machinery/cooker/cereal,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/galley)
 "TX" = (


### PR DESCRIPTION
The kitchen counter tends to be a dark corner of the mess if the bar is closed. This adds a light that fixes that, and moves the fire alarm to the other wall to avoid colliding sprites.

## Changelog
:cl: SierraKomodo
maptweak: A light fixture has been added to the kitchen, next to the counter, to shed some light on the dark corners of the mess hall.
/:cl: