### PR TITLE
Add a preference for getting notified of ghosttrap roles

### DIFF
--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -289,6 +289,12 @@ var/global/list/_client_preferences_by_type
 			winset(C, "output", "is-visible=true;is-disabled=false")
 			winset(C, "browseroutput", "is-visible=false")
 
+/datum/client_preference/notify_ghost_trap
+	description = "Notify when ghost-trap roles are available."
+	key = "GHOST_TRAP"
+	options = list(GLOB.PREF_YES, GLOB.PREF_NO)
+	default_value = GLOB.PREF_YES
+
 /********************
 * General Staff Preferences *
 ********************/

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -80,6 +80,8 @@ var/global/list/ghost_traps
 		unregister_target(target)
 
 	for(var/mob/observer/ghost/O in GLOB.player_list)
+		if (O.client.get_preference_value(/datum/client_preference/notify_ghost_trap) == GLOB.PREF_NO)
+			return
 		if(!assess_candidate(O, target, FALSE))
 			continue
 		if(O.client)


### PR DESCRIPTION
:cl: Mucker
rscadd: Added a preference for hearing/seeing notifications of ghost-trap roles as an observer. 
/:cl:

Closes #33080