### PR TITLE
Makes Substations appear in order

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -7797,7 +7797,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/power/smes/buildable/preset/torch/substation{
-	RCon_tag = "Substation - Fifth Deck"
+	RCon_tag = "Substation - 5th Deck"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/fifthdeck)

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -5625,7 +5625,7 @@
 /area/maintenance/substation/fourthdeck)
 "ts" = (
 /obj/machinery/power/smes/buildable/preset/torch/substation{
-	RCon_tag = "Substation - Fourth Deck"
+	RCon_tag = "Substation - 4th Deck"
 	},
 /obj/structure/cable/green,
 /obj/structure/cable/green{

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -1898,7 +1898,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/buildable/preset/torch/substation{
-	RCon_tag = "Substation - Third Deck"
+	RCon_tag = "Substation - 3rd Deck"
 	},
 /obj/item/device/radio/intercom{
 	pixel_y = 23

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -3325,7 +3325,7 @@
 /area/space)
 "gF" = (
 /obj/machinery/power/smes/buildable/preset/torch/substation{
-	RCon_tag = "Substation - Second Deck"
+	RCon_tag = "Substation - 2nd Deck"
 	},
 /obj/structure/cable/green{
 	d2 = 4;

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -4963,7 +4963,7 @@
 	pixel_x = -21
 	},
 /obj/machinery/power/smes/buildable/preset/torch/substation{
-	RCon_tag = "Substation - First Deck"
+	RCon_tag = "Substation - 1st Deck"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/substation/firstdeck)


### PR DESCRIPTION
:cl: SingingSpock
tweak: Deck substations use actual numbers, causing them to show up in order
/:cl:

Exactly what it says on the tin. As I played engineer, I got frustrated by how annoying it is to go through a jumbled list of substations, only some of which are decks, and pick out the decks I wanted. Occasionally I would accidentally miss one. So now they're grouped together and in order (except B-deck... maybe I should put a 0 at the front of it)

![image](https://user-images.githubusercontent.com/29682682/214964369-0c37cf70-2ae7-43ba-b583-668a765c8fa7.png)
