### PR TITLE
Removed falloff from sniper beam

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -225,13 +225,9 @@
 	name = "sniper beam"
 	icon_state = "xray"
 	fire_sound = 'sound/weapons/marauder.ogg'
-	damage = 50
+	damage = 35
 	armor_penetration = 10
-	damage_falloff_list = list(
-		list(8, 0.97),
-		list(12, 0.94),
-		list(16, 0.88),
-	)
+	damage_falloff_list = null
 
 	muzzle_type = /obj/effect/projectile/laser/xray/muzzle
 	tracer_type = /obj/effect/projectile/laser/xray/tracer


### PR DESCRIPTION
:cl: Ryan180602
tweak: Removes fall-off from sniper beam. Decreases damage to 35.
/:cl:

Laser fall-off in general has been a good change. But that does come at the cost of nerfing the marksman rifle to a great amount. It is slow-firing and has a scope for obvious reasons, but can fall short at longer rangers due to the fall-off.

This makes it so that the marksman rifle is a viable pick by personnel.

Damage also falls between a carbine and laser cannon, tending to the carbine. 50 damage with no fall-off over long distance does sound OP. So that was dumbed down to 35. So, close-by a carbine would still be better (higher base damage/pen), but far away, you will want to use the marksman rifle for no malus.