### PR TITLE
Increases the Explosive Harpoon TC Cost

### DIFF
--- a/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
+++ b/code/datums/uplink/highly_visible_and_dangerous_weapons.dm
@@ -206,7 +206,7 @@
 
 /datum/uplink_item/item/visible_weapons/harpoonbomb
 	name = "Explosive Harpoon"
-	item_cost = 32
+	item_cost = 68
 	path = /obj/item/material/harpoon/bomb
 
 /datum/uplink_item/item/visible_weapons/incendiary_laser


### PR DESCRIPTION
:cl:
tweak: The explosive harpoon now costs 68 TC, the same as an anti-materiel rifle.
/:cl:

To more accurately reflect the explosive harpoon's extreme stopping power, being basically a single-use AMR, it now costs as much as an AMR to prevent rapidly spawning them in your hands.

I considered keeping the same cost and restricting the weapon to Mercenary/Ninja only but after consulting with someone else, increasing the cost may be a better solution. I encourage developers to give their input.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->