### PR TITLE
Officer Access, Officer Mess is now Officers Only

### DIFF
--- a/code/datums/mil_ranks.dm
+++ b/code/datums/mil_ranks.dm
@@ -103,8 +103,9 @@ GLOBAL_DATUM_INIT(mil_branches, /datum/mil_branches, new)
 	var/list/spawn_ranks_            // Ranks which the player can choose for spawning, not including species restrictions
 	var/list/spawn_ranks_by_species_ // Ranks which the player can choose for spawning, with species restrictions. Populated on a needed basis
 
-	var/list/rank_types       // list of paths used to init the ranks list
-	var/list/spawn_rank_types // list of paths used to init the spawn_ranks list. Subset of rank_types
+	var/list/rank_types       	// list of paths used to init the ranks list
+	var/list/spawn_rank_types 	// list of paths used to init the spawn_ranks list. Subset of rank_types
+	var/list/officer_rank_types	// list of paths belonging to commissioned officers
 
 	var/assistant_job = DEFAULT_JOB_TYPE
 
@@ -129,6 +130,7 @@ GLOBAL_DATUM_INIT(mil_branches, /datum/mil_branches, new)
 
 		if(rank_path in spawn_rank_types)
 			spawn_ranks_[rank.name] = rank
+
 
 /datum/mil_branch/proc/spawn_ranks(datum/species/S)
 	if(!S)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -319,6 +319,8 @@ var/global/const/NO_EMAG_ACT = -50
 		id_card.military_branch = char_branch
 	if(GLOB.using_map.flags & MAP_HAS_RANK)
 		id_card.military_rank = char_rank
+	if(is_type_in_list(char_rank, char_branch.officer_rank_types))
+		id_card.access.Add("ACCESS_OFFICER")
 
 /obj/item/card/id/proc/dat()
 	var/list/dat = list("<table><tr><td>")

--- a/maps/torch/job/torch_access.dm
+++ b/maps/torch/job/torch_access.dm
@@ -129,6 +129,12 @@ var/global/const/access_chief_steward = "ACCESS_TORCH_CHIEF_STEWARD"
 	desc = "Chief Steward"
 	region = ACCESS_REGION_COMMAND
 
+var/global/const/access_officer = "ACCESS_OFFICER"
+/datum/access/officer
+	id = access_officer
+	desc = "Officer"
+	region = ACCESS_REGION_COMMAND
+
 /datum/access/psychiatrist
 	desc = "Mental Health"
 

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -960,7 +960,7 @@
 /obj/machinery/door/airlock/command{
 	autoset_access = 0;
 	name = "Officer's Mess";
-	req_access = newlist()
+	req_access = list("ACCESS_OFFICER","ACCESS_TORCH_CREW")
 	},
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -624,6 +624,7 @@
 	icon_state = "bar"
 	sound_env = MEDIUM_SOFTFLOOR
 	lighting_tone = AREA_LIGHTING_WARM
+	req_access = list(list(access_kitchen, access_officer), access_solgov_crew)
 
 /area/command/pathfinder
 	name = "\improper Pathfinder's Office"

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -134,6 +134,13 @@
 		/datum/mil_rank/ec/o6
 	)
 
+	officer_rank_types = list(
+		/datum/mil_rank/ec/o1,
+		/datum/mil_rank/ec/o3,
+		/datum/mil_rank/ec/o5,
+		/datum/mil_rank/ec/o6
+	)
+
 	assistant_job = /datum/job/crew
 
 	min_skill = list(	SKILL_HAULING = SKILL_BASIC,
@@ -189,6 +196,22 @@
 		/datum/mil_rank/fleet/o5
 	)
 
+	officer_rank_types = list(
+		/datum/mil_rank/fleet/o1,
+		/datum/mil_rank/fleet/o2,
+		/datum/mil_rank/fleet/o3,
+		/datum/mil_rank/fleet/o4,
+		/datum/mil_rank/fleet/o5,
+		/datum/mil_rank/fleet/o6,
+		/datum/mil_rank/fleet/o7,
+		/datum/mil_rank/fleet/o8,
+		/datum/mil_rank/fleet/o9,
+		/datum/mil_rank/fleet/o10,
+		/datum/mil_rank/fleet/o10_alt
+	)
+
+
+
 	assistant_job = /datum/job/crew
 	min_skill = list(	SKILL_HAULING = SKILL_BASIC,
 						SKILL_WEAPONS = SKILL_BASIC,
@@ -212,6 +235,20 @@
 		/datum/mil_rank/army/e9,
 		/datum/mil_rank/army/e9_alt1,
 		/datum/mil_rank/army/e9_alt2,
+		/datum/mil_rank/army/o1,
+		/datum/mil_rank/army/o2,
+		/datum/mil_rank/army/o3,
+		/datum/mil_rank/army/o4,
+		/datum/mil_rank/army/o5,
+		/datum/mil_rank/army/o6,
+		/datum/mil_rank/army/o7,
+		/datum/mil_rank/army/o8,
+		/datum/mil_rank/army/o9,
+		/datum/mil_rank/army/o10,
+		/datum/mil_rank/army/o10_alt
+	)
+
+	officer_rank_types = list(
 		/datum/mil_rank/army/o1,
 		/datum/mil_rank/army/o2,
 		/datum/mil_rank/army/o3,

--- a/packs/faction_iccgn/faction.dm
+++ b/packs/faction_iccgn/faction.dm
@@ -53,6 +53,19 @@
 		/datum/mil_rank/iccgn/of9_alt
 	)
 
+	officer_rank_types = list(
+		/datum/mil_rank/iccgn/of1,
+		/datum/mil_rank/iccgn/of2,
+		/datum/mil_rank/iccgn/of3,
+		/datum/mil_rank/iccgn/of4,
+		/datum/mil_rank/iccgn/of5,
+		/datum/mil_rank/iccgn/of6,
+		/datum/mil_rank/iccgn/of7,
+		/datum/mil_rank/iccgn/of8,
+		/datum/mil_rank/iccgn/of9,
+		/datum/mil_rank/iccgn/of9_alt
+	)
+
 
 /datum/mil_branch/iccgn/New()
 	rank_types = subtypesof(/datum/mil_rank/iccgn)


### PR DESCRIPTION
:cl: SingingSpock
rscadd: Officer access, applied to all commissioned officers
maptweak: Changed main officer mess door to require officer access. Those with kitchen access can still access the O-mess through that staircase
/:cl:

At long last, the O-Mess is a place for officers to be away from the enlisted again. There is now an ACCESS_OFFICER that is automatically assigned to anyone who spawns as an officer (of any defined faction). The O-Mess requires solgov_crew access as well as officer access, to make sure that any Terran officers visiting the ship can't waltz in.