### PR TITLE
Use fixes

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -122,13 +122,13 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		user.do_attack_animation(src)
 		var/damage_flags = weapon.damage_flags()
 		if (!can_damage_health(weapon.force, weapon.damtype, damage_flags))
-			playsound(src, damage_hitsound, 50)
+			playsound(src, damage_hitsound, 50, TRUE)
 			user.visible_message(
 				SPAN_WARNING("\The [user] hits \the [src] with \a [weapon], but it bounces off!"),
 				SPAN_WARNING("You hit \the [src] with \the [weapon], but it bounces off!")
 			)
 			return TRUE
-		playsound(src, damage_hitsound, 75)
+		playsound(src, damage_hitsound, 75, TRUE)
 		user.visible_message(
 			SPAN_DANGER("\The [user] hits \the [src] with \a [weapon]!"),
 			SPAN_DANGER("You hit \the [src] with \the [weapon]!")

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -83,8 +83,8 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		if (blocked)
 			to_chat(src, SPAN_WARNING("\The [blocked] is in the way!"))
 			return TRUE
-		if (devour(tool))
-			return TRUE
+		devour(tool)
+		return TRUE
 
 	return ..()
 

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -118,7 +118,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	SHOULD_CALL_PARENT(TRUE)
 	// Standardized damage
 	if (weapon.force > 0 && get_max_health() && !HAS_FLAGS(weapon.item_flags, ITEM_FLAG_NO_BLUDGEON))
-		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.setClickCooldown(user.get_attack_speed(weapon))
 		user.do_attack_animation(src)
 		var/damage_flags = weapon.damage_flags()
 		if (!can_damage_health(weapon.force, weapon.damtype, damage_flags))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -449,6 +449,7 @@
 			grab.affecting.Weaken(5)
 			grab.affecting.apply_damage(20, DAMAGE_BRUTE, def_zone, used_weapon = src)
 			hit(50, grab.assailant, grab.affecting)
+		return TRUE
 
 	return ..()
 


### PR DESCRIPTION
Applies some tweaks and fixes to the use proc chain that were found while working on other PRs.

## Changelog
:cl: SierraKomodo
bugfix: Attack click cooldown when hitting things with standardized health now applies the mob's and weapon's intended cooldown timers, instead of the generic default time.
bugfix: Using grabs to slam someone into a window no longer slams them twice per click.
/:cl:

## Other Changes
- Adds the `vary` flag to the playsound when hitting things with standardized health.