### PR TITLE
Revert Ghost Trap Prefs. Removal

### DIFF
--- a/code/__defines/gamemode.dm
+++ b/code/__defines/gamemode.dm
@@ -14,6 +14,8 @@
 #define END_GAME_AWAITING_TICKETS 6
 #define END_GAME_DELAYED          7
 
+#define BE_PLANT "BE_PLANT"
+#define BE_SYNTH "BE_SYNTH"
 #define BE_PAI   "BE_PAI"
 
 // Antagonist datum flags.

--- a/code/modules/client/preference_setup/antagonism/01_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/01_candidacy.dm
@@ -48,15 +48,38 @@
 			. += "<a href='?src=\ref[src];add_special=[antag.id]'>High</a> <a href='?src=\ref[src];add_maybe=[antag.id]'>Low</a> [SPAN_CLASS("linkOn", "Never")]</br>"
 
 		. += "</td></tr>"
+	. += "</table>"
+	. += "<b>Ghost Role Availability:</b>"
+	. += "<table>"
+	var/list/ghost_traps = get_ghost_traps()
+	for(var/ghost_trap_key in ghost_traps)
+		var/datum/ghosttrap/ghost_trap = ghost_traps[ghost_trap_key]
+		if(!ghost_trap.list_as_special_role)
+			continue
 
-	// Special handling for pAI role
-	. += "<tr></tr><tr><td>pAI:</td>"
-	if (BE_PAI in pref.be_special_role)
-		. += "<td>[SPAN_CLASS("linkOn", "Yes")] <a href='?src=\ref[src];del_special=[BE_PAI]'>No</a></br></td></tr>"
-	else
-		. += "<td><a href='?src=\ref[src];add_special=[BE_PAI]'>Yes</a> [SPAN_CLASS("linkOn", "No")]</br></td></tr>"
+		. += "<tr><td>[(ghost_trap.ghost_trap_role)]: </td><td>"
+		if(banned_from_ghost_role(preference_mob(), ghost_trap))
+			. += "<span class='danger'>\[BANNED\]</span><br>"
+		else if (!ghost_trap.assess_whitelist(user))
+			var/datum/species/S = new ghost_trap.species_whitelist()
+			. += "[SPAN_DANGER("\[WHITELIST RESTRICTED - [S]\]")]<br />"
+		else if(ghost_trap.pref_check in pref.be_special_role)
+			. += "<span class='linkOn'>High</span> <a href='?src=\ref[src];add_maybe=[ghost_trap.pref_check]'>Low</a> <a href='?src=\ref[src];del_special=[ghost_trap.pref_check]'>Never</a></br>"
+		else if(ghost_trap.pref_check in pref.may_be_special_role)
+			. += "<a href='?src=\ref[src];add_special=[ghost_trap.pref_check]'>High</a> <span class='linkOn'>Low</span> <a href='?src=\ref[src];del_special=[ghost_trap.pref_check]'>Never</a></br>"
+		else
+			. += "<a href='?src=\ref[src];add_special=[ghost_trap.pref_check]'>High</a> <a href='?src=\ref[src];add_maybe=[ghost_trap.pref_check]'>Low</a> <span class='linkOn'>Never</span></br>"
+
+		. += "</td></tr>"
+	. += "<tr><td>Select All: </td><td><a href='?src=\ref[src];select_all=2'>High</a> <a href='?src=\ref[src];select_all=1'>Low</a> <a href='?src=\ref[src];select_all=0'>Never</a></td></tr>"
 	. += "</table>"
 	. = jointext(.,null)
+
+/datum/category_item/player_setup_item/proc/banned_from_ghost_role(mob/h, datum/ghosttrap/ghost_trap)
+	for(var/ban_type in ghost_trap.ban_checks)
+		if(jobban_isbanned(h, ban_type))
+			return TRUE
+	return FALSE
 
 /datum/category_item/player_setup_item/antagonism/candidacy/OnTopic(href,list/href_list, mob/user)
 	if(href_list["add_special"])
@@ -108,8 +131,15 @@
 				continue
 		private_valid_special_roles += antag_type
 
-	// Special handling to allow pAI selection as it is not an antagonist but does have a role pref
-	private_valid_special_roles += BE_PAI
+	var/list/ghost_traps = get_ghost_traps()
+	for(var/ghost_trap_key in ghost_traps)
+		var/datum/ghosttrap/ghost_trap = ghost_traps[ghost_trap_key]
+		if(!ghost_trap.list_as_special_role)
+			continue
+		if(!include_bans)
+			if(banned_from_ghost_role(preference_mob(), ghost_trap))
+				continue
+		private_valid_special_roles += ghost_trap.pref_check
 
 
 	return private_valid_special_roles


### PR DESCRIPTION
Reverts #32015 
With the new noise and rather large text, not being able to toggle these is irritating, especially as an admin or individual with multiple whitelists. Specifically nymphs, which *very* frequently grow unsupervised. 

🆑 Jux
tweak: Ghost Traps like Nymphs, Positronic Brains and Shades now have role toggles for them again.
/🆑

Hasty revert. Not yet tested. 