### PR TITLE
Health cleanup

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -377,7 +377,7 @@
 
 	to_chat(user, "[icon2html(src, user)] That's [f_name] [suffix]")
 	to_chat(user, desc)
-	if (health_max)
+	if (get_max_health())
 		examine_damage_state(user)
 	return TRUE
 
@@ -447,18 +447,19 @@
  * stronger.
  */
 /atom/proc/ex_act(severity, turf_breaker)
-	if (get_max_health())
+	var/max_health = get_max_health()
+	if (max_health)
 		// No hitsound here to avoid noise spam.
 		// Damage is based on severity and maximum health, with DEVASTATING being guaranteed death without any resistances.
 		var/damage_flags = turf_breaker ? DAMAGE_FLAG_TURF_BREAKER : EMPTY_BITFIELD
 		var/damage = 0
 		switch (severity)
 			if (EX_ACT_DEVASTATING)
-				damage = round(health_max * (rand(100, 200) / 100)) // So that even atoms resistant to explosions may still be heavily damaged at this severity. Effective range of 100% to 200%.
+				damage = round(max_health * (rand(100, 200) / 100)) // So that even atoms resistant to explosions may still be heavily damaged at this severity. Effective range of 100% to 200%.
 			if (EX_ACT_HEAVY)
-				damage = round(health_max * (rand(50, 100) / 100)) // Effective range of 50% to 100%.
+				damage = round(max_health * (rand(50, 100) / 100)) // Effective range of 50% to 100%.
 			if (EX_ACT_LIGHT)
-				damage = round(health_max * (rand(10, 50) / 100)) // Effective range of 10% to 50%.
+				damage = round(max_health * (rand(10, 50) / 100)) // Effective range of 10% to 50%.
 		if (damage)
 			damage_health(damage, DAMAGE_EXPLODE, damage_flags, severity)
 

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -61,7 +61,7 @@
  */
 /atom/proc/can_restore_health(damage, damage_type = null)
 	SHOULD_CALL_PARENT(TRUE)
-	if (!health_max)
+	if (!get_max_health())
 		return FALSE
 	if (!damage)
 		return FALSE
@@ -75,7 +75,7 @@
  */
 /atom/proc/can_damage_health(damage, damage_type = null, damage_flags = EMPTY_BITFIELD)
 	SHOULD_CALL_PARENT(TRUE)
-	if (!health_max)
+	if (!get_max_health())
 		return FALSE
 	if (health_dead)
 		return FALSE
@@ -98,7 +98,7 @@
  */
 /atom/proc/mod_health(health_mod, damage_type, skip_death_state_change = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
-	if (!health_max)
+	if (!get_max_health())
 		return FALSE
 	health_mod = round(health_mod)
 	var/death_state = health_dead
@@ -122,7 +122,7 @@
  */
 /atom/proc/set_health(new_health, skip_death_state_change = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
-	var/health_mod = new_health - health_current
+	var/health_mod = new_health - get_current_health()
 	return mod_health(health_mod, skip_death_state_change = skip_death_state_change)
 
 /**
@@ -172,7 +172,7 @@
  */
 /atom/proc/revive_health()
 	SHOULD_CALL_PARENT(TRUE)
-	return set_health(health_max)
+	return set_health(get_max_health())
 
 /// Proc called when the atom transitions from alive to dead.
 /atom/proc/on_death()
@@ -190,9 +190,9 @@
 	SHOULD_CALL_PARENT(TRUE)
 	health_max = round(new_max_health)
 	if (set_current_health)
-		set_health(health_max)
+		set_health(get_max_health())
 	else
-		set_health(min(health_current, health_max))
+		set_health(min(get_current_health(), get_max_health()))
 
 /**
  * Sets the atom's resistance/weakness to the given damage type.

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -40,36 +40,29 @@
  * Whether or not the atom's health is damaged.
  */
 /atom/proc/health_damaged()
-	if (!health_max)
-		return
 	return get_current_health() < get_max_health()
 
 /**
  * Retrieves the atom's current damage, or `null` if not using health.
  */
 /atom/proc/get_damage_value()
-	if (!health_max)
-		return
 	return get_max_health() - get_current_health()
 
 /**
  * Retrieves the atom's current damage as a percentage where `100%` is `100`.
  */
 /atom/proc/get_damage_percentage()
-	if (!health_max)
-		return
 	return Percent(get_damage_value(), get_max_health(), 0)
 
 /**
  * Checks if the atom's health can be restored.
  * Should be called before `restore_health()` in most cases.
- * Returns `null` if health is not in use.
  * NOTE: Does not include a check for death state by default, to allow repairing/healing atoms back to life.
  */
 /atom/proc/can_restore_health(damage, damage_type = null)
 	SHOULD_CALL_PARENT(TRUE)
 	if (!health_max)
-		return
+		return FALSE
 	if (!damage)
 		return FALSE
 	if (get_current_health() == get_max_health())
@@ -79,12 +72,11 @@
 /**
  * Checks if the atom's health can be damaged.
  * Should be called before `damage_health()` in most cases.
- * Returns `null` if health is not in use.
  */
 /atom/proc/can_damage_health(damage, damage_type = null, damage_flags = EMPTY_BITFIELD)
 	SHOULD_CALL_PARENT(TRUE)
 	if (!health_max)
-		return
+		return FALSE
 	if (health_dead)
 		return FALSE
 	if (!damage || damage < health_min_damage)
@@ -102,12 +94,12 @@
  * Health modification for the health system. Applies `health_mod` directly to `simple_health` via addition and calls `handle_death_change` as needed.
  * Has no pre-modification checks, you should be using `damage_health()` or `restore_health()` instead of this.
  * `skip_death_state_change` will skip calling `handle_death_change()` when applicable. Used for when the originally calling proc needs handle it in a unique way.
- * Returns `TRUE` if the death state changes, `null` if the atom is not using health, `FALSE` otherwise.
+ * Returns `TRUE` if the death state changes, `FALSE` otherwise.
  */
 /atom/proc/mod_health(health_mod, damage_type, skip_death_state_change = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
 	if (!health_max)
-		return
+		return FALSE
 	health_mod = round(health_mod)
 	var/death_state = health_dead
 	health_current = round(clamp(health_current + health_mod, 0, get_max_health()))
@@ -130,8 +122,6 @@
  */
 /atom/proc/set_health(new_health, skip_death_state_change = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
-	if (!health_max)
-		return
 	var/health_mod = new_health - health_current
 	return mod_health(health_mod, skip_death_state_change = skip_death_state_change)
 
@@ -140,8 +130,6 @@
  */
 /atom/proc/restore_health(damage, damage_type = null, skip_death_state_change = FALSE, skip_can_restore_check = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
-	if (!health_max)
-		return
 	if (!skip_can_restore_check && !can_restore_health(damage, damage_type))
 		return FALSE
 	return mod_health(damage, damage_type, skip_death_state_change)
@@ -156,8 +144,6 @@
  */
 /atom/proc/damage_health(damage, damage_type, damage_flags = EMPTY_BITFIELD, severity, skip_can_damage_check = FALSE)
 	SHOULD_CALL_PARENT(TRUE)
-	if (!health_max)
-		return
 	if (!skip_can_damage_check && !can_damage_health(damage, damage_type, damage_flags))
 		return FALSE
 

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -65,7 +65,7 @@
 		return FALSE
 	if (!damage)
 		return FALSE
-	if (get_current_health() == get_max_health())
+	if (!health_damaged())
 		return FALSE
 	return TRUE
 
@@ -81,7 +81,7 @@
 		return FALSE
 	if (!damage || damage < health_min_damage)
 		return FALSE
-	if (get_damage_resistance(damage_type) == 0)
+	if (is_damage_immune(damage_type))
 		return FALSE
 	return TRUE
 
@@ -253,7 +253,7 @@
 
 /mob/examine_damage_state(mob/user)
 	if (health_dead)
-		to_chat(user, SPAN_DANGER("They look severely hurt and is not moving or responding to anything around them."))
+		to_chat(user, SPAN_DANGER("They look severely hurt and are not moving or responding to anything around them."))
 		return
 
 	var/damage_percentage = get_damage_percentage()

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -27,9 +27,7 @@
  */
 /atom/proc/get_current_health()
 	SHOULD_CALL_PARENT(TRUE)
-	if (!health_max)
-		return
-	return health_current
+	return min(health_current, get_max_health())
 
 /**
  * Retrieves the atom's maximum health.

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -101,9 +101,10 @@
 	if (!get_max_health())
 		return FALSE
 	health_mod = round(health_mod)
+	var/prior_health = get_current_health()
 	var/death_state = health_dead
 	health_current = round(clamp(health_current + health_mod, 0, get_max_health()))
-	post_health_change(health_mod, damage_type)
+	post_health_change(health_mod, prior_health, damage_type)
 	var/new_death_state = health_current > 0 ? FALSE : TRUE
 	if (death_state == new_death_state)
 		return FALSE
@@ -157,7 +158,7 @@
 /**
  * Proc called after any health changes made by the system
  */
-/atom/proc/post_health_change(health_mod, damage_type = null)
+/atom/proc/post_health_change(health_mod, prior_health, damage_type = null)
 	return
 
 /**

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -39,34 +39,26 @@
 /**
  * Whether or not the atom's health is damaged.
  */
-/atom/proc/health_damaged(use_raw_values)
+/atom/proc/health_damaged()
 	if (!health_max)
 		return
-	if (use_raw_values)
-		return health_current < health_max
 	return get_current_health() < get_max_health()
 
 /**
  * Retrieves the atom's current damage, or `null` if not using health.
- * If `use_raw_values` is `TRUE`, uses the raw var values instead of the `get_*` proc results.
  */
-/atom/proc/get_damage_value(use_raw_values)
+/atom/proc/get_damage_value()
 	if (!health_max)
 		return
-	if (use_raw_values)
-		return health_max - health_current
-	else
-		return get_max_health() - get_current_health()
+	return get_max_health() - get_current_health()
 
 /**
  * Retrieves the atom's current damage as a percentage where `100%` is `100`.
- * If `use_raw_values` is `TRUE`, uses the raw var values instead of the `get_*` proc results.
  */
-/atom/proc/get_damage_percentage(use_raw_values)
+/atom/proc/get_damage_percentage()
 	if (!health_max)
 		return
-	var/max_health = use_raw_values ? health_max : get_max_health()
-	return Percent(get_damage_value(use_raw_values), max_health, 0)
+	return Percent(get_damage_value(), get_max_health(), 0)
 
 /**
  * Checks if the atom's health can be restored.

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -147,7 +147,7 @@
 
 /obj/machinery/ex_act(severity)
 	..()
-	if (health_max)
+	if (get_max_health())
 		return
 	switch(severity)
 		if(EX_ACT_DEVASTATING)

--- a/code/game/machinery/bluespace_drive.dm
+++ b/code/game/machinery/bluespace_drive.dm
@@ -66,7 +66,7 @@
 		playsound(loc, damage_hitsound, 80)
 
 
-/obj/machinery/bluespacedrive/post_health_change(health_mod, damage_type)
+/obj/machinery/bluespacedrive/post_health_change(health_mod, prior_health, damage_type)
 	. = ..()
 	var/damage_percentage = get_damage_percentage()
 	if (damage_percentage >= 50 && !(state & STATE_UNSTABLE))

--- a/code/game/machinery/bluespace_drive.dm
+++ b/code/game/machinery/bluespace_drive.dm
@@ -71,10 +71,10 @@
 	var/damage_percentage = get_damage_percentage()
 	if (damage_percentage >= 50 && !(state & STATE_UNSTABLE))
 		state |= STATE_UNSTABLE
-		update_icon()
+		queue_icon_update()
 	else if (damage_percentage < 50 && (state & STATE_UNSTABLE))
 		state &= ~STATE_UNSTABLE
-		update_icon()
+		queue_icon_update()
 
 
 /obj/machinery/bluespacedrive/on_death()

--- a/code/game/machinery/doors/airlock_interactions.dm
+++ b/code/game/machinery/doors/airlock_interactions.dm
@@ -41,7 +41,7 @@
  * Whether or not the atom can be crushed and damaged by a closing airlock.
  */
 /atom/movable/proc/airlock_can_crush()
-	if (health_max)
+	if (get_max_health())
 		return TRUE
 	return FALSE
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -267,11 +267,11 @@
 		set_broken(TRUE)
 		return 1
 
-/obj/machinery/door/post_health_change(health_mod, damage_type)
+/obj/machinery/door/post_health_change(health_mod, prior_health, damage_type)
 	. = ..()
 	queue_icon_update()
 	if (health_mod < 0 && !health_dead)
-		var/initial_damage_percentage = round(((get_current_health() - health_mod) / get_max_health()) * 100)
+		var/initial_damage_percentage = round((prior_health / get_max_health()) * 100)
 		var/damage_percentage = get_damage_percentage()
 		if (damage_percentage >= 75 && initial_damage_percentage < 75)
 			visible_message("\The [src] looks like it's about to break!" )

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -359,7 +359,7 @@ var/global/list/turret_icons
 		damage = damage / 8
 	. = ..()
 
-/obj/machinery/porta_turret/post_health_change(health_mod, damage_type)
+/obj/machinery/porta_turret/post_health_change(health_mod, prior_health, damage_type)
 	. = ..()
 	if (health_mod < 0)
 		if (!emagged && enabled)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -152,7 +152,7 @@
 
 /obj/item/ex_act(severity)
 	..()
-	if (health_max)
+	if (get_max_health())
 		return
 	switch(severity)
 		if(EX_ACT_DEVASTATING)

--- a/code/game/objects/items/weapons/material/ashtray.dm
+++ b/code/game/objects/items/weapons/material/ashtray.dm
@@ -56,7 +56,7 @@
 	..()
 
 /obj/item/material/ashtray/throw_impact(atom/hit_atom)
-	if (health_max)
+	if (get_max_health())
 		if (length(contents))
 			visible_message(SPAN_DANGER("\The [src] slams into [hit_atom], spilling its contents!"))
 			for (var/obj/O in contents)

--- a/code/game/objects/structures/crates_lockers/closets/statue.dm
+++ b/code/game/objects/structures/crates_lockers/closets/statue.dm
@@ -40,7 +40,7 @@
 			icon_state = "corgi"
 			desc = "If it takes forever, I will wait for you..."
 
-	if(health_max == 0) //meaning if the statue didn't find a valid target
+	if(!get_max_health()) //meaning if the statue didn't find a valid target
 		qdel(src)
 		return
 

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -118,7 +118,7 @@
 			to_chat(user, SPAN_NOTICE("You dislodged the girder!"))
 			icon_state = "displaced"
 			anchored = FALSE
-			health_max = 50
+			set_max_health(50)
 			cover = 25
 		return
 
@@ -195,7 +195,7 @@
 
 /obj/structure/girder/proc/reinforce_girder()
 	cover = 75
-	health_max = 500
+	set_max_health(500)
 	state = 2
 	icon_state = "reinforced"
 	reinforcing = 0

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -152,11 +152,11 @@
 /obj/structure/window/CanFluidPass(coming_from)
 	return (!is_fulltile() && coming_from != dir)
 
-/obj/structure/window/post_health_change(health_mod, damage_type)
+/obj/structure/window/post_health_change(health_mod, prior_health, damage_type)
 	..()
 	update_icon()
 	if (health_mod < 0)
-		var/initial_damage_percentage = round(((get_current_health() - health_mod) / get_max_health()) * 100)
+		var/initial_damage_percentage = round((prior_health / get_max_health()) * 100)
 		var/damage_percentage = get_damage_percentage()
 		if (damage_percentage >= 75 && initial_damage_percentage < 75)
 			visible_message(SPAN_DANGER("\The [src] looks like it's about to shatter!"))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -154,7 +154,7 @@
 
 /obj/structure/window/post_health_change(health_mod, prior_health, damage_type)
 	..()
-	update_icon()
+	queue_icon_update()
 	if (health_mod < 0)
 		var/initial_damage_percentage = round((prior_health / get_max_health()) * 100)
 		var/damage_percentage = get_damage_percentage()

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -163,7 +163,7 @@
 	if (locate(/obj/effect/overlay/wallrot) in src)
 		. = round(. / 10)
 
-/turf/simulated/wall/post_health_change(damage, damage_type)
+/turf/simulated/wall/post_health_change(damage, prior_health, damage_type)
 	..()
 	update_icon()
 

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -165,7 +165,7 @@
 
 /turf/simulated/wall/post_health_change(damage, prior_health, damage_type)
 	..()
-	update_icon()
+	queue_icon_update()
 
 /turf/simulated/wall/on_death()
 	dismantle_wall(TRUE)

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -77,7 +77,7 @@
 	playsound(loc, 'sound/effects/splat.ogg', 50, 1)
 	qdel(src)
 
-/obj/effect/blob/post_health_change(health_mod, damage_type)
+/obj/effect/blob/post_health_change(health_mod, prior_health, damage_type)
 	update_icon()
 
 /obj/effect/blob/proc/regen()

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -78,7 +78,8 @@
 	qdel(src)
 
 /obj/effect/blob/post_health_change(health_mod, prior_health, damage_type)
-	update_icon()
+	..()
+	queue_icon_update()
 
 /obj/effect/blob/proc/regen()
 	restore_health(regen_rate)

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -256,7 +256,7 @@
 	wake_neighbors()
 	qdel(src)
 
-/obj/effect/vine/post_health_change(health_mod, damage_type)
+/obj/effect/vine/post_health_change(health_mod, prior_health, damage_type)
 	..()
 	queue_icon_update()
 

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -82,7 +82,7 @@
 	icon = 0
 	addtimer(new Callback(src, .proc/fall_apart), 5.1)
 
-/obj/item/device/electronic_assembly/post_health_change(health_mod, damage_type)
+/obj/item/device/electronic_assembly/post_health_change(health_mod, prior_health, damage_type)
 	..()
 	if (get_damage_percentage() >= 75)
 		if(battery && battery.charge > 0)

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -89,7 +89,7 @@
 			visible_message(SPAN_WARNING("\The [src] sputters and sparks!"))
 			spark_system.start()
 		opened = TRUE
-		on_update_icon()
+		queue_icon_update()
 
 /obj/item/device/electronic_assembly/proc/check_interactivity(mob/user)
 	return (!user.incapacitated() && CanUseTopic(user))

--- a/code/modules/mob/living/carbon/resist.dm
+++ b/code/modules/mob/living/carbon/resist.dm
@@ -66,17 +66,16 @@
 			return
 		if(!handcuffed || buckled)
 			return
-	if (handcuffed.health_max) // Improvised cuffs can break because their health is > 0
-		if (handcuffed.damage_health(handcuffed.get_max_health() / 2))
-			visible_message(
-				SPAN_DANGER("\The [src] manages to remove \the [handcuffed], breaking them!"),
-				SPAN_NOTICE("You successfully remove \the [handcuffed], breaking them!"), range = 2
-				)
-			QDEL_NULL(handcuffed)
-			if(buckled && buckled.buckle_require_restraints)
-				buckled.unbuckle_mob()
-			update_inv_handcuffed()
-			return
+	if (handcuffed.damage_health(handcuffed.get_max_health() / 2))
+		visible_message(
+			SPAN_DANGER("\The [src] manages to remove \the [handcuffed], breaking them!"),
+			SPAN_NOTICE("You successfully remove \the [handcuffed], breaking them!"), range = 2
+			)
+		QDEL_NULL(handcuffed)
+		if(buckled && buckled.buckle_require_restraints)
+			buckled.unbuckle_mob()
+		update_inv_handcuffed()
+		return
 	visible_message(
 		SPAN_WARNING("\The [src] manages to remove \the [handcuffed]!"),
 		SPAN_NOTICE("You successfully remove \the [handcuffed]!"), range = 2

--- a/code/modules/modular_computers/hardware/_hardware.dm
+++ b/code/modules/modular_computers/hardware/_hardware.dm
@@ -88,7 +88,7 @@
 /obj/item/stock_parts/computer/proc/set_damage_failure()
 	if (get_damage_value() >= damage_failure)
 		return
-	set_health(health_max - damage_failure)
+	set_health(get_max_health() - damage_failure)
 
 
 /**
@@ -104,7 +104,7 @@
 /obj/item/stock_parts/computer/proc/set_damage_malfunction()
 	if (get_damage_value() >= damage_malfunction)
 		return
-	set_health(health_max - damage_malfunction)
+	set_health(get_max_health() - damage_malfunction)
 
 
 /**

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -35,7 +35,7 @@
 	if(!height || air_group) return 0
 	else return ..()
 
-/obj/machinery/shield/post_health_change(health_mod, damage_type)
+/obj/machinery/shield/post_health_change(health_mod, prior_health, damage_type)
 	. = ..()
 	if (health_dead)
 		return
@@ -144,7 +144,7 @@
 		else
 			check_delay--
 
-/obj/machinery/shieldgen/post_health_change(health_mod, damage_type)
+/obj/machinery/shieldgen/post_health_change(health_mod, prior_health, damage_type)
 	. = ..()
 	queue_icon_update()
 	if (get_current_health() <= 30)

--- a/code/modules/xenoarcheaology/artifacts/artifact.dm
+++ b/code/modules/xenoarcheaology/artifacts/artifact.dm
@@ -204,11 +204,11 @@
 			damage_desc += "concentrated high-energy bursts."
 
 
-/obj/machinery/artifact/post_health_change(health_mod, damage_type)
+/obj/machinery/artifact/post_health_change(health_mod, prior_health, damage_type)
 	..()
 	queue_icon_update()
 	if (health_mod < 0)
-		var/initial_damage_percentage = round(((get_current_health() - health_mod) / get_max_health()) * 100)
+		var/initial_damage_percentage = round((prior_health / get_max_health()) * 100)
 		var/damage_percentage = get_damage_percentage()
 		if (damage_percentage >= 75 && initial_damage_percentage < 75)
 			visible_message("\The [src] looks like it's about to break!")


### PR DESCRIPTION
Some general maintenance and cleanup of the standardized health procs. NUFC.

## Changes
- `get_current_health()` is now limited to the value of `health_max`, in case `health_current` somehow exceeds it. This prevents potential cases of negative damage values that will break logic elsewhere.
- Removes the `use_raw_values` parameter from health procs. This was unused and creates some unnecessary complications in planning other updates.
- Removes `!health_max` checks from various health procs. Mostly unnecessary, and created some unnecessary ambiguation between `null` and `FALSE` return values.
- Replaces various direct references to `health_current` and `health_max` with their getters and setters.
- Adds `prior_health` parameter to `post_health_change()`, removing the need to calculate pre-change health in various overrides.
- `post_health_change()` overrides now call `queue_icon_update()` instead of `update_icon()` (And the one situation that was calling `on_update_icon()` directly for some reason). This should help with some proc overhead during high damage events, such as explosions or fires.