### PR TITLE
Fixes brainworms and their description, adds extra chemicals to their repertoire

### DIFF
--- a/code/game/antagonist/alien/borer.dm
+++ b/code/game/antagonist/alien/borer.dm
@@ -7,7 +7,7 @@ GLOBAL_DATUM_INIT(borers, /datum/antagonist/borer, new)
 	flags = ANTAG_OVERRIDE_MOB | ANTAG_RANDSPAWN | ANTAG_OVERRIDE_JOB
 
 	mob_path = /mob/living/simple_animal/borer
-	welcome_text = "Use your Infest power to crawl into the ear of a host and fuse with their brain. You can only take control temporarily, and at risk of hurting your host, so be clever and careful; your host is encouraged to help you however they can. Talk to your fellow borers with :x."
+	welcome_text = "Use your Infest power to crawl into the ear of a host and fuse with their brain. You can only take control temporarily, and at risk of hurting your host, so be clever and careful; your host is encouraged to help you however they can. On grab intent, you will use the infest ability. On disarm intent at a distance, you will expell psionic waves to paralyze potential hosts, or enemies. Talk to your fellow borers with ,z."
 	antag_indicator = "hudborer"
 	antaghud_indicator = "hudborer"
 

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -28,7 +28,11 @@
 	var/static/list/chemical_types = list(
 		"bicaridine" = /datum/reagent/bicaridine,
 		"hyperzine" =  /datum/reagent/hyperzine,
-		"tramadol" =   /datum/reagent/tramadol
+		"tramadol" =   /datum/reagent/tramadol,
+		"dermaline" =  /datum/reagent/dermaline,
+		"peridaxon" =  /datum/reagent/peridaxon,
+		"inaprovaline" =  /datum/reagent/inaprovaline,
+		"dylovene" =  /datum/reagent/dylovene
 	)
 
 	var/generation = 1

--- a/code/modules/mob/living/simple_animal/borer/borer_hud.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_hud.dm
@@ -28,7 +28,7 @@
 /obj/screen/borer/toggle_host_control
 	name = "Seize Control"
 	icon_state = "seize_control"
-	screen_loc = "WEST-3,NORTH-1"
+	screen_loc = "WEST, NORTH"
 
 /obj/screen/borer/toggle_host_control/Click(location, control, params)
 	. = ..()
@@ -85,7 +85,7 @@
 /obj/screen/borer/inject_chemicals
 	name = "Inject Chemicals"
 	icon_state = "inject_chemicals"
-	screen_loc = "WEST-2,NORTH-1"
+	screen_loc = "WEST+1, NORTH"
 
 /obj/screen/borer/inject_chemicals/Click(location, control, params)
 	. = ..()
@@ -112,7 +112,7 @@
 /obj/screen/borer/leave_host
 	name = "Leave Host"
 	icon_state = "leave_host"
-	screen_loc = "WEST-1,NORTH-1"
+	screen_loc = "WEST+2, NORTH"
 
 /obj/screen/borer/leave_host/Click(location, control, params)
 	. = ..()


### PR DESCRIPTION
Borers in general were generally functioning; Only thing that "broke" them was an overlooked difference between nebula and bay during the port of a fix; Resulting in the screen being skewed 3(!) tiles to the left. This fixes that.

It also adds extra chemicals for the borer to help their host, making them more viable to keep around. 

Adds hints to the starting text about HOW to use your abilities, such as infest and psionic lance. Also fixed it referring to speak as :x, and not ,z, as it should.

:cl: SomeAngryMiner
rscadd: Borers can now inyect Inaprovaline, Dylovene, Dermaline and Peridaxon.
rscadd: Borer ability buttons have been fixed and are placed in the top left corner of the screen.
/:cl: 