### PR TITLE
Increase small/midlaser falloff distance

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -34,9 +34,8 @@
 	damage = 35
 	distance_falloff = 2
 	damage_falloff_list = list(
-		list(3, 0.90),
-		list(5, 0.80),
-		list(7, 0.60),
+		list(5, 0.87),
+		list(7, 0.67),
 	)
 
 /obj/item/projectile/beam/midlaser
@@ -44,9 +43,8 @@
 	armor_penetration = 10
 	distance_falloff = 1
 	damage_falloff_list = list(
-		list(4, 0.96),
-		list(6, 0.92),
-		list(8, 0.86),
+		list(6, 0.98),
+		list(8, 0.92),
 	)
 
 /obj/item/projectile/beam/heavylaser


### PR DESCRIPTION
:cl: Ryan180602
balance: Increase small/midlaser falloff distance/damage multiplier.
/:cl:

tl;dr, increases the range at which damage decrease due to falloff comes into effect for on-torch smarties and carbines (and any lasers using those two projectiles). Also decreases the amount by which damage reduces for fall-off.

for smallaser, beyond 5 tiles the reduction will be noticeable. For midlaser, beyond 6 tiles the reduction will be noticeable. Plus the damage multiplier changes that can be seen in the diffs.

Ultimately it's been noticed that while fall-off was a good change, it severely disadvantaged security (especially in team antag modes like raider/merc), where ballistics currently reign supreme (as they probably should), and lasers being the more accurate but arguably worse damage-wise against merc/antag armours.

It comes at the issue where exploration and engineering are more effective at engaging hostiles when the going gets tough and security *does* need extra help. This should probably not be the case and security should likely be expected to hold on their own, while not being overwhelmingly strong.

This should allow for that, considering the weapons security can get without improvised weapons and supply being a factor. Of course, just like all balancing changes, things are subjected to change. And this does affect non-torch laser weapons too, which use small and midlasers.

Currently carbines deal 22-20/13-10 damage (no organ damage/minor organ damage on varying falloff) to merc voidsuits, and 13-10/8-5 damage to antag plate carriers. This should probably not be a thing for weapons that a government vessel would consider to be the "oh god oh fuck theres an actual bad hostile", short of "oh god oh fuck this thing needs something more than carbines". The latter of which, should really only be reserved for really bad situations rather than being the go-to. (supply/improvised weapons) 

