### PR TITLE
Heat/Flame Additional Features/Functions

### DIFF
--- a/code/_helpers/tools.dm
+++ b/code/_helpers/tools.dm
@@ -102,9 +102,13 @@
 #define isFlameSource(A) (A?.IsFlameSource())
 
 
-/// Returns an integer value of temperature when this atom can be used as a heat source. This is for hot objects.
+/**
+ * Returns an integer value of temperature when this atom can be used as a heat source. This is for hot objects.
+ *
+ * Defaults to `1000` if `IsFlameSource()` returns `TRUE`, otherwise `0`.
+ */
 /atom/proc/IsHeatSource()
-	return 0
+	return IsFlameSource() ? 1000 : 0
 
 /// 0 if A does not exist, or the heat value of A
 #define isHeatSource(A) (A ? A.IsHeatSource() : 0)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -379,6 +379,12 @@
 	to_chat(user, desc)
 	if (get_max_health())
 		examine_damage_state(user)
+
+	if (IsFlameSource())
+		to_chat(user, SPAN_DANGER("It has an open flame."))
+	else if (distance <= 1 && IsHeatSource())
+		to_chat(user, SPAN_WARNING("It's hot to the touch."))
+
 	return TRUE
 
 /**

--- a/code/game/objects/items/weapons/flame.dm
+++ b/code/game/objects/items/weapons/flame.dm
@@ -73,7 +73,3 @@
 	if(burnt)
 		icon_state = "match_burnt"
 		item_state = "cigoff"
-
-
-/obj/item/flame/match/IsHeatSource()
-	return lit ? 1000 : 0


### PR DESCRIPTION
Some additional features and functionality for heat and flame checks not included in #33089.

## Changelog
:cl: SierraKomodo
rscadd: Atoms that serve as flame or heat sources for interaction checks now display "It has an open flame" or "It feels hot to the touch" messages when examined. (NOTE: The heat examine message only appears if you can physically touch the atom).
rscadd: Atoms that serve as a flame source (Has an open flame - Lit candles, matches, welding tools, etc) now also serve as a heat source for interaction checks.
/:cl:

## Dependencies
- #33089

## Other Changes
None

## Todo
- [X] Add examine information for flame and heat sources.
- [X] Add default heat source value based on flame source.