### PR TITLE
Fix invalid id_tag in SFV Arbiter external airlock sensor

### DIFF
--- a/maps/event/sfv_arbiter/sfv_arbiter.dmm
+++ b/maps/event/sfv_arbiter/sfv_arbiter.dmm
@@ -605,7 +605,7 @@
 "sS" = (
 /obj/machinery/airlock_sensor{
 	frequency = 1380;
-	id_tag = s;
+	id_tag = "sfv_arbiter_shuttle_exterior_sensor";
 	pixel_y = 24
 	},
 /turf/template_noop,


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: The SFV Arbiter's airlock now properly detects and reads the external air sensor.
/:cl:

Also fixes the mapdiffbot crashing anytime someone edits the arbiter's dmm file.