### PR TITLE
Tweak Vat-Grown name randomizer to not give invalid names.

### DIFF
--- a/code/modules/culture_descriptor/culture/cultures_human.dm
+++ b/code/modules/culture_descriptor/culture/cultures_human.dm
@@ -175,7 +175,7 @@
 		if(1) return NAME
 		if(2) return "[LTR][LTR]-[FIRST]"
 		if(3) return "[FIRST]-[NUM][NUM][NUM]"
-		if(4) return "[LTR][LTR]-[NUM][NUM][NUM]"
+		if(4) return "[NUM][NUM][NUM]-[FIRST]"
 	. = 1 // Never executed, works around http://www.byond.com/forum/?post=2072419
 	#undef LTR
 	#undef NUM


### PR DESCRIPTION
:cl: Mucker
tweak: Tweaked the Vat-Grown name randomizer so it doesn't give names that violate the naming convention. 
/:cl: