### PR TITLE
replaced "edit referenced object" in vv with vv

### DIFF
--- a/code/modules/admin/verbs/massmodvar.dm
+++ b/code/modules/admin/verbs/massmodvar.dm
@@ -115,7 +115,7 @@
 			to_chat(usr, "If a direction, direction is: [dir]")
 
 	var/class = input("What kind of variable?","Variable Type",default) as null|anything in list("text",
-		"num","type","icon","file","edit referenced object","restore to default")
+		"num","type","icon","file","view variables","restore to default")
 
 	if(!class)
 		return
@@ -163,8 +163,9 @@
 						if (A.type == O.type)
 							A.vars[variable] = O.vars[variable]
 
-		if("edit referenced object")
-			return .(O.vars[variable])
+		if("view variables")
+			debug_variables(O)
+			return
 
 		if("text")
 			var/new_value = input("Enter new text:","Text",O.vars[variable]) as text|null//todo: sanitize ???

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -1,6 +1,6 @@
 /client/proc/mod_list_add_ass()
 	var/class = "text"
-	var/list/class_input = list("text","num","type","reference","mob reference", "icon","file","color","list","edit referenced object","restore to default")
+	var/list/class_input = list("text","num","type","reference","mob reference", "icon","file","color","list","view variables","restore to default")
 	if(src.holder)
 		var/datum/marked_datum = holder.marked_datum()
 		if(marked_datum)
@@ -53,7 +53,7 @@
 /client/proc/mod_list_add(list/L, atom/O, original_name, objectvar)
 
 	var/class = "text"
-	var/list/class_input = list("text","num","type","reference","mob reference", "icon","file","list","color","edit referenced object","restore to default")
+	var/list/class_input = list("text","num","type","reference","mob reference", "icon","file","list","color","view variables","restore to default")
 	if(src.holder)
 		var/datum/marked_datum = holder.marked_datum()
 		if(marked_datum)
@@ -214,7 +214,7 @@
 		if(dir)
 			to_chat(usr, "If a direction, direction is: [dir]")
 	var/class = "text"
-	var/list/class_input = list("text","num","type","reference","mob reference", "icon","file","list","edit referenced object","restore to default")
+	var/list/class_input = list("text","num","type","reference","mob reference", "icon","file","list","view variables","restore to default")
 
 	if(src.holder)
 		var/datum/marked_datum = holder.marked_datum()
@@ -250,8 +250,9 @@
 			else
 				L[L.Find(variable)] = new_var
 
-		if("edit referenced object")
-			modify_variables(variable)
+		if("view variables")
+			debug_variables(variable)
+			return
 
 		if("DELETE FROM LIST")
 			to_world_log("### ListVarEdit by [src]: [O.type] [objectvar]: REMOVED=[html_encode("[variable]")]")
@@ -464,7 +465,7 @@
 					dir = null
 			if(dir)
 				to_chat(usr, "If a direction, direction is: [dir]")
-		var/list/class_input = list("text","num","type","reference","mob reference", "icon","file","list","json","color","edit referenced object","restore to default")
+		var/list/class_input = list("text","num","type","reference","mob reference", "icon","file","list","json","color","view variables","restore to default")
 		if(src.holder)
 			var/datum/marked_datum = holder.marked_datum()
 			if(marked_datum)
@@ -494,8 +495,9 @@
 		if("restore to default")
 			var_value = O.get_initial_variable_value(variable)
 
-		if("edit referenced object")
-			return .(O.get_variable_value(variable))
+		if("view variables")
+			debug_variables(O)
+			return
 
 		if("text")
 			var/var_new = input("Enter new text:","Text",O.get_variable_value(variable)) as null|text

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -8,10 +8,11 @@ var/global/list/view_variables_no_assoc = list("verbs", "contents","screen","ima
 	set category = "Debug"
 	set name = "View Variables"
 
-	if(!check_rights(0))
+	if(!istype(D, /datum))
+		to_chat(usr, SPAN_WARNING("Not a viewable datum."))
 		return
 
-	if(!D)
+	if(!check_rights())
 		return
 
 	var/static/cookieoffset = rand(1, 9999) //to force cookies to reset after the round.


### PR DESCRIPTION
:cl:
admin: The "Edit Referenced Object" option on list entries in VV is replaced with View Variables on the entry.
/:cl: