### PR TITLE
`grab_attack()` to `use_grab()`

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -52,8 +52,6 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		return TRUE
 	if (A == user)
 		. = user.use_user(src, click_params)
-	if (!. && istype(src, /obj/item/grab))
-		. = A.use_grab(src, click_params)
 	if (!. && user.a_intent == I_HURT)
 		. = A.use_weapon(src, user, click_params)
 	if (!.)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -759,17 +759,6 @@
 		object_shaken()
 
 /**
- * Called when the atom is clicked on with an active grab.
- *
- * **Parameters**:
- * - `G` - The grab the atom was clicked on with.
- *
- * Returns boolean. Whether or not the interaction was handled. If `TRUE`, skips `attackby()` and `afterattack()` calls.
- */
-/atom/proc/grab_attack(obj/item/grab/G)
-	return FALSE
-
-/**
  * Verb to allow climbing onto an object. Passes directly to `/atom/proc/do_climb(usr)`.
  */
 /atom/proc/climb_on()

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -79,6 +79,13 @@
 	return ..()
 
 
+/obj/structure/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_GRAB_AGGRESSIVE] = "<p>On harm intent, slams the victim against \the [initial(name)], causing damage to both the victim and object.</p>"
+	if (HAS_FLAGS(initial(atom_flags), ATOM_FLAG_CLIMBABLE))
+		.[CODEX_INTERACTION_GRAB_AGGRESSIVE] += "<p>On non-harm intent, places the victim on \the [initial(name)] after a 3 second timer.</p>"
+
+
 /obj/structure/use_grab(obj/item/grab/grab, list/click_params)
 	// Harm intent - Slam face against the structure
 	if (grab.assailant == I_HURT)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -78,39 +78,55 @@
 				attack_generic(user,1,"slices")
 	return ..()
 
-/obj/structure/grab_attack(obj/item/grab/G)
-	if (!G.force_danger())
-		to_chat(G.assailant, SPAN_DANGER("You need a better grip to do that!"))
-		return TRUE
-	if (G.assailant.a_intent == I_HURT)
-		// Slam their face against the table.
-		var/blocked = G.affecting.get_blocked_ratio(BP_HEAD, DAMAGE_BRUTE, damage = 8)
+
+/obj/structure/use_grab(obj/item/grab/grab, list/click_params)
+	// Harm intent - Slam face against the structure
+	if (grab.assailant == I_HURT)
+		if (!grab.force_danger())
+			to_chat(grab.assailant, SPAN_WARNING("You need a better grip to slam \the [grab.affecting]'s face on \the [src]."))
+			return TRUE
+		var/blocked = grab.affecting.get_blocked_ratio(BP_HEAD, DAMAGE_BRUTE, damage = 8)
 		if (prob(30 * (1 - blocked)))
-			G.affecting.Weaken(5)
-		G.affecting.apply_damage(8, DAMAGE_BRUTE, BP_HEAD)
-		visible_message(SPAN_DANGER("[G.assailant] slams [G.affecting]'s face against \the [src]!"))
+			grab.affecting.Weaken(5)
+		grab.affecting.apply_damage(8, DAMAGE_BRUTE, BP_HEAD)
+		visible_message(
+			SPAN_DANGER("\The [grab.assailant] slams \the [grab.affecting]'s face against \the [src]!"),
+			SPAN_DANGER("You slam \the [grab.affecting]'s face against \the [src]!")
+		)
 		if (material)
-			playsound(loc, material.tableslam_noise, 50, 1)
+			playsound(src, material.tableslam_noise, 50, 1)
 		else
-			playsound(loc, 'sound/weapons/tablehit1.ogg', 50, 1)
+			playsound(src, 'sound/weapons/tablehit1.ogg', 50, 1)
 		damage_health(rand(1, 5), DAMAGE_BRUTE)
-		qdel(G)
-	else if(atom_flags & ATOM_FLAG_CLIMBABLE)
+		qdel(grab)
+		return TRUE
+
+	// Climbable structure - Put victim on it
+	if (HAS_FLAGS(atom_flags, ATOM_FLAG_CLIMBABLE))
+		if (!grab.force_danger())
+			to_chat(grab.assailant, SPAN_WARNING("You need a better grip to put \the [grab.affecting] on \the [src]."))
+			return TRUE
 		var/obj/occupied = turf_is_crowded()
 		if (occupied)
-			to_chat(G.assailant, SPAN_DANGER("There's \a [occupied] in the way."))
+			to_chat(grab.assailant, SPAN_DANGER("There's \a [occupied] blocking \the [src]."))
 			return TRUE
-		if (!do_after(G.assailant, 3 SECONDS, G.affecting, DO_PUBLIC_UNIQUE))
+		if (!do_after(grab.assailant, 3 SECONDS, grab.affecting, DO_PUBLIC_UNIQUE))
 			return TRUE
 		occupied = turf_is_crowded()
 		if (occupied)
-			to_chat(G.assailant, SPAN_DANGER("There's \a [occupied] in the way."))
+			to_chat(grab.assailant, SPAN_DANGER("There's \a [occupied] blocking \the [src]."))
 			return TRUE
-		G.affecting.forceMove(src.loc)
-		G.affecting.Weaken(rand(2,5))
-		visible_message(SPAN_DANGER("[G.assailant] puts [G.affecting] on \the [src]."))
-		qdel(G)
+		grab.affecting.forceMove(loc)
+		grab.affecting.Weaken(rand(2,5))
+		visible_message(
+			SPAN_WARNING("\The [grab.assailant] puts \the [grab.affecting] on \the [src]."),
+			SPAN_WARNING("You put \the [grab.affecting] on \the [src].")
+		)
+		qdel(grab)
 		return TRUE
+
+	return ..()
+
 
 /obj/structure/proc/can_visually_connect()
 	return anchored

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -416,6 +416,7 @@
 
 	..()
 
+
 /obj/structure/window/proc/dismantle()
 	var/obj/item/stack/material/S = material.place_sheet(loc, is_fulltile() ? 4 : 1)
 	if(S && reinf_material)
@@ -424,25 +425,33 @@
 		S.update_icon()
 	qdel(src)
 
-/obj/structure/window/grab_attack(obj/item/grab/G)
-	if (G.assailant.a_intent != I_HURT)
-		return TRUE
-	if (!G.force_danger())
-		to_chat(G.assailant, SPAN_DANGER("You need a better grip to do that!"))
-		return TRUE
-	var/def_zone = ran_zone(BP_HEAD, 20)
-	if(G.damage_stage() < 2)
-		G.affecting.visible_message(SPAN_DANGER("[G.assailant] bashes [G.affecting] against \the [src]!"))
-		if (prob(50))
-			G.affecting.Weaken(1)
-		G.affecting.apply_damage(10, DAMAGE_BRUTE, def_zone, used_weapon = src)
-		hit(25, G.assailant, G.affecting)
-	else
-		G.affecting.visible_message(SPAN_DANGER("[G.assailant] crushes [G.affecting] against \the [src]!"))
-		G.affecting.Weaken(5)
-		G.affecting.apply_damage(20, DAMAGE_BRUTE, def_zone, used_weapon = src)
-		hit(50, G.assailant, G.affecting)
-	return TRUE
+/obj/structure/window/use_grab(obj/item/grab/grab, list/click_params)
+	// Harm intent - Bash against the window
+	if (grab.assailant.a_intent == I_HURT)
+		if (!grab.force_danger())
+			to_chat(grab.assailant, SPAN_WARNING("You need a better grip to smash \the [grab.affecting] against \the [src]."))
+			return TRUE
+		var/def_zone = ran_zone(BP_HEAD, 20)
+		if (grab.damage_stage() < 2)
+			grab.assailant.visible_message(
+				SPAN_DANGER("\The [grab.assailant] bashes \the [grab.affecting] against \the [src]!"),
+				SPAN_DANGER("You bash \the [grab.affecting] against \the [src]!")
+			)
+			if (prob(50))
+				grab.affecting.Weaken(1)
+			grab.affecting.apply_damage(10, DAMAGE_BRUTE, def_zone, used_weapon = src)
+			hit(25, grab.assailant, grab.affecting)
+		else
+			grab.assailant.visible_message(
+				SPAN_DANGER("\The [grab.assailant] crushes \the [grab.affecting] against \the [src]!"),
+				SPAN_DANGER("You crush \the [grab.affecting] against \the [src]!")
+			)
+			grab.affecting.Weaken(5)
+			grab.affecting.apply_damage(20, DAMAGE_BRUTE, def_zone, used_weapon = src)
+			hit(50, grab.assailant, grab.affecting)
+
+	return ..()
+
 
 /obj/structure/window/proc/hit(damage, mob/user, atom/weapon = null, damage_type = DAMAGE_BRUTE)
 	if (can_damage_health(damage, damage_type))

--- a/code/modules/codex/codex_atom.dm
+++ b/code/modules/codex/codex_atom.dm
@@ -53,6 +53,12 @@
 /atom/var/const/CODEX_INTERACTION_USE_SELF = "Use On Self"
 /atom/var/const/CODEX_INTERACTION_HAND = "Empty Hand"
 
+// Grabs
+/atom/var/const/CODEX_INTERACTION_GRAB = "Grabbed Mob"
+/atom/var/const/CODEX_INTERACTION_GRAB_PASSIVE = "Grabbed Mob (Passive - Yellow)"
+/atom/var/const/CODEX_INTERACTION_GRAB_AGGRESSIVE = "Grabbed Mob (Aggressive - Blue)"
+/atom/var/const/CODEX_INTERACTION_GRAB_NECK = "Grabbed Mob (Neck - Red)"
+
 // Other cases
 /atom/var/const/CODEX_INTERACTION_EMAG = "Cryptographic Sequencer (EMAG)"
 /atom/var/const/CODEX_INTERACTION_EMP = "EMP"

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -79,13 +79,13 @@
 /obj/item/grab/resolve_attackby(atom/A, mob/user, click_params)
 	if (QDELETED(src) || !assailant)
 		return TRUE
-	assailant.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	if(!A.grab_attack(src))
-		return ..()
-	action_used()
-	if (current_grab.downgrade_on_action)
-		downgrade()
-	return TRUE
+	if (A.use_grab(src, user, click_params))
+		assailant.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		action_used()
+		if (current_grab.downgrade_on_action)
+			downgrade()
+		return TRUE
+	return ..()
 
 /obj/item/grab/dropped()
 	..()


### PR DESCRIPTION
I have discovered that `grab_attack()` exists. This transfers that over to `use_grab()` and moves the use call over the grab item's `resolve_attackby()`. Also adds codex entries for the grab interactions.

## Changelog
:cl: SierraKomodo
rscadd: For structures that allow it, the codex will now inform you that you can use grabs to place mobs onto things, i.e. tables. Codex will also inform you of an attack interaction with mobs against structures.
/:cl:

## Other Changes
- Added `CODEX_INTERACTION_GRAB_*` constants for use in describing various grab state interactions.
- Replaced `grab_attack()` with `use_grab()`, including references and overrides.
- Removed the `use_grab()` call from `/atom/proc/resolve_attackby()`, in favor of `/obj/item/grab/resolve_attackby()`.
- Adjusted `/obj/item/grab/resolve_attackby()` to only call downgrades and use calls if `use_grab()` returns `TRUE`.