### PR TITLE
Use resolution tweaks

### DIFF
--- a/code/__defines/feedback.dm
+++ b/code/__defines/feedback.dm
@@ -1,2 +1,11 @@
 #define FEEDBACK_YOU_LACK_DEXTERITY SPAN_WARNING("You don't have the dexterity to do this!")
 #define FEEDBACK_ACCESS_DENIED SPAN_WARNING("Access Denied!")
+
+/// Generic feedback failure message handler.
+#define FEEDBACK_FAILURE(USER, MSG) to_chat(USER, SPAN_WARNING(MSG))
+
+/// Feedback messages intended for use in `use_*` overrides. These assume the presence of the `user` variable.
+#define USE_FEEDBACK_FAILURE(MSG) FEEDBACK_FAILURE(user, MSG)
+
+/// Feedback messages intended for use in `use_grab()` overrides. These assume the presence of the `grab` variable.
+#define USE_FEEDBACK_GRAB_FAILURE(MSG) FEEDBACK_FAILURE(grab.assailant, MSG)

--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -20,6 +20,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define ATOM_FLAG_NO_TEMP_CHANGE         FLAG(6)  // Reagents do not cool or heat to ambient temperature in this container.
 #define ATOM_FLAG_CAN_BE_PAINTED         FLAG(7)  // Can be painted using a paint sprayer or similar.
 #define ATOM_FLAG_ADJACENT_EXCEPTION     FLAG(8)  // Skips adjacent checks for atoms that should always be reachable in window tiles
+#define ATOM_FLAG_NO_TOOLS               FLAG(9)  // Blocks tool interactions.
 
 #define MOVABLE_FLAG_PROXMOVE       FLAG(0)  // Does this object require proximity checking in Enter()?
 #define MOVABLE_FLAG_Z_INTERACT     FLAG(1)  // Should attackby and attack_hand be relayed through ladders and open spaces?

--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -319,3 +319,12 @@
 
 // Helper macro for generating stringified name text for IDs located inside objects, i.e. PDAs or wallets. Used for feedback and interaction messages.
 #define GET_ID_NAME(ID, HOLDER) (ID == HOLDER ? "\the [ID]" : "\the [ID] in \the [HOLDER]")
+
+
+// Flags for `use_sanity_check()`
+/// Do not display user feedback messages.
+#define SANITY_CHECK_SILENT FLAG(0)
+/// Verify the tool can be unequipped from user.
+#define SANITY_CHECK_TOOL_UNEQUIP FLAG(1)
+/// Verify the target can be unequipped from user. Includes `target.loc == src` check to allow items the user isn't holding.
+#define SANITY_CHECK_TARGET_UNEQUIP FLAG(2)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -61,6 +61,43 @@ avoid code duplication. This includes items that may sometimes act as a standard
 
 
 /**
+ * Validates the mob can perform general interactions. Primarily intended for use after inputs, sleeps, timers, etc to ensure the action can still be completed.
+ *
+ * **Parameters**:
+ * - `target` - The atom being interacted with.
+ * - `tool` - The item being used to interact. Optional. Defaults to `FALSE` to differentiate between a nulled reference and an empty parameter.
+ * - `flags` - Bitflags of additional settings. See `code\__defines\misc.dm`.
+ *
+ * Returns boolean.
+ */
+/mob/proc/use_sanity_check(atom/target, obj/item/tool = FALSE, flags = EMPTY_BITFIELD)
+	if (QDELETED(src))
+		return FALSE
+	var/silent = HAS_FLAGS(flags, SANITY_CHECK_SILENT)
+	if (QDELETED(target))
+		if (!silent)
+			to_chat(src, SPAN_WARNING("[target ? "\The [target]" : "The object you were interacting with"] no longer exists."))
+		return FALSE
+	if (tool != FALSE && QDELETED(tool))
+		if (!silent)
+			to_chat(src, SPAN_WARNING("[tool ? "\The [tool]" : "The item you were using"] no longer exists."))
+		return FALSE
+	if (!Adjacent(target))
+		if (!silent)
+			to_chat(src, SPAN_WARNING("You must remain next to \the [target]."))
+		return FALSE
+	if (HAS_FLAGS(flags, SANITY_CHECK_TOOL_UNEQUIP) && !canUnEquip(tool))
+		if (!silent)
+			to_chat(src, SPAN_WARNING("You can't drop \the [tool]."))
+		return FALSE
+	if (target.loc == src && HAS_FLAGS(flags, SANITY_CHECK_TARGET_UNEQUIP) && !canUnEquip(target))
+		if (!silent)
+			to_chat(src, SPAN_WARNING("You can't drop \the [target]."))
+		return FALSE
+	return TRUE
+
+
+/**
  * Interaction handler for using an item on yourself. This is called and the result checked before the other `use_*`
  * interaction procs are called, regardless of user intent.
  *

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -48,6 +48,8 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /obj/item/proc/resolve_attackby(atom/A, mob/user, click_params)
 	if(!(item_flags & ITEM_FLAG_NO_PRINT))
 		add_fingerprint(user)
+	if (A.atom_flags & ATOM_FLAG_NO_TOOLS)
+		return FALSE
 	if ((item_flags & ITEM_FLAG_TRY_ATTACK) && attack(A, user))
 		return TRUE
 	if (A == user)


### PR DESCRIPTION
# Use Resolution Tweaks
Some backend stuff for use/attack resolution calls. Some of it not currently used but intended to be used by the big refactors of existing attack calls.

Does not update any existing logic with the exception of `resolve_attackby()`. Changes will be applied to subtypes in a separate PR.

## Changelog
:cl: SierraKomodo
tweak: Fingerprints are now always added to held items and clicked objects if there was a valid interaction, except when the tool is flagged to not leave fingerprints.
/:cl:

## Other Changes
- Adds `/mob/proc/use_sanity_check()` - Intended for calling after input or do_after to ensure the interaction is still valid. Includes some flags for certain additional checks, such as not sending feedback messages, or checking if the tool or target can be unequipped.
- Adds `ATOM_FLAG_NO_TOOLS` flag for `/atom/var/atom_flags`, which if set, blocks all calls to the use procs if clicked on.
- Adds `/atom/proc/can_use_item()` - Intended for checking if a use interaction can be performed. Currently, checks for the `ATOM_FLAG_NO_TOOLS` flag and for objects that are hidden under plating but visible due to i.e., t-ray scanners.
- Adds `/atom/proc/pre_use_item()` and `/atom/proc/post_use_item()` - Intended for additional logic to be occured both before and after handling interactions. Currently only used for adding fingerprints after interactions.
- Addes `FEEDBACK_FAILURE()`, `USE_FEEDBACK_FAILURE()`, and `USE_FEEDBACK_GRAB_FAILURE()` defines to help standardize some feedback messages. Intended to make propagating changes to standard feedback messages easier in the future by just updating the defines. Also intended to have more added with pre-determined messages that are based off these three.