### PR TITLE
Heat/Flame Check Refactor

### DIFF
--- a/code/_helpers/tools.dm
+++ b/code/_helpers/tools.dm
@@ -92,3 +92,11 @@
 
 /// True when A exists and can be used as a hatchet.
 #define isHatchet(A) (A?.IsHatchet())
+
+
+/// True when this atom can be used as a flame source. This is for open flames.
+/atom/proc/IsFlameSource()
+	return FALSE
+
+/// True when A exists and can be used as a flame source.
+#define isFlameSource(A) (A?.IsFlameSource())

--- a/code/_helpers/tools.dm
+++ b/code/_helpers/tools.dm
@@ -108,3 +108,7 @@
 
 /// 0 if A does not exist, or the heat value of A
 #define isHeatSource(A) (A ? A.IsHeatSource() : 0)
+
+
+/// True when A exists and is either a flame or heat source
+#define isFlameOrHeatSource(A) (A && (A.IsFlameSource() || !!A.IsHeatSource()))

--- a/code/_helpers/tools.dm
+++ b/code/_helpers/tools.dm
@@ -100,3 +100,11 @@
 
 /// True when A exists and can be used as a flame source.
 #define isFlameSource(A) (A?.IsFlameSource())
+
+
+/// Returns an integer value of temperature when this atom can be used as a heat source. This is for hot objects.
+/atom/proc/IsHeatSource()
+	return 0
+
+/// 0 if A does not exist, or the heat value of A
+#define isHeatSource(A) (A ? A.IsHeatSource() : 0)

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -864,41 +864,6 @@ GLOBAL_LIST_INIT(duplicate_object_disallowed_vars, list(
 	return TRUE
 
 
-/proc/is_hot(obj/item/W as obj)
-	switch(W.type)
-		if(/obj/item/weldingtool)
-			var/obj/item/weldingtool/WT = W
-			if(WT.isOn())
-				return 3800
-			else
-				return 0
-		if(/obj/item/flame/lighter)
-			if(W:lit)
-				return 1500
-			else
-				return 0
-		if(/obj/item/flame/match)
-			if(W:lit)
-				return 1000
-			else
-				return 0
-		if(/obj/item/clothing/mask/smokable/cigarette)
-			if(W:lit)
-				return 1000
-			else
-				return 0
-		if(/obj/item/gun/energy/plasmacutter)
-			return 3800
-		if(/obj/item/melee/energy)
-			return 3500
-		if(/obj/item/blob_tendril)
-			if (W.damtype == DAMAGE_BURN)
-				return 1000
-			else
-				return 0
-		else
-			return 0
-
 //Whether or not the given item counts as sharp in terms of dealing damage
 /proc/is_sharp(obj/O as obj)
 	if (!O) return 0

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1216,9 +1216,9 @@ About the new airlock wires panel:
 	qdel(src)
 
 	return da
-/obj/machinery/door/airlock/phoron/attackby(C as obj, mob/user as mob)
+/obj/machinery/door/airlock/phoron/attackby(atom/C, mob/user)
 	if(C)
-		ignite(is_hot(C))
+		ignite(C.IsHeatSource())
 	..()
 
 /obj/machinery/door/airlock/set_broken(new_state)

--- a/code/game/objects/items/weapons/candle/candle.dm
+++ b/code/game/objects/items/weapons/candle/candle.dm
@@ -39,12 +39,12 @@
 
 /obj/item/flame/candle/attackby(obj/item/W as obj, mob/user as mob)
 	..()
-	if (W.IsFlameSource() || is_hot(W))
+	if (W.IsFlameSource() || W.IsHeatSource())
 		light(user)
 
 /obj/item/flame/candle/resolve_attackby(atom/A, mob/user)
 	. = ..()
-	if(istype(A, /obj/item/flame/candle) && is_hot(src))
+	if (istype(A, /obj/item/flame/candle) && IsHeatSource())
 		var/obj/item/flame/candle/other_candle = A
 		other_candle.light()
 

--- a/code/game/objects/items/weapons/candle/candle.dm
+++ b/code/game/objects/items/weapons/candle/candle.dm
@@ -39,7 +39,7 @@
 
 /obj/item/flame/candle/attackby(obj/item/W as obj, mob/user as mob)
 	..()
-	if (W.IsFlameSource() || W.IsHeatSource())
+	if (isFlameOrHeatSource(W))
 		light(user)
 
 /obj/item/flame/candle/resolve_attackby(atom/A, mob/user)

--- a/code/game/objects/items/weapons/candle/candle.dm
+++ b/code/game/objects/items/weapons/candle/candle.dm
@@ -39,7 +39,7 @@
 
 /obj/item/flame/candle/attackby(obj/item/W as obj, mob/user as mob)
 	..()
-	if(isflamesource(W) || is_hot(W))
+	if (W.IsFlameSource() || is_hot(W))
 		light(user)
 
 /obj/item/flame/candle/resolve_attackby(atom/A, mob/user)

--- a/code/game/objects/items/weapons/flame.dm
+++ b/code/game/objects/items/weapons/flame.dm
@@ -19,21 +19,10 @@
 		if(submerged(depth))
 			extinguish(no_message = TRUE)
 
-/proc/isflamesource(atom/A)
-	if(!istype(A))
-		return FALSE
-	if(isWelder(A))
-		var/obj/item/weldingtool/WT = A
-		return (WT.isOn())
-	else if(istype(A, /obj/item/flame))
-		var/obj/item/flame/F = A
-		return (F.lit)
-	else if(istype(A, /obj/item/clothing/mask/smokable) && !istype(A, /obj/item/clothing/mask/smokable/pipe))
-		var/obj/item/clothing/mask/smokable/S = A
-		return (S.lit)
-	else if(istype(A, /obj/item/device/assembly/igniter))
-		return TRUE
-	return FALSE
+
+/obj/item/flame/IsFlameSource()
+	return lit
+
 
 ///////////
 //MATCHES//

--- a/code/game/objects/items/weapons/flame.dm
+++ b/code/game/objects/items/weapons/flame.dm
@@ -73,3 +73,7 @@
 	if(burnt)
 		icon_state = "match_burnt"
 		item_state = "cigoff"
+
+
+/obj/item/flame/match/IsHeatSource()
+	return lit ? 1000 : 0

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -106,6 +106,10 @@
 		location.hotspot_expose(700, 5)
 
 
+/obj/item/flame/lighter/IsHeatSource()
+	return lit ? 1500 : 0
+
+
 /obj/item/flame/lighter/red
 	color = COLOR_RED
 	name = "red lighter"

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -105,6 +105,7 @@
 	if(location)
 		location.hotspot_expose(700, 5)
 
+
 /obj/item/flame/lighter/red
 	color = COLOR_RED
 	name = "red lighter"

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -85,7 +85,7 @@
 
 
 /obj/item/melee/energy/IsHeatSource()
-	return 3500
+	return active ? 3500 : 0
 
 
 /*

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -83,6 +83,11 @@
 		return ITEM_SIZE_NO_CONTAINER
 	return ..()
 
+
+/obj/item/melee/energy/IsHeatSource()
+	return 3500
+
+
 /*
  * Energy Axe
  */

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -296,6 +296,11 @@
 	else
 		return ..()
 
+
+/obj/item/weldingtool/IsFlameSource()
+	return isOn()
+
+
 /obj/item/weldingtool/mini
 	tank = /obj/item/welder_tank/mini
 

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -301,6 +301,10 @@
 	return isOn()
 
 
+/obj/item/weldingtool/IsHeatSource()
+	return isOn() ? 3800 : 0
+
+
 /obj/item/weldingtool/mini
 	tank = /obj/item/welder_tank/mini
 

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -171,8 +171,9 @@
 
 	if(W)
 		radiate()
-		if(is_hot(W))
-			burn(is_hot(W))
+		var/heat_value = W.IsHeatSource()
+		if (heat_value)
+			burn(heat_value)
 
 	if(locate(/obj/effect/overlay/wallrot) in src)
 		if(isWelder(W))

--- a/code/modules/assembly/igniter.dm
+++ b/code/modules/assembly/igniter.dm
@@ -35,3 +35,7 @@
 	activate()
 	add_fingerprint(user)
 	return
+
+
+/obj/item/device/assembly/igniter/IsFlameSource()
+	return TRUE

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -413,6 +413,11 @@ regen() will cover update_icon() for this proc
 			new /obj/effect/decal/cleanable/ash(src.loc)
 			qdel(src)
 
+
+/obj/item/blob_tendril/IsHeatSource()
+	return damtype == DAMAGE_BURN ? 1000 : 0
+
+
 /obj/item/blob_tendril/core
 	name = "asteroclast nucleus sample"
 	desc = "A sample taken from an asteroclast's nucleus. It pulses with energy."

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -132,7 +132,7 @@
 
 /obj/item/clothing/mask/smokable/attackby(obj/item/W, mob/user)
 	..()
-	if (W.IsFlameSource() || is_hot(W))
+	if (W.IsFlameSource() || W.IsHeatSource())
 		var/text = matchmes
 		if(istype(W, /obj/item/flame/match))
 			text = matchmes

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -132,7 +132,7 @@
 
 /obj/item/clothing/mask/smokable/attackby(obj/item/W, mob/user)
 	..()
-	if(isflamesource(W) || is_hot(W))
+	if (W.IsFlameSource() || is_hot(W))
 		var/text = matchmes
 		if(istype(W, /obj/item/flame/match))
 			text = matchmes
@@ -158,6 +158,11 @@
 		return 1
 	else
 		return ..()
+
+
+/obj/item/clothing/mask/smokable/IsFlameSource()
+	return lit
+
 
 /obj/item/clothing/mask/smokable/cigarette
 	name = "cigarette"
@@ -548,6 +553,11 @@
 	user.update_inv_wear_mask(0)
 	user.update_inv_l_hand(0)
 	user.update_inv_r_hand(1)
+
+
+/obj/item/clothing/mask/smokable/pipe/IsFlameSource()
+	return FALSE
+
 
 /obj/item/clothing/mask/smokable/pipe/cobpipe
 	name = "corn cob pipe"

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -132,7 +132,7 @@
 
 /obj/item/clothing/mask/smokable/attackby(obj/item/W, mob/user)
 	..()
-	if (W.IsFlameSource() || W.IsHeatSource())
+	if (isFlameOrHeatSource(W))
 		var/text = matchmes
 		if(istype(W, /obj/item/flame/match))
 			text = matchmes

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -46,7 +46,7 @@
 		remove_contents(user)
 
 /obj/item/reagent_containers/glass/rag/attackby(obj/item/W, mob/user)
-	if(!on_fire && isflamesource(W))
+	if (!on_fire && W.IsFlameSource())
 		ignite()
 		if(on_fire)
 			user.visible_message(

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -189,6 +189,11 @@
 	handle_click_empty(M)
 	return 0
 
+
+/obj/item/gun/energy/plasmacutter/IsHeatSource()
+	return 3800
+
+
 /obj/item/gun/energy/incendiary_laser
 	name = "dispersive blaster"
 	desc = "The A&M 'Shayatin' was the first of a class of dispersive laser weapons which, instead of firing a focused beam, scan over a target rapidly with the goal of setting it ablaze."

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -74,7 +74,7 @@
 	if (!rag && istype(W, /obj/item/reagent_containers/glass/rag))
 		insert_rag(W, user)
 		return
-	if (rag && isflamesource(W))
+	if (rag && W.IsFlameSource())
 		rag.attackby(W, user)
 		return
 	..()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -208,7 +208,7 @@
 			test.Shift(EAST,6)
 			overlays += test
 
-	else if(isflamesource(W))
+	else if (W.IsFlameSource())
 		if(user.a_intent != I_HURT)
 			to_chat(user, SPAN_WARNING("You almost got \the [W] too close to [src]! That could have ended very badly for you."))
 			return

--- a/code/modules/xenoarcheaology/triggers/temperature.dm
+++ b/code/modules/xenoarcheaology/triggers/temperature.dm
@@ -38,7 +38,7 @@
 
 /datum/artifact_trigger/temperature/heat/on_hit(obj/O, mob/user)
 	. = ..()
-	if(!. && isflamesource(O))
+	if (!. && O.IsFlameSource())
 		return TRUE
 
 /datum/artifact_trigger/temperature/heat/on_explosion(severity)


### PR DESCRIPTION
Replaces the existing monolith flame source and is hot procs with atom-level procs that are overridden as needed by subtypes.

## Changelog
:cl: SierraKomodo
bugfix: Energy weapons no longer function as heat sources when turned off.
/:cl:

## Other Changes
- Replaces `/proc/isflamesource()` with `/atom/proc/IsFlameSource()` and `#define isFlameSource()`.
- Replaces `/proc/is_hot()` with `/atom/proc/IsHeatSource()` and `#define isHeatSource()`.
- Adds `#define isFlameOrHeatSource()` for checking both flame and heat source during interactions.

## Todo
- [X] Replace `isflamesource()`.
- [X] Replace `is_hot()`.
- [X] Add check for both flame or heat sources.
- [X] Fix energy weapons being a heat source even when off.

## Todo (Separate PR)
These are items for a separate PR, as the scope of this PR is solely refactoring/bug fixing and not adding additional features or functionality.

- Add examine information for flame and heat sources.
- Add default heat source value based on flame source.