### PR TITLE
Fixes sprites & lighting for arc welders

### DIFF
--- a/code/game/objects/items/weapons/electric_welder.dm
+++ b/code/game/objects/items/weapons/electric_welder.dm
@@ -78,9 +78,19 @@
 
 /obj/item/weldingtool/electric/on_update_icon()
 	underlays.Cut()
-	item_state = welding ? "welder1" : "welder"
+	if(welding)
+		icon_state = "welder_arc1"
+		set_light(0.6, 0.5, 2.5, l_color = COLOR_LIGHT_CYAN)
+	else
+		icon_state = "welder_arc"
+		set_light(0)
 	if(cell)
 		underlays += image(icon = icon, icon_state = "[initial(icon_state)]_cell")
+	item_state = welding ? "welder1" : "welder"
+	var/mob/M = loc
+	if(istype(M))
+		M.update_inv_l_hand()
+		M.update_inv_r_hand()
 
 /obj/item/weldingtool/electric/proc/spend_charge(amount)
 	var/obj/item/cell/cell = get_cell()

--- a/code/game/objects/items/weapons/tools_crystal.dm
+++ b/code/game/objects/items/weapons/tools_crystal.dm
@@ -12,8 +12,14 @@
 	return
 
 /obj/item/weldingtool/electric/crystal/on_update_icon()
-	icon_state = welding ? "crystal_welder_on" : "crystal_welder"
-	item_state = welding ? "crystal_tool_lit"  : "crystal_tool"
+	if(welding)
+		icon_state = "crystal_welder_on"
+		item_state = "crystal_tool_lit"
+		set_light(0.6, 0.5, 2.5, l_color = COLOR_LIGHT_CYAN)
+	else
+		icon_state = "crystal_welder"
+		item_state = "crystal_tool"
+		set_light(0)
 	var/mob/M = loc
 	if(istype(M))
 		M.update_inv_l_hand()


### PR DESCRIPTION
Arc welders always emitted light even when off, and their sprite did not change when toggled.
Also applies to adherent welders.
Fixes #30449.

:cl: EvenInDeathIStillServe
bugfix: Fixed sprites and improper lighting for arc welders.
/:cl: