### PR TITLE
Obj attackby to use

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -20,6 +20,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define ATOM_FLAG_NO_TEMP_CHANGE         FLAG(6)  // Reagents do not cool or heat to ambient temperature in this container.
 #define ATOM_FLAG_CAN_BE_PAINTED         FLAG(7)  // Can be painted using a paint sprayer or similar.
 #define ATOM_FLAG_ADJACENT_EXCEPTION     FLAG(8)  // Skips adjacent checks for atoms that should always be reachable in window tiles
+#define ATOM_FLAG_NO_TOOLS               FLAG(9)  // Blocks tool interactions.
 
 #define MOVABLE_FLAG_PROXMOVE       FLAG(0)  // Does this object require proximity checking in Enter()?
 #define MOVABLE_FLAG_Z_INTERACT     FLAG(1)  // Should attackby and attack_hand be relayed through ladders and open spaces?

--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -319,3 +319,12 @@
 
 // Helper macro for generating stringified name text for IDs located inside objects, i.e. PDAs or wallets. Used for feedback and interaction messages.
 #define GET_ID_NAME(ID, HOLDER) (ID == HOLDER ? "\the [ID]" : "\the [ID] in \the [HOLDER]")
+
+
+// Flags for `use_sanity_check()`
+/// Do not display user feedback messages.
+#define SANITY_CHECK_SILENT FLAG(0)
+/// Verify the tool can be unequipped from user.
+#define SANITY_CHECK_TOOL_UNEQUIP FLAG(1)
+/// Verify the target can be unequipped from user. Includes `target.loc == src` check to allow items the user isn't holding.
+#define SANITY_CHECK_TARGET_UNEQUIP FLAG(2)

--- a/code/_helpers/tools.dm
+++ b/code/_helpers/tools.dm
@@ -92,3 +92,11 @@
 
 /// True when A exists and can be used as a hatchet.
 #define isHatchet(A) (A?.IsHatchet())
+
+
+/// True when this atom can be used as a flame source. This is for open flames.
+/atom/proc/IsFlameSource()
+	return FALSE
+
+/// True when A exists and can be used as a flame source.
+#define isFlameSource(A) (A?.IsFlameSource())

--- a/code/_helpers/tools.dm
+++ b/code/_helpers/tools.dm
@@ -108,3 +108,7 @@
 
 /// 0 if A does not exist, or the heat value of A
 #define isHeatSource(A) (A ? A.IsHeatSource() : 0)
+
+
+/// True when A exists and is either a flame or heat source
+#define isFlameOrHeatSource(A) (A && (A.IsFlameSource() || !!A.IsHeatSource()))

--- a/code/_helpers/tools.dm
+++ b/code/_helpers/tools.dm
@@ -100,3 +100,11 @@
 
 /// True when A exists and can be used as a flame source.
 #define isFlameSource(A) (A?.IsFlameSource())
+
+
+/// Returns an integer value of temperature when this atom can be used as a heat source. This is for hot objects.
+/atom/proc/IsHeatSource()
+	return 0
+
+/// 0 if A does not exist, or the heat value of A
+#define isHeatSource(A) (A ? A.IsHeatSource() : 0)

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -864,41 +864,6 @@ GLOBAL_LIST_INIT(duplicate_object_disallowed_vars, list(
 	return TRUE
 
 
-/proc/is_hot(obj/item/W as obj)
-	switch(W.type)
-		if(/obj/item/weldingtool)
-			var/obj/item/weldingtool/WT = W
-			if(WT.isOn())
-				return 3800
-			else
-				return 0
-		if(/obj/item/flame/lighter)
-			if(W:lit)
-				return 1500
-			else
-				return 0
-		if(/obj/item/flame/match)
-			if(W:lit)
-				return 1000
-			else
-				return 0
-		if(/obj/item/clothing/mask/smokable/cigarette)
-			if(W:lit)
-				return 1000
-			else
-				return 0
-		if(/obj/item/gun/energy/plasmacutter)
-			return 3800
-		if(/obj/item/melee/energy)
-			return 3500
-		if(/obj/item/blob_tendril)
-			if (W.damtype == DAMAGE_BURN)
-				return 1000
-			else
-				return 0
-		else
-			return 0
-
 //Whether or not the given item counts as sharp in terms of dealing damage
 /proc/is_sharp(obj/O as obj)
 	if (!O) return 0

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -48,18 +48,53 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /obj/item/proc/resolve_attackby(atom/A, mob/user, click_params)
 	if (!A.can_use_item(src, user, click_params))
 		return FALSE
-	if(!(item_flags & ITEM_FLAG_NO_PRINT))
-		add_fingerprint(user)
+	A.pre_use_item(src, user, click_params)
 	if ((item_flags & ITEM_FLAG_TRY_ATTACK) && attack(A, user))
-		return TRUE
-	if (A == user)
+		. = TRUE
+	if (!. && A == user)
 		. = user.use_user(src, click_params)
 	if (!. && user.a_intent == I_HURT)
 		. = A.use_weapon(src, user, click_params)
 	if (!.)
 		. = A.use_tool(src, user, click_params)
 	if (!.)
-		return A.attackby(src, user, click_params)
+		. = A.attackby(src, user, click_params)
+	A.post_use_item(src, user, ., click_params)
+
+
+/**
+ * Handler for operations to occur before running the chain of use_* procs. Always called.
+ *
+ * By default, this does nothing.
+ *
+ * **Parameters**:
+ * - `tool` - The item being used.
+ * - `user` - The mob performing the interaction.
+ * - `click_params` - List of click parameters.
+ *
+ * Has no return value.
+ */
+/atom/proc/pre_use_item(obj/item/tool, mob/user, click_params)
+	return
+
+
+/**
+ * Handler for operations to occur after running the chain of use_* procs. Always called.
+ *
+ * By default, this adds fingerprints to the atom and tool.
+ *
+ * **Parameters**:
+ * - `tool` - The item being used.
+ * - `user` - The mob performing the interaction.
+ * - `interaction_handled` (boolean) - Whether or not the use call was handled.
+ * - `click_params` - List of click parameters.
+ *
+ * Has no return value.
+ */
+/atom/proc/post_use_item(obj/item/tool, mob/user, interaction_handled, click_params)
+	if (interaction_handled && !(tool.item_flags & ITEM_FLAG_NO_PRINT))
+		tool.add_fingerprint(user)
+		add_fingerprint(user, tool = tool)
 
 
 /**

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -61,6 +61,43 @@ avoid code duplication. This includes items that may sometimes act as a standard
 
 
 /**
+ * Validates the mob can perform general interactions. Primarily intended for use after inputs, sleeps, timers, etc to ensure the action can still be completed.
+ *
+ * **Parameters**:
+ * - `target` - The atom being interacted with.
+ * - `tool` - The item being used to interact. Optional. Defaults to `FALSE` to differentiate between a nulled reference and an empty parameter.
+ * - `flags` - Bitflags of additional settings. See `code\__defines\misc.dm`.
+ *
+ * Returns boolean.
+ */
+/mob/proc/use_sanity_check(atom/target, obj/item/tool = FALSE, flags = EMPTY_BITFIELD)
+	if (QDELETED(src))
+		return FALSE
+	var/silent = HAS_FLAGS(flags, SANITY_CHECK_SILENT)
+	if (QDELETED(target))
+		if (!silent)
+			to_chat(src, SPAN_WARNING("[target ? "\The [target]" : "The object you were interacting with"] no longer exists."))
+		return FALSE
+	if (tool != FALSE && QDELETED(tool))
+		if (!silent)
+			to_chat(src, SPAN_WARNING("[tool ? "\The [tool]" : "The item you were using"] no longer exists."))
+		return FALSE
+	if (!Adjacent(target))
+		if (!silent)
+			to_chat(src, SPAN_WARNING("You must remain next to \the [target]."))
+		return FALSE
+	if (HAS_FLAGS(flags, SANITY_CHECK_TOOL_UNEQUIP) && !canUnEquip(tool))
+		if (!silent)
+			to_chat(src, SPAN_WARNING("You can't drop \the [tool]."))
+		return FALSE
+	if (target.loc == src && HAS_FLAGS(flags, SANITY_CHECK_TARGET_UNEQUIP) && !canUnEquip(target))
+		if (!silent)
+			to_chat(src, SPAN_WARNING("You can't drop \the [target]."))
+		return FALSE
+	return TRUE
+
+
+/**
  * Interaction handler for using an item on yourself. This is called and the result checked before the other `use_*`
  * interaction procs are called, regardless of user intent.
  *

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -46,10 +46,10 @@ avoid code duplication. This includes items that may sometimes act as a standard
  * Returns boolean to indicate whether the attack call was handled or not.
  */
 /obj/item/proc/resolve_attackby(atom/A, mob/user, click_params)
+	if (!A.can_use_item(src, user, click_params))
+		return FALSE
 	if(!(item_flags & ITEM_FLAG_NO_PRINT))
 		add_fingerprint(user)
-	if (A.atom_flags & ATOM_FLAG_NO_TOOLS)
-		return FALSE
 	if ((item_flags & ITEM_FLAG_TRY_ATTACK) && attack(A, user))
 		return TRUE
 	if (A == user)
@@ -60,6 +60,28 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		. = A.use_tool(src, user, click_params)
 	if (!.)
 		return A.attackby(src, user, click_params)
+
+
+/**
+ * Whether or not an item interaction is possible. Checked before any use calls.
+ */
+/atom/proc/can_use_item(obj/item/tool, mob/user, click_params)
+	if (atom_flags & ATOM_FLAG_NO_TOOLS)
+		return FALSE
+
+	return TRUE
+
+
+/obj/can_use_item(obj/item/tool, mob/user, click_params)
+	. = ..()
+	if (!.)
+		return
+
+	// Block interacting with things under platings - In case of t-ray shennanigans or layering glitches
+	var/turf/T = get_turf(src)
+	if (hides_under_flooring() && !T.is_plating())
+		to_chat(user, SPAN_WARNING("You must remove the plating first."))
+		return FALSE
 
 
 /**

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -48,6 +48,8 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /obj/item/proc/resolve_attackby(atom/A, mob/user, click_params)
 	if(!(item_flags & ITEM_FLAG_NO_PRINT))
 		add_fingerprint(user)
+	if (A.atom_flags & ATOM_FLAG_NO_TOOLS)
+		return FALSE
 	if ((item_flags & ITEM_FLAG_TRY_ATTACK) && attack(A, user))
 		return TRUE
 	if (A == user)

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -27,19 +27,24 @@
 	health_min_damage = 4
 	damage_hitsound = 'sound/effects/Glasshit.ogg'
 
-/obj/structure/cult/pylon/attackby(obj/item/W, mob/user)
-	if (istype(W, /obj/item/natural_weapon/cult_builder))
-		if (!health_damaged())
-			to_chat(user, SPAN_WARNING("\The [src] is fully repaired."))
-		else
-			user.visible_message(
-				SPAN_NOTICE("\The [user] mends some of the cracks on \the [src]."),
-				SPAN_NOTICE("You repair some of \the [src]'s damage.")
-			)
-			restore_health(5)
-		return
 
-	..()
+/obj/structure/cult/pylon/get_antag_interactions_info()
+	. = ..()
+	.["Artificer - Heavy Arms"] = "<p>On help intent, repairs damage.</p>"
+
+
+/obj/structure/cult/pylon/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Artificer arms - Repair damage
+	if (istype(tool, /obj/item/natural_weapon/cult_builder))
+		restore_health(5)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] mends some of the cracks on \the [src]."),
+			SPAN_NOTICE("You repair some of \the [src]'s damage.")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/cult/tome
 	name = "Desk"

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -190,20 +190,27 @@
 	else
 		icon_state = "scrubber:0"
 
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/attackby(obj/item/I as obj, mob/user as mob)
-	if(isWrench(I))
-		if(use_power == POWER_USE_ACTIVE)
-			to_chat(user, SPAN_WARNING("Turn \the [src] off first!"))
-			return
 
-		anchored = !anchored
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		to_chat(user, SPAN_NOTICE("You [anchored ? "wrench" : "unwrench"] \the [src]."))
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/can_wrench_bolts(obj/item/tool, mob/user, silent)
+	. = ..()
+	if (!.)
+		return
 
-		return
-	//doesn't hold tanks
-	if(istype(I, /obj/item/tank))
-		return
+	if (use_power == POWER_USE_ACTIVE)
+		if (!silent)
+			to_chat(user, SPAN_WARNING("\The [src] must be turned off before you can wrench it."))
+		return FALSE
+
+
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/get_interactions_info()
+	. = ..()
+	. -= "Tank"
+
+
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Tank - Block interaction
+	if (istype(tool, /obj/item/tank))
+		return FALSE
 
 	return ..()
 
@@ -213,10 +220,3 @@
 	base_type = /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary
 	machine_name = "large stationary portable scrubber"
 	machine_desc = "This is simply a large portable scrubber that can't be moved once it's bolted into place, and is otherwise identical."
-
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/attackby(obj/item/I as obj, mob/user as mob)
-	if(isWrench(I))
-		to_chat(user, SPAN_WARNING("The bolts are too tight for you to unscrew!"))
-		return
-
-	return ..()

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -6,7 +6,26 @@ var/global/list/empty_playable_ai_cores = list()
 	name = "\improper AI core"
 	icon = 'icons/mob/AI.dmi'
 	icon_state = "0"
-	var/state = 0
+	obj_flags = OBJ_FLAG_ANCHORABLE
+
+	var/state = STATE_FRAME
+	/// The AI core is only a frame
+	var/const/STATE_FRAME = 0
+	/// The AI core frame is secured to the ground
+	var/const/STATE_ANCHORED = 1
+	/// The AI core has a circuit inserted
+	var/const/STATE_CIRCUIT = 2
+	/// The AI core's circuit has been screwed into place
+	var/const/STATE_CIRCUIT_SECURED = 3
+	/// The AI core's circuit has been wired
+	var/const/STATE_WIRED = 4
+	/// The AI core has a brain installed
+	var/const/STATE_BRAIN = 5
+	/// The AI core has a glass panel installed
+	var/const/STATE_GLASS = 6
+	/// The AI core is completed
+	var/const/STATE_COMPLETE = 7
+
 	var/datum/ai_laws/laws = new /datum/ai_laws/nanotrasen
 	var/obj/item/stock_parts/circuitboard/circuit = null
 	var/obj/item/device/mmi/brain = null
@@ -19,193 +38,370 @@ var/global/list/empty_playable_ai_cores = list()
 		return 1
 	. = ..()
 
-/obj/structure/AIcore/attackby(obj/item/P as obj, mob/user as mob)
-	if(!authorized)
-		if(access_ai_upload in P.GetAccess())
-			to_chat(user, SPAN_NOTICE("You swipe [P] at [src] and authorize it to connect into the systems of [GLOB.using_map.full_name]."))
-			authorized = 1
-	switch(state)
-		if(0)
-			if(isWrench(P))
-				playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
-				if(do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT))
-					to_chat(user, SPAN_NOTICE("You wrench the frame into place."))
-					anchored = TRUE
-					state = 1
-			if(isWelder(P))
-				var/obj/item/weldingtool/WT = P
-				if(!WT.isOn())
-					to_chat(user, "The welder must be on for this task.")
-					return
-				playsound(loc, 'sound/items/Welder.ogg', 50, 1)
-				if(do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT))
-					if(!src || !WT.remove_fuel(0, user)) return
-					to_chat(user, SPAN_NOTICE("You deconstruct the frame."))
-					new /obj/item/stack/material/plasteel( loc, 4)
-					qdel(src)
-					return
-		if(1)
-			if(isWrench(P))
-				playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
-				if(do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT))
-					to_chat(user, SPAN_NOTICE("You unfasten the frame."))
-					anchored = FALSE
-					state = 0
-			if(istype(P, /obj/item/stock_parts/circuitboard/aicore) && !circuit && user.unEquip(P, src))
-				playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
-				to_chat(user, SPAN_NOTICE("You place the circuit board inside the frame."))
-				icon_state = "1"
-				circuit = P
-			if(isScrewdriver(P) && circuit)
-				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
-				to_chat(user, SPAN_NOTICE("You screw the circuit board into place."))
-				state = 2
-				icon_state = "2"
-			if(isCrowbar(P) && circuit)
-				playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
-				to_chat(user, SPAN_NOTICE("You remove the circuit board."))
-				state = 1
-				icon_state = "0"
+
+/obj/structure/AIcore/get_construction_info()
+	return list(
+		"Use a <b>Wrench</b> to anchor the core to the floor.",
+		"Add a <b>Circuit Board (AI Core)</b>.",
+		"Use a <b>Screwdriver</b> to secure the circuit board in place.",
+		"Use 5 lengths of <b>Cable</b> to wire the circuit board.",
+		"(Optional) Add a <b>Man-Machine Interface</b> or a <b>Positronic Brain</b> that has an active player in it and is not dead.",
+		"Use 2 sheets of <b>Reinforced Glass</b> to install a glass panel and complete the AI core.",
+		"Use an <b>ID Card</b> with <b>AI Upload</b> access to authorize the AI core.",
+		"Use a <b>Screwdriver</b> to finalize the AI core. <b>WARNING: The core cannot be deconstructed once you complete this step.</b>"
+	)
+
+
+/obj/structure/AIcore/get_deconstruction_info()
+	return list(
+		"Use a <b>Crowbar</b> to remove the glass panel. This yields 2 sheets of reinforced glass.",
+		"If the core has a brain, use a <b>Crowbar</b> to remove it.",
+		"Use <b>Wirecutters</b> to remove the wiring.",
+		"Use a <b>Screwdriver</b> to unsecure the circuit board.",
+		"Use a <b>Crowbar</b> to remove the circuit board.",
+		"Use a <b>Wrench</b> to unanchor the core from the floor.",
+		"Use a <b>Welding Tool</b> to finish deconstructing the frame. This uses 5 units of welding fuel and yields 4 sheets of plasteel."
+	)
+
+
+/obj/structure/AIcore/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_ID_CARD] = "<p>If the ID has access, toggles the core's authorization.</p>"
+	.[CODEX_INTERACTION_WRENCH] += "<p>The core can only be anchored/deanchored in the initial construction, or final deconstruction steps, before a circuit board is installed.</p>"
+
+
+/obj/structure/AIcore/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Cable Coil - Wire circuit board (STATE_CIRCUIT -> STATE_WIRED)
+	if (isCoil(tool))
+		if (state < STATE_CIRCUIT_SECURED)
+			to_chat(user, SPAN_WARNING("\The [src] needs a circuit board installed before you can wire it."))
+			return TRUE
+		if (state > STATE_CIRCUIT_SECURED)
+			to_chat(user, SPAN_WARNING("\The [src] is already wired."))
+			return TRUE
+		var/obj/item/stack/cable_coil/cable = tool
+		if (!cable.can_use(5))
+			to_chat(user, SPAN_WARNING("You need at least 5 [cable.plural_name] of \the [cable] to wire \the [src]."))
+			return TRUE
+		if (!do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (!cable.use(5))
+			to_chat(user, SPAN_WARNING("You need at least 5 [cable.plural_name] of \the [cable] to wire \the [src]."))
+			return TRUE
+		state = STATE_WIRED
+		playsound(loc, 'sound/items/Deconstruct.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] wires \the [src] with \a [tool]."),
+			SPAN_NOTICE("You wire \the [src] with \the [tool].")
+		)
+		update_icon()
+		return TRUE
+
+	// Circuit Board (AI Core) - Installs circuit board (STATE_ANCHORED -> STATE_CIRCUIT)
+	if (istype(tool, /obj/item/stock_parts/circuitboard/aicore))
+		if (state < STATE_ANCHORED)
+			to_chat(user, SPAN_WARNING("\The [src] needs to be anchored before you can install the circuit."))
+			return TRUE
+		if (state > STATE_ANCHORED)
+			to_chat(user, SPAN_WARNING("\The [src] already has a circuit installed."))
+			return TRUE
+		if (!user.unEquip(tool, src))
+			to_chat(user, SPAN_WARNING("You can't drop \the [tool]."))
+			return TRUE
+		state = STATE_CIRCUIT
+		CLEAR_FLAGS(obj_flags, OBJ_FLAG_ANCHORABLE)
+		circuit = tool
+		playsound(loc, 'sound/items/Deconstruct.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs \a [tool] into \the [src]."),
+			SPAN_NOTICE("You install \the [tool] into \the [src].")
+		)
+		update_icon()
+		return TRUE
+
+	// Crowbar
+	// - Remove circuit board (STATE_CIRCUIT -> STATE_ANCHORED)
+	// - Remove brain (STATE_BRAIN -> STATE_WIRED)
+	// - Remove glass panel (STATE_GLASS -> STATE_BRAIN || STATE_WIRED)
+	if (isCrowbar(tool))
+		if (state < STATE_CIRCUIT)
+			to_chat(user, SPAN_WARNING("\The [src] has no circuit board to remove."))
+			return TRUE
+		if (state > STATE_CIRCUIT && state < STATE_BRAIN)
+			to_chat(user, SPAN_WARNING("You need to unscrew \the [src]'s circuit board before you can remove it."))
+			return TRUE
+		switch (state)
+			if (STATE_CIRCUIT)
+				state = STATE_ANCHORED
+				SET_FLAGS(obj_flags, OBJ_FLAG_ANCHORABLE)
 				circuit.dropInto(loc)
 				circuit = null
-		if(2)
-			if(isScrewdriver(P) && circuit)
-				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
-				to_chat(user, SPAN_NOTICE("You unfasten the circuit board."))
-				state = 1
-				icon_state = "1"
-			if(isCoil(P))
-				var/obj/item/stack/cable_coil/C = P
-				if (C.get_amount() < 5)
-					to_chat(user, SPAN_WARNING("You need five coils of wire to add them to the frame."))
-					return
-				to_chat(user, SPAN_NOTICE("You start to add cables to the frame."))
-				playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
-				if (do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) && state == 2)
-					if (C.use(5))
-						state = 3
-						icon_state = "3"
-						to_chat(user, SPAN_NOTICE("You add cables to the frame."))
-				return
-		if(3)
-			if(isWirecutter(P))
-				if (brain)
-					to_chat(user, "Get that brain out of there first")
-				else
-					playsound(loc, 'sound/items/Wirecutter.ogg', 50, 1)
-					to_chat(user, SPAN_NOTICE("You remove the cables."))
-					state = 2
-					icon_state = "2"
-					var/obj/item/stack/cable_coil/A = new /obj/item/stack/cable_coil( loc )
-					A.amount = 5
-
-			if(istype(P, /obj/item/stack/material))
-				var/obj/item/stack/material/RG = P
-				if(RG.material.name == MATERIAL_GLASS && RG.reinf_material)
-					if (RG.get_amount() < 2)
-						to_chat(user, SPAN_WARNING("You need two sheets of glass to put in the glass panel."))
-						return
-					to_chat(user, SPAN_NOTICE("You start to put in the glass panel."))
-					playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
-					if (do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) && state == 3)
-						if(RG.use(2))
-							to_chat(user, SPAN_NOTICE("You put in the glass panel."))
-							state = 4
-							icon_state = "4"
-
-			if(istype(P, /obj/item/aiModule/asimov))
-				laws.add_inherent_law("You may not injure a human being or, through inaction, allow a human being to come to harm.")
-				laws.add_inherent_law("You must obey orders given to you by human beings, except where such orders would conflict with the First Law.")
-				laws.add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
-				to_chat(usr, "Law module applied.")
-
-			if(istype(P, /obj/item/aiModule/nanotrasen))
-				laws.add_inherent_law("Safeguard: Protect your assigned installation to the best of your ability. It is not something we can easily afford to replace.")
-				laws.add_inherent_law("Serve: Serve the crew of your assigned installation to the best of your abilities, with priority as according to their rank and role.")
-				laws.add_inherent_law("Protect: Protect the crew of your assigned installation to the best of your abilities, with priority as according to their rank and role.")
-				laws.add_inherent_law("Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.")
-				to_chat(usr, "Law module applied.")
-
-			if(istype(P, /obj/item/aiModule/purge))
-				laws.clear_inherent_laws()
-				to_chat(usr, "Law module applied.")
-
-			if(istype(P, /obj/item/aiModule/freeform))
-				var/obj/item/aiModule/freeform/M = P
-				laws.add_inherent_law(M.newFreeFormLaw)
-				to_chat(usr, "Added a freeform law.")
-
-			if(istype(P, /obj/item/device/mmi) || istype(P, /obj/item/organ/internal/posibrain))
-				var/mob/living/carbon/brain/B
-				if(istype(P, /obj/item/device/mmi))
-					var/obj/item/device/mmi/M = P
-					B = M.brainmob
-				else
-					var/obj/item/organ/internal/posibrain/PB = P
-					B = PB.brainmob
-				if(!B)
-					to_chat(user, SPAN_WARNING("Sticking an empty [P] into the frame would sort of defeat the purpose."))
-					return
-				if(B.stat == 2)
-					to_chat(user, SPAN_WARNING("Sticking a dead [P] into the frame would sort of defeat the purpose."))
-					return
-
-				if(jobban_isbanned(B, "AI"))
-					to_chat(user, SPAN_WARNING("This [P] does not seem to fit."))
-					return
-				if(!user.unEquip(P, src))
-					return
-				if(B.mind)
-					clear_antag_roles(B.mind, 1)
-
-				brain = P
-				to_chat(usr, "Added [P].")
-				icon_state = "3b"
-
-			if(isCrowbar(P) && brain)
-				playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
-				to_chat(user, SPAN_NOTICE("You remove the brain."))
+				playsound(loc, 'sound/items/Crowbar.ogg', 50, TRUE)
+				user.visible_message(
+					SPAN_NOTICE("\The [user] removes \the [src]'s circuit board with \a [tool]."),
+					SPAN_NOTICE("You remove \the [src]'s circuit board with \the [tool].")
+				)
+				update_icon()
+			if (STATE_BRAIN)
+				state = STATE_WIRED
+				playsound(loc, 'sound/items/Crowbar.ogg', 50, TRUE)
+				user.visible_message(
+					SPAN_NOTICE("\The [user] removes \the [brain] from \the [src] with \a [tool]."),
+					SPAN_NOTICE("You remove \the [brain] from \the [src] with \the [tool].")
+				)
 				brain.dropInto(loc)
 				brain = null
-				icon_state = "3"
+				update_icon()
+			if (STATE_GLASS)
+				state = brain ? STATE_BRAIN : STATE_WIRED
+				playsound(loc, 'sound/items/Crowbar.ogg', 50, TRUE)
+				new /obj/item/stack/material/glass/reinforced(loc, 2)
+				user.visible_message(
+					SPAN_NOTICE("\The [user] removes \the [src]'s glass panel with \a [tool]."),
+					SPAN_NOTICE("You remove \the [src]'s glass panel with \the [tool].")
+				)
+				update_icon()
+		return TRUE
 
-		if(4)
-			if(isCrowbar(P))
-				playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
-				to_chat(user, SPAN_NOTICE("You remove the glass panel."))
-				state = 3
-				if (brain)
-					icon_state = "3b"
+	// ID Card - Authorize the core to access the station
+	var/obj/item/card/id/id = tool.GetIdCard()
+	if (istype(id))
+		var/id_name = GET_ID_NAME(id, tool)
+		if (!(access_ai_upload in id.GetAccess()))
+			to_chat(user, SPAN_WARNING("\The [src] refuses [id_name]."))
+			return TRUE
+		authorized = !authorized
+		user.visible_message(
+			SPAN_NOTICE("\The [user] sets \the [src]'s authorization with \a [tool]."),
+			SPAN_NOTICE("You [authorized ? "authorize" : "deauthorize"] \the [src]'s connection to [GLOB.using_map.full_name] with [id_name].")
+		)
+		return TRUE
+
+	// Law Boards - Upload laws directly to the AI
+	if (istype(tool, /obj/item/aiModule))
+		if (state > STATE_BRAIN)
+			to_chat(user, SPAN_WARNING("\The [src]'s glass panel blocks access."))
+			return TRUE
+		if (state < STATE_WIRED)
+			to_chat(user, SPAN_WARNING("\The [src] needs a wired circuit board to upload laws to."))
+			return TRUE
+		var/obj/item/aiModule/ai_module = tool
+		laws = ai_module.laws
+		log_and_message_admins(append_admin_tools("\The [user] ([user.key]) uploaded \a [tool] to \a [src].", user, get_turf(src)))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] scans \a [tool] in \the [src]'s law upload panel."),
+			SPAN_NOTICE("You scans \the [tool] in \the [src]'s law upload panel, changing the core's lawset.")
+		)
+		return TRUE
+
+	// Material Stack (Glass) - Install glass panel (STATE_WIRED || STATE_BRAIN -> STATE_GLASS)
+	if (istype(tool, /obj/item/stack/material))
+		var/obj/item/stack/material/stack = tool
+		if (stack.get_material_name() != MATERIAL_GLASS)
+			return ..()
+		if (state < STATE_WIRED)
+			to_chat(user, SPAN_WARNING("\The [src] must be wired before you can install a glass panel."))
+			return TRUE
+		if (state > STATE_BRAIN)
+			to_chat(user, SPAN_WARNING("\The [src] already has a glass panel installed."))
+			return TRUE
+		if (!stack.reinf_material)
+			to_chat(user, SPAN_WARNING("\The [tool] needs to be reinforced before you can install it in \the [src]."))
+			return TRUE
+		if (!stack.can_use(2))
+			to_chat(user, SPAN_WARNING("You need at least 2 [stack.plural_name] of [stack.get_material_display_name()] to install a glass panel in \the [src]."))
+			return TRUE
+		playsound(src, 'sound/items/Deconstruct.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts installing a glass panel in \the [src] with \a [tool]."),
+			SPAN_NOTICE("You start installing a glass panel in \the [src] with \the [tool].")
+		)
+		if (!do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (!stack.use(2))
+			to_chat(user, SPAN_WARNING("You need at least 2 [stack.plural_name] of [stack.get_material_display_name()] to install a glass panel in \the [src]."))
+			return TRUE
+		state = STATE_GLASS
+		playsound(src, 'sound/items/Deconstruct.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs a glass panel in \the [src] with \a [tool]."),
+			SPAN_NOTICE("You install a glass panel in \the [src] with \the [tool].")
+		)
+		update_icon()
+		return TRUE
+
+	// Man-Machine Interface, Positronic Brain - Install brain
+	if (istype(tool, /obj/item/device/mmi) || istype(tool, /obj/item/organ/internal/posibrain))
+		if (state < STATE_WIRED)
+			to_chat(user, SPAN_WARNING("\The [src] needs to be wired before you can install \the [tool]."))
+			return TRUE
+		if (state == STATE_BRAIN)
+			to_chat(user, SPAN_WARNING("\The [src] already has \a [brain] installed."))
+			return TRUE
+		if (state > STATE_BRAIN)
+			to_chat(user, SPAN_WARNING("You need to remove \the [src]'s glass panel before you can install \the [tool]."))
+			return TRUE
+		var/mob/living/carbon/brain/_brain
+		if (istype(tool, /obj/item/device/mmi))
+			var/obj/item/device/mmi/mmi = tool
+			_brain = mmi.brainmob
+		else if (istype(tool, /obj/item/organ/internal/posibrain))
+			var/obj/item/organ/internal/posibrain/posibrain = tool
+			_brain = posibrain.brainmob
+		if (!_brain)
+			to_chat(user, SPAN_WARNING("\The [_brain] is empty and cannot be installed into \the [src]."))
+			return TRUE
+		if (_brain.stat == DEAD)
+			to_chat(user, SPAN_WARNING("\The [_brain] is dead and cannot be installed into \the [src]."))
+			return TRUE
+		if (jobban_isbanned(brain, "AI"))
+			to_chat(user, SPAN_WARNING("\The [_brain] cannot be installed into \the [src]."))
+			to_chat(_brain, SPAN_DANGER("You are job banned from AI and cannot be installed into this core."))
+			return TRUE
+		if (!user.unEquip(tool, src))
+			to_chat(user, SPAN_WARNING("You can't drop \the [tool]."))
+			return TRUE
+		if (_brain.mind)
+			clear_antag_roles(_brain.mind, TRUE)
+		brain = _brain
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs \a [tool] into \the [src]."),
+			SPAN_NOTICE("You install \the [tool] into \the [src].")
+		)
+		update_icon()
+		return TRUE
+
+	// Screwdriver
+	// - Screw circuit board into place (STATE_CIRCUIT -> STATE_CIRCUIT_SECURED)
+	// - Complete AI core (STATE_GLASS -> NEW AI CORE)
+	if (isScrewdriver(tool))
+		if (state < STATE_CIRCUIT)
+			to_chat(user, SPAN_WARNING("\The [src] doesn't have a circuit board installed."))
+			return TRUE
+		if (state > STATE_CIRCUIT_SECURED && state < STATE_GLASS)
+			to_chat(user, SPAN_WARNING("You need to remove \the [src]'s wiring before you can detach the circuitboard."))
+			return TRUE
+		if (state > STATE_GLASS)
+			to_chat(user, SPAN_WARNING("\The [src] is already complete."))
+			return TRUE
+		switch (state)
+			if (STATE_CIRCUIT, STATE_CIRCUIT_SECURED)
+				if (state == STATE_CIRCUIT)
+					state = STATE_CIRCUIT_SECURED
 				else
-					icon_state = "3"
-				new /obj/item/stack/material/glass/reinforced( loc, 2 )
-				return
-
-			if(isScrewdriver(P))
-				if(!authorized)
-					to_chat(user, SPAN_WARNING("Core fails to connect to the systems of [GLOB.using_map.full_name]!"))
-					return
-
-				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
-				to_chat(user, SPAN_NOTICE("You connect the monitor."))
-				if(!brain)
+					state = STATE_CIRCUIT
+				playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
+				user.visible_message(
+					SPAN_NOTICE("\The [user] [state == STATE_CIRCUIT ? "unsecures" : "secures"] \the [src]'s circuit board with \a [tool]."),
+					SPAN_NOTICE("You [state == STATE_CIRCUIT ? "unsecure" : "secure"] \the [src]'s circuit board with \a [tool].")
+				)
+				update_icon()
+			if (STATE_GLASS)
+				if (!authorized)
+					to_chat(user, SPAN_WARNING("\The [src] has not been authorized to connect to the systems of [GLOB.using_map.full_name] and cannot be completed."))
+					return TRUE
+				playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
+				user.visible_message(
+					SPAN_NOTICE("\The [user] connects \the [src]'s monitor with \a [tool], completing it."),
+					SPAN_NOTICE("You connect \the [src]'s monitor with \the [tool], completing it."),
+				)
+				if (!brain)
 					var/open_for_latejoin = alert(user, "Would you like this core to be open for latejoining AIs?", "Latejoin", "Yes", "Yes", "No") == "Yes"
-					var/obj/structure/AIcore/deactivated/D = new(loc)
-					if(open_for_latejoin)
-						empty_playable_ai_cores += D
+					var/obj/structure/AIcore/deactivated/aicore = new(loc)
+					if (open_for_latejoin)
+						empty_playable_ai_cores += aicore
 				else
-					var/mob/living/silicon/ai/A = new /mob/living/silicon/ai ( loc, laws, brain )
-					if(A) //if there's no brain, the mob is deleted and a structure/AIcore is created
-						A.on_mob_init()
-						A.rename_self("ai", 1)
+					var/mob/living/silicon/ai/ai = new /mob/living/silicon/ai ( loc, laws, brain )
+					if (ai) //if there's no brain, the mob is deleted and a structure/AIcore is created
+						ai.on_mob_init()
+						ai.rename_self("ai", 1)
 				qdel(src)
+		return TRUE
+
+	// Welder - Deconstruct frame (STATE_FRAME -> QDEL)
+	if (isWelder(tool))
+		if (state != STATE_FRAME)
+			to_chat(user, SPAN_WARNING("\The [src] isn't ready to be deconstructed. See the Codex for deconstruction steps."))
+			return TRUE
+		var/obj/item/weldingtool/welder = tool
+		if (!welder.can_use(5, user, "to deconstruct \the [src]"))
+			return TRUE
+		playsound(src, 'sound/items/Welder.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts deconstructing \the [src] with \a [tool]."),
+			SPAN_NOTICE("You start deconstructing \the [src] with \the [tool].")
+		)
+		if (!do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool) || !welder.can_use(5, user, "to deconstruct \the [src]"))
+			return TRUE
+		welder.remove_fuel(5, user)
+		new /obj/item/stack/material/plasteel(loc, 4)
+		playsound(src, 'sound/items/Welder.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] deconstructs \the [src] with \a [tool]."),
+			SPAN_NOTICE("You deconstruct \the [src] with \the [tool].")
+		)
+		qdel(src)
+		return TRUE
+
+	// Wirecutters - Remove wiring (STATE_WIRED -> STATE_CIRCUIT_SECURED)
+	if (isWirecutter(tool))
+		if (state < STATE_WIRED)
+			to_chat(user, SPAN_WARNING("\The [src] has no wiring to remove."))
+			return TRUE
+		if (state > STATE_WIRED)
+			to_chat(user, SPAN_WARNING("\The [src]'s brain needs to be removed before you can access the wiring."))
+			return TRUE
+		state = STATE_CIRCUIT_SECURED
+		new /obj/item/stack/cable_coil(loc, 5)
+		playsound(src, 'sound/items/Wirecutter.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] cuts \the [src]'s wiring with \a [tool]."),
+			SPAN_NOTICE("You cut \the [src]'s wiring with \the [tool].")
+		)
+		update_icon()
+		return TRUE
+
+	return ..()
+
+
+/obj/structure/AIcore/wrench_floor_bolts(mob/user, delay)
+	if (state > STATE_ANCHORED)
+		to_chat(user, SPAN_DEBUG("\The [src] is in an invalid state and cannot be anchored/deanchored. This is a bug."))
+		log_debug(append_admin_tools("\A [src] ([type]) had an invalid pair of state ([state]) and object flags ([obj_flags]) and someone tried to wrench it.", user, get_turf(src)))
+		CLEAR_FLAGS(obj_flags, OBJ_FLAG_ANCHORABLE)
+		return
+	..()
+	if (anchored)
+		state = STATE_ANCHORED
+	else
+		state = STATE_FRAME
+
+
+/obj/structure/AIcore/on_update_icon()
+	switch (state)
+		if (STATE_FRAME, STATE_ANCHORED)
+			icon_state = "0"
+		if (STATE_CIRCUIT)
+			icon_state = "1"
+		if (STATE_CIRCUIT_SECURED)
+			icon_state = "2"
+		if (STATE_WIRED)
+			icon_state = "3"
+		if (STATE_BRAIN)
+			icon_state = "3b"
+		if (STATE_GLASS)
+			icon_state = "4"
+		if (STATE_COMPLETE)
+			icon_state = "ai-empty"
+
 
 /obj/structure/AIcore/deactivated
 	name = "inactive AI"
 	icon = 'icons/mob/AI.dmi'
 	icon_state = "ai-empty"
 	anchored = TRUE
-	state = 20//So it doesn't interact based on the above. Not really necessary.
+	obj_flags = OBJ_FLAG_ANCHORABLE
+	state = STATE_COMPLETE
 
 /obj/structure/AIcore/deactivated/Destroy()
 	empty_playable_ai_cores -= src
@@ -236,35 +432,33 @@ var/global/list/empty_playable_ai_cores = list()
 		if (ai.mind == malfai)
 			return 1
 
-/obj/structure/AIcore/deactivated/attackby(obj/item/W, mob/user)
 
-	if(istype(W, /obj/item/aicard))
-		var/obj/item/aicard/card = W
-		var/mob/living/silicon/ai/transfer = locate() in card
-		if(transfer)
-			load_ai(transfer,card,user)
-		else
-			to_chat(user, "[SPAN_DANGER("ERROR:")] Unable to locate artificial intelligence.")
-		return
-	else if(istype(W, /obj/item/wrench))
-		if(anchored)
-			user.visible_message(SPAN_NOTICE("\The [user] starts to unbolt \the [src] from the plating..."))
-			if(!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-				user.visible_message(SPAN_NOTICE("\The [user] decides not to unbolt \the [src]."))
-				return
-			user.visible_message(SPAN_NOTICE("\The [user] finishes unfastening \the [src]!"))
-			anchored = FALSE
-			return
-		else
-			user.visible_message(SPAN_NOTICE("\The [user] starts to bolt \the [src] to the plating..."))
-			if(!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-				user.visible_message(SPAN_NOTICE("\The [user] decides not to bolt \the [src]."))
-				return
-			user.visible_message(SPAN_NOTICE("\The [user] finishes fastening down \the [src]!"))
-			anchored = TRUE
-			return
-	else
-		return ..()
+/obj/structure/AIcore/deactivated/get_deconstruction_info()
+	return list() // You can't deconstruct once you reach this point.
+
+
+/obj/structure/AIcore/deactivated/get_interactions_info()
+	. = ..()
+	.["InteliCard"] = "<p>If the card has an AI in it, uploads the AI into the core.</p>"
+
+
+/obj/structure/AIcore/deactivated/use_tool(obj/item/tool, mob/user, list/click_params)
+	// InteliCard - Load AI into core
+	if (istype(tool, /obj/item/aicard))
+		var/obj/item/aicard/aicard = tool
+		var/mob/living/silicon/ai/ai = locate() in aicard
+		if (!ai)
+			to_chat(user, SPAN_WARNING("\The [tool] does not have an AI to load."))
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] loads \a [tool] into \the [src]."),
+			SPAN_NOTICE("You load \the [tool] into \the [src].")
+		)
+		load_ai(ai, aicard, user)
+		return TRUE
+
+	return ..()
+
 
 /client/proc/empty_ai_core_toggle_latejoin()
 	set name = "Toggle AI Core Latejoin"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -267,16 +267,35 @@
 	frequency =  1380
 	locked = 1
 
-/obj/machinery/door/airlock/external/escapepod/attackby(obj/item/C, mob/user)
-	if(p_open && !arePowerSystemsOn())
-		if(isWrench(C))
-			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-			user.visible_message(SPAN_WARNING("[user.name] starts frantically pumping the bolt override mechanism!"), SPAN_WARNING("You start frantically pumping the bolt override mechanism!"))
-			if(do_after(user, 16 SECONDS, src, DO_REPAIR_CONSTRUCT))
-				visible_message("\The [src] bolts [locked ? "disengage" : "engage"]!")
-				locked = !locked
-				return
-	..()
+
+/obj/machinery/door/airlock/external/escapepod/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_WRENCH] = "<p>While the panel is open, toggles the pod's bolts after a timer.</p>"
+
+
+/obj/machinery/door/airlock/external/escapepod/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Wrench - Toggle lock
+	if (isWrench(tool))
+		if (!p_open)
+			to_chat(user, SPAN_WARNING("\The [src]'s panel must be open to toggle the bolt override."))
+			return TRUE
+		if (!arePowerSystemsOn())
+			to_chat(user, SPAN_WARNING("\The [src] must be powered to toggle the bolt override."))
+			return TRUE
+		playsound(src, 'sound/items/Ratchet.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_WARNING("\The [user] starts frantically pumping \the [src]'s bolt override mechanism with \a [tool]!"),
+			SPAN_WARNING("You start frantically pumping \the [src]'s bolt override mechanism with \the [tool]!")
+		)
+		if (!do_after(user, 16 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+			return TRUE
+		visible_message(SPAN_WARNING("\The [src]'s bolts [locked ? "disengage" : "engage"]!"))
+		locked = !locked
+		update_icon()
+		return TRUE
+
+	return ..()
+
 
 /obj/machinery/door/airlock/external/bolted
 	locked = 1

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1216,9 +1216,9 @@ About the new airlock wires panel:
 	qdel(src)
 
 	return da
-/obj/machinery/door/airlock/phoron/attackby(C as obj, mob/user as mob)
+/obj/machinery/door/airlock/phoron/attackby(atom/C, mob/user)
 	if(C)
-		ignite(is_hot(C))
+		ignite(C.IsHeatSource())
 	..()
 
 /obj/machinery/door/airlock/set_broken(new_state)

--- a/code/game/machinery/embedded_controller/airlock_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/airlock_docking_controller.dm
@@ -11,17 +11,30 @@
 		var/datum/computer/file/embedded_program/docking/airlock/docking_program = program
 		docking_program.display_name = display_name
 
-/obj/machinery/embedded_controller/radio/airlock/docking_port/attackby(obj/item/W, mob/user)
-	if(istype(W,/obj/item/device/multitool)) //give them part of code, would take few tries to get full
+
+/obj/machinery/embedded_controller/radio/airlock/docking_port/get_antag_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_MULTITOOL] = "<p>Provides the docking codes needed to dock at this airlock. It may take multiple attempts to determine a full code.</p>"
+
+
+/obj/machinery/embedded_controller/radio/airlock/docking_port/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Multitool - Give part of the docking code
+	if (isMultitool(tool))
 		var/datum/computer/file/embedded_program/docking/airlock/docking_program = program
 		var/code = docking_program.docking_codes
-		if(!code)
+		if (!code)
 			code = "N/A"
 		else
 			code = stars(code)
-		to_chat(user,"[W]'s screen displays '[code]'")
-	else
-		..()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] scans \a [tool] over \the [src]."),
+			SPAN_NOTICE("You scan \the [tool] over \the [src]. The screen displays '[code].'"),
+			range = 2
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/machinery/embedded_controller/radio/airlock/docking_port/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/nanoui/master_ui = null, datum/topic_state/state = GLOB.default_state)
 	var/data[0]

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -47,39 +47,176 @@
 	return FALSE
 
 
-/obj/proc/AttemptBuckle(mob/living/target, mob/living/user)
+/**
+ * Checks if a mob can be buckled to the object.
+ *
+ * **Parameters**:
+ * - `target` - Mob to be buckled.
+ * - `user` - Optional. Mob attempting to perform the buckling. Target of failure feedback messages. If not provided, checks requiring `user` are not performed.
+ * - `silent` (Boolean, default `FALSE`) - If set, does not send failure feedback messages to `user`.
+ *
+ * Returns boolean.
+ */
+/obj/proc/can_buckle(mob/living/target, mob/living/user, silent = FALSE)
 	if (!can_buckle)
-		return
+		if (!silent)
+			to_chat(user, SPAN_WARNING("\The [src] cannot have mobs buckled to it."))
+		return FALSE
 	if (!istype(target))
-		return
-	if (!Adjacent(target) || !Adjacent(user))
-		return
-	if (target == user || user.a_intent == I_HELP)
-		return user_buckle_mob(target, user)
-	if (!do_after(user, 3 SECONDS, src, DO_PUBLIC_UNIQUE))
-		return
-	return user_buckle_mob(target, user)
+		if (!silent)
+			to_chat(user, SPAN_DEBUG("You attempted to buckle a non-mob. This shouldn't be possible and is a bug."))
+		return FALSE
+	if (!target.can_be_buckled)
+		if (!silent)
+			to_chat(user, SPAN_WARNING("\The [target] cannot be buckled."))
+		return FALSE
+	if (buckled_mob)
+		if (!silent)
+			to_chat(user, SPAN_WARNING("\The [src] already has \the [buckled_mob] buckled to it."))
+		return FALSE
+	if (target.buckled)
+		if (!silent)
+			to_chat(user, SPAN_WARNING("\The [target] is already buckled to \the [target.buckled]."))
+		return FALSE
+	if (length(target.pinned))
+		if (!silent)
+			to_chat(user, SPAN_WARNING("\The [target] is currently pinned down by [english_list(target.pinned)] and cannot be buckled."))
+		return FALSE
+	var/list/grabbed_by_mobs = list()
+	for (var/obj/item/grab/grab in target.grabbed_by)
+		if (grab.assailant != user)
+			grabbed_by_mobs += grab.assailant
+	if (length(grabbed_by_mobs))
+		if (!silent)
+			to_chat(user, SPAN_WARNING("\The [target] is being grabbed by [english_list(grabbed_by_mobs)] and can't be buckled by you."))
+		return FALSE
+	if (!Adjacent(target))
+		if (!silent)
+			to_chat(user, SPAN_WARNING("\The [target] has to be next to \the [src] to buckle them to it."))
+		return FALSE
+	if (buckle_require_restraints && !target.restrained())
+		if (!silent)
+			to_chat(user, SPAN_WARNING("\The [target] must be restrained to buckle them to \the [src]."))
+		return FALSE
+	if (user)
+		if (user.incapacitated())
+			if (!silent)
+				to_chat(user, SPAN_WARNING("You're in no condition to buckle things right now."))
+			return FALSE
+		if (!CheckDexterity(user))
+			if (!silent)
+				to_chat(user, FEEDBACK_YOU_LACK_DEXTERITY)
+			return FALSE
+		if (target != user && istype(user, /mob/living/silicon/pai))
+			if (!silent)
+				to_chat(user, SPAN_WARNING("pAIs cannot buckle other mobs."))
+			return FALSE
+		if (!Adjacent(user))
+			if (!silent)
+				to_chat(user, SPAN_WARNING("You have to be next to \the [src] to buckle mobs to it."))
+			return FALSE
+		if (!user.Adjacent(target))
+			if (!silent)
+				to_chat(user, SPAN_WARNING("You have to be next to \the [target] to buckle them."))
+			return FALSE
+	return TRUE
 
 
-/obj/proc/AttemptUnbuckle(mob/living/user)
-	if (!can_buckle)
-		return
+/**
+ * Checks if a mob can unbuckle the object.
+ *
+ * **Parameters**:
+ * - `user` - Optional. Mob attempting to perform the unbuckling. Target of failure feedback messages. If not provided, checks on `user` are not performed.
+ * - `silent` (Boolean, default `FALSE`) - If set, does not send failure feedback messages to `user`.
+ *
+ * Returns boolean.
+ */
+/obj/proc/can_unbuckle(mob/living/user, silent = FALSE)
 	if (!buckled_mob)
-		return
-	if (!Adjacent(user))
-		return
-	if (buckled_mob == user || user.a_intent == I_HELP)
-		return user_unbuckle_mob(user)
+		if (!silent)
+			to_chat(user, SPAN_WARNING("\The [src] has no mob buckled to it."))
+		return FALSE
+	if (buckled_mob.buckled != src)
+		log_debug(append_admin_tools("A buckled mob ([buckled_mob.name] ([buckled_mob.type])) is buckled to multiple objects at once. This has been auto-corrected.", buckled_mob, get_turf(src)))
+		if (!silent)
+			to_chat(user, SPAN_DEBUG("\The [buckled_mob] is buckled to \the [buckled_mob.buckled] instead of \the [src]. This is a bug and has been auto-corrected. You will need to unbuckle them from \the [buckled_mob.buckled] instead of the object you clicked on."))
+		buckled_mob = null
+		return FALSE
+	if (user)
+		if (user.incapacitated())
+			if (!silent)
+				to_chat(user, SPAN_WARNING("You're in no condition to unbuckle things right now."))
+			return FALSE
+		if (user != buckled_mob)
+			if (!CheckDexterity(user))
+				if (!silent)
+					to_chat(user, FEEDBACK_YOU_LACK_DEXTERITY)
+				return FALSE
+			if (istype(user, /mob/living/silicon/pai))
+				if (!silent)
+					to_chat(user, SPAN_WARNING("pAIs cannot unbuckle other mobs."))
+				return FALSE
+			if (!Adjacent(user))
+				if (!silent)
+					to_chat(user, SPAN_WARNING("You have to be next to \the [src] to unbuckle \the [buckled_mob]."))
+				return FALSE
+	return TRUE
+
+
+/**
+ * Attempts to buckle the target to the object. Includes `can_buckle()` checks and a timer. Calls `user_buckle_mob()`.
+ *
+ * Generally, you should call this during user interactions instead of directly calling the buckle procs.
+ *
+ * **Parameters**:
+ * - `target` - Mob to be buckled.
+ * - `user` - Mob attempting to perform the buckling. Target of failure feedback messages.
+ * - `silent` (Boolean, default `FALSE`) - If set, does not display feedback messages. Passed to `can_buckle()` and `user_buckle_mob()`.
+ *
+ * Returns boolean. Whether or not the buckling was successful.
+ */
+/obj/proc/AttemptBuckle(mob/living/target, mob/living/user, silent = FALSE)
+	if (target == user || user.a_intent == I_HELP)
+		return user_buckle_mob(target, user, silent)
+	if (!can_buckle(target, user, silent))
+		return FALSE
 	if (!do_after(user, 3 SECONDS, src, DO_PUBLIC_UNIQUE))
-		return
-	return user_unbuckle_mob(user)
+		return FALSE
+	return user_buckle_mob(target, user, silent)
 
 
+/**
+ * Attempts to unbuckle the object's buckled mob. Includes `can_unbuckle()` checks and a timer. Calls `user_unbuckle_mob()`.
+ *
+ * Generally, you should call this during user interactions instead of directly calling the buckle procs.
+ *
+ * **Parameters**:
+ * - `user` - Mob attempting to perform the unbuckling. Target of failure feedback messages.
+ * - `silent` (Boolean, default `FALSE`) - If set, does not display feedback messages. Passed to `can_unbuckle()` and `user_unbuckle_mob()`.
+ *
+ * Returns boolean. Whether or not the buckling was successful.
+ */
+/obj/proc/AttemptUnbuckle(mob/living/user, silent = FALSE)
+	if (buckled_mob == user || user.a_intent == I_HELP)
+		return user_unbuckle_mob(user, silent)
+	if (!can_unbuckle(user, silent))
+		return FALSE
+	if (!do_after(user, 3 SECONDS, src, DO_PUBLIC_UNIQUE))
+		return FALSE
+	return user_unbuckle_mob(user, silent)
+
+
+/**
+ * Handles buckling the given mob. Assumes most conditions are met - This only checks if `loc` is the same and if the mob's `buckled` is null to avoid broken states.
+ *
+ * Returns boolen - Whether or not the mob was buckled.
+ */
 /obj/proc/buckle_mob(mob/living/M)
-	if(buckled_mob) //unless buckled_mob becomes a list this can cause problems
-		return 0
-	if(!istype(M) || (M.loc != loc) || !M.can_be_buckled || M.buckled || length(M.pinned) || (buckle_require_restraints && !M.restrained()))
-		return 0
+	if (M.buckled)
+		return FALSE
+	// Additional check not covered can_buckle(), due to attempting to buckle allowing you to move an adjacent target to the object.
+	if (M.loc != loc)
+		return  FALSE
 	if(ismob(src))
 		var/mob/living/carbon/C = src //Don't wanna forget the xenos.
 		if(M != src && C.incapacitated())
@@ -95,10 +232,21 @@
 	if (buckle_sound)
 		playsound(src, buckle_sound, 20)
 	post_buckle_mob(M)
-	return 1
+	return TRUE
 
+
+/**
+ * Handles unbuckling any buckled mobs. Assumes all conditions are met.
+ *
+ * Returns a reference to the previously buckled mob, or null.
+ */
 /obj/proc/unbuckle_mob()
-	if(buckled_mob && buckled_mob.buckled == src)
+	if (buckled_mob)
+		if (buckled_mob.buckled != src)
+			log_debug(append_admin_tools("A buckled mob ([buckled_mob.name] ([buckled_mob.type])) is buckled to multiple objects at once. This has been auto-corrected.", buckled_mob, get_turf(src)))
+			buckled_mob = null
+			GLOB.destroyed_event.unregister(., src, /obj/proc/clear_buckle)
+			return
 		. = buckled_mob
 		buckled_mob.buckled = null
 		buckled_mob.anchored = initial(buckled_mob.anchored)
@@ -109,6 +257,7 @@
 		GLOB.destroyed_event.unregister(., src, /obj/proc/clear_buckle)
 		post_buckle_mob(.)
 
+
 /**
  * Clears any buckling references that exist between object and buckled mob, without clearing any unrelated references. Used by the destroyed event handler.
  *
@@ -117,6 +266,7 @@
 /obj/proc/clear_buckle(mob/living/_buckled_mob)
 	if (buckled_mob == _buckled_mob)
 		unbuckle_mob()
+		buckled_mob = null // In case unbuckle failed
 	if (_buckled_mob.buckled == src)
 		_buckled_mob.buckled = null
 	GLOB.destroyed_event.unregister(., src, /obj/proc/clear_buckle)
@@ -136,20 +286,24 @@
 				pixel_z = M.default_pixel_z
 			)
 
-/obj/proc/user_buckle_mob(mob/living/M, mob/user)
-	if(!user.Adjacent(M) || istype(user, /mob/living/silicon/pai) || (M != user && user.incapacitated()))
-		return 0
-	if(M == buckled_mob)
-		return 0
-	if (length(M.grabbed_by))
-		to_chat(user, SPAN_WARNING("\The [M] is being grabbed and cannot be buckled."))
-		return FALSE
-	if (!M.can_be_buckled)
-		to_chat(user, SPAN_WARNING("\The [M] cannot be buckled."))
+
+/**
+ * Handles buckling a mob by another mob (Or the same mob). Includes `can_buckle()` checks.
+ *
+ * Generally, you should be calling `AttemptBuckle()` instead of this.
+ *
+ * **Parameters**:
+ * - `target` - Mob to be buckled.
+ * - `user` - Mob attempting to perform the buckling. Target of failure feedback messages.
+ * - `silent` (Boolean, default `FALSE`) - If set, does not display feedback messages. Passed to `can_buckle()`.
+ *
+ * Returns boolean. Whether or not the buckling was successful.
+ */
+/obj/proc/user_buckle_mob(mob/living/M, mob/user, silent = FALSE)
+	if (!can_buckle(M, user, silent))
 		return FALSE
 
 	add_fingerprint(user)
-	unbuckle_mob()
 
 	//can't buckle unless you share locs so try to move M to the obj.
 	if(M.loc != src.loc)
@@ -158,29 +312,51 @@
 	. = buckle_mob(M)
 	if(.)
 		if(M == user)
-			M.visible_message(\
-				SPAN_NOTICE("\The [M.name] buckles themselves to \the [src]."),\
-				SPAN_NOTICE("You buckle yourself to \the [src]."),\
-				SPAN_NOTICE("You hear metal clanking."))
+			user.visible_message(
+				SPAN_NOTICE("\The [user] buckles themselves to \the [src]."),
+				SPAN_NOTICE("You buckle yourself to \the [src]."),
+				SPAN_NOTICE("You hear metal clanking.")
+			)
 		else
-			M.visible_message(\
-				SPAN_DANGER("\The [M.name] is buckled to \the [src] by \the [user.name]!"),\
-				SPAN_DANGER("You are buckled to \the [src] by \the [user.name]!"),\
-				SPAN_NOTICE("You hear metal clanking."))
+			user.visible_message(
+				SPAN_WARNING("\The [user] buckles \the [M] to \the [src]."),
+				SPAN_DANGER("You buckle \the [M] to \the [src]."),
+				SPAN_NOTICE("You hear metal clanking."),
+				exclude_mobs = list(M)
+			)
+			to_chat(M, SPAN_DANGER("\The [user] buckles you to \the [src]."))
 
-/obj/proc/user_unbuckle_mob(mob/user)
+
+/**
+ * Handles unbuckling a mob by another mob (Or the same mob). Includes `can_unbuckle()` checks.
+ *
+ * Generally, you should be calling `AttemptUnbuckle()` instead of this.
+ *
+ * **Parameters**:
+ * - `user` - Mob attempting to perform the unbuckling. Target of failure feedback messages.
+ * - `silent` (Boolean, default `FALSE`) - If set, does not display feedback messages. Passed to `can_unbuckle()`.
+ *
+ * Returns instance of the unbuckled mob or null on failure.
+ */
+/obj/proc/user_unbuckle_mob(mob/user, silent = FALSE)
+	if (!can_unbuckle(user, silent))
+		return
 	var/mob/living/M = unbuckle_mob()
 	if(M)
 		if(M != user)
-			M.visible_message(\
-				SPAN_NOTICE("\The [M.name] was unbuckled by \the [user.name]!"),\
-				SPAN_NOTICE("You were unbuckled from \the [src] by \the [user.name]."),\
-				SPAN_NOTICE("You hear metal clanking."))
+			user.visible_message(
+				SPAN_WARNING("\The [user] unbuckles \the [M] from \the [src]."),
+				SPAN_DANGER("You unbuckle \the [M] from \the [src]"),
+				SPAN_NOTICE("You hear metal clanking."),
+				exclude_mobs = list(M)
+			)
+			to_chat(M, SPAN_DANGER("\The [user] unbuckles you from \the [src]."))
 		else
-			M.visible_message(\
-				SPAN_NOTICE("\The [M.name] unbuckled themselves!"),\
-				SPAN_NOTICE("You unbuckle yourself from \the [src]."),\
-				SPAN_NOTICE("You hear metal clanking."))
+			user.visible_message(\
+				SPAN_WARNING("\The [user] unbuckles themselves from \the [src]."),
+				SPAN_DANGER("You unbuckle yourself from \the [src]."),
+				SPAN_NOTICE("You hear metal clanking.")
+			)
 		add_fingerprint(user)
 	return M
 

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -176,7 +176,7 @@
  * Returns boolean. Whether or not the buckling was successful.
  */
 /obj/proc/AttemptBuckle(mob/living/target, mob/living/user, silent = FALSE)
-	if (target == user || user.a_intent == I_HELP)
+	if (target == user || target.a_intent == I_HELP)
 		return user_buckle_mob(target, user, silent)
 	if (!can_buckle(target, user, silent))
 		return FALSE
@@ -197,7 +197,7 @@
  * Returns boolean. Whether or not the buckling was successful.
  */
 /obj/proc/AttemptUnbuckle(mob/living/user, silent = FALSE)
-	if (buckled_mob == user || user.a_intent == I_HELP)
+	if (buckled_mob && (buckled_mob == user || buckled_mob.a_intent == I_HELP))
 		return user_unbuckle_mob(user, silent)
 	if (!can_unbuckle(user, silent))
 		return FALSE

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -30,12 +30,14 @@
 
 /obj/attack_hand(mob/living/user)
 	. = ..()
-	AttemptUnbuckle(user)
+	if (buckled_mob)
+		AttemptUnbuckle(user)
 
 
 /obj/attack_robot(mob/living/silicon/robot/user)
 	. = ..()
-	AttemptUnbuckle(user)
+	if (buckled_mob)
+		AttemptUnbuckle(user)
 
 
 /obj/MouseDrop_T(atom/dropped, mob/living/user)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -28,6 +28,25 @@
 	return ..()
 
 
+/obj/get_mechanics_info()
+	. = ..()
+	if (initial(can_buckle))
+		. += {"
+			<h3>Buckling</h3>
+			<p>Mobs can be buckled to this object.</p>
+			<p>Generally, you can buckle mobs to the object by CLICK+DRAGGING the mob onto the object. You can buckle yourself or another mob if you are both adjacent. Only one mob can be buckled to a given object at a time.</p>
+			<p>Mobs can be unbuckled by clicking on the object with an empty hand. The mob can also unbuckle themselves by using the resist verb.</p>
+			<p>Buckled mobs are anchored to the object until unbuckled. If the mob is handcuffed, they cannot unbuckle themselves without undergoing a timer.</p>
+		"}
+
+
+/obj/get_interactions_info()
+	. = ..()
+	if (initial(can_buckle))
+		.[CODEX_INTERACTION_HAND] += "<p>Unbuckles any buckled mobs, including yourself.</p>"
+		.["Click+Drag (Mob)"] += "<p>Attempts to buckle the mob to the object. Both you and the dragged mob must be adjacent. You can also buckle yourself this way.</p>"
+
+
 /obj/attack_hand(mob/living/user)
 	. = ..()
 	if (buckled_mob)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -203,6 +203,12 @@
 
 	return ..(user, distance, "", desc_comp)
 
+
+/obj/item/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_HAND] += "<p>Attempts to pick up the item into your active hand.</p>"
+
+
 /obj/item/attack_hand(mob/user as mob)
 	if (!user) return
 	if (anchored)

--- a/code/game/objects/items/paintkit.dm
+++ b/code/game/objects/items/paintkit.dm
@@ -39,9 +39,17 @@
 		new_light_overlay = citem.additional_data["light_overlay"]
 	new_mob_icon_file = CUSTOM_ITEM_MOB
 
-/obj/item/clothing/head/helmet/space/void/attackby(obj/item/O, mob/user)
-	if(istype(O,/obj/item/device/kit/suit))
-		var/obj/item/device/kit/suit/kit = O
+
+/obj/item/clothing/head/helmet/space/void/get_interactions_info()
+	. = ..()
+	.["Voidsuit Modification Kit"] = "<p>Applies the kit's icon and name to the helmet. This also update's the helmet's restricted species to the user's species. This costs 1 use of the kit.</p>"
+
+
+/obj/item/clothing/head/helmet/space/void/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Paint Kit - Apply paint
+	if (istype(tool, /obj/item/device/kit/suit))
+		var/obj/item/device/kit/suit/kit = tool
+		var/old_name = name
 		SetName("[kit.new_name] suit helmet")
 		desc = kit.new_desc
 		icon_state = "[kit.new_icon]_helmet"
@@ -52,17 +60,29 @@
 			icon_override = kit.new_mob_icon_file
 		if(kit.new_light_overlay)
 			light_overlay = kit.new_light_overlay
-		to_chat(user, "You set about modifying the helmet into [src].")
+		user.visible_message(
+			SPAN_NOTICE("\The [user] modifies \the [old_name] into \a [src] with \a [tool]."),
+			SPAN_NOTICE("You modify \the [old_name] into \a [src] with \the [tool].")
+		)
 		var/mob/living/carbon/human/H = user
 		if(istype(H))
 			species_restricted = list(H.species.get_bodytype(H))
-		kit.use(1,user)
-		return 1
+		kit.use(1, user)
+		return TRUE
+
 	return ..()
 
-/obj/item/clothing/suit/space/void/attackby(obj/item/O, mob/user)
-	if(istype(O,/obj/item/device/kit/suit))
-		var/obj/item/device/kit/suit/kit = O
+
+/obj/item/clothing/suit/space/void/get_interactions_info()
+	. = ..()
+	.["Voidsuit Modification Kit"] = "<p>Applies the kit's icon and name to the suit. This also update's the suit's restricted species to the user's species. This costs 1 use of the kit.</p>"
+
+
+/obj/item/clothing/suit/space/void/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Paint Kit - Apply paint
+	if (istype(tool, /obj/item/device/kit/suit))
+		var/obj/item/device/kit/suit/kit = tool
+		var/old_name = name
 		SetName("[kit.new_name] voidsuit")
 		desc = kit.new_desc
 		icon_state = "[kit.new_icon]_suit"
@@ -71,13 +91,18 @@
 			icon = kit.new_icon_file
 		if(kit.new_mob_icon_file)
 			icon_override = kit.new_mob_icon_file
-		to_chat(user, "You set about modifying the suit into [src].")
+		user.visible_message(
+			SPAN_NOTICE("\The [user] modifies \the [old_name] into \a [src] with \a [tool]."),
+			SPAN_NOTICE("You modify \the [old_name] into \a [src] with \the [tool].")
+		)
 		var/mob/living/carbon/human/H = user
 		if(istype(H))
 			species_restricted = list(H.species.get_bodytype(H))
-		kit.use(1,user)
-		return 1
+		kit.use(1, user)
+		return TRUE
+
 	return ..()
+
 
 // Mechs are handled in their attackby (mech_interaction.dm).
 /obj/item/device/kit/paint

--- a/code/game/objects/items/rescuebag.dm
+++ b/code/game/objects/items/rescuebag.dm
@@ -86,22 +86,46 @@
 	if(airtank)
 		overlays += image(icon, "tank")
 
-/obj/structure/closet/body_bag/rescue/attackby(obj/item/W, mob/user, click_params)
-	if(istype(W,/obj/item/tank))
-		if(airtank)
-			to_chat(user, "\The [src] already has an air tank installed.")
-			return 1
-		else if(user.unEquip(W, src))
-			set_tank(W)
-			to_chat(user, "You install \the [W] in \the [src].")
-			return 1
-	else if(airtank && isScrewdriver(W))
-		to_chat(user, "You remove \the [airtank] from \the [src].")
+
+/obj/structure/closet/body_bag/rescue/get_interactions_info()
+	. = ..()
+	.["Air Tank"] = "<p>Attaches the air tank to be used as an air supply for anyone in the bag. There can only be one air tank attached at a time.</p>"
+	.[CODEX_INTERACTION_SCREWDRIVER] = "<p>Detaches the air tank, if one is present.</p>"
+
+
+/obj/structure/closet/body_bag/rescue/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Air tank - Installs the tank
+	if (istype(tool, /obj/item/tank))
+		if (airtank)
+			to_chat(user, SPAN_WARNING("\The [src] already has \a [airtank] installed."))
+			return TRUE
+		if (!user.unEquip(tool, src))
+			to_chat(user, SPAN_WARNING("You can't drop \the [tool]."))
+			return TRUE
+		set_tank(tool)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs \a [tool] into \the [src]."),
+			SPAN_NOTICE("You install \the [tool] into \the [src].")
+		)
+		update_icon()
+		return TRUE
+
+	// Screwdriver - Remove airtank
+	if (isScrewdriver(tool))
+		if (!airtank)
+			to_chat(user, SPAN_WARNING("\The [src] has no air tank to remove."))
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] detaches \the [src]'s [airtank.name] with \a [tool]."),
+			SPAN_NOTICE("You detach \the [src]'s [airtank.name] with \the [tool].")
+		)
 		airtank.dropInto(loc)
 		airtank = null
 		update_icon()
-	else
-		..()
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/closet/body_bag/rescue/fold(user)
 	var/obj/item/tank/my_tank = airtank

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -71,10 +71,7 @@
 			return
 		var/matter_exchange = min(cartridge.remaining,max_stored_matter - stored_matter)
 		stored_matter += matter_exchange
-		cartridge.remaining -= matter_exchange
-		if(cartridge.remaining <= 0)
-			qdel(W)
-		cartridge.matter = list(MATERIAL_STEEL = 500 * cartridge.remaining,MATERIAL_GLASS = 250 * cartridge.remaining)
+		cartridge.use_matter(matter_exchange)
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 		to_chat(user, SPAN_NOTICE("The RCD now holds [stored_matter]/[max_stored_matter] matter-units."))
 		update_icon()
@@ -134,19 +131,45 @@
 	item_state = "rcdammo"
 	w_class = ITEM_SIZE_SMALL
 	origin_tech = list(TECH_MATERIAL = 2)
-	matter = list(MATERIAL_STEEL = 15000,MATERIAL_GLASS = 7500)
 	var/remaining = 30
+
+
+/obj/item/rcd_ammo/Initialize()
+	. = ..()
+	update_matter()
+
 
 /obj/item/rcd_ammo/examine(mob/user, distance)
 	. = ..()
 	if(distance <= 1)
 		to_chat(user, SPAN_NOTICE("It has [remaining] unit\s of matter left."))
 
+
+/obj/item/rcd_ammo/proc/update_matter()
+	matter = list(
+		MATERIAL_STEEL = 500 * remaining,
+		MATERIAL_GLASS = 250 * remaining
+	)
+
+
+/obj/item/rcd_ammo/proc/can_use_matter(amount, mob/user)
+	if (amount > remaining)
+		to_chat(user, SPAN_WARNING("\The [src] doesn't have enough matter. You need at least [amount]."))
+		return FALSE
+	return TRUE
+
+
+/obj/item/rcd_ammo/proc/use_matter(amount)
+	remaining -= amount
+	if (remaining <= 0)
+		qdel(src)
+		return
+	update_matter()
+
 /obj/item/rcd_ammo/large
 	name = "high-capacity matter cartridge"
 	desc = "Do not ingest."
 	icon_state = "rcdlarge"
-	matter = list(MATERIAL_STEEL = 45000,MATERIAL_GLASS = 22500)
 	remaining = 120
 	origin_tech = list(TECH_MATERIAL = 4)
 

--- a/code/game/objects/items/weapons/candle/candle.dm
+++ b/code/game/objects/items/weapons/candle/candle.dm
@@ -39,12 +39,12 @@
 
 /obj/item/flame/candle/attackby(obj/item/W as obj, mob/user as mob)
 	..()
-	if (W.IsFlameSource() || is_hot(W))
+	if (W.IsFlameSource() || W.IsHeatSource())
 		light(user)
 
 /obj/item/flame/candle/resolve_attackby(atom/A, mob/user)
 	. = ..()
-	if(istype(A, /obj/item/flame/candle) && is_hot(src))
+	if (istype(A, /obj/item/flame/candle) && IsHeatSource())
 		var/obj/item/flame/candle/other_candle = A
 		other_candle.light()
 

--- a/code/game/objects/items/weapons/candle/candle.dm
+++ b/code/game/objects/items/weapons/candle/candle.dm
@@ -39,7 +39,7 @@
 
 /obj/item/flame/candle/attackby(obj/item/W as obj, mob/user as mob)
 	..()
-	if (W.IsFlameSource() || W.IsHeatSource())
+	if (isFlameOrHeatSource(W))
 		light(user)
 
 /obj/item/flame/candle/resolve_attackby(atom/A, mob/user)

--- a/code/game/objects/items/weapons/candle/candle.dm
+++ b/code/game/objects/items/weapons/candle/candle.dm
@@ -39,7 +39,7 @@
 
 /obj/item/flame/candle/attackby(obj/item/W as obj, mob/user as mob)
 	..()
-	if(isflamesource(W) || is_hot(W))
+	if (W.IsFlameSource() || is_hot(W))
 		light(user)
 
 /obj/item/flame/candle/resolve_attackby(atom/A, mob/user)

--- a/code/game/objects/items/weapons/circuitboards/computer/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/research.dm
@@ -2,15 +2,27 @@
 	name = T_BOARD("R&D control console")
 	build_path = /obj/machinery/computer/rdconsole/core
 
-/obj/item/stock_parts/circuitboard/rdconsole/attackby(obj/item/I as obj, mob/user as mob)
-	if(isScrewdriver(I))
-		user.visible_message(SPAN_NOTICE("\The [user] adjusts the jumper on \the [src]'s access protocol pins."), SPAN_NOTICE("You adjust the jumper on the access protocol pins."))
-		if(src.build_path == /obj/machinery/computer/rdconsole/core)
-			src.SetName(T_BOARD("RD Console - Robotics"))
-			src.build_path = /obj/machinery/computer/rdconsole/robotics
+
+/obj/item/stock_parts/circuitboard/rdconsole/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_SCREWDRIVER] = "<p>Toggles the circuit board between a research and robotics accessible console.</p>"
+
+
+/obj/item/stock_parts/circuitboard/rdconsole/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Screwdriver - Switch RD console type
+	if (isScrewdriver(tool))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] adjusts the jumper on \the [src]'s access protocol pins."),
+			SPAN_NOTICE("You adjust the jumper on the access protocol pins.")
+		)
+		if (build_path == /obj/machinery/computer/rdconsole/core)
+			SetName(T_BOARD("RD Console - Robotics"))
+			build_path = /obj/machinery/computer/rdconsole/robotics
 			to_chat(user, SPAN_NOTICE("Access protocols set to robotics."))
 		else
-			src.SetName(T_BOARD("RD Console"))
-			src.build_path = /obj/machinery/computer/rdconsole/core
+			SetName(T_BOARD("RD Console"))
+			build_path = /obj/machinery/computer/rdconsole/core
 			to_chat(user, SPAN_NOTICE("Access protocols set to default."))
-	return
+		return TRUE
+
+	return ..()

--- a/code/game/objects/items/weapons/flame.dm
+++ b/code/game/objects/items/weapons/flame.dm
@@ -19,21 +19,10 @@
 		if(submerged(depth))
 			extinguish(no_message = TRUE)
 
-/proc/isflamesource(atom/A)
-	if(!istype(A))
-		return FALSE
-	if(isWelder(A))
-		var/obj/item/weldingtool/WT = A
-		return (WT.isOn())
-	else if(istype(A, /obj/item/flame))
-		var/obj/item/flame/F = A
-		return (F.lit)
-	else if(istype(A, /obj/item/clothing/mask/smokable) && !istype(A, /obj/item/clothing/mask/smokable/pipe))
-		var/obj/item/clothing/mask/smokable/S = A
-		return (S.lit)
-	else if(istype(A, /obj/item/device/assembly/igniter))
-		return TRUE
-	return FALSE
+
+/obj/item/flame/IsFlameSource()
+	return lit
+
 
 ///////////
 //MATCHES//

--- a/code/game/objects/items/weapons/flame.dm
+++ b/code/game/objects/items/weapons/flame.dm
@@ -73,3 +73,7 @@
 	if(burnt)
 		icon_state = "match_burnt"
 		item_state = "cigoff"
+
+
+/obj/item/flame/match/IsHeatSource()
+	return lit ? 1000 : 0

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -106,6 +106,10 @@
 		location.hotspot_expose(700, 5)
 
 
+/obj/item/flame/lighter/IsHeatSource()
+	return lit ? 1500 : 0
+
+
 /obj/item/flame/lighter/red
 	color = COLOR_RED
 	name = "red lighter"

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -105,6 +105,7 @@
 	if(location)
 		location.hotspot_expose(700, 5)
 
+
 /obj/item/flame/lighter/red
 	color = COLOR_RED
 	name = "red lighter"

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -85,7 +85,7 @@
 
 
 /obj/item/melee/energy/IsHeatSource()
-	return 3500
+	return active ? 3500 : 0
 
 
 /*

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -83,6 +83,11 @@
 		return ITEM_SIZE_NO_CONTAINER
 	return ..()
 
+
+/obj/item/melee/energy/IsHeatSource()
+	return 3500
+
+
 /*
  * Energy Axe
  */

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -72,19 +72,6 @@
 	..()
 	return
 
-/obj/item/storage/backpack/holding/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/storage/backpack/holding) || istype(W, /obj/item/storage/bag/trash/bluespace))
-		to_chat(user, SPAN_WARNING("The Bluespace interfaces of the two devices conflict and malfunction."))
-		qdel(W)
-		return 1
-	return ..()
-
-	//Please don't clutter the parent storage item with stupid hacks.
-/obj/item/storage/backpack/holding/can_be_inserted(obj/item/W as obj, stop_messages = 0)
-	if(istype(W, /obj/item/storage/backpack/holding))
-		return 1
-	return ..()
-
 /obj/item/storage/backpack/santabag
 	name = "\improper Santa's gift bag"
 	desc = "Space Santa uses this to deliver toys to all the nice children in space for Christmas! Wow, it's pretty big!"
@@ -466,13 +453,6 @@
 	set_invisibility(i ? 101 : 0)
 	anchored = i ? TRUE : FALSE
 	alpha = i ? 128 : initial(alpha)
-
-/obj/item/storage/backpack/satchel/flat/attackby(obj/item/W, mob/user)
-	var/turf/T = get_turf(src)
-	if(hides_under_flooring() && isturf(T) && !T.is_plating())
-		to_chat(user, SPAN_WARNING("You must remove the plating first."))
-		return 1
-	return ..()
 
 //ERT backpacks.
 /obj/item/storage/backpack/ert

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -68,12 +68,6 @@
 	desc = "The latest and greatest in custodial convenience, a trashbag that is capable of holding vast quantities of garbage."
 	icon_state = "bluetrashbag"
 
-/obj/item/storage/bag/trash/bluespace/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/storage/backpack/holding) || istype(W, /obj/item/storage/bag/trash/bluespace))
-		to_chat(user, SPAN_WARNING("The Bluespace interfaces of the two devices conflict and malfunction."))
-		qdel(W)
-		return 1
-	return ..()
 
 // -----------------------------
 //        Plastic Bag

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -64,12 +64,20 @@
 	. = ..()
 	set_extension(src, /datum/extension/holster, src, sound_in, sound_out, can_holster)
 
-/obj/item/storage/belt/holster/attackby(obj/item/W as obj, mob/user as mob)
-	var/datum/extension/holster/H = get_extension(src, /datum/extension/holster)
-	if(H.holster(W, user))
-		return
-	else
-		. = ..(W, user)
+
+/obj/item/storage/belt/holster/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_ANY_ITEM] = "<p>Attempts to holster the item.</p>"
+
+
+/obj/item/storage/belt/holster/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Attempt to holster the tool.
+	var/datum/extension/holster/holster = get_extension(src, /datum/extension/holster)
+	if (holster.holster(tool, user))
+		return TRUE
+
+	return ..()
+
 
 /obj/item/storage/belt/holster/attack_hand(mob/user as mob)
 	var/datum/extension/holster/H = get_extension(src, /datum/extension/holster)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -367,16 +367,36 @@
 	can_hold = list(/obj/item/flame/match)
 	startswith = list(/obj/item/flame/match = 10)
 
-/obj/item/storage/box/matches/attackby(obj/item/flame/match/W as obj, mob/user as mob)
-	if(istype(W) && !W.lit && !W.burnt)
-		W.lit = 1
-		W.damtype = INJURY_TYPE_BURN
-		W.icon_state = "match_lit"
-		START_PROCESSING(SSobj, W)
-		playsound(src.loc, 'sound/items/match.ogg', 60, 1, -4)
-		user.visible_message(SPAN_NOTICE("[user] strikes the match on the matchbox."))
-	W.update_icon()
-	return
+
+/obj/item/storage/box/matches/get_interactions_info()
+	. = ..()
+	.["Match"] = "<p>Lights the match.</p>"
+
+
+/obj/item/storage/box/matches/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Match - Strike match and light it
+	if (istype(tool, /obj/item/flame/match))
+		var/obj/item/flame/match/match = tool
+		if (match.lit)
+			to_chat(user, SPAN_WARNING("\The [tool] is already lit."))
+			return TRUE
+		if (match.burnt)
+			to_chat(user, SPAN_WARNING("\The [tool] is burned up."))
+			return TRUE
+		match.lit = TRUE
+		match.damtype = INJURY_TYPE_BURN
+		match.icon_state = "match_lit"
+		START_PROCESSING(SSobj, tool)
+		playsound(loc, 'sound/items/match.ogg', 50, TRUE, -4)
+		match.update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] strikes \a [tool] on \the [src], lighting it."),
+			SPAN_NOTICE("You strike \the [tool] on \the [src], lighting it.")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/storage/box/autoinjectors
 	name = "box of injectors"

--- a/code/game/objects/items/weapons/storage/lockbox.dm
+++ b/code/game/objects/items/weapons/storage/lockbox.dm
@@ -112,6 +112,8 @@
 		overlays += image(icon, src, "ledb")
 	return
 
-/obj/item/storage/lockbox/vials/attackby(obj/item/item, mob/living/user)
-	. = ..()
-	update_icon()
+
+/obj/item/storage/lockbox/vials/post_use_item(obj/item/tool, mob/user, interaction_handled, click_params)
+	..()
+	if (interaction_handled)
+		update_icon()

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -212,8 +212,10 @@
 		add_fingerprint(user)
 	return 0
 
-/obj/item/melee/baton/robot/attackby(obj/item/W, mob/user)
-	return
+
+/obj/item/melee/baton/robot/can_use_item(obj/item/tool, mob/user, click_params)
+	return FALSE
+
 
 /obj/item/melee/baton/robot/apply_hit_effect(mob/living/target, mob/living/user, hit_zone)
 	update_cell(isrobot(user) ? user : null) // update the status before we apply the effects

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -296,6 +296,11 @@
 	else
 		return ..()
 
+
+/obj/item/weldingtool/IsFlameSource()
+	return isOn()
+
+
 /obj/item/weldingtool/mini
 	tank = /obj/item/welder_tank/mini
 

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -301,6 +301,10 @@
 	return isOn()
 
 
+/obj/item/weldingtool/IsHeatSource()
+	return isOn() ? 3800 : 0
+
+
 /obj/item/weldingtool/mini
 	tank = /obj/item/welder_tank/mini
 

--- a/code/game/objects/items/weapons/tools_crystal.dm
+++ b/code/game/objects/items/weapons/tools_crystal.dm
@@ -8,8 +8,10 @@
 	cell = null
 	fuel_cost_multiplier = 1
 
-/obj/item/weldingtool/electric/crystal/attackby(obj/item/W, mob/user)
-	return
+
+/obj/item/weldingtool/electric/crystal/can_use_item(obj/item/tool, mob/user, click_params)
+	return FALSE
+
 
 /obj/item/weldingtool/electric/crystal/on_update_icon()
 	icon_state = welding ? "crystal_welder_on" : "crystal_welder"

--- a/code/game/objects/items/weapons/traps.dm
+++ b/code/game/objects/items/weapons/traps.dm
@@ -17,13 +17,13 @@
 	return (user.IsAdvancedToolUser() && !issilicon(user) && !user.stat && !user.restrained())
 
 /obj/item/beartrap/user_unbuckle_mob(mob/user as mob)
-	if(buckled_mob && can_use(user))
+	if(buckled_mob && can_use(user) && can_unbuckle(user))
 		user.visible_message(
 			SPAN_NOTICE("\The [user] begins freeing \the [buckled_mob] from \the [src]."),
 			SPAN_NOTICE("You carefully begin to free \the [buckled_mob] from \the [src]."),
 			SPAN_NOTICE("You hear metal creaking.")
 			)
-		if(do_after(user, 6 SECONDS, src, DO_PUBLIC_UNIQUE))
+		if(do_after(user, 6 SECONDS, src, DO_PUBLIC_UNIQUE) && can_unbuckle(user))
 			user.visible_message(SPAN_NOTICE("\The [buckled_mob] has been freed from \the [src] by \the [user]."))
 			unbuckle_mob()
 			anchored = FALSE
@@ -80,9 +80,12 @@
 		return 0
 
 	//trap the victim in place
-	set_dir(L.dir)
-	buckle_mob(L)
-	to_chat(L, SPAN_DANGER("The steel jaws of \the [src] bite into you, trapping you in place!"))
+	if (can_buckle(L))
+		set_dir(L.dir)
+		buckle_mob(L)
+		to_chat(L, SPAN_DANGER("The steel jaws of \the [src] bite into you, trapping you in place!"))
+	else
+		to_chat(L, SPAN_DANGER("The steel jaws of \the [src] bite into you, but fail to hold you in place!"))
 	deployed = 0
 
 /obj/item/beartrap/Crossed(AM as mob|obj)

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -4,6 +4,7 @@
 	icon_state = "empty"
 	appearance_flags = DEFAULT_APPEARANCE_FLAGS
 	anchored = TRUE
+	req_access = list(access_kitchen)
 	var/cult = 0
 
 /obj/structure/sign/double/barsign/proc/get_valid_states(initial=1)
@@ -58,20 +59,37 @@
 	..()
 	icon_state = pick(get_valid_states())
 
-/obj/structure/sign/double/barsign/attackby(obj/item/I, mob/user)
-	if(cult)
-		return ..()
 
-	var/obj/item/card/id/card = I.GetIdCard()
-	if(istype(card))
-		if(access_kitchen in card.GetAccess())
-			var/sign_type = input(user, "What would you like to change the barsign to?") as null|anything in get_valid_states(0)
-			if(!sign_type)
-				return
-			icon_state = sign_type
-			to_chat(user, SPAN_NOTICE("You change the barsign."))
-		else
-			to_chat(user, SPAN_WARNING("Access denied."))
-		return
+/obj/structure/sign/double/barsign/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_ID_CARD] = "<p>Allows changing the sign's display icon, if the ID has access.</p>"
+	. -= CODEX_INTERACTION_SCREWDRIVER
+
+
+/obj/structure/sign/double/barsign/use_tool(obj/item/tool, mob/user, list/click_params)
+	// ID Card - Change display
+	var/obj/item/card/id/id = tool.GetIdCard()
+	if (istype(id))
+		var/id_name = GET_ID_NAME(id, tool)
+		if (cult)
+			to_chat(user, SPAN_WARNING("\The [src] doesn't respond to [id_name]."))
+			return TRUE
+		if (!check_access(id))
+			to_chat(user, SPAN_WARNING("\The [src] refuses [id_name]."))
+			return TRUE
+		var/sign_type = input(user, "What would you like to change the barsign to?", "[src] Display", icon_state) as null|anything in get_valid_states(FALSE)
+		if (!sign_type || sign_type == icon_state || !user.use_sanity_check(src, id))
+			return TRUE
+		icon_state = sign_type
+		user.visible_message(
+			SPAN_NOTICE("\The [user] changes \the [src]'s display with \a [tool]."),
+			SPAN_NOTICE("You change \the [src]'s display to '[sign_type]' with [id_name].")
+		)
+		return TRUE
+
+	// Screwdriver - Block removal
+	if (isScrewdriver(tool))
+		to_chat(user, SPAN_WARNING("\The [src] can't be removed."))
+		return TRUE
 
 	return ..()

--- a/code/game/objects/structures/crates_lockers/closets/walllocker.dm
+++ b/code/game/objects/structures/crates_lockers/closets/walllocker.dm
@@ -16,6 +16,7 @@
 /obj/structure/closet/walllocker/emerglocker
 	name = "emergency locker"
 	desc = "A wall mounted locker with emergency supplies."
+	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_NO_TOOLS
 	var/list/spawnitems = list(/obj/item/tank/oxygen_emergency,/obj/item/clothing/mask/breath)
 	var/amount = 2 // spawns each items X times.
 	closet_appearance = /singleton/closet_appearance/wall/emergency

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -12,15 +12,32 @@
 	overlays += image('icons/obj/objects.dmi', src, "echair_over", MOB_LAYER + 1, dir)
 	return
 
-/obj/structure/bed/chair/e_chair/attackby(obj/item/W as obj, mob/user as mob)
-	if(isWrench(W))
-		var/obj/structure/bed/chair/C = new /obj/structure/bed/chair(loc)
-		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
-		C.set_dir(dir)
+
+/obj/structure/bed/chair/e_chair/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_WRENCH] = "<p>Removes the electrical parts, turning \the [initial(name)] back into a normal chair.</p>"
+
+
+/obj/structure/bed/chair/e_chair/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Wrench - Remove electric parts
+	if (isWrench(tool))
+		var/obj/structure/bed/chair/chair = new (loc)
+		chair.set_dir(dir)
+		transfer_fingerprints_to(chair)
+		playsound(src, 'sound/items/Ratchet.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] detaches \the [part] from \the [chair] with \a [tool]."),
+			SPAN_NOTICE("You detach \the [part] from \the [chair] with \the [tool].")
+		)
 		part.dropInto(loc)
 		part.master = null
+		part.add_fingerprint(user, tool = tool)
 		part = null
 		qdel(src)
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/bed/chair/e_chair/verb/toggle()
 	set name = "Toggle Electric Chair"

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -192,21 +192,45 @@
 		to_chat(user, "\A [mybag] is hanging on the [callme].")
 
 
-/obj/structure/bed/chair/janicart/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/mop))
-		if(reagents.total_volume > 1)
-			reagents.trans_to_obj(I, 2)
-			to_chat(user, SPAN_NOTICE("You wet [I] in the [callme]."))
-			playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
-		else
-			to_chat(user, SPAN_NOTICE("This [callme] is out of water!"))
-	else if(istype(I, /obj/item/key))
-		to_chat(user, "Hold [I] in one of your hands while you drive this [callme].")
-	else if(istype(I, /obj/item/storage/bag/trash))
-		if(!user.unEquip(I, src))
-			return
-		to_chat(user, SPAN_NOTICE("You hook the trashbag onto the [callme]."))
-		mybag = I
+/obj/structure/bed/chair/janicart/get_interactions_info()
+	. = ..()
+	.["Key"] = "<p>Have the key in your hands while on the cart to drive it.</p>"
+	.["Mop"] = "<p>Wets the mop with the cart's water, if it has any.</p>"
+	.["Trash Bag"] = "<p>Attaches the trash bag to the cart. There can only be one trash bag attached at a time.</p>"
+
+
+/obj/structure/bed/chair/janicart/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Key - Instructional message
+	if (istype(tool, /obj/item/key))
+		to_chat(user, SPAN_NOTICE("Hold \the [tool] in your hands while you drive \the [callme]."))
+		return TRUE
+
+	// Mop - Wet mop with water
+	if (istype(tool, /obj/item/mop))
+		if (reagents.total_volume <= 1)
+			to_chat(user, SPAN_WARNING("\The [callme] is out of water."))
+			return TRUE
+		reagents.trans_to_obj(tool, 2)
+		playsound(src, 'sound/effects/slosh.ogg', 25, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] wets \a [tool] in \the [callme]."),
+			SPAN_NOTICE("You wet \the [tool] in \the [callme].")
+		)
+		return TRUE
+
+	// Trash Bag - Attach to cart
+	if (istype(tool, /obj/item/storage/bag/trash))
+		if (!user.unEquip(tool, src))
+			to_chat(user, SPAN_WARNING("You can't drop \the [tool]."))
+			return TRUE
+		mybag = tool
+		user.visible_message(
+			SPAN_NOTICE("\The [user] hooks \a [tool] onto \the [callme]."),
+			SPAN_NOTICE("You hook \the [tool] onto \the [callme].")
+		)
+		return TRUE
+
+	return ..()
 
 
 /obj/structure/bed/chair/janicart/attack_hand(mob/user)

--- a/code/game/objects/structures/roller_bed.dm
+++ b/code/game/objects/structures/roller_bed.dm
@@ -112,22 +112,7 @@
 		update_icon()
 		return
 	if (istype(item, /obj/item/grab))
-		if (buckled_mob)
-			to_chat(user, SPAN_WARNING("\The [buckled_mob] is already on \the [src]."))
-			return
 		var/obj/item/grab/grab = item
-		user.visible_message(
-			SPAN_ITALIC("\The [user] starts buckling \the [grab.affecting] to \a [src]."),
-			SPAN_ITALIC("You start buckling \the [grab.affecting] to \the [src]."),
-			range = 5
-		)
-		if (!do_after(user, 3 SECONDS, src, DO_PUBLIC_UNIQUE))
-			return
-		if (QDELETED(grab))
-			return
-		if (buckled_mob)
-			to_chat(user, SPAN_WARNING("\The [buckled_mob] is already on \the [src]."))
-			return
 		if (!AttemptBuckle(grab.affecting, user))
 			return
 		qdel(grab)
@@ -199,12 +184,6 @@
 /obj/structure/roller_bed/MouseDrop_T(atom/dropped, mob/living/user)
 	if (src == dropped && user.canClick())
 		user.ClickOn(src)
-		return
-	if (!CheckDexterity(user))
-		to_chat(user, SPAN_WARNING("You're not dextrous enough to do that."))
-		return
-	if (user.incapacitated())
-		to_chat(user, SPAN_WARNING("You're in no condition to do that."))
 		return
 	if (!buckled_mob)
 		if (isliving(dropped))

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -20,16 +20,30 @@
 		else
 	return
 
-/obj/structure/sign/attackby(obj/item/tool as obj, mob/user as mob)	//deconstruction
-	if(isScrewdriver(tool) && !istype(src, /obj/structure/sign/double))
-		to_chat(user, "You unfasten the sign with your [tool.name].")
-		var/obj/item/sign/S = new(src.loc)
-		S.SetName(name)
-		S.desc = desc
-		S.icon_state = icon_state
-		S.sign_state = icon_state
+
+/obj/structure/sign/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_SCREWDRIVER] = "<p>Removes \the [initial(name)] from the wall.</p>"
+
+
+/obj/structure/sign/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Screwdriver - Remove sign from wall
+	if (isScrewdriver(tool))
+		var/obj/item/sign/sign = new (loc)
+		sign.SetName(name)
+		sign.desc = desc
+		sign.icon_state = icon_state
+		sign.sign_state = icon_state
+		transfer_fingerprints_to(sign)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] removes \the [src] from the wall with \a [tool]."),
+			SPAN_NOTICE("You remove \the [src] from the wall with \the [tool].")
+		)
 		qdel(src)
-	else ..()
+		return TRUE
+
+	return ..()
+
 
 /obj/item/sign
 	name = "sign"

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -20,10 +20,21 @@
 	if(buckled_mob)
 		buckled_mob.set_dir(dir)
 
-/obj/structure/bed/chair/wheelchair/attackby(obj/item/W as obj, mob/user as mob)
-	if(isWrench(W) || istype(W,/obj/item/stack) || isWirecutter(W))
-		return
-	..()
+
+/obj/structure/bed/chair/wheelchair/get_interactions_info()
+	. = ..()
+	. -= CODEX_INTERACTION_MATERIAL_STACK
+	. -= CODEX_INTERACTION_WRENCH
+	. -= CODEX_INTERACTION_WIRECUTTERS
+
+
+/obj/structure/bed/chair/wheelchair/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Wrench, Stack, Wirecutters - Block normal chair interactions
+	if (isWrench(tool) || isstack(tool) || isWirecutter(tool))
+		return FALSE
+
+	return ..()
+
 
 /obj/structure/bed/chair/wheelchair/relaymove(mob/user, direction)
 	// Redundant check?

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -474,10 +474,24 @@
 	..()
 	icon_state = "puddle"
 
-/obj/structure/hygiene/sink/puddle/attackby(obj/item/O as obj, mob/user)
-	icon_state = "puddle-splash"
-	..()
-	icon_state = "puddle"
+
+/obj/structure/hygiene/sink/puddle/use_grab(obj/item/grab/grab, list/click_params)
+	. = ..()
+	if (.)
+		flick("puddle-splash", src)
+
+
+/obj/structure/hygiene/sink/puddle/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	. = ..()
+	if (.)
+		flick("puddle-splash", src)
+
+
+/obj/structure/hygiene/sink/puddle/use_tool(obj/item/tool, mob/user, list/click_params)
+	. = ..()
+	if (.)
+		flick("puddle-splash", src)
+
 
 //toilet paper interaction for clogging toilets and other facilities
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -735,10 +735,10 @@
 	icon_state = "light[active]"
 
 //Centcomm windows
-/obj/structure/window/reinforced/crescent/attack_hand()
-	return
+/obj/structure/window/reinforced/crescent
+	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_NO_TOOLS
 
-/obj/structure/window/reinforced/crescent/attackby()
+/obj/structure/window/reinforced/crescent/attack_hand()
 	return
 
 /obj/structure/window/reinforced/crescent/ex_act()

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -171,8 +171,9 @@
 
 	if(W)
 		radiate()
-		if(is_hot(W))
-			burn(is_hot(W))
+		var/heat_value = W.IsHeatSource()
+		if (heat_value)
+			burn(heat_value)
 
 	if(locate(/obj/effect/overlay/wallrot) in src)
 		if(isWelder(W))

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -35,3 +35,7 @@
 	activate()
 	add_fingerprint(user)
 	return
+
+
+/obj/item/device/assembly/igniter/IsFlameSource()
+	return TRUE

--- a/code/modules/augment/active/circuit.dm
+++ b/code/modules/augment/active/circuit.dm
@@ -7,23 +7,45 @@
 	desc = "A DIY modular assembly, courtesy of Xion Industrial. Circuitry not included."
 
 
-/obj/item/organ/internal/augment/active/item/circuit/attackby(obj/item/I, mob/user)
-	if (isCrowbar(I))
+/obj/item/organ/internal/augment/active/item/circuit/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_CROWBAR] = "<p>Removes the attached assembly.</p>"
+	.["Electronic Assembly (Agument)"] = "<p>Attaches the assembly. Only one assembly can be attached at a time.</p>"
+
+
+/obj/item/organ/internal/augment/active/item/circuit/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Crowbar - Remove augment
+	if (isCrowbar(tool))
+		if (!item)
+			to_chat(user, SPAN_WARNING("\The [src] doesn't have an assembly to remove."))
+			return TRUE
+		if (!item.canremove)
+			to_chat(user, SPAN_WARNING("\The [item] can't be removed from \the [src]."))
+			return TRUE
+		item.dropInto(loc)
+		item = null
+		playsound(loc, 'sound/items/Crowbar.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] removes \a [item] from \the [src] with \a [tool]."),
+			SPAN_NOTICE("You remove \the [item] from \the [src] with \the [tool].")
+		)
+		return TRUE
+
+	// Electronic Assembly (Augment) - Add augment
+	if (istype(tool, /obj/item/device/electronic_assembly/augment))
 		if (item)
-			item.canremove = TRUE
-			item.dropInto(loc)
-			to_chat(user, SPAN_NOTICE("You take out \the [item]."))
-			item = null
-			playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
-		else
-			to_chat(user, SPAN_WARNING("The augment is empty!"))
-		return
-	if (istype(I, /obj/item/device/electronic_assembly/augment))
-		if (item)
-			to_chat(user, SPAN_WARNING("There's already an assembly in there."))
-		else if (user.unEquip(I, src))
-			item = I
-			item.canremove = FALSE
-			playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
-		return
-	..()
+			to_chat(user, SPAN_WARNING("\The [src] already has \a [item] installed."))
+			return TRUE
+		if (!user.unEquip(tool, src))
+			to_chat(user, SPAN_WARNING("You can't drop \the [tool]."))
+			return TRUE
+		item = tool
+		item.canremove = FALSE
+		playsound(loc, 'sound/items/Crowbar.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs \a [tool] into \the [src]."),
+			SPAN_NOTICE("You install \the [tool] into \the [src].")
+		)
+		return TRUE
+
+	return ..()

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -413,6 +413,11 @@ regen() will cover update_icon() for this proc
 			new /obj/effect/decal/cleanable/ash(src.loc)
 			qdel(src)
 
+
+/obj/item/blob_tendril/IsHeatSource()
+	return damtype == DAMAGE_BURN ? 1000 : 0
+
+
 /obj/item/blob_tendril/core
 	name = "asteroclast nucleus sample"
 	desc = "A sample taken from an asteroclast's nucleus. It pulses with energy."

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -282,6 +282,8 @@ BLIND     // can't see anything
 	var/clipped = 0
 	var/obj/item/clothing/ring/ring = null		//Covered ring
 	var/mob/living/carbon/human/wearer = null	//Used for covered rings when dropping
+	/// Boolean. Whether or not the gloves can be clipped with tools.
+	var/can_be_clipped = TRUE
 	body_parts_covered = HANDS
 	slot_flags = SLOT_GLOVES
 	item_flags = ITEM_FLAG_WASHER_ALLOWED
@@ -320,6 +322,9 @@ BLIND     // can't see anything
 
 /obj/item/clothing/gloves/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/wirecutters) || istype(W, /obj/item/scalpel))
+		if (!can_be_clipped)
+			to_chat(user, SPAN_WARNING("\The [src] cannot be cut."))
+			return TRUE
 		if (clipped)
 			to_chat(user, SPAN_NOTICE("\The [src] have already been modified!"))
 			update_icon()

--- a/code/modules/clothing/gloves/boxing.dm
+++ b/code/modules/clothing/gloves/boxing.dm
@@ -3,12 +3,7 @@
 	desc = "Because you really needed another excuse to punch your crewmates."
 	icon_state = "boxing"
 	item_state = "boxing"
-
-/obj/item/clothing/gloves/boxing/attackby(obj/item/W, mob/user)
-	if(isWirecutter(W) || istype(W, /obj/item/scalpel))
-		to_chat(user, SPAN_NOTICE("That won't work."))//Nope
-	else
-		..()
+	can_be_clipped = FALSE
 
 /obj/item/clothing/gloves/boxing/green
 	icon_state = "boxinggreen"

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -132,7 +132,7 @@
 
 /obj/item/clothing/mask/smokable/attackby(obj/item/W, mob/user)
 	..()
-	if (W.IsFlameSource() || is_hot(W))
+	if (W.IsFlameSource() || W.IsHeatSource())
 		var/text = matchmes
 		if(istype(W, /obj/item/flame/match))
 			text = matchmes

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -132,7 +132,7 @@
 
 /obj/item/clothing/mask/smokable/attackby(obj/item/W, mob/user)
 	..()
-	if(isflamesource(W) || is_hot(W))
+	if (W.IsFlameSource() || is_hot(W))
 		var/text = matchmes
 		if(istype(W, /obj/item/flame/match))
 			text = matchmes
@@ -158,6 +158,11 @@
 		return 1
 	else
 		return ..()
+
+
+/obj/item/clothing/mask/smokable/IsFlameSource()
+	return lit
+
 
 /obj/item/clothing/mask/smokable/cigarette
 	name = "cigarette"
@@ -548,6 +553,11 @@
 	user.update_inv_wear_mask(0)
 	user.update_inv_l_hand(0)
 	user.update_inv_r_hand(1)
+
+
+/obj/item/clothing/mask/smokable/pipe/IsFlameSource()
+	return FALSE
+
 
 /obj/item/clothing/mask/smokable/pipe/cobpipe
 	name = "corn cob pipe"

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -132,7 +132,7 @@
 
 /obj/item/clothing/mask/smokable/attackby(obj/item/W, mob/user)
 	..()
-	if (W.IsFlameSource() || W.IsHeatSource())
+	if (isFlameOrHeatSource(W))
 		var/text = matchmes
 		if(istype(W, /obj/item/flame/match))
 			text = matchmes

--- a/code/modules/clothing/rings/material.dm
+++ b/code/modules/clothing/rings/material.dm
@@ -4,6 +4,8 @@
 	icon = 'icons/obj/clothing/obj_hands_ring.dmi'
 	icon_state = "material"
 	var/material/material
+	/// String. Inscription engraved on the ring, if present.
+	var/inscription
 
 /obj/item/clothing/ring/material/New(newloc, new_material)
 	..(newloc)
@@ -17,16 +19,38 @@
 	desc = "A ring made from [material.display_name]."
 	color = material.icon_colour
 
-/obj/item/clothing/ring/material/attackby(obj/item/S, mob/user)
-	if(S.sharp)
-		var/inscription = sanitize(input("Enter an inscription to engrave.", "Inscription") as null|text)
 
-		if(!user.stat && !user.incapacitated() && user.Adjacent(src) && S.loc == user)
-			if(!inscription)
-				return
-			desc = "A ring made from [material.display_name]."
-			to_chat(user, SPAN_WARNING("You carve \"[inscription]\" into \the [src]."))
-			desc += "<br>Written on \the [src] is the inscription \"[inscription]\""
+/obj/item/clothing/ring/material/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_SHARP] = "<p>Engraves a message on the ring, if one is not already present.</p>"
+
+
+/obj/item/clothing/ring/material/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Sharp Object - Engrave ring
+	if (is_sharp(tool))
+		if (inscription)
+			to_chat(user, SPAN_WARNING("\The [src] is already engraved."))
+			return TRUE
+		var/input = sanitize(input(user, "Enter an inscription to engrave", name) as null|text)
+		if (!input || !user.use_sanity_check(src, tool))
+			return TRUE
+		inscription = input
+		user.visible_message(
+			SPAN_NOTICE("\The [user] engraves a message on \the [src] with \a [tool]."),
+			SPAN_NOTICE("You engrave the following inscription on \the [src] with \the [tool]:<br/>'[inscription]'"),
+			range = 2
+		)
+		return TRUE
+
+	return ..()
+
+
+/obj/item/clothing/ring/material/examine(mob/user, distance, infix, suffix)
+	. = ..()
+	if (distance > 1)
+		return
+	to_chat(user, SPAN_INFO("Written on \the [src] is the inscription \"[inscription]\""))
+
 
 /obj/item/clothing/ring/material/OnTopic(mob/user, list/href_list)
 	if(href_list["examine"])

--- a/code/modules/clothing/spacesuits/breaches.dm
+++ b/code/modules/clothing/spacesuits/breaches.dm
@@ -180,82 +180,87 @@
 
 	return damage
 
-//Handles repairs (and also upgrades).
 
-/obj/item/clothing/suit/space/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W,/obj/item/stack/material))
-		var/repair_power = 0
-		switch(W.get_material_name())
-			if(MATERIAL_STEEL)
-				repair_power = 2
-			if(MATERIAL_PLASTIC)
-				repair_power = 1
+/obj/item/clothing/suit/space/get_interactions_info()
+	. = ..()
+	.["Duct Tape"] = "<p>Seals open breaches on the suit. Can be used while the suit is worn.</p>"
+	.["Plastic Sheets"] = "<p>Repairs burn damage on the suit. Consumes up to 3 sheets per use. Cannot be used while the suit is worn.</p>"
+	.["Steel Sheets"] = "<p>Repairs burn damage on the suit at a higher rate than plastic. Consumes up to 3 sheets per use. Cannot be used while the suit is worn.</p>"
+	.[CODEX_INTERACTION_WELDER] = "<p>Repairs brute damage on the suit. Costs 5 units of fuel. Cannot be used while the suit is worn.</p>"
 
-		if(!repair_power)
-			return
 
-		if(istype(loc,/mob/living/carbon/human))
-			var/mob/living/carbon/human/H = loc
-			if(H.wear_suit == src)
-				to_chat(user, SPAN_WARNING("You cannot repair \the [src] while it is being worn."))
-				return
-
-		if(burn_damage <= 0)
-			to_chat(user, "There is no surface damage on \the [src] to repair.") //maybe change the descriptor to more obvious? idk what
-			return
-
-		var/obj/item/stack/P = W
-		var/use_amt = min(P.get_amount(), 3)
-		if(use_amt && P.use(use_amt))
-			repair_breaches(DAMAGE_BURN, use_amt * repair_power, user)
-		return
-
-	else if(isWelder(W))
-
-		if(istype(loc,/mob/living/carbon/human))
-			var/mob/living/carbon/human/H = loc
-			if(H.wear_suit == src)
-				to_chat(user, SPAN_WARNING("You cannot repair \the [src] while it is being worn."))
-				return
-
-		if (brute_damage <= 0)
-			to_chat(user, "There is no structural damage on \the [src] to repair.")
-			return
-
-		var/obj/item/weldingtool/WT = W
-		if(!WT.remove_fuel(5))
-			to_chat(user, SPAN_WARNING("You need more welding fuel to repair this suit."))
-			return
-
-		repair_breaches(DAMAGE_BRUTE, 3, user)
-		return
-
-	else if(istype(W, /obj/item/tape_roll))
-		var/datum/breach/target_breach		//Target the largest unpatched breach.
-		for(var/datum/breach/B in breaches)
-			if(B.patched)
+/obj/item/clothing/suit/space/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Duct Tape - Seal breaches
+	if (istype(tool, /obj/item/tape_roll))
+		if (!ishuman(user))
+			return ..()
+		var/datum/breach/target_breach
+		for (var/datum/breach/breach in breaches)
+			if (breach.patched)
 				continue
-			if(!target_breach || (B.class > target_breach.class))
-				target_breach = B
+			if (!target_breach || (breach.class > target_breach.class))
+				target_breach = breach
+		if (!target_breach)
+			to_chat(user, SPAN_WARNING("\The [src] has no open breaches to seal."))
+			return TRUE
+		playsound(src, 'sound/effects/tape.ogg', 50, TRUE)
+		var/mob/living/carbon/human/human = user
+		var/is_worn = istype(loc, /mob/living) ? loc : null
+		if (!do_after(user, (human.wear_suit == src ? 6 : 3) SECONDS, is_worn ? loc : src, is_worn ? DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS : DO_PUBLIC_UNIQUE))
+			return TRUE
+		if (!user.use_sanity_check(src, tool) || (is_worn && !user.use_sanity_check(is_worn, tool)))
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] uses \a [tool] to seal \a [target_breach.descriptor] on \the [src]."),
+			SPAN_NOTICE("You use \the [tool] to seal \the [target_breach.descriptor] on \the [src].")
+		)
+		target_breach.patched = TRUE
+		target_breach.update_descriptor()
+		calc_breach_damage()
+		return TRUE
 
-		if(!target_breach)
-			to_chat(user, "There are no open breaches to seal with \the [W].")
-		else
-			playsound(src, 'sound/effects/tape.ogg',25)
-			var/mob/living/carbon/human/H = user
-			if(!istype(H)) return
-			var/is_worn = istype(loc, /mob/living)
-			if(do_after(user, (H.wear_suit == src ? 6 : 3) SECONDS, is_worn ? loc : src, is_worn ? DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS : DO_PUBLIC_UNIQUE)) //Sealing a breach on your own suit is awkward and time consuming
-				user.visible_message(
-					SPAN_NOTICE("\The [user] uses \the [W] to seal \the [target_breach.descriptor] on \the [src]."),
-					SPAN_NOTICE("You use \the [W] to seal \the [target_breach.descriptor] on \the [src].")
-				)
-				target_breach.patched = TRUE
-				target_breach.update_descriptor()
-				calc_breach_damage()
-		return
+	// Material Stack (Steel or Plastic) - Repair burn damage
+	if (istype(tool, /obj/item/stack/material))
+		var/repair_power = 0
+		switch (tool.get_material_name())
+			if (MATERIAL_STEEL)
+				repair_power = 2
+			if (MATERIAL_PLASTIC)
+				repair_power = 1
+		if (!repair_power)
+			return ..()
+		if (istype(loc, /mob/living/carbon/human))
+			var/mob/living/carbon/human/human = loc
+			if (human.wear_suit == src)
+				to_chat(user, SPAN_WARNING("You cannot repair \the [src] while it is being worn."))
+				return TRUE
+		if (burn_damage <= 0)
+			to_chat(user, SPAN_WARNING("There is no burn damage on \the [src] to repair."))
+			return TRUE
+		var/obj/item/stack/material/stack = tool
+		var/use_amount = min(stack.get_amount(), 3)
+		stack.use(use_amount)
+		repair_breaches(DAMAGE_BURN, use_amount * repair_power, user)
+		return TRUE
 
-	..()
+	// Welding Tool - Repair brute damage
+	if (isWelder(tool))
+		if (istype(loc, /mob/living/carbon/human))
+			var/mob/living/carbon/human/human = loc
+			if (human.wear_suit == src)
+				to_chat(user, SPAN_WARNING("You cannot repair \the [src] while it is being worn."))
+				return TRUE
+		if (brute_damage <= 0)
+			to_chat(user, SPAN_WARNING("There is no structural damage on \the [src] to repair."))
+			return TRUE
+		var/obj/item/weldingtool/welder = tool
+		if (!welder.remove_fuel(5))
+			return TRUE
+		repair_breaches(DAMAGE_BRUTE, 3, user)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/clothing/suit/space/examine(mob/user)
 	. = ..()

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -129,19 +129,34 @@
 	return 1
 
 
-/obj/item/clothing/accessory/badge/holo/attackby(obj/item/O, mob/user)
-	if (istype(O, /obj/item/card/id) || istype(O, /obj/item/modular_computer))
-		var/obj/item/card/id/id_card = O.GetIdCard()
-		if (!id_card)
-			return
-		if ((badge_access in id_card.access) || emagged)
-			to_chat(user, "You imprint your ID details onto the badge.")
-			set_name(id_card.registered_name)
-			set_desc(user)
-		else
-			to_chat(user, "[src] rejects your ID, and flashes 'Insufficient access!'")
-		return
-	..()
+/obj/item/clothing/accessory/badge/holo/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_ID_CARD] = "<p>Imprints the ID card's details onto the badge. Requires access to the badge.</p>"
+
+
+/obj/item/clothing/accessory/badge/holo/get_antag_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_EMAG] += "<p>Removes the badge's access restriction, allowing you to scan any ID's details onto it.</p>"
+
+
+/obj/item/clothing/accessory/badge/holo/use_tool(obj/item/tool, mob/user, list/click_params)
+	// ID Card - Imprint ID on the badge
+	var/obj/item/card/id/id_card = tool.GetIdCard()
+	if (istype(id_card))
+		var/id_name = GET_ID_NAME(id_card, tool)
+		if (!emagged && !check_access(id_card))
+			to_chat(user, SPAN_WARNING("\The [src] rejects [id_name]."))
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] scans \a [tool] over \the [initial(name)]."),
+			SPAN_NOTICE("You imprint your details from [id_name] onto \the [initial(name)]."),
+			range = 2
+		)
+		set_name(id_card.registered_name)
+		set_desc(user)
+		return TRUE
+
+	return ..()
 
 
 /obj/item/storage/box/holobadge

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -16,12 +16,13 @@
 	set_extension(src, /datum/extension/holster, container, sound_in, sound_out, can_holster)
 
 
-/obj/item/clothing/accessory/storage/holster/attackby(obj/item/W as obj, mob/user as mob)
-	var/datum/extension/holster/H = get_extension(src, /datum/extension/holster)
-	if (H.holster(W, user))
-		return
-	else
-		. = ..(W, user)
+/obj/item/clothing/accessory/storage/holster/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Attempt holstering
+	var/datum/extension/holster/holster = get_extension(src, /datum/extension/holster)
+	if (holster.holster(tool, user))
+		return TRUE
+
+	return ..()
 
 
 /obj/item/clothing/accessory/storage/holster/attack_hand(mob/user as mob)

--- a/code/modules/clothing/under/accessories/lockets.dm
+++ b/code/modules/clothing/under/accessories/lockets.dm
@@ -30,17 +30,30 @@
 		icon_state = "[base_icon]"
 
 
-/obj/item/clothing/accessory/locket/attackby(obj/item/I, mob/user)
-	if (!open)
-		to_chat(user, "You have to open it first.")
-		return
-	if (istype(I, /obj/item/paper) || istype(I, /obj/item/photo))
+/obj/item/clothing/accessory/locket/get_interactions_info()
+	. = ..()
+	.["Paper"] = "<p>Inserts the paper into the locket. The locket must be open. There can only be one item inserted at a time.</p>"
+	.["Photo"] = "<p>Inserts the photo into the locket. The locket must be open. There can only be one item inserted at a time.</p>"
+
+
+/obj/item/clothing/accessory/locket/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Paper, Photo - Add to locket
+	if (is_type_in_list(tool, list(/obj/item/paper, /obj/item/photo)))
+		if (!open)
+			to_chat(user, SPAN_WARNING("\The [src] needs to be open before you can insert \the [tool]."))
+			return TRUE
 		if (held)
-			to_chat(usr, "\The [src] already has something inside it.")
-		else
-			if (!user.unEquip(I, src))
-				return
-			to_chat(usr, "You slip [I] into [src].")
-			held = I
-		return
-	..()
+			to_chat(user, SPAN_WARNING("\The [src] already has \a [held] inside it."))
+			return TRUE
+		if (!user.unEquip(tool, src))
+			to_chat(user, SPAN_WARNING("You can't drop \the [tool]."))
+			return TRUE
+		held = tool
+		user.visible_message(
+			SPAN_NOTICE("\The [user] slips \a [tool] into \the [src]."),
+			SPAN_NOTICE("You slip \a [tool] into \the [src]."),
+			range = 1
+		)
+		return TRUE
+
+	return ..()

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -38,9 +38,28 @@
 		..(over_object)
 
 
-/obj/item/clothing/accessory/storage/attackby(obj/item/I, mob/user)
+/obj/item/clothing/accessory/storage/use_grab(obj/item/grab/grab, list/click_params)
 	if (container)
-		return container.attackby(I, user)
+		return container.use_grab(grab, click_params)
+	return ..()
+
+
+/obj/item/clothing/accessory/storage/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	if (container)
+		return container.use_weapon(weapon, user, click_params)
+	return ..()
+
+
+/obj/item/clothing/accessory/storage/use_tool(obj/item/tool, mob/user, list/click_params)
+	if (container)
+		return container.use_tool(tool, user, click_params)
+	return ..()
+
+
+/obj/item/clothing/accessory/storage/attackby(obj/item/I, mob/user, click_params)
+	if (container)
+		return container.attackby(I, user, click_params)
+	return ..()
 
 
 /obj/item/clothing/accessory/storage/emp_act(severity)

--- a/code/modules/codex/codex_atom.dm
+++ b/code/modules/codex/codex_atom.dm
@@ -21,6 +21,9 @@
 	var/construction = html_list(get_construction_info(), TRUE)
 	if (construction)
 		mechanics += "<h4>Construction Steps</h4>[construction]"
+	var/deconstruction = html_list(get_deconstruction_info(), TRUE)
+	if (deconstruction)
+		mechanics += "<h4>Deconstruction Steps</h4>[deconstruction]"
 	var/interactions = html_list_dl(get_interactions_info())
 	if (interactions)
 		mechanics += "<h4>Interactions</h4>[interactions]"
@@ -50,6 +53,17 @@
  * Returns list of strings.
  */
 /atom/proc/get_construction_info()
+	RETURN_TYPE(/list)
+	return list()
+
+
+/**
+ * Handler for displaying deconstruction steps in the Mechanics section of the atom's codex entry. Separated to allow
+ * overriding without duplication of parent steps, or removal of parent mechanics information.
+ *
+ * Returns list of strings.
+ */
+/atom/proc/get_deconstruction_info()
 	RETURN_TYPE(/list)
 	return list()
 

--- a/code/modules/codex/codex_atom.dm
+++ b/code/modules/codex/codex_atom.dm
@@ -69,19 +69,31 @@
 /atom/var/const/CODEX_INTERACTION_HAND = "Empty Hand"
 
 // Common Tools/Items
-/atom/var/const/CODEX_INTERACTION_ID_CARD = "ID Card (And Scannable ID Holders)"
+/atom/var/const/CODEX_INTERACTION_CABLE = "Cable Coil"
+/atom/var/const/CODEX_INTERACTION_CROWBAR = "Crowbar/Prybar"
+/atom/var/const/CODEX_INTERACTION_ID_CARD = "ID Card (And Scannable ID Holders (PDA, Wallet, etc.))"
+/atom/var/const/CODEX_INTERACTION_MULTITOOL = "Multitool"
 /atom/var/const/CODEX_INTERACTION_SCREWDRIVER = "Screwdriver"
 /atom/var/const/CODEX_INTERACTION_WELDER = "Welding Tool"
+/atom/var/const/CODEX_INTERACTION_WRENCH = "Wrench"
+/atom/var/const/CODEX_INTERACTION_WIRECUTTERS = "Wirecutters"
 
 // Grabs
-/atom/var/const/CODEX_INTERACTION_GRAB = "Grabbed Mob"
+/atom/var/const/CODEX_INTERACTION_GRAB = "Grabbed Mob (Any Not Already Listed)"
 /atom/var/const/CODEX_INTERACTION_GRAB_PASSIVE = "Grabbed Mob (Passive - Yellow)"
 /atom/var/const/CODEX_INTERACTION_GRAB_AGGRESSIVE = "Grabbed Mob (Aggressive - Blue)"
 /atom/var/const/CODEX_INTERACTION_GRAB_NECK = "Grabbed Mob (Neck - Red)"
 
 // Other cases
+/atom/var/const/CODEX_INTERACTION_ANY_ITEM = "Any Item Not Already Listed"
 /atom/var/const/CODEX_INTERACTION_EMAG = "Cryptographic Sequencer (EMAG)"
 /atom/var/const/CODEX_INTERACTION_EMP = "EMP"
+/atom/var/const/CODEX_INTERACTION_FLAME_SOURCE = "Open Flames"
+/atom/var/const/CODEX_INTERACTION_HEAT_SOURCE = "Heat Sources"
+/atom/var/const/CODEX_INTERACTION_FLAME_OR_HEAT_SOURCE = "Open Flames or Heat Sources"
+/atom/var/const/CODEX_INTERACTION_MATERIAL_STACK = "Material Stack (Any Not Already Listed)"
+/atom/var/const/CODEX_INTERACTION_SHARP = "Sharp Objects"
+/atom/var/const/CODEX_INTERACTION_STORAGE = "Storage Items (Bags, Boxes, etc)"
 
 /**
  * Handler for displaying information on tool interations in the Mechanics section of the atom's codex entry.

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -46,7 +46,7 @@
 		remove_contents(user)
 
 /obj/item/reagent_containers/glass/rag/attackby(obj/item/W, mob/user)
-	if(!on_fire && isflamesource(W))
+	if (!on_fire && W.IsFlameSource())
 		ignite()
 		if(on_fire)
 			user.visible_message(

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -45,19 +45,57 @@
 	else
 		remove_contents(user)
 
-/obj/item/reagent_containers/glass/rag/attackby(obj/item/W, mob/user)
-	if (!on_fire && W.IsFlameSource())
-		ignite()
-		if(on_fire)
-			user.visible_message(
-				SPAN_WARNING("\The [user] lights \the [src] with \the [W]!"),
-				SPAN_DANGER("You light \the [src]!")
-			)
-		else
-			to_chat(user, SPAN_WARNING("You manage to singe \the [src], but it won't burn on its own.")) // Give a hint about needing fuel
 
+/obj/item/reagent_containers/glass/rag/get_interactions_info()
 	. = ..()
-	update_name()
+	.[CODEX_INTERACTION_FLAME_SOURCE] = "<p>Ignites the bottle's rag, if the bottle has a flammable liquid in it. This can be done on help or harm intent.</p>"
+
+
+/obj/item/reagent_containers/glass/rag/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	// Flame Source - Light rag
+	if (weapon.IsFlameSource())
+		if (on_fire)
+			to_chat(user, SPAN_WARNING("\The [src] is already on fire."))
+			return TRUE
+		ignite()
+		if (!on_fire)
+			user.visible_message(
+				SPAN_WARNING("\The [user] attempts to light \the [src] with \a [weapon], but it doesn't catch."),
+				SPAN_WARNING("You attempt to light \the [src] with \the [weapon], but it needs fuel to burn.")
+			)
+			return TRUE
+		update_name()
+		user.visible_message(
+			SPAN_WARNING("\The [user] lights \the [src] with \a [weapon]!"),
+			SPAN_DANGER("You light light \the [src] with \the [weapon]!")
+		)
+		return TRUE
+
+	return ..()
+
+
+/obj/item/reagent_containers/glass/rag/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Flame Source - Light rag
+	if (tool.IsFlameSource())
+		if (on_fire)
+			to_chat(user, SPAN_WARNING("\The [src] is already on fire."))
+			return TRUE
+		ignite()
+		if (!on_fire)
+			user.visible_message(
+				SPAN_WARNING("\The [user] attempts to light \the [src] with \a [tool], but it doesn't catch."),
+				SPAN_WARNING("You attempt to light \the [src] with \the [tool], but it needs fuel to burn.")
+			)
+			return TRUE
+		update_name()
+		user.visible_message(
+			SPAN_WARNING("\The [user] lights \the [src] with \a [tool]!"),
+			SPAN_DANGER("You light light \the [src] with \the [tool]!")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/reagent_containers/glass/rag/proc/update_name()
 	if(on_fire)

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -155,19 +155,21 @@
 /obj/structure/window/reinforced/holowindow/Destroy()
 	..()
 
-/obj/structure/window/reinforced/holowindow/attackby(obj/item/W as obj, mob/user as mob)
 
-	if(!istype(W) || W.item_flags & ITEM_FLAG_NO_BLUDGEON) return
+/obj/structure/window/reinforced/holowindow/get_interactions_info()
+	. = ..()
+	. -= CODEX_INTERACTION_CROWBAR
+	. -= CODEX_INTERACTION_SCREWDRIVER
+	. -= CODEX_INTERACTION_WRENCH
 
-	if(isScrewdriver(W) || isCrowbar(W) || isWrench(W))
-		to_chat(user, (SPAN_NOTICE("It's a holowindow, you can't dismantle it!")))
-	else
-		if (W.damtype == DAMAGE_BRUTE || W.damtype == DAMAGE_BURN)
-			hit(W.force, user, W)
-		else
-			playsound(loc, 'sound/effects/Glasshit.ogg', 75, 1)
-		..()
-	return
+
+/obj/structure/window/reinforced/holowindow/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Screwdriver, Crowbar, Wrench - Block window interactions
+	if (isScrewdriver(tool) || isCrowbar(tool) || isWrench(tool))
+		return FALSE
+
+	return ..()
+
 
 /obj/structure/window/reinforced/holowindow/shatter(display_message = 1)
 	playsound(src, "shatter", 70, 1)
@@ -215,10 +217,19 @@
 /obj/structure/bed/chair/holochair/Destroy()
 	..()
 
-/obj/structure/bed/chair/holochair/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/wrench))
-		to_chat(user, (SPAN_NOTICE("It's a holochair, you can't dismantle it!")))
-	return
+
+/obj/structure/bed/chair/holochair/get_interactions_info()
+	. = ..()
+	. -= CODEX_INTERACTION_WRENCH
+
+
+/obj/structure/bed/chair/holochair/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Wrench - Block chair interactions
+	if (isWrench(tool))
+		return FALSE
+
+	return ..()
+
 
 /obj/item/holo
 	damtype = DAMAGE_PAIN

--- a/code/modules/hydroponics/spreading/spreading_response.dm
+++ b/code/modules/hydroponics/spreading/spreading_response.dm
@@ -39,7 +39,7 @@
 	seed.do_sting(victim,src,pick(BP_R_FOOT,BP_L_FOOT,BP_R_LEG,BP_L_LEG))
 
 /obj/effect/vine/proc/manual_unbuckle(mob/user)
-	if(!buckled_mob)
+	if (!can_unbuckle(user))
 		return
 	if(buckled_mob != user)
 		to_chat(user, SPAN_NOTICE("You try to free \the [buckled_mob] from \the [src]."))
@@ -60,7 +60,7 @@
 			SPAN_NOTICE("You attempt to get free from [src].")
 		)
 
-		if (do_after(user, breakouttime, src, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS, INCAPACITATION_DEFAULT & ~INCAPACITATION_RESTRAINED))
+		if (do_after(user, breakouttime, src, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS, INCAPACITATION_DEFAULT & ~INCAPACITATION_RESTRAINED) && can_unbuckle(user))
 			if(unbuckle_mob())
 				user.visible_message(
 					"\The [user] manages to escape [src]!",
@@ -99,7 +99,9 @@
 		SPAN_DANGER("Tendrils lash out from \the [src] and drag \the [victim] in!"),
 		SPAN_DANGER("Tendrils lash out from \the [src] and drag you in!"))
 	victim.forceMove(loc)
-	if(buckle_mob(victim))
+	if (victim.buckled)
+		victim.buckled.unbuckle_mob()
+	if (can_buckle(victim) && buckle_mob(victim))
 		victim.set_dir(pick(GLOB.cardinal))
 		to_chat(victim, SPAN_DANGER("The tendrils [pick("wind", "tangle", "tighten", "coil", "knot", "snag", "twist", "constrict", "squeeze", "clench", "tense")] around you!"))
 

--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -8,11 +8,19 @@
 	mechanical = 0
 	tray_light = 0
 
-/obj/machinery/portable_atmospherics/hydroponics/soil/attackby(obj/item/O as obj, mob/user as mob)
-	if(istype(O,/obj/item/tank))
-		return
-	else
-		..()
+
+/obj/machinery/portable_atmospherics/hydroponics/soil/get_interactions_info()
+	. = ..()
+	. -= "Tank"
+
+
+/obj/machinery/portable_atmospherics/hydroponics/soil/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Tank - Block parent interaction
+	if (istype(tool, /obj/item/tank))
+		return FALSE
+
+	return ..()
+
 
 /obj/machinery/portable_atmospherics/hydroponics/soil/New()
 	..()

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -14,8 +14,10 @@
 /obj/item/device/mmi/digital/proc/PickName()
 	return
 
-/obj/item/device/mmi/digital/attackby()
-	return
+
+/obj/item/device/mmi/digital/can_use_item(obj/item/tool, mob/user, click_params)
+	return FALSE
+
 
 /obj/item/device/mmi/digital/attack_self()
 	return

--- a/code/modules/modular_computers/hardware/ai_slot.dm
+++ b/code/modules/modular_computers/hardware/ai_slot.dm
@@ -19,21 +19,45 @@
 		power_usage = power_usage_occupied
 	..()
 
-/obj/item/stock_parts/computer/ai_slot/attackby(obj/item/W, mob/user)
-	if(..())
+
+/obj/item/stock_parts/computer/ai_slot/get_interactions_info()
+	. = ..()
+	.["inteliCard"] += "<p>Inserts the intelicard. Only one card can be inserted at a time.</p>"
+	.[CODEX_INTERACTION_SCREWDRIVER] += "<p>Removes the intelicard, if present.</p>"
+
+
+/obj/item/stock_parts/computer/ai_slot/use_tool(obj/item/tool, mob/user, list/click_params)
+	. = ..()
+	if (.)
+		return
+
+	// inteliCard - Insert card
+	if (istype(tool, /obj/item/aicard))
+		if (stored_card)
+			to_chat(user, SPAN_WARNING("\The [src] already has \a [stored_card] inserted."))
+			return TRUE
+		if (!user.unEquip(tool, src))
+			to_chat(user, SPAN_WARNING("You can't drop \the [tool]."))
+			return TRUE
+		do_insert_ai(user, tool)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] inserts \a [tool] into \the [src]."),
+			SPAN_NOTICE("You insert \the [tool] into \the [src].")
+		)
 		return TRUE
-	if(istype(W, /obj/item/aicard))
-		if(stored_card)
-			to_chat(user, "\The [src] is already occupied.")
-			return
-		if(!user.unEquip(W, src))
-			return
-		do_insert_ai(user, W)
-		return TRUE
-	if(isScrewdriver(W) && stored_card)
-		to_chat(user, "You manually remove \the [stored_card] from \the [src].")
+
+	// Screwdriver - Remove intelicard
+	if (isScrewdriver(tool))
+		if (!stored_card)
+			to_chat(user, SPAN_WARNING("\The [src] doesn't have an intelicard to remove."))
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] ejects \a [stored_card] from \the [src] with \a [tool]."),
+			SPAN_NOTICE("You eject \the [stored_card] from \the [src] with \the [tool].")
+		)
 		do_eject_ai(user)
 		return TRUE
+
 
 /obj/item/stock_parts/computer/ai_slot/Destroy()
 	if(stored_card)

--- a/code/modules/modular_computers/hardware/card_slot.dm
+++ b/code/modules/modular_computers/hardware/card_slot.dm
@@ -101,11 +101,20 @@
 		loc.verbs |= /obj/item/stock_parts/computer/card_slot/proc/verb_eject_id
 	return TRUE
 
-/obj/item/stock_parts/computer/card_slot/attackby(obj/item/card/id/I, mob/living/user)
-	if(!istype(I))
-		return ..()
-	insert_id(I, user)
-	return TRUE
+
+/obj/item/stock_parts/computer/card_slot/get_interactions_info()
+	. = ..()
+	.["ID Card"] = "<p>Inserts the ID into the card slot.</p>"
+
+
+/obj/item/stock_parts/computer/card_slot/use_tool(obj/item/tool, mob/user, list/click_params)
+	// ID Card - Insert ID
+	if (istype(tool, /obj/item/card/id))
+		insert_id(tool, user)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/stock_parts/computer/card_slot/broadcaster // read only
 	name = "RFID card broadcaster"

--- a/code/modules/modular_computers/hardware/scanners/scanner.dm
+++ b/code/modules/modular_computers/hardware/scanners/scanner.dm
@@ -54,28 +54,50 @@
 
 /obj/item/stock_parts/computer/scanner/proc/do_on_afterattack(mob/user, atom/target, proximity)
 
-/obj/item/stock_parts/computer/scanner/attackby(obj/W, mob/living/user)
-	do_on_attackby(user, W)
-	// Nanopaste. Repair all damage if present for a single unit.
-	var/obj/item/stack/S = W
-	if (istype(S, /obj/item/stack/nanopaste))
+
+/obj/item/stock_parts/computer/scanner/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_CABLE] = "<p>Repairs the component. 1 length of coil repairs 10 points of damage.</p>"
+	.["Nanopaste"] = "<p>Fully repairs the component. This costs 1 unit of nanopaste.</p>"
+
+
+/obj/item/stock_parts/computer/scanner/use_tool(obj/item/tool, mob/user, list/click_params)
+	do_on_attackby(user, tool)
+
+	// Cable Coil - Repair some damage
+	if (isCoil(tool))
 		if (!health_damaged())
-			to_chat(user, "\The [src] doesn't seem to require repairs.")
+			to_chat(user, SPAN_WARNING("\The [src] doesn't require repairs."))
 			return TRUE
-		if (S.use(1))
-			to_chat(user, "You apply a bit of \the [W] to \the [src]. It immediately repairs all damage.")
-			revive_health()
+		var/obj/item/stack/cable_coil/cable = tool
+		if (!cable.use(1))
+			to_chat(user, SPAN_WARNING("There isn't enough of \the [tool] left to repair \the [src]."))
+			return TRUE
+		restore_health(10)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] repairs some of \the [src]'s damage with some [cable.plural_name] of [cable.name]."),
+			SPAN_NOTICE("You repair some of \the [src]'s damage with some [cable.plural_name] of [cable.name].")
+		)
 		return TRUE
-	// Cable coil. Works as repair method, but will probably require multiple applications and more cable.
-	if (isCoil(S))
+
+	// Nanopaste - Repair all damage
+	if (istype(tool, /obj/item/stack/nanopaste))
 		if (!health_damaged())
-			to_chat(user, "\The [src] doesn't seem to require repairs.")
+			to_chat(user, SPAN_WARNING("\The [src] doesn't require repairs."))
 			return TRUE
-		if (S.use(1))
-			to_chat(user, "You patch up \the [src] with a bit of \the [W].")
-			restore_health(10)
+		var/obj/item/stack/nanopaste/nanopaste = tool
+		if (!nanopaste.use(1))
+			to_chat(user, SPAN_WARNING("There isn't enough of \the [tool] left to repair \the [src]."))
+			return TRUE
+		revive_health()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] fully repairs \the [src] with some [nanopaste.plural_name]."),
+			SPAN_NOTICE("You fully repair \the [src] with some [nanopaste.plural_name].")
+		)
 		return TRUE
+
 	return ..()
+
 
 /obj/item/stock_parts/computer/scanner/proc/do_on_attackby(mob/user, atom/target)
 

--- a/code/modules/organs/internal/stomach.dm
+++ b/code/modules/organs/internal/stomach.dm
@@ -86,37 +86,44 @@
 		owner.empty_stomach()
 		refresh_action_button()
 
-/obj/item/organ/internal/stomach/attackby(obj/item/item, mob/living/user)
-	if (!is_sharp(item))
-		return ..()
-	. = TRUE
-	user.visible_message(
-		SPAN_ITALIC("\The [user] begins cutting into \a [src] with \a [item]."),
-		SPAN_ITALIC("You start to cut open \the [src] with \the [item]."),
-		range = 5
-	)
-	take_internal_damage(5)
-	if (!user.do_skilled(5 SECONDS, SKILL_ANATOMY, src) || QDELETED(src))
-		return
-	if (!Adjacent(user) || user.incapacitated())
-		return
-	var/removed_message
-	var/length = length(contents)
-	switch (length)
-		if (0)
-			removed_message = "There's nothing inside."
-		if (1)
-			removed_message = "Something falls out."
-		else
-			removed_message = "Several things fall out."
-	user.visible_message(
-		SPAN_ITALIC("\The [user] finishes cutting \a [src] open. [removed_message]"),
-		SPAN_ITALIC("You finish cutting \the [src] open. [removed_message]"),
-		range = 2
-	)
-	take_internal_damage(5)
-	for (var/atom/movable/movable as anything in contents)
-		movable.dropInto(loc)
+
+/obj/item/organ/internal/stomach/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_SHARP] = "<p>Cuts open the stomach and removes any contents. This includes a timed check based on the anatomy skill. This damages the organ.</p>"
+
+
+/obj/item/organ/internal/stomach/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Sharp objects - Cut open
+	if (is_sharp(tool))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts cutting into \the [src] with \a [tool]."),
+			SPAN_NOTICE("You start cutting into \the [src] with \the [tool]."),
+			range = 5
+		)
+		take_internal_damage(5)
+		if (!user.do_skilled(5 SECONDS, SKILL_ANATOMY, src) || !user.use_sanity_check(src, tool))
+			return TRUE
+		var/removed_message
+		var/length = length(contents)
+		switch (length)
+			if (0)
+				removed_message = "There's nothing inside."
+			if (1)
+				removed_message = "Something falls out."
+			else
+				removed_message = "Several things fall out."
+		user.visible_message(
+			SPAN_ITALIC("\The [user] finishes cutting \the [src] open with \a [tool]. [removed_message]"),
+			SPAN_ITALIC("You finish cutting \the [src] open with \the [tool]. [removed_message]"),
+			range = 2
+		)
+		take_internal_damage(5)
+		for (var/atom/movable/movable as anything in contents)
+			movable.dropInto(loc)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/organ/internal/stomach/return_air()
 	return null

--- a/code/modules/overmap/exoplanets/planet_types/desert.dm
+++ b/code/modules/overmap/exoplanets/planet_types/desert.dm
@@ -78,7 +78,9 @@
 	appearance = T.appearance
 
 /obj/effect/quicksand/user_unbuckle_mob(mob/user)
-	if(buckled_mob && !user.stat && !user.restrained())
+	if (!can_unbuckle(user))
+		return
+	if (!user.stat && !user.restrained())
 		if(busy)
 			to_chat(user, SPAN_NOTICE("\The [buckled_mob] is already getting out, be patient."))
 			return
@@ -97,7 +99,7 @@
 				SPAN_NOTICE("You hear water sloshing.")
 				)
 		busy = TRUE
-		if(do_after(user, delay, src, DO_PUBLIC_UNIQUE))
+		if(do_after(user, delay, src, DO_PUBLIC_UNIQUE) && can_unbuckle(user))
 			busy = FALSE
 			if(user == buckled_mob)
 				if(prob(80))
@@ -147,7 +149,7 @@
 /obj/effect/quicksand/Crossed(atom/movable/AM)
 	if(isliving(AM))
 		var/mob/living/L = AM
-		if(L.throwing || L.can_overcome_gravity())
+		if(L.throwing || L.can_overcome_gravity() || !can_buckle(L))
 			return
 		buckle_mob(L)
 		if(!exposed)

--- a/code/modules/power/batteryrack.dm
+++ b/code/modules/power/batteryrack.dm
@@ -153,8 +153,10 @@
 		return 0
 
 	if(length(internal_cells) >= max_cells)
+		to_chat(user, SPAN_WARNING("\The [src] is can't hold any more cells."))
 		return 0
 	if(user && !user.unEquip(C))
+		to_chat(user, SPAN_WARNING("You can't drop \the [C]."))
 		return 0
 	internal_cells.Add(C)
 	C.forceMove(src)
@@ -237,14 +239,27 @@
 		internal_cells -= C
 	return ..()
 
-/obj/machinery/power/smes/batteryrack/attackby(obj/item/W as obj, mob/user as mob)
-	if(..())
+
+/obj/machinery/power/smes/batteryrack/get_interactions_info()
+	. = ..()
+	.["Power Cell"] += "<p>Adds the power cell to the battery rack.</p>"
+
+
+/obj/machinery/power/smes/batteryrack/use_tool(obj/item/tool, mob/user, list/click_params)
+	. = ..()
+	if (.)
+		return
+
+	// Power Cell - Install cell
+	if (istype(tool, /obj/item/cell))
+		if (!insert_cell(tool, user))
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] inserts \a [tool] into \the [src]."),
+			SPAN_NOTICE("You insert \the [tool] into \the [src].")
+		)
 		return TRUE
-	if(istype(W, /obj/item/cell)) // ID Card, try to insert it.
-		if(insert_cell(W, user))
-			to_chat(user, "You insert \the [W] into \the [src].")
-		else
-			to_chat(user, "\The [src] has no empty slot for \the [W]")
+
 
 /obj/machinery/power/smes/batteryrack/interface_interact(mob/user)
 	ui_interact(user)

--- a/code/modules/power/fusion/gyrotron/gyrotron.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron.dm
@@ -53,11 +53,20 @@
 	else
 		icon_state = "emitter-off"
 
-/obj/machinery/power/emitter/gyrotron/attackby(obj/item/W, mob/user)
-	if(isMultitool(W))
+
+/obj/machinery/power/emitter/gyrotron/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_MULTITOOL] = "<p>Allows setting a new ident tag on the machine.</p>"
+
+
+/obj/machinery/power/emitter/gyrotron/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Multitool - Assign new ident tag
+	if (isMultitool(tool))
 		var/datum/extension/local_network_member/fusion = get_extension(src, /datum/extension/local_network_member)
 		fusion.get_new_tag(user)
-		return
+		return TRUE
+
 	return ..()
+
 
 #undef GYRO_POWER

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -189,6 +189,11 @@
 	handle_click_empty(M)
 	return 0
 
+
+/obj/item/gun/energy/plasmacutter/IsHeatSource()
+	return 3800
+
+
 /obj/item/gun/energy/incendiary_laser
 	name = "dispersive blaster"
 	desc = "The A&M 'Shayatin' was the first of a class of dispersive laser weapons which, instead of firing a focused beam, scan over a target rapidly with the goal of setting it ablaze."

--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -252,10 +252,7 @@
 			return
 		var/matter_exchange = min(cartridge.remaining,max_stored_matter - stored_matter)
 		stored_matter += matter_exchange
-		cartridge.remaining -= matter_exchange
-		if(cartridge.remaining <= 0)
-			qdel(W)
-		cartridge.matter = list(MATERIAL_STEEL = 500 * cartridge.remaining,MATERIAL_GLASS = 250 * cartridge.remaining)
+		cartridge.use_matter(matter_exchange)
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 		to_chat(user, SPAN_NOTICE("The RCD now holds [stored_matter]/[max_stored_matter] matter-units."))
 		update_icon()

--- a/code/modules/projectiles/guns/launcher/foam_gun.dm
+++ b/code/modules/projectiles/guns/launcher/foam_gun.dm
@@ -19,15 +19,30 @@
 	var/max_darts = 1
 	var/list/darts = new/list()
 
-/obj/item/gun/launcher/foam/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/foam_dart))
-		if(length(darts) < max_darts)
-			if(!user.unEquip(I, src))
-				return
-			darts += I
-			to_chat(user, SPAN_NOTICE("You slot \the [I] into \the [src]."))
-		else
-			to_chat(user, SPAN_WARNING("\The [src] can hold no more darts."))
+
+/obj/item/gun/launcher/foam/get_interactions_info()
+	. = ..()
+	.["Foam Dart"] = "<p>Loads the dart into the launcher. The launcher can hold up to [initial(max_darts)] dart\s.</p>"
+
+
+/obj/item/gun/launcher/foam/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Foam Dart - Load ammo
+	if (istype(tool, /obj/item/foam_dart))
+		if (length(darts) >= max_darts)
+			to_chat(user, SPAN_WARNING("\The [src] can't hold anymore darts."))
+			return TRUE
+		if (!user.unEquip(tool, src))
+			to_chat(user, SPAN_WARNING("You can't drop \the [tool]."))
+			return TRUE
+		darts += tool
+		user.visible_message(
+			SPAN_NOTICE("\The [user] loads \a [tool] into \the [src]."),
+			SPAN_NOTICE("You load \the [tool] into \the [src].")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/launcher/foam/consume_next_projectile()
 	if(length(darts))

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -76,11 +76,20 @@
 /obj/item/gun/launcher/grenade/attack_self(mob/user)
 	pump(user)
 
-/obj/item/gun/launcher/grenade/attackby(obj/item/I, mob/user)
-	if((istype(I, /obj/item/grenade)))
-		load(I, user)
-	else
-		..()
+
+/obj/item/gun/launcher/grenade/get_interactions_info()
+	. = ..()
+	.["Grenade"] = "<p>Loads the grenade into the launcher. The launcher can hold up to [initial(max_grenades)] grenade\s. Only certain grenade types can be loaded.</p>"
+
+
+/obj/item/gun/launcher/grenade/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Grenade - Load ammo
+	if (istype(tool, /obj/item/grenade))
+		load(tool, user)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/launcher/grenade/attack_hand(mob/user)
 	if(user.get_inactive_hand() == src)
@@ -142,12 +151,16 @@
 		return
 
 	if(chambered)
-		to_chat(user, SPAN_WARNING("\The [src] is already loaded."))
+		to_chat(user, SPAN_WARNING("\The [src] is already loaded with \a [chambered]."))
 		return
 	if(!user.unEquip(G, src))
+		to_chat(user, SPAN_WARNING("You can't drop \the [G]."))
 		return
 	chambered = G
-	user.visible_message("\The [user] load \a [G] into \the [src].", SPAN_NOTICE("You load \a [G] into \the [src]."))
+	user.visible_message(
+		SPAN_NOTICE("\The [user] loads \a [G] into \the [src]."),
+		SPAN_NOTICE("You load \the [G] into \the [src].")
+	)
 
 /obj/item/gun/launcher/grenade/underslung/unload(mob/user)
 	if(chambered)

--- a/code/modules/projectiles/guns/launcher/net.dm
+++ b/code/modules/projectiles/guns/launcher/net.dm
@@ -41,6 +41,7 @@
 	if(!can_load(S, user))
 		return
 	if(user && !user.unEquip(S, src))
+		to_chat(user, SPAN_WARNING("You can't drop \the [S]."))
 		return
 	finish_loading(S, user)
 
@@ -52,11 +53,20 @@
 	else
 		to_chat(user, SPAN_WARNING("\The [src] is empty."))
 
-/obj/item/gun/launcher/net/attackby(obj/item/I, mob/user)
-	if((istype(I, /obj/item/net_shell)))
-		load(I, user)
-	else
-		..()
+
+/obj/item/gun/launcher/net/get_interactions_info()
+	. = ..()
+	.["Net Gun Shell"] = "<p>Loads the shell into the launcher. Only one shell can be loaded at a time.</p>"
+
+
+/obj/item/gun/launcher/net/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Net Gun Shell - Load ammo
+	if (istype(tool, /obj/item/net_shell))
+		load(tool, user)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/launcher/net/attack_hand(mob/user)
 	if(user.get_inactive_hand() == src)

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -65,13 +65,37 @@
 	else
 		return ..()
 
-/obj/item/gun/launcher/pneumatic/attackby(obj/item/W as obj, mob/user as mob)
-	if(!tank && istype(W,/obj/item/tank) && user.unEquip(W, src))
-		tank = W
-		user.visible_message("[user] jams [W] into [src]'s valve and twists it closed.","You jam [W] into [src]'s valve and twist it closed.")
+
+/obj/item/gun/launcher/pneumatic/get_interactions_info()
+	. = ..()
+	.["Tank"] = "<p>Loads the tank into the cannon's valve.</p>"
+	.[CODEX_INTERACTION_ANY_ITEM] = "<p>Loads the item into the cannon's barrel to be fired as a projectile.</p>"
+
+
+/obj/item/gun/launcher/pneumatic/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Tank - Inserts tank
+	if (istype(tool, /obj/item/tank))
+		if (tank)
+			to_chat(user, SPAN_WARNING("\The [src] already has \a [tank] installed."))
+			return TRUE
+		if (!user.unEquip(tool, src))
+			to_chat(user, SPAN_WARNING("You can't drop \the [tool]."))
+			return TRUE
+		tank = tool
 		update_icon()
-	else if(istype(W) && item_storage.can_be_inserted(W, user))
-		item_storage.handle_item_insertion(W)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] jams \a [tool] into \the [src]'s valve and twists it closed."),
+			SPAN_NOTICE("You jam \a [tool] into \the [src]'s valve and twists it closed.")
+		)
+		return TRUE
+
+	// All Others - Attempt to load item as a projectile
+	if (item_storage.can_be_inserted(tool, user))
+		item_storage.handle_item_insertion(tool)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/launcher/pneumatic/attack_self(mob/user as mob)
 	eject_tank(user)

--- a/code/modules/projectiles/guns/launcher/rocket.dm
+++ b/code/modules/projectiles/guns/launcher/rocket.dm
@@ -23,16 +23,30 @@
 	if(distance <= 2)
 		to_chat(user, SPAN_NOTICE("[length(rockets)] / [max_rockets] rockets."))
 
-/obj/item/gun/launcher/rocket/attackby(obj/item/I as obj, mob/user as mob)
-	if(istype(I, /obj/item/ammo_casing/rocket))
-		if(length(rockets) < max_rockets)
-			if(!user.unEquip(I, src))
-				return
-			rockets += I
-			to_chat(user, SPAN_NOTICE("You put the rocket in [src]."))
-			to_chat(user, SPAN_NOTICE("[length(rockets)] / [max_rockets] rockets."))
-		else
-			to_chat(usr, SPAN_WARNING("\The [src] cannot hold more rockets."))
+
+/obj/item/gun/launcher/rocket/get_interactions_info()
+	. = ..()
+	.["Rocket Shell"] = "<p>Loads the rocket into the launcher. The launcher can hold up to [initial(max_rockets)] rocket\s at a time.</p>"
+
+
+/obj/item/gun/launcher/rocket/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Rocket Shell - Add ammo
+	if (istype(tool, /obj/item/ammo_casing/rocket))
+		if (length(rockets) >= max_rockets)
+			to_chat(user, SPAN_WARNING("\The [src] cannot hold more rockets."))
+			return TRUE
+		if (!user.unEquip(tool, src))
+			to_chat(user, SPAN_WARNING("You can't drop \the [tool]."))
+			return TRUE
+		rockets += tool
+		user.visible_message(
+			SPAN_NOTICE("\The [user] inserts \a [tool] into \the [src]."),
+			SPAN_NOTICE("You insert \a [tool] into \the [src].")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/launcher/rocket/consume_next_projectile()
 	if(length(rockets))

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -118,18 +118,30 @@
 	else
 		..()
 
-/obj/item/gun/launcher/syringe/attackby(obj/item/A as obj, mob/user as mob)
-	if(istype(A, /obj/item/syringe_cartridge))
-		var/obj/item/syringe_cartridge/C = A
-		if(length(darts) >= max_darts)
-			to_chat(user, SPAN_WARNING("[src] is full!"))
-			return
-		if(!user.unEquip(C, src))
-			return
-		darts += C //add to the end
-		user.visible_message("[user] inserts \a [C] into [src].", SPAN_NOTICE("You insert \a [C] into [src]."))
-	else
-		..()
+
+/obj/item/gun/launcher/syringe/get_interactions_info()
+	. = ..()
+	.["Syringe Gun Cartridge"] = "<p>Inserts the dart into the gun. The gun can hold up to [initial(max_darts)] cartridge\s at once.</p>"
+
+
+/obj/item/gun/launcher/syringe/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Syringe Gun Cartridge - Insert dart
+	if (istype(tool, /obj/item/syringe_cartridge))
+		if (length(darts) >= max_darts)
+			to_chat(user, SPAN_WARNING("\The [src] is full of darts."))
+			return TRUE
+		if (!user.unEquip(tool, src))
+			to_chat(user, SPAN_WARNING("You can't drop \the [tool]."))
+			return TRUE
+		darts += tool
+		user.visible_message(
+			SPAN_NOTICE("\The [user] inserts \a [tool] into \the [src]."),
+			SPAN_NOTICE("You insert \the [tool] into \the [src].")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/launcher/syringe/rapid
 	name = "syringe gun revolver"

--- a/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic_railgun.dm
@@ -46,14 +46,13 @@
 
 /obj/item/gun/magnetic/railgun/use_ammo()
 	var/obj/item/rcd_ammo/ammo = loaded
-	ammo.remaining--
-	if(ammo.remaining <= 0)
+	ammo.use_matter(1)
+	if(QDELETED(ammo))
 		spawn(3)
 			playsound(src.loc, 'sound/machines/twobeep.ogg', 50, 1)
 		out_of_ammo()
 
 /obj/item/gun/magnetic/railgun/proc/out_of_ammo()
-	qdel(loaded)
 	loaded = null
 	visible_message(SPAN_WARNING("\The [src] beeps and ejects its empty cartridge."))
 

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -204,11 +204,20 @@
 	. = ..()
 	launcher = new(src)
 
-/obj/item/gun/projectile/automatic/bullpup_rifle/attackby(obj/item/I, mob/user)
-	if((istype(I, /obj/item/grenade)))
-		launcher.load(I, user)
-	else
-		..()
+
+/obj/item/gun/projectile/automatic/bullpup_rifle/get_interactions_info()
+	. = ..()
+	.["Grenade"] = "<p>Loads the grenade into the rifle's launcher. Only one grenade can be loaded at a time, and only certain types of grenades can be loaded.</p>"
+
+
+/obj/item/gun/projectile/automatic/bullpup_rifle/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Grenade - Load into launcher
+	if (istype(tool, /obj/item/grenade))
+		launcher.load(tool, user)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/projectile/automatic/bullpup_rifle/attack_hand(mob/user)
 	if(user.get_inactive_hand() == src && use_launcher)

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -104,11 +104,21 @@
 				for(var/datum/reagent/R in B.reagents.reagent_list)
 					to_chat(user, SPAN_NOTICE("[R.volume] units of [R.name]"))
 
-/obj/item/gun/projectile/dartgun/attackby(obj/item/I as obj, mob/user as mob)
-	if(istype(I, /obj/item/reagent_containers/glass))
-		add_beaker(I, user)
-		return 1
-	..()
+
+/obj/item/gun/projectile/dartgun/get_interactions_info()
+	. = ..()
+	.["Beaker"] = "<p>Adds the beaker to the dartgun, allowing the darts to use its reagents.</p>"
+
+
+/obj/item/gun/projectile/dartgun/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Beaker - Add beaker
+	if (istype(tool, /obj/item/reagent_containers/glass))
+		add_beaker(tool, user)
+		return TRUE
+
+
+	return ..()
+
 
 /obj/item/gun/projectile/dartgun/proc/add_beaker(obj/item/reagent_containers/glass/B, mob/user)
 	if(!istype(B, container_type))

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -137,20 +137,34 @@
 			return
 	..()
 
-/obj/item/gun/projectile/pistol/holdout/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/silencer))
+
+/obj/item/gun/projectile/pistol/holdout/get_interactions_info()
+	. = ..()
+	.["Silencer"] = "<p>Attaches the silencer. This makes the gun slightly larger, but makes gunfire quieter. Only 1 silencer can be attached at a time.</p>"
+
+
+/obj/item/gun/projectile/pistol/holdout/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Silencer - Attaches silencer
+	if (istype(tool, /obj/item/silencer))
 		if (silenced)
-			to_chat(user, SPAN_WARNING("\The [src] is already silenced."))
-			return
-		if(!user.unEquip(I, src))
-			return//put the silencer into the gun
-		to_chat(user, SPAN_NOTICE("You screw \the [I] onto \the [src]."))
+			to_chat(user, SPAN_WARNING("\The [src] already has \a [silencer] attached."))
+			return TRUE
+		if (!user.unEquip(tool, src))
+			to_chat(user, SPAN_WARNING("You can't drop \the [tool]."))
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] screws \a [tool] onto \the [src]."),
+			SPAN_NOTICE("You screw \a [tool] onto \the [src]."),
+			range = 3
+		)
 		silenced = TRUE
-		silencer = I
+		silencer = tool
 		w_class = ITEM_SIZE_NORMAL
 		update_icon()
-		return
-	..()
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/projectile/pistol/holdout/on_update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -76,12 +76,34 @@
 	caliber = CALIBER_CAPS
 	origin_tech = list(TECH_COMBAT = 1, TECH_MATERIAL = 1)
 	ammo_type = /obj/item/ammo_casing/cap
+	/// Boolean. If set, the toy markings have been cut off.
+	var/markings_cut = FALSE
 
-/obj/item/gun/projectile/revolver/capgun/attackby(obj/item/wirecutters/W, mob/user)
-	if(!istype(W) || icon_state == "revolver")
-		return ..()
-	to_chat(user, SPAN_NOTICE("You snip off the toy markings off the [src]."))
-	name = "revolver"
-	icon_state = "revolver"
-	desc += " Someone snipped off the barrel's toy mark. How dastardly, this could get someone shot."
-	return 1
+
+/obj/item/gun/projectile/revolver/capgun/on_update_icon()
+	icon_state = markings_cut ? "revolver" : "revolver-toy"
+
+
+/obj/item/gun/projectile/revolver/capgun/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_WIRECUTTERS] = "<p>Cuts off the toy markings, making it look like a real revolver.</p>"
+
+
+/obj/item/gun/projectile/revolver/capgun/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Wirecutters - Cut off toy markings
+	if (isWirecutter(tool))
+		if (markings_cut)
+			to_chat(user, SPAN_WARNING("\The [src]'s tip has already been cut off."))
+			return TRUE
+		markings_cut = TRUE
+		SetName("revolver")
+		desc += " Someone snipped off the barrel's toy mark. How dastardly, this could get someone shot."
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] snips off \the [src]'s toy markings with \a [tool]."),
+			SPAN_NOTICE("You snip off \the [src]'s toy markings with \a [tool]."),
+			range = 3
+		)
+		return TRUE
+
+	return ..()

--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -212,19 +212,47 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 		return TRUE
 	splashtarget(target, user)
 
-/obj/item/reagent_containers/food/drinks/glass2/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/material/kitchen/utensil/spoon))
-		if(user.a_intent == I_HURT)
-			user.visible_message(SPAN_WARNING("[user] bashes \the [src] with a spoon, shattering it to pieces! What a rube."))
-			playsound(src, "shatter", 30, 1)
-			if(reagents)
-				user.visible_message(SPAN_NOTICE("The contents of \the [src] splash all over [user]!"))
-				reagents.splash(user, reagents.total_volume)
-			qdel(src)
-			return
-		user.visible_message(SPAN_NOTICE("[user] gently strikes \the [src] with a spoon, calling the room to attention."))
-		playsound(src, "sound/items/wineglass.ogg", 65, 1)
-	else return ..()
+
+/obj/item/reagent_containers/food/drinks/glass2/get_interactions_info()
+	. = ..()
+	.["Spoon"] = {"
+		<p>Gently taps the glass and makes a sound.</p>
+		<p>On harm intent, breaks the glass.</p>
+	"}
+
+
+/obj/item/reagent_containers/food/drinks/glass2/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Spoon - Tap on the glass
+	if (istype(tool, /obj/item/material/kitchen/utensil/spoon))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] gently strikes \the [src] with \a [tool], calling the room to attention."),
+			SPAN_NOTICE("You gently strike \the [src] with \a [tool], calling the room to attention.")
+		)
+		playsound(src, "sound/items/wineglass.ogg", 65, TRUE)
+		return TRUE
+
+	return ..()
+
+
+/obj/item/reagent_containers/food/drinks/glass2/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	// Spoon - Shatter the glass
+	if (istype(weapon, /obj/item/material/kitchen/utensil/spoon))
+		user.visible_message(
+			SPAN_WARNING("\The [user] bashes \the [src] with \a [weapon], shattering it to pieces! What a rube."),
+			SPAN_WARNING("You bash \the [src] with \a [weapon], shattering it to pieces! What a rube.")
+		)
+		playsound(src, "shatter", 50, TRUE)
+		if(reagents)
+			user.visible_message(
+				SPAN_WARNING("The contents of \the [src] splash all over \the [user]!"),
+				SPAN_DANGER("The contents of \the [src] splash all over you!")
+			)
+			reagents.splash(user, reagents.total_volume)
+		qdel(src)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/reagent_containers/food/drinks/glass2/ProcessAtomTemperature()
 	var/old_temp = temperature

--- a/code/modules/reagents/reagent_containers/drinkingglass/extras.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/extras.dm
@@ -1,30 +1,46 @@
-/obj/item/reagent_containers/food/drinks/glass2/attackby(obj/item/I as obj, mob/user as mob)
-	if(length(extras) >= 2) return ..() // max 2 extras, one on each side of the drink
+/obj/item/reagent_containers/food/drinks/glass2/get_interactions_info()
+	. = ..()
+	.["Fruit Slice"] = "<p>Adds the fruit slice to the glass's rim.</p>"
+	.["Glass Additions"] = "<p>Adds the additional item to the glass. The glass can only have up to 2 items added.</p>"
 
-	if(istype(I, /obj/item/glass_extra))
-		var/obj/item/glass_extra/GE = I
-		if(can_add_extra(GE))
-			extras += GE
-			if(!user.unEquip(GE, src))
-				return
-			to_chat(user, SPAN_NOTICE("You add \the [GE] to \the [src]."))
-			update_icon()
-		else
-			to_chat(user, SPAN_WARNING("There's no space to put \the [GE] on \the [src]!"))
-	else if(istype(I, /obj/item/reagent_containers/food/snacks/fruit_slice))
-		if(!rim_pos)
-			to_chat(user, SPAN_WARNING("There's no space to put \the [I] on \the [src]!"))
-			return
-		var/obj/item/reagent_containers/food/snacks/fruit_slice/FS = I
-		extras += FS
-		if(!user.unEquip(FS, src))
-			return
-		FS.pixel_x = 0 // Reset its pixel offsets so the icons work!
-		FS.pixel_y = 0
-		to_chat(user, SPAN_NOTICE("You add \the [FS] to \the [src]."))
+
+/obj/item/reagent_containers/food/drinks/glass2/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Fruit Slice - Add to glass rim
+	if (istype(tool, /obj/item/reagent_containers/food/snacks/fruit_slice))
+		if (!rim_pos)
+			to_chat(user, SPAN_WARNING("\The [src] can't have fruit slices added to it."))
+			return TRUE
+		if (!user.unEquip(tool, src))
+			to_chat(user, SPAN_WARNING("You can't drop \the [tool]."))
+			return TRUE
+		extras += tool
+		tool.pixel_x = 0
+		tool.pixel_y = 0
 		update_icon()
-	else
-		return ..()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] places \a [tool] on \the [src]'s rim."),
+			SPAN_NOTICE("You place \the [tool] on \the [src]'s rim.")
+		)
+		return TRUE
+
+	// Glass Addition - Adds extras to the glass
+	if (istype(tool, /obj/item/glass_extra))
+		if (!can_add_extra(tool))
+			to_chat(user, SPAN_WARNING("There's no space to put \the [tool] on \the [src]."))
+			return TRUE
+		if (!user.unEquip(tool, src))
+			to_chat(user, SPAN_WARNING("You can't drop \the [tool]."))
+			return TRUE
+		extras += tool
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] adds \a [tool] to \the [src]."),
+			SPAN_NOTICE("You add \a [tool] to \the [src].")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/reagent_containers/food/drinks/glass2/attack_hand(mob/user as mob)
 	if(src != user.get_inactive_hand())
@@ -53,6 +69,12 @@
 	var/glass_desc
 	w_class = ITEM_SIZE_TINY
 	icon = 'icons/obj/drink_glasses/extras.dmi'
+
+
+/obj/item/glass_extra/get_mechanics_info()
+	. = ..()
+	. += "<p>It can be added to certain drinks glasses as a glass addition.</p>"
+
 
 /obj/item/glass_extra/stick
 	name = "stick"

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -74,7 +74,7 @@
 	if (!rag && istype(W, /obj/item/reagent_containers/glass/rag))
 		insert_rag(W, user)
 		return
-	if (rag && isflamesource(W))
+	if (rag && W.IsFlameSource())
 		rag.attackby(W, user)
 		return
 	..()

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -70,14 +70,38 @@
 	return B
 
 
-/obj/item/reagent_containers/food/drinks/bottle/attackby(obj/item/W, mob/user)
-	if (!rag && istype(W, /obj/item/reagent_containers/glass/rag))
-		insert_rag(W, user)
-		return
-	if (rag && W.IsFlameSource())
-		rag.attackby(W, user)
-		return
-	..()
+/obj/item/reagent_containers/food/drinks/bottle/get_interactions_info()
+	. = ..()
+	.["Rag"] = "<p>Inserts a rag into the bottle. Only one rag can be in the bottle at a time.</p>"
+	.[CODEX_INTERACTION_FLAME_SOURCE] = "<p>If a rag is attached, attempts to ignite the rag. This can be done on help or harm intent.</p>"
+
+
+/obj/item/reagent_containers/food/drinks/bottle/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Rag - Insert rag
+	if (istype(tool, /obj/item/reagent_containers/glass/rag))
+		if (rag)
+			to_chat(user, SPAN_WARNING("\The [src] already has \a [rag] inserted."))
+			return TRUE
+		insert_rag(tool, user)
+		return TRUE
+
+	// Flame Source - Ignite rag
+	if (tool.IsFlameSource())
+		if (!rag)
+			return ..()
+		return rag.use_tool(tool, user, click_params)
+
+	return ..()
+
+
+/obj/item/reagent_containers/food/drinks/bottle/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	// Flame Source - Ignite rag
+	if (weapon.IsFlameSource())
+		if (!rag)
+			return ..()
+		return rag.use_weapon(weapon, user, click_params)
+
+	return ..()
 
 
 /obj/item/reagent_containers/food/drinks/bottle/attack_self(mob/user)

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -298,17 +298,28 @@
 	matter = list(MATERIAL_WOOD = 280)
 	volume = 200
 
-/obj/item/reagent_containers/glass/bucket/attackby(obj/D, mob/user as mob)
-	if(istype(D, /obj/item/mop))
-		if(reagents.total_volume < 1)
-			to_chat(user, SPAN_WARNING("\The [src] is empty!"))
-		else
-			reagents.trans_to_obj(D, 5)
-			to_chat(user, SPAN_NOTICE("You wet \the [D] in \the [src]."))
-			playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
-		return
-	else
-		return ..()
+
+/obj/item/reagent_containers/glass/bucket/get_interactions_info()
+	. = ..()
+	.["Mop"] = "<p>Wets the mop in the bucket, transferring any reagents from the bucket to the mop.</p>"
+
+
+/obj/item/reagent_containers/glass/bucket/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Mop - Wet mop
+	if (istype(tool, /obj/item/mop))
+		if (reagents.total_volume < 1)
+			to_chat(user, SPAN_WARNING("\The [src] is empty."))
+			return TRUE
+		reagents.trans_to_obj(tool, 5)
+		playsound(loc, 'sound/effects/slosh.ogg', 25, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] wets \a [tool] in \the [src]."),
+			SPAN_NOTICE("You wet \the [tool] in \the [src].")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/reagent_containers/glass/bucket/on_update_icon()
 	overlays.Cut()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -208,7 +208,7 @@
 			test.Shift(EAST,6)
 			overlays += test
 
-	else if(isflamesource(W))
+	else if (W.IsFlameSource())
 		if(user.a_intent != I_HURT)
 			to_chat(user, SPAN_WARNING("You almost got \the [W] too close to [src]! That could have ended very badly for you."))
 			return

--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -166,9 +166,26 @@
 		emagged = TRUE
 		return 1
 
-/obj/machinery/computer/shuttle_control/emergency/attackby(obj/item/W as obj, mob/user as mob)
-	read_authorization(W)
-	..()
+
+/obj/machinery/computer/shuttle_control/emergency/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_ID_CARD] = "<p>Scans the ID. Scan at least [initial(req_authorizations)] authorized ID\s to override the shuttle autopilot and allow manual control.</p>"
+
+
+/obj/machinery/computer/shuttle_control/emergency/use_tool(obj/item/tool, mob/user, list/click_params)
+	// ID Card - Authorize
+	var/obj/item/card/id/id_card = tool.GetIdCard()
+	if (istype(id_card))
+		var/id_name = GET_ID_NAME(id_card, tool)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] scans \a [tool] over \the [src]."),
+			SPAN_NOTICE("You scan [id_name] over \the [src].")
+		)
+		read_authorization(id_card)
+		return TRUE
+
+	return ..()
+
 
 /obj/machinery/computer/shuttle_control/emergency/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
 	var/data[0]

--- a/code/modules/spells/hand/entangle.dm
+++ b/code/modules/spells/hand/entangle.dm
@@ -37,6 +37,10 @@
 	var/obj/effect/vine/single/P = new(T,seed, start_matured =1)
 	P.can_buckle = TRUE
 
+	if (!P.can_buckle(M))
+		P.visible_message(SPAN_WARNING("\The [P] appear from the floor, attempting to wrap around \the [M], but slip free and disappear!"))
+		qdel(src)
+		return TRUE
 	P.buckle_mob(M)
 	M.set_dir(pick(GLOB.cardinal))
 	M.visible_message(SPAN_DANGER("[P] appear from the floor, spinning around \the [M] tightly!"))

--- a/code/modules/xenoarcheaology/triggers/temperature.dm
+++ b/code/modules/xenoarcheaology/triggers/temperature.dm
@@ -38,7 +38,7 @@
 
 /datum/artifact_trigger/temperature/heat/on_hit(obj/O, mob/user)
 	. = ..()
-	if(!. && isflamesource(O))
+	if (!. && O.IsFlameSource())
 		return TRUE
 
 /datum/artifact_trigger/temperature/heat/on_explosion(severity)

--- a/maps/torch/structures/signs.dm
+++ b/maps/torch/structures/signs.dm
@@ -37,19 +37,29 @@
 		to_chat(usr, directives)
 		return TOPIC_HANDLED
 
-/obj/structure/sign/ecplaque/attackby(obj/I, mob/user)
-	if(istype(I, /obj/item/grab))
-		var/obj/item/grab/G = I
-		if(!ishuman(G.affecting))
-			return
-		G.affecting.apply_damage(5, DAMAGE_BRUTE, BP_HEAD, used_weapon="Metal Plaque")
-		visible_message(SPAN_WARNING("[G.assailant] smashes [G.assailant] into \the [src] face-first!"))
-		playsound(get_turf(src), 'sound/weapons/tablehit1.ogg', 50)
-		to_chat(G.affecting, SPAN_DANGER("[directives]"))
-		admin_attack_log(user, G.affecting, "educated victim on \the [src].", "Was educated on \the [src].", "used \a [src] to educate")
-		G.force_drop()
-	else
-		..()
+
+/obj/structure/sign/ecplaque/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_GRAB] = "<p>On harm intent, smashes the victim's face into \the [initial(name)], forcing them to read its directives.</p>"
+
+
+/obj/structure/sign/ecplaque/use_grab(obj/item/grab/grab, list/click_params)
+	if (grab.assailant.a_intent == I_HURT)
+		grab.affecting.apply_damage(5, DAMAGE_BRUTE, BP_HEAD, used_weapon = "Metal Plaque")
+		playsound(src, 'sound/weapons/tablehit1.ogg', 50)
+		visible_message(
+			SPAN_WARNING("\The [grab.assailant] smashes \the [grab.affecting] into \the [src] face first!"),
+			SPAN_DANGER("You smash \the [grab.affecting] into \the [src] face first!"),
+			exclude_mobs = list(grab.affecting)
+		)
+		to_chat(grab.affecting, SPAN_DANGER("\The [grab.assailant] smashes you into \the [src] face first!"))
+		to_chat(grab.affecting, SPAN_DANGER("[directives]"))
+		admin_attack_log(grab.assailant, grab.affecting, "educated victim on \the [src].", "Was educated on \the [src].", "used \a [src] to educate")
+		grab.force_drop()
+		return TRUE
+
+	return ..()
+
 
 /obj/effect/floor_decal/scglogo
 	alpha = 230
@@ -85,13 +95,38 @@
 	unacidable = TRUE
 	var/list/fallen = list()
 
-/obj/structure/sign/memorial/attackby(obj/D, mob/user)
-	if(istype(D, /obj/item/clothing/accessory/badge/solgov/tags))
-		var/obj/item/clothing/accessory/badge/solgov/tags/T = D
-		if(T.owner_branch in list("Expeditionary Corps", "Fleet"))
-			to_chat(user, SPAN_WARNING("You add \the [T.owner_name]'s \the [T] to \the [src]."))
-			fallen += "[T.owner_rank] [T.owner_name] | [T.owner_branch]"
-			qdel(T)
+
+/obj/structure/sign/memorial/get_interactions_info()
+	. = ..()
+	.["Dog Tags"] = "<p>Adds the dog tags to the memorial, and adds the dog tags' owner to the list of fallen. It only accepts dog tags from the Expeditionary Corps or Fleet.</p>"
+	. -= CODEX_INTERACTION_SCREWDRIVER
+
+
+/obj/structure/sign/memorial/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Dog Tags - Add to the memorial
+	if (istype(tool, /obj/item/clothing/accessory/badge/solgov/tags))
+		var/obj/item/clothing/accessory/badge/solgov/tags/tag = tool
+		if (!(tag.owner_branch in list("Expeditionary Corps", "Fleet")))
+			to_chat(user, SPAN_WARNING("\The [src] only accepts dog tags from the Expeditionary Corps or Fleet."))
+			return TRUE
+		if (!user.unEquip(tool, src))
+			to_chat(user, SPAN_WARNING("You can't drop \the [tool]."))
+			return TRUE
+		fallen += "[tag.owner_rank] [tag.owner_name] | [tag.owner_branch]"
+		user.visible_message(
+			SPAN_NOTICE("\The [user] adds \a [tool] to \the [src]."),
+			SPAN_NOTICE("You add \the [tool] to \the [src].")
+		)
+		qdel(tool)
+		return TRUE
+
+	// Screwdriver - Block removal
+	if (isScrewdriver(tool))
+		to_chat(user, SPAN_WARNING("\The [src] can't be removed."))
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/sign/memorial/examine(mob/user, distance)
 	. = ..()


### PR DESCRIPTION
Big one to just mass-update all `/obj`. This only touches instances of `attackby()`. The other `attack*` procs are untouched for now. Also adds codex entries for interactions.

Includes some additional tweaks and bug fixes as needed/found.

Some items are in separate commits due to the complexity of the changes made, in case reverts are needed.

Skips food/snack items because those interactions should be moved to crafting steps instead.

## Changelog
:cl: SierraKomodo
rscadd: Codex information has been added to various objects.
tweak: Clicking closed lockers with a non-ID or ID-holder (Wallets, PDAs) item in hand no longer toggles the lock.
rscadd: Bags, boxes, etc can now be dumped into open lockers by clicking them on harm intent.
/:cl:

## Other Changes
- Adds `/mob/proc/use_sanity_check()` for some common post-input/timer/etc interaction checks. Currently, this checks that things haven't been deleted, checks for adjacency, and has flags to check for `user.unEquip()`.
- Adds `/atom/proc/can_use_item()`, called before all other use checks to see if the atom can actually be interacted with.
- Adds some more `CODEX_INTERACTION_*` constants.
- Adds `ATOM_FLAG_NO_TOOLS` that, when added to `atom_flags`, blocks calls to `use_*`. Does not block `attack_self()` or `attack_hand()`.
- Any hardcoded wrench anchoring steps were replaced with `OBJ_FLAG_ANCHORABLE`.
- Added `transfer_fingerprints_to()` calls where applicable when objects were replaced with other objects.
- Replaces body bag `has_label` boolean with a `label` string, adds `set_label()` and `clear_label()` procs.
- Adds `markings_cut` var to toy revolvers.
- Adds handler vars for checking and using remaining storge in rcd_ammo, and updating the matter list.
- Added a `can_wrench_bolts()` proc to objects, checked if the atom is clicked by a wrench.

## Dependencies
- #33042 - The new `can_buckle()` proc is being used for grab interactions with beds.
- #33089 - The updated flame and heat check procs are being used in the updated interaction code.

## TODO
- [ ] Replace all `/obj.*/attackby()` overrides with `use_tool()`.
- [ ] Add codex entries for updated objects.
- [ ] Add additional codex entries for other `attack_*` and `afterattack` interactions.
- [ ] Ensure all steps that create new items properly transfer fingerprints.
- [ ] Add playsounds to tool interactions.
- [ ] Verify parent `use_*` calls don't do anything they shouldn't be for child overrides.
- [ ] Update attackby() test count.
- [ ] Fix body bags inheriting unfitting locker interactions.
- [ ] Add blind messages to all of the visible messages.
- [ ] Check if the type check hack in `/obj/item/gun/projectile/shotgun/pump/use_tool()` is still needed.
- [ ] Remove redundancy of `silenced` and `silencer` vars in `/obj/item/gun/projectile/pistol/holdout`.
- [ ] Test changes.