### PR TITLE
Re-adds CoS office console

### DIFF
--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -12890,6 +12890,10 @@
 	pixel_x = 32
 	},
 /obj/item/modular_computer/tablet/lease/preset/command,
+/obj/machinery/computer/modular/preset/cardslot/command_sec{
+	dir = 8;
+	icon_state = "console"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "Mq" = (


### PR DESCRIPTION
:cl: SingingSpock
maptweak: Re-adds the CoS terminal. Oops.
/:cl:

I did a little fucky-wucky and removed the CoS' console in my modular console PR. I have no clue how, since there were no intended changes to it. This adds it back.