### PR TITLE
Changes to preset modular computers

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/preset_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_console.dm
@@ -49,7 +49,6 @@
 		/datum/computer_file/program/records,
 		/datum/computer_file/program/wordprocessor
 	)
-	autorun_program = /datum/computer_file/program/suit_sensors
 
 /obj/machinery/computer/modular/preset/aislot/research
 	default_software = list(
@@ -95,6 +94,22 @@
 		/datum/computer_file/program/forceauthorization
 	)
 
+/obj/machinery/computer/modular/preset/cardslot/command_eng
+	default_software = list(
+		/datum/computer_file/program/comm,
+		/datum/computer_file/program/camera_monitor,
+		/datum/computer_file/program/email_client,
+		/datum/computer_file/program/records,
+		/datum/computer_file/program/docking,
+		/datum/computer_file/program/wordprocessor,
+		/datum/computer_file/program/power_monitor,
+		/datum/computer_file/program/supermatter_monitor,
+		/datum/computer_file/program/alarm_monitor,
+		/datum/computer_file/program/atmos_control,
+		/datum/computer_file/program/rcon_console,
+		/datum/computer_file/program/shields_monitor
+	)
+
 /obj/machinery/computer/modular/preset/security
 	default_software = list(
 		/datum/computer_file/program/digitalwarrant,
@@ -116,10 +131,12 @@
 /obj/machinery/computer/modular/preset/dock
 	default_software = list(
 		/datum/computer_file/program/reports,
+		/datum/computer_file/program/camera_monitor,
 		/datum/computer_file/program/records,
 		/datum/computer_file/program/email_client,
 		/datum/computer_file/program/supply,
-		/datum/computer_file/program/docking
+		/datum/computer_file/program/docking,
+		/datum/computer_file/program/deck_management
 	)
 
 /obj/machinery/computer/modular/preset/supply_public

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -1108,8 +1108,9 @@
 /area/guppy_hangar/start)
 "cl" = (
 /obj/machinery/light,
-/obj/machinery/computer/modular/preset/medical{
-	dir = 8
+/obj/machinery/computer/modular/preset/dock{
+	dir = 8;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/crew)
@@ -2657,11 +2658,11 @@
 /obj/effect/floor_decal/corner/mauve/half{
 	dir = 4
 	},
-/obj/machinery/computer/modular/preset/civilian{
+/obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/computer/modular/preset/dock{
 	dir = 8;
 	icon_state = "console"
 	},
-/obj/effect/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/exploration)
 "fX" = (
@@ -5010,10 +5011,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/storage)
 "lt" = (
-/obj/machinery/computer/modular/preset/civilian,
 /obj/machinery/computer/guestpass{
 	pixel_y = 32
 	},
+/obj/machinery/computer/modular/preset/dock,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/pilot)
 "lu" = (

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -5736,10 +5736,6 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/disciplinary_board_room/deliberation)
 "nJ" = (
-/obj/machinery/computer/modular/preset/cardslot/command{
-	dir = 1;
-	icon_state = "console"
-	},
 /obj/effect/floor_decal/corner/blue/three_quarters{
 	dir = 4
 	},
@@ -5761,6 +5757,10 @@
 	id = "bridge_port";
 	pixel_x = 24;
 	pixel_y = -35
+	},
+/obj/machinery/computer/modular/preset/dock{
+	dir = 1;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
@@ -6376,19 +6376,19 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "pE" = (
-/obj/machinery/computer/modular/preset/cardslot/command{
+/obj/machinery/computer/modular/preset/cardslot/command_sec{
 	dir = 1;
 	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bridgecheck)
 "pF" = (
-/obj/machinery/computer/modular/preset/cardslot/command{
-	dir = 1;
-	icon_state = "console"
-	},
 /obj/effect/floor_decal/corner/red/half{
 	dir = 4
+	},
+/obj/machinery/computer/modular/preset/cardslot/command_sec{
+	dir = 1;
+	icon_state = "console"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bridgecheck)
@@ -6586,7 +6586,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/bed/chair/comfy/blue,
+/obj/structure/bed/chair/comfy/blue{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "qi" = (
@@ -10290,10 +10292,6 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/bridge/fore)
 "AZ" = (
-/obj/machinery/computer/modular/preset/cardslot/command{
-	dir = 8;
-	icon_state = "console"
-	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Chief Engineer's Desk";
@@ -10303,6 +10301,9 @@
 	},
 /obj/effect/floor_decal/corner/yellow/mono,
 /obj/item/modular_computer/tablet/lease/preset/command,
+/obj/machinery/computer/modular/preset/cardslot/command_eng{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
 "Bc" = (
@@ -11780,7 +11781,6 @@
 /turf/simulated/wall/r_wall/hull,
 /area/bridge)
 "HF" = (
-/obj/machinery/computer/modular/preset/dock,
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
@@ -11789,6 +11789,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/computer/modular/preset/medical,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "HG" = (
@@ -12880,10 +12881,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
 "Mn" = (
-/obj/machinery/computer/modular/preset/cardslot/command_sec{
-	dir = 8;
-	icon_state = "console"
-	},
 /obj/effect/floor_decal/corner/red/mono,
 /obj/machinery/requests_console{
 	announcementConsole = 1;
@@ -14660,7 +14657,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/bed/chair/comfy/blue,
+/obj/structure/bed/chair/comfy/blue{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
 "TM" = (


### PR DESCRIPTION
:cl: SingingSpock
tweak: Docking modular computers now have the deck management and camera monitoring programs
tweak: Medical modular consoles no longer autorun suit sensor monitoring (the telescreens still do)
tweak: The CE now has their own modular computer preset, like the CoS, with command and engineering programs
maptweak: The Charon, Pilot's Office, and Exploration prep rooms now all have docking modular computers rather than civilian or medical
maptweak: The bridge's modular console presets were changed a bit to fit the seat theming better
/:cl:

There have long been little annoying things about the preset modular computers. This attempts to fix the ones I have experienced and/or seen talked about the most. The specific changes to the bridge consoles are that the docking computer was 'moved' to be the one next to the supply computer (deck chief/XO seating) and the console commonly set to suit sensors is now a medical console (CMO seating).