### PR TITLE
Allows O4 officers to use senior officer trim.

### DIFF
--- a/maps/torch/datums/uniforms_fleet.dm
+++ b/maps/torch/datums/uniforms_fleet.dm
@@ -24,7 +24,7 @@
 
 /singleton/hierarchy/mil_uniform/fleet/com/seniorofficer
 	name = "Fleet senior command"
-	min_rank = 15
+	min_rank = 14
 
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/command
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/command
@@ -103,7 +103,7 @@
 
 /singleton/hierarchy/mil_uniform/fleet/eng/officer/com/seniorofficer
 	name = "Fleet engineering senior command"
-	min_rank = 15
+	min_rank = 14
 
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/command
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/command
@@ -184,7 +184,7 @@
 
 /singleton/hierarchy/mil_uniform/fleet/sec/officer/com/seniorofficer
 	name = "Fleet security senior command"
-	min_rank = 15
+	min_rank = 14
 
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/command
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/command
@@ -258,7 +258,7 @@
 
 /singleton/hierarchy/mil_uniform/fleet/med/officer/com/seniorofficer
 	name = "Fleet medical senior command"
-	min_rank = 15
+	min_rank = 14
 
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/command
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/command
@@ -328,7 +328,7 @@
 
 /singleton/hierarchy/mil_uniform/fleet/sup/seniorofficer
 	name = "Fleet supply senior command"
-	min_rank = 15
+	min_rank = 14
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/command
@@ -521,7 +521,7 @@
 
 /singleton/hierarchy/mil_uniform/fleet/spt/seniorofficer
 	name = "Fleet senior command support"
-	min_rank = 15
+	min_rank = 14
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/command


### PR DESCRIPTION
:cl: Sbotkin
tweak: LCDR now has access to senior officer uniforms.
/:cl:

O-4 XOs and CMOs, rejoice!
Changed other departmental uniforms too, however they aren't used. It's weird that we have departmental uniforms for flag officers at all.

(also the corporate pilot helmet should probably be resprited since the EXO's colour is green, not red for a while now)