### PR TITLE
Allows steward to be up to E-6

### DIFF
--- a/maps/torch/job/service_jobs.dm
+++ b/maps/torch/job/service_jobs.dm
@@ -82,9 +82,12 @@
 	allowed_ranks = list(
 		/datum/mil_rank/civ/contractor,
 		/datum/mil_rank/ec/e3,
+		/datum/mil_rank/ec/e5,
 		/datum/mil_rank/fleet/e2,
 		/datum/mil_rank/fleet/e3,
-		/datum/mil_rank/fleet/e4
+		/datum/mil_rank/fleet/e4,
+		/datum/mil_rank/fleet/e5,
+		/datum/mil_rank/fleet/e6
 	)
 	min_skill = list(
 		SKILL_BOTANY = SKILL_BASIC,


### PR DESCRIPTION
:cl: Sbotkin
tweak: Allows the steward to have a rank up to E-6.
/:cl:

Reasoning: being the solo person whose duty is to feed _the entire vessel's crew_ is not easy (also to handle the food inventories on board and hydroponics) and requires significantly more training than a janitor. Realistically speaking, it could be an entire mini-department, like the Supply, but we don't have so many people on Torch and so many mechanics to justify that. For the same reason, no SNCOs.