### PR TITLE
fix reagent overuse when volume < metabolism

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents.dm
+++ b/code/modules/reagents/Chemistry-Reagents.dm
@@ -106,7 +106,7 @@
 			overdose(M)
 
 	//determine the metabolism rate
-	var/removed = metabolism
+	var/removed = min(metabolism, volume)
 	if(ingest_met && (location == CHEM_INGEST))
 		removed = ingest_met
 	if(touch_met && (location == CHEM_TOUCH))


### PR DESCRIPTION
:cl:
bugfix: Tiny reagent volumes no longer process their full metabolism amount.
/:cl: