### PR TITLE
Apply `use_*` overrides and codex interactions to bots.

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -315,3 +315,7 @@
 #define ATOM_FLOURESCENCE_NONE 0 // Not flourescent
 #define ATOM_FLOURESCENCE_INACTIVE 1 // Flourescent but not actively lit
 #define ATOM_FLOURESCENCE_ACTVE 2 // Flourescent and actively lit. Helps prevent repeated processing on a flourescent atom by multiple UV lights
+
+
+// Helper macro for generating stringified name text for IDs located inside objects, i.e. PDAs or wallets. Used for feedback and interaction messages.
+#define GET_ID_NAME(ID, HOLDER) (ID == HOLDER ? "\the [ID]" : "\the [ID] in \the [HOLDER]")

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -197,6 +197,23 @@
 	master = null
 	. = ..()
 
+/atom/movable/overlay/use_grab(obj/item/grab/grab, list/click_params)
+	if (master)
+		return master.use_grab(grab, click_params)
+	return FALSE
+
+/atom/movable/overlay/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	SHOULD_CALL_PARENT(FALSE)
+	if (master)
+		return master.use_weapon(weapon, user, click_params)
+	return FALSE
+
+/atom/movable/overlay/use_tool(obj/item/tool, mob/user, list/click_params)
+	SHOULD_CALL_PARENT(FALSE)
+	if (master)
+		return master.use_tool(tool, user, click_params)
+	return FALSE
+
 /atom/movable/overlay/attackby(obj/item/I, mob/user)
 	if (master)
 		return master.attackby(I, user)

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -150,21 +150,34 @@
 /obj/item/weldingtool/proc/get_fuel()
 	return tank ? tank.reagents.get_reagent_amount(/datum/reagent/fuel) : 0
 
+
+/**
+ * Checks if the tool can be used for the given amount of fuel without actually using it.
+ *
+ * Returns boolean.
+ */
+/obj/item/weldingtool/proc/can_use(amount = 1, mob/user = null, interaction_message = "to complete this task.", silent = FALSE)
+	if (!isOn())
+		if (!silent && user)
+			to_chat(user, SPAN_WARNING("\The [src] must be turned on [interaction_message]"))
+		return FALSE
+	if (get_fuel() < amount)
+		if (!silent && user)
+			to_chat(user, SPAN_WARNING("You need at least [amount] unit\s of [welding_resource] [interaction_message]"))
+		return FALSE
+	return TRUE
+
+
 //Removes fuel from the welding tool. If a mob is passed, it will perform an eyecheck on the mob. This should probably be renamed to use()
 /obj/item/weldingtool/proc/remove_fuel(amount = 1, mob/M = null)
-	if(!welding)
+	if(!can_use(amount, M))
 		return 0
-	if(get_fuel() >= amount)
-		burn_fuel(amount)
-		if(M)
-			M.welding_eyecheck()//located in mob_helpers.dm
-			set_light(0.7, 2, 5, l_color = COLOR_LIGHT_CYAN)
-			addtimer(new Callback(src, /atom/proc/update_icon), 5)
-		return 1
-	else
-		if(M)
-			to_chat(M, SPAN_NOTICE("You need more [welding_resource] to complete this task."))
-		return 0
+	burn_fuel(amount)
+	if(M)
+		M.welding_eyecheck()//located in mob_helpers.dm
+		set_light(0.7, 2, 5, l_color = COLOR_LIGHT_CYAN)
+		addtimer(new Callback(src, /atom/proc/update_icon), 5)
+	return 1
 
 /obj/item/weldingtool/proc/burn_fuel(amount)
 	if(!tank)

--- a/code/modules/codex/codex_atom.dm
+++ b/code/modules/codex/codex_atom.dm
@@ -53,6 +53,11 @@
 /atom/var/const/CODEX_INTERACTION_USE_SELF = "Use On Self"
 /atom/var/const/CODEX_INTERACTION_HAND = "Empty Hand"
 
+// Common Tools/Items
+/atom/var/const/CODEX_INTERACTION_ID_CARD = "ID Card (And Scannable ID Holders)"
+/atom/var/const/CODEX_INTERACTION_SCREWDRIVER = "Screwdriver"
+/atom/var/const/CODEX_INTERACTION_WELDER = "Welding Tool"
+
 // Grabs
 /atom/var/const/CODEX_INTERACTION_GRAB = "Grabbed Mob"
 /atom/var/const/CODEX_INTERACTION_GRAB_PASSIVE = "Grabbed Mob (Passive - Yellow)"

--- a/code/modules/codex/codex_atom.dm
+++ b/code/modules/codex/codex_atom.dm
@@ -18,6 +18,9 @@
 
 	var/lore = get_lore_info()
 	var/mechanics = get_mechanics_info()
+	var/construction = html_list(get_construction_info(), TRUE)
+	if (construction)
+		mechanics += "<h4>Construction Steps</h4>[construction]"
 	var/interactions = html_list_dl(get_interactions_info())
 	if (interactions)
 		mechanics += "<h4>Interactions</h4>[interactions]"
@@ -38,6 +41,18 @@
  */
 /atom/proc/get_mechanics_info()
 	return
+
+
+/**
+ * Handler for displaying construction steps in the Mechanics section of the atom's codex entry. Separated to allow
+ * overriding without duplication of parent steps, or removal of parent mechanics information.
+ *
+ * Returns list of strings.
+ */
+/atom/proc/get_construction_info()
+	RETURN_TYPE(/list)
+	return list()
+
 
 // Constants for use to describe special handlers in `get_interactions_info()`. These allow for consistant key names for overriding and stacking purposes.
 // Click handlers

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -79,37 +79,70 @@
 /mob/living/bot/death()
 	explode()
 
-/mob/living/bot/attackby(obj/item/O, mob/user)
-	if(O.GetIdCard())
-		if(access_scanner.allowed(user) && !open)
-			locked = !locked
-			to_chat(user, SPAN_NOTICE("Controls are now [locked ? "locked." : "unlocked."]"))
-			Interact(usr)
-		else if(open)
-			to_chat(user, SPAN_WARNING("Please close the access panel before locking it."))
-		else
-			to_chat(user, SPAN_WARNING("Access denied."))
-		return
-	else if(isScrewdriver(O))
-		if(!locked)
-			open = !open
-			to_chat(user, SPAN_NOTICE("Maintenance panel is now [open ? "opened" : "closed"]."))
-			Interact(usr)
-		else
-			to_chat(user, SPAN_NOTICE("You need to unlock the controls first."))
-		return
-	else if(isWelder(O))
-		if(health < maxHealth)
-			if(open)
-				health = min(maxHealth, health + 10)
-				user.visible_message(SPAN_NOTICE("\The [user] repairs \the [src]."),SPAN_NOTICE("You repair \the [src]."))
-			else
-				to_chat(user, SPAN_NOTICE("Unable to repair with the maintenance panel closed."))
-		else
-			to_chat(user, SPAN_NOTICE("\The [src] does not need a repair."))
-		return
-	else
-		..()
+
+/mob/living/bot/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_ID_CARD] = "<p>Toggles the access panel lock. The ID must have access, and the panel must be closed.</p>"
+	.[CODEX_INTERACTION_SCREWDRIVER] = "<p>Opens and closes the access panel. The panel must be unlocked.</p>"
+	.[CODEX_INTERACTION_WELDER] = "<p>Repairs 10 points of damage. The access panel must be open. Uses 5 units of fuel.</p>"
+
+
+/mob/living/bot/use_tool(obj/item/tool, mob/user, list/click_params)
+	// ID Card - Toggle access panel lock
+	var/obj/item/card/id/id = tool.GetIdCard()
+	if (istype(id))
+		if (open)
+			to_chat(user, SPAN_WARNING("\The [src]'s access panel must be closed before you can lock it."))
+			return TRUE
+		var/id_name = GET_ID_NAME(id, tool)
+		if (!access_scanner.check_access(id))
+			to_chat(user, SPAN_WARNING("\The [src]'s access panel lock refuses [id_name]."))
+			return TRUE
+		locked = !locked
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [locked ? "locks" : "unlocks"] \the [src]'s access panel lock with \a [tool]."),
+			SPAN_NOTICE("You [locked ? "lock" : "unlock"] \the [src]'s access panel lock with \the [tool].")
+		)
+		Interact(user)
+		return TRUE
+
+	// Screwdriver - Toggle access panel open/closed
+	if (isScrewdriver(tool))
+		if (locked)
+			to_chat(user, SPAN_WARNING("\The [src]'s access panel must be unlocked before you can open it."))
+			return TRUE
+		open = !open
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [open ? "opens" : "closes"] \the [src]'s access panel with \a [tool]."),
+			SPAN_NOTICE("You [open ? "open" : "close"] \the [src]'s access panel with \the [tool].")
+		)
+		Interact(user)
+		return TRUE
+
+	// Welder - Repairs damage
+	if (isWelder(tool))
+		if (health >= maxHealth)
+			to_chat(user, SPAN_WARNING("\The [src] doesn't need any repairs."))
+			return TRUE
+		if (!open)
+			to_chat(user, SPAN_WARNING("\The [src]'s access panel must be open to repair it."))
+			return TRUE
+		var/obj/item/weldingtool/welder = tool
+		if (!welder.can_use(5, user, "to repair \the [src]."))
+			return TRUE
+		welder.remove_fuel(5, user)
+		health = min(maxHealth, health + 10)
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] repairs some of \the [src]'s damage with \a [tool]."),
+			SPAN_NOTICE("You repair some of \the [src]'s damage with \the [tool].")
+		)
+		return TRUE
+
+	return ..()
+
 
 /mob/living/bot/attack_ai(mob/user)
 	Interact(user)

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -143,6 +143,19 @@
 		screwloose = 1
 		return 1
 
+
+/mob/living/bot/cleanbot/get_construction_info()
+	return list(
+		"Attach a <b>Proximity Sensor</b> to a <b>Bucket</b>.",
+		"Add a <b>Robot Arm</b> to complete the cleanbot."
+	)
+
+
+/mob/living/bot/cleanbot/get_antag_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_EMAG] += "<p>Turns on malfunctions that causes \the [initial(name)] to spew out gibs and water.</p>"
+
+
 /mob/living/bot/cleanbot/proc/get_targets()
 	target_types = list()
 

--- a/code/modules/mob/living/bot/ed209bot.dm
+++ b/code/modules/mob/living/bot/ed209bot.dm
@@ -20,6 +20,22 @@
 	var/shot_delay = 4
 	var/last_shot = 0
 
+
+/mob/living/bot/secbot/ed209/get_construction_info()
+	return list(
+		"Use <b>5 Sheets of Steel</b> on a <b>Standard Robot Frame</b> that has no other parts installed.",
+		"Add a robotic <b>Left Leg</b> and a robotic <b>Right Leg</b>.",
+		"Add an <b>Armor Plate</b>.",
+		"Use a <b>Welding Tool</b> to secure the armor plating.",
+		"Add a <b>Helmet</b>.",
+		"Add a <b>Proximity Sensor</b>.",
+		"Add <b>1 Length of Cable Coil</b>.",
+		"Add an <b>Electrolaser</b>.",
+		"Use a <b>Screwdriver</b> to secure the taser in place.",
+		"Add a <p>Power Cell</p> to complete the ED-209."
+	)
+
+
 /mob/living/bot/secbot/ed209/update_icons()
 	icon_state = "ed2090"
 

--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -279,3 +279,17 @@
 		return FARMBOT_NUTRIMENT
 
 	return 0
+
+
+/mob/living/bot/farmbot/get_construction_info()
+	return list(
+		"Attach a <b>Plant Scanner</b> to a <b>Water Tank</b>.",
+		"Add a <b>Bucket</b>.",
+		"Add a <b>Minihoe</b>.",
+		"Add a <b>Proximity Sensor</b> to complete the farmbot."
+	)
+
+
+/mob/living/bot/farmbot/get_antag_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_EMAG] += "<p>Enables a malfunction that causes \the [initial(name)] to attack mobs, except yourself.</p>"

--- a/code/modules/mob/living/bot/floorbot.dm
+++ b/code/modules/mob/living/bot/floorbot.dm
@@ -75,6 +75,20 @@
 				if(emagged < 2)
 					emagged = !emagged
 
+
+/mob/living/bot/floorbot/get_construction_info()
+	return list(
+		"Add <b>10 Floor Tiles</b> to a <b>Toolbox</b>.",
+		"Add a <b>Proximity Sensor</b>.",
+		"Add a robotic <b>Left Arm</b> or <b>Right Arm</b> to finish the floorbot."
+	)
+
+
+/mob/living/bot/floorbot/get_antag_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_EMAG] += "<p>Causes \the [initial(name)] to tear up and remove floors instead of build them.</p>"
+
+
 /mob/living/bot/floorbot/emag_act(remaining_charges, mob/user)
 	. = ..()
 	if(!emagged)

--- a/code/modules/mob/living/bot/medibot.dm
+++ b/code/modules/mob/living/bot/medibot.dm
@@ -93,22 +93,46 @@
 	else
 		icon_state = "medibot[on]"
 
-/mob/living/bot/medbot/attackby(obj/item/O, mob/user)
-	if(istype(O, /obj/item/reagent_containers/glass))
-		if(locked)
-			to_chat(user, SPAN_NOTICE("You cannot insert a beaker because the panel is locked."))
-			return
-		if(!isnull(reagent_glass))
-			to_chat(user, SPAN_NOTICE("There is already a beaker loaded."))
-			return
 
-		if(!user.unEquip(O, src))
-			return
-		reagent_glass = O
-		to_chat(user, SPAN_NOTICE("You insert [O]."))
-		return
-	else
-		..()
+/mob/living/bot/medbot/get_construction_info()
+	return list(
+		"Add a robotic <b>Left Arm</b> or <b>Right Arm</b> to a <b>First-Aid Kit</b>.",
+		"Add a <b>Health Analyzer</b>.",
+		"Add a <b>Proximity Sensor</b> to complete the medbot."
+	)
+
+
+/mob/living/bot/medbot/get_interactions_info()
+	. = ..()
+	.["Beaker"] = "<p>Installs the beaker into \the [initial(name)]. If installed, it will use the contents of the beaker for injections instead of tricordrazine. Only one beaker can be installed at a time. The access panel must be unlocked.</p>"
+
+
+/mob/living/bot/medbot/get_antag_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_EMAG] += "<p>Causes \the [initial(name)] to synthesize and inject toxins instead of tricordrazine. It will also try to inject any mob in sight except the one who emagged it, regardless of injury state.</p>"
+
+
+/mob/living/bot/medbot/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Beaker - Inserts a beaker
+	if (istype(tool, /obj/item/reagent_containers/glass))
+		if (locked)
+			to_chat(user, SPAN_WARNING("\The [src]'s access panel must be open before you can insert a beaker."))
+			return TRUE
+		if (reagent_glass)
+			to_chat(user, SPAN_WARNING("\The [src] already has \a [reagent_glass] installed."))
+			return TRUE
+		if (!user.unEquip(tool, src))
+			to_chat(user, SPAN_WARNING("You can't drop \the [src]."))
+			return TRUE
+		reagent_glass = tool
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs \a [tool] into \the [src]."),
+			SPAN_NOTICE("You install \the [tool] into \the [src].")
+		)
+		return TRUE
+
+	return ..()
+
 
 /mob/living/bot/medbot/GetInteractTitle()
 	. = "<head><title>Medibot v1.0 controls</title></head>"

--- a/code/modules/mob/living/bot/mulebot.dm
+++ b/code/modules/mob/living/bot/mulebot.dm
@@ -52,6 +52,12 @@
 	suffix = num2text(++amount)
 	name = "Mulebot #[suffix]"
 
+
+/mob/living/bot/mulebot/get_antag_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_EMAG] = "<p>Toggles the access panel lock.</p>"
+
+
 /mob/living/bot/mulebot/MouseDrop_T(atom/movable/C, mob/user)
 	if(user.stat)
 		return
@@ -119,10 +125,6 @@
 			if("safety")
 				safety = !safety
 
-/mob/living/bot/mulebot/attackby(obj/item/O, mob/user)
-	..()
-	update_icons()
-
 /mob/living/bot/mulebot/proc/obeyCommand(command)
 	switch(command)
 		if("Home")
@@ -152,7 +154,7 @@
 	playsound(loc, 'sound/effects/sparks1.ogg', 100, 0)
 	return 1
 
-/mob/living/bot/mulebot/update_icons()
+/mob/living/bot/mulebot/on_update_icon()
 	if(open)
 		icon_state = "mulebot-hatch"
 		return
@@ -164,7 +166,7 @@
 /mob/living/bot/mulebot/handleRegular()
 	if(!safety && prob(1))
 		flick("mulebot-emagged", src)
-	update_icons()
+	update_icon()
 
 /mob/living/bot/mulebot/handleFrustrated()
 	custom_emote(2, "makes a sighing buzz.")

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -107,11 +107,35 @@
 				if(emagged < 2)
 					emagged = !emagged
 
-/mob/living/bot/secbot/attackby(obj/item/O, mob/user)
-	var/curhealth = health
+
+/mob/living/bot/secbot/get_mechanics_info()
 	. = ..()
-	if(health < curhealth)
+	. += {"
+		<p>If attacked and damaged, it will attempt to arrest or subdue the attacker.</p>
+	"}
+
+
+/mob/living/bot/secbot/get_construction_info()
+	return list(
+		"Attach a <b>Remote Signalling Device</b> to a <b>Helmet</b>.",
+		"Use a <b>Welding Tool</b>.",
+		"Add a <b>Proximity Sensor</b>.",
+		"Add a robotic <b>Left Arm</b> or <b>Right Arm</b>.",
+		"Add a <b>Stunbaton</b> to complete the securitron."
+	)
+
+
+/mob/living/bot/secbot/get_antag_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_EMAG] += "<p>Causes \the [initial(name)] to attack and arrest anyone around it, except the person who emagged it.</p>"
+
+
+/mob/living/bot/secbot/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	var/previous_health = health
+	. = ..()
+	if (. && health < previous_health)
 		react_to_attack(user)
+
 
 /mob/living/bot/secbot/emag_act(remaining_charges, mob/user)
 	. = ..()


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
rscadd: Added some codex information for bots, including interactions and construction steps.
/:cl:

## Other Changes
- Added `use_*()` overrides to `/atom/movable/overlay`.
- Added `can_use()` to welding tools, allowing code to check if a welding tool is turned on, has, fuel, etc without actually using the fuel.
- Added `GET_ID_NAME()` macro for generating a string incorporating object names of both an ID and its holder. Intended to be used alongside `GetIdCard()` and user feedback messages.
- Added additional `CODEX_INTERACTION_*` constants for some common tools and items.
- Added `get_construction_info()` for listing construction steps. Separated proc allows for overrides that don't override parent general mechanics info, or include duplicate parent construction steps. See `/mob/living/bot/secbot` and `/mob/living/bot/secbot/ed209` for an example conflict that inspired this change.
- Replaced mulebot's `update_icons()` call and override with `update_icon()` and `on_update_icon()`.
- Replaced `attackby()` with `get_*()` for `/mob/living/bot`. Also cleaned up and standardized the transferred code.