### PR TITLE
Add attackby override test

### DIFF
--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -53,6 +53,7 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 5 "uses of .len" '\.len\b' -P
+exactly 614 "attackby() override" '\/attackby\((.*)\)'  -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 num=`find ./html/changelogs -not -name "*.yml" | wc -l`


### PR DESCRIPTION
Added a test for `attackby()` overrides to help enforce deprecation of this proc and usage of `use_*()` instead.