### PR TITLE
Fix item on mob interactions

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -141,14 +141,6 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	return FALSE
 
 
-/mob/living/use_weapon(obj/item/weapon, mob/user, list/click_params)
-	// Legacy mob attack code is handled by the weapon
-	if (weapon.attack(src, user, user.zone_sel ? user.zone_sel.selecting : ran_zone()))
-		return TRUE
-
-	return ..()
-
-
 /**
  * Interaction handler for using an item on this atom with a non-harm intent, or if `use_weapon()` did not resolve an
  * action. Generally, this is for any standard interactions with items.
@@ -187,6 +179,9 @@ avoid code duplication. This includes items that may sometimes act as a standard
  * Returns boolean to indicate whether the attack call was handled or not.
  */
 /atom/proc/attackby(obj/item/W, mob/user, click_params)
+	// Legacy mob attack code is handled by the weapon
+	if (W.attack(src, user, user.zone_sel ? user.zone_sel.selecting : ran_zone()))
+		return TRUE
 	return FALSE
 
 


### PR DESCRIPTION
hate hate hate

## Changelog
:cl: SierraKomodo
bugfix: Food and other items that use the attack proc that was documented as being for ATTACKING instead of interactions are now fixed. I should stop assuming people actually follow what the comments say for these things.
/:cl: