### PR TITLE
Add fake cryostorage item

### DIFF
--- a/code/datums/uplink/services.dm
+++ b/code/datums/uplink/services.dm
@@ -40,6 +40,12 @@
 	item_cost = 40
 	path = /obj/item/device/uplink_service/jamming
 
+/datum/uplink_item/item/services/fake_cryo_announcement
+	name = "Fake Cryostorage Announcement"
+	desc = "A single-use device, that when activated, creates a fake cryogenic storage announcement and removes your name from the manifest. Perfect for the sneaky traitor!"
+	item_cost = 24
+	path = /obj/item/device/uplink_service/fake_cryo_announcement
+
 /***************
 * Service Item *
 ***************/
@@ -328,3 +334,28 @@
 	. = ..()
 
 #undef COPY_VALUE
+
+/*********************************
+	* Fake Cryo Announcement *
+*********************************/
+/obj/item/device/uplink_service/fake_cryo_announcement
+	service_label = "Cryogenic Storage Announcement"
+	var/obj/item/device/radio/headset/announcer
+
+/obj/item/device/uplink_service/fake_cryo_announcement/New()
+	announcer = new /obj/item/device/radio/headset(src)
+	..()
+
+/obj/item/device/uplink_service/fake_cryo_announcement/enable(mob/user = usr)
+
+	//Delete the user off the manifest/records
+	var/sanitized_name = user.real_name
+	sanitized_name = sanitize(sanitized_name)
+	var/datum/computer_file/report/crew_record/R = get_crewmember_record(sanitized_name)
+	if (R)
+		qdel(R)
+
+	//Make the announcement
+	var/role_alt_title = user.mind ? user.mind.role_alt_title : "Unknown"
+	invoke_async(announcer, /obj/item/device/radio/proc/autosay, "[user.real_name], [role_alt_title], has entered long-term storage.", "Cryogenic Oversight")
+	. = ..()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: SealCure
rscadd: Adds the fake cryostorage announcement item to the uplink. Use to generate a fake message saying you've entered cryo and remove your name from the manifest. Lull your targets into a false sense of security!
/:cl:
Anyone notice how most of my PRs start with 'add'?
Basically as above. There's an item for a fake cryo arrival, so I think the reverse would be cool. This doesn't free job slots or anything, so you can't have 2 heads or something like that.
Although that would be funny.

Shoutout to Al-1ce for always giving my PRs a thumbs up, whoever that is 