### PR TITLE
Harm intent check fixes

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -119,7 +119,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /atom/proc/use_weapon(obj/item/weapon, mob/user, list/click_params = list())
 	SHOULD_CALL_PARENT(TRUE)
 	// Standardized damage
-	if (user.a_intent == I_HURT && weapon.force > 0 && get_max_health() && !HAS_FLAGS(weapon.item_flags, ITEM_FLAG_NO_BLUDGEON))
+	if (weapon.force > 0 && get_max_health() && !HAS_FLAGS(weapon.item_flags, ITEM_FLAG_NO_BLUDGEON))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(src)
 		var/damage_flags = weapon.damage_flags()

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -151,12 +151,16 @@
 
 	damage_health(damage, Proj.damage_type)
 
-/obj/structure/grille/attackby(obj/item/W as obj, mob/user as mob)
-	if (user.a_intent == I_HURT)
-		if (!(W.obj_flags & OBJ_FLAG_CONDUCTIBLE) || !shock(user, 70))
-			..()
-		return
 
+/obj/structure/grille/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	// Check shock
+	if (HAS_FLAGS(weapon.obj_flags, OBJ_FLAG_CONDUCTIBLE) && shock(user, 70))
+		return TRUE
+
+	return ..()
+
+
+/obj/structure/grille/attackby(obj/item/W as obj, mob/user as mob)
 	if(isWirecutter(W))
 		if(!shock(user, 100))
 			playsound(loc, 'sound/items/Wirecutter.ogg', 100, 1)

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -3,6 +3,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	icon = 'icons/obj/inflatable.dmi'
 	health_max = 10
+	health_min_damage = 10
 	var/deploy_path = null
 
 /obj/item/inflatable/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
@@ -141,13 +142,17 @@
 	add_fingerprint(user)
 	return
 
+
+/obj/structure/inflatable/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	// Check if the weapon can puncture. TODO: Pass this through to `can_damage_health()`.
+	if (!weapon.can_puncture())
+		return FALSE
+
+	return ..()
+
+
 /obj/structure/inflatable/attackby(obj/item/W, mob/user)
 	if(!istype(W) || istype(W, /obj/item/inflatable_dispenser)) return
-
-	if (user.a_intent == I_HURT)
-		if (W.can_puncture() || W.force > 10)
-			..()
-		return
 
 	if(istype(W, /obj/item/tape_roll) && get_damage_value() >= 3)
 		if(taped)

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -192,37 +192,46 @@
 		return 0
 	return 1
 
+
+/obj/structure/railing/use_grab(obj/item/grab/grab, list/click_params)
+	var/obj/occupied = turf_is_crowded()
+	if (occupied)
+		to_chat(grab.assailant, SPAN_WARNING("There's \a [occupied] blocking \the [src]."))
+		return TRUE
+
+	if (!grab.force_danger())
+		var/action = grab.assailant.a_intent == I_HURT ? "slam them against" : "throw them over"
+		to_chat(grab.assailant, SPAN_WARNING("You need a better grip on \the [grab.affecting] to [action] \the [src]."))
+		return TRUE
+
+	// Harm intent - Face slamming
+	if (grab.assailant.a_intent == I_HURT)
+		var/blocked = grab.affecting.get_blocked_ratio(BP_HEAD, DAMAGE_BRUTE, damage = 8)
+		if (prob(30 * (1 - blocked)))
+			grab.affecting.Weaken(5)
+		grab.affecting.apply_damage(8, DAMAGE_BRUTE, BP_HEAD)
+		playsound(src, 'sound/effects/grillehit.ogg', 50, 1)
+		grab.assailant.visible_message(
+			SPAN_WARNING("\The [grab.assailant] slams \the [grab.affecting]'s face against \the [src]!"),
+			SPAN_DANGER("You slam \the [grab.affecting]'s face against \the [src]!")
+		)
+		return TRUE
+
+	if (get_turf(grab.affecting) == get_turf(src))
+		grab.affecting.forceMove(get_step(src, dir))
+	else
+		grab.affecting.dropInto(loc)
+	grab.affecting.Weaken(5)
+	grab.assailant.visible_message(
+		SPAN_WARNING("\The [grab.assailant] throws \the [grab.affecting] over \the [src]."),
+		SPAN_WARNING("You throw \the [grab.affecting] over \the [src]."),
+	)
+	return TRUE
+
+
 /obj/structure/railing/attackby(obj/item/W, mob/user)
 	if (user.a_intent == I_HURT)
 		..()
-		return
-
-	// Handle harm intent grabbing/tabling.
-	if(istype(W, /obj/item/grab) && get_dist(src,user)<2)
-		var/obj/item/grab/G = W
-		if(istype(G.affecting, /mob/living/carbon/human))
-			var/obj/occupied = turf_is_crowded()
-			if(occupied)
-				to_chat(user, SPAN_DANGER("There's \a [occupied] in the way."))
-				return
-
-			if(G.force_danger())
-				if(user.a_intent == I_HURT)
-					visible_message(SPAN_DANGER("[G.assailant] slams [G.affecting]'s face against \the [src]!"))
-					playsound(loc, 'sound/effects/grillehit.ogg', 50, 1)
-					var/blocked = G.affecting.get_blocked_ratio(BP_HEAD, DAMAGE_BRUTE, damage = 8)
-					if (prob(30 * (1 - blocked)))
-						G.affecting.Weaken(5)
-					G.affecting.apply_damage(8, DAMAGE_BRUTE, BP_HEAD)
-				else
-					if (get_turf(G.affecting) == get_turf(src))
-						G.affecting.forceMove(get_step(src, src.dir))
-					else
-						G.affecting.dropInto(loc)
-					G.affecting.Weaken(5)
-					visible_message(SPAN_DANGER("[G.assailant] throws \the [G.affecting] over \the [src]."))
-			else
-				to_chat(user, SPAN_DANGER("You need a better grip to do that!"))
 		return
 
 	// Dismantle

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -91,7 +91,7 @@
 	. = ..()
 
 /obj/structure/table/attackby(obj/item/W, mob/user, click_params)
-	if(!reinforced && !carpeted && material && isWrench(W) && user.a_intent == I_HURT) //robots dont have disarm so it's harm
+	if(!reinforced && !carpeted && material && isWrench(W) && user.a_intent != I_HELP) //robots dont have disarm so it's harm
 		remove_material(W, user)
 		if(!material)
 			update_connections(1)
@@ -102,7 +102,7 @@
 			update_material()
 		return 1
 
-	if(!carpeted && !reinforced && !material && isWrench(W) && user.a_intent == I_HURT)
+	if(!carpeted && !reinforced && !material && isWrench(W) && user.a_intent != I_HELP)
 		dismantle(W, user)
 		return 1
 


### PR DESCRIPTION
Hotfix for various broken intent checks relating to attackby calls

## Changelog
:cl: SierraKomodo
bugfix: Grilles on wires will now shock users that hit them.
bugfix: Inflatables will no longer take damage from melee weapons that can't puncture or with a weak damage value.
bugfix: Table deconstruction steps can now be performed on disarm or grab intent. Harm intent will still attack the table, and help intent will still place items on the table.
/:cl:

## Other Changes
- Removes the redundant harm intent check in the root `use_weapon()` call.
- Moved railing grab interactions to a `use_grab()` override.