### PR TITLE
Rotates Aquila air tanks

### DIFF
--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -14321,9 +14321,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "So" = (
-/obj/machinery/atmospherics/unary/tank/air{
-	dir = 6
-	},
+/obj/machinery/atmospherics/unary/tank/air,
 /obj/effect/floor_decal/industrial/outline/blue,
 /turf/simulated/floor/plating,
 /area/aquila/air)


### PR DESCRIPTION
🆑SingingSpock 
maptweak: Rotates aquila unary air tanks so they actually connect to the pipenet
/:cl:

Just what it says on the tin: the Aquila's unary air tanks were not actually filling the pipenet because they were rotated to face west. I have made them face south so they actually work.