### PR TITLE
fixes insect meat

### DIFF
--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -1371,16 +1371,32 @@
 	)
 	result_path = /obj/item/reagent_containers/food/snacks/meatball
 
-
-/datum/microwave_recipe/cutlet
+/datum/microwave_recipe/cutlet/meat
 	required_items = list(
-		/obj/item/reagent_containers/food/snacks/rawcutlet
+		/obj/item/reagent_containers/food/snacks/rawcutlet/meat
+	)
+	result_path = /obj/item/reagent_containers/food/snacks/cutlet/meat
+
+
+/datum/microwave_recipe/cutlet ///this is fucking stupid but it works
+	required_items = list(
+		/obj/item/reagent_containers/food/snacks/rawcutlet,
+		/obj/item/projectile
 	)
 	result_path = /obj/item/reagent_containers/food/snacks/cutlet
 
-/datum/microwave_recipe/bacon
+
+/datum/microwave_recipe/bacon/meat
 	required_items = list(
-		/obj/item/reagent_containers/food/snacks/rawbacon
+		/obj/item/reagent_containers/food/snacks/rawbacon/meat
+	)
+	result_path = /obj/item/reagent_containers/food/snacks/bacon/meat
+
+
+/datum/microwave_recipe/bacon ///see cutlet note
+	required_items = list(
+		/obj/item/reagent_containers/food/snacks/rawbacon,
+		/obj/item/projectile
 	)
 	result_path = /obj/item/reagent_containers/food/snacks/bacon
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1043,7 +1043,7 @@
 	desc = "A piece of unseasoned cooked meat."
 	icon = 'icons/obj/food_ingredients.dmi'
 	icon_state = "steak"
-	slice_path = /obj/item/reagent_containers/food/snacks/cutlet
+	slice_path = /obj/item/reagent_containers/food/snacks/cutlet/meat
 	slices_num = 3
 	filling_color = "#7a3d11"
 	center_of_mass = "x=16;y=13"
@@ -3039,8 +3039,9 @@
 	reagents.add_reagent(/datum/reagent/nutriment/protein, 3)
 
 /obj/item/reagent_containers/food/snacks/rawcutlet
-	name = "raw cutlet"
-	desc = "A thin piece of raw meat."
+	abstract_type = /obj/item/reagent_containers/food/snacks/rawcutlet
+	name = "parent raw cutlet"
+	desc = "You probably shouldn't be seeing this."
 	icon = 'icons/obj/food_ingredients.dmi'
 	icon_state = "rawcutlet"
 	filling_color = "#fb8258"
@@ -3049,42 +3050,62 @@
 	bitesize = 1
 	center_of_mass = "x=17;y=20"
 
-/obj/item/reagent_containers/food/snacks/rawcutlet/Initialize()
+/obj/item/reagent_containers/food/snacks/rawcutlet/meat
+	name = "raw cutlet"
+	desc = "A thin piece of raw meat."
+	slice_path = /obj/item/reagent_containers/food/snacks/rawbacon/meat
+
+/obj/item/reagent_containers/food/snacks/rawcutlet/meat/Initialize()
 	.=..()
 	reagents.add_reagent(/datum/reagent/nutriment/protein, 1)
 
 /obj/item/reagent_containers/food/snacks/cutlet
-	name = "cutlet"
-	desc = "A tasty meat slice."
+	abstract_type = /obj/item/reagent_containers/food/snacks/cutlet
+	name = "parent cutlet"
+	desc = "You probably shouldn't be seeing this."
 	icon = 'icons/obj/food_ingredients.dmi'
 	icon_state = "cutlet"
 	filling_color = "#d75608"
 	bitesize = 2
 	center_of_mass = "x=17;y=20"
 
-/obj/item/reagent_containers/food/snacks/cutlet/Initialize()
+/obj/item/reagent_containers/food/snacks/cutlet/meat
+	name = "cutlet"
+	desc = "A tasty meat slice."
+
+/obj/item/reagent_containers/food/snacks/cutlet/meat/Initialize()
 	.=..()
 	reagents.add_reagent(/datum/reagent/nutriment/protein, 2)
 
 /obj/item/reagent_containers/food/snacks/rawbacon
-	name = "raw bacon"
-	desc = "A raw, fatty strip of meat."
+	abstract_type = /obj/item/reagent_containers/food/snacks/rawbacon
+	name = "master raw bacon"
+	desc = "You probably shouldn't be seeing this."
 	icon_state = "rawbacon"
 	filling_color = "#ffa7a3"
 	bitesize = 1
 	center_of_mass = "x=16;y=15"
+
+/obj/item/reagent_containers/food/snacks/rawbacon/meat
+	name = "raw bacon"
+	desc = "A raw, fatty strip of meat."
 
 /obj/item/reagent_containers/food/snacks/rawbacon/Initialize()
 	.=..()
 	reagents.add_reagent(/datum/reagent/nutriment/protein, 1)
 
 /obj/item/reagent_containers/food/snacks/bacon
-	name = "bacon"
-	desc = "A delicious, crispy strip of meat."
+	abstract_type = /obj/item/reagent_containers/food/snacks/bacon
+	name = "master bacon"
+	desc = "You probably shouldn't be seeing this."
 	icon_state = "bacon"
 	filling_color = "#cb5d27"
 	bitesize = 2
 	center_of_mass = "x=16;y=15"
+
+/obj/item/reagent_containers/food/snacks/bacon/meat
+	name = "bacon"
+	desc = "A delicious, crispy strip of meat."
 
 /obj/item/reagent_containers/food/snacks/bacon/Initialize()
 	.=..()

--- a/code/modules/reagents/reagent_containers/food/snacks/bugmeat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/bugmeat.dm
@@ -40,11 +40,9 @@
 	name = "insect protein"
 	desc = "A small mass of cooked extruded bug stuff."
 	icon = 'icons/obj/food_bugmeat.dmi'
-	icon_state = "cutlet"
 	filling_color = "#858040"
 	slice_path = /obj/item/reagent_containers/food/snacks/bacon/bugmeat
 	slices_num = 2
-	bitesize = 2
 	center_of_mass = "x=16;y=16"
 	nutriment_desc = list("rubbery meat" = 10)
 
@@ -64,14 +62,12 @@
 	name = "sliced insect protein"
 	desc = "A small mass of cooked extruded bug stuff, lovingly cut thin."
 	icon = 'icons/obj/food_bugmeat.dmi'
-	icon_state = "bacon"
 	filling_color = "#858040"
-	bitesize = 2
 	center_of_mass = "x=16;y=16"
 	nutriment_desc = list("rubbery meat" = 10)
 
 
-/datum/microwave_recipe/bugmeat_cutlet
+/datum/microwave_recipe/cutlet/bugmeat
 	required_items = list(
 		/obj/item/reagent_containers/food/snacks/rawcutlet/bugmeat
 	)

--- a/code/modules/reagents/reagent_containers/food/snacks/meat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/meat.dm
@@ -3,7 +3,7 @@
 	desc = "A slab of meat."
 	icon = 'icons/obj/food_ingredients.dmi'
 	icon_state = "meat"
-	slice_path = /obj/item/reagent_containers/food/snacks/rawcutlet
+	slice_path = /obj/item/reagent_containers/food/snacks/rawcutlet/meat
 	slices_num = 3
 	filling_color = "#ff1c1c"
 	center_of_mass = "x=16;y=14"


### PR DESCRIPTION
🆑 Gy1ta23
bugfix: you can now microwave insect meat without it turning into normal meat cutlets. this also goes for insect bacon
/🆑

I am very, very tired, so I will give you this one PR where I don't spend three hours of my life on flowery prose. At the moment, if you try to microwave insect meat or insect bacon it'll turn into normal cutlets or bacon. After extensive testing involving bashing my head against a wall for about six hours, I've thought up the optimal (in the most loose definition of optimal) solution of making meat cutlets/bacon not the base cutlet/bacon for everything but instead making that its own thing. This fixes insect meat and allows for other types of meat to be added more easily (which I will probably do later so we can have bacon that's actually made out of the correct animal). I probably fucked something up doing this but I've looked really hard and I can't find it, and I've tested a reasonable amount of meat recipes and they all work fine (and keep the insect meat functionality that they can be used for all cutlet recipes, as stated on the wiki). 

😘😘