### PR TITLE
Adds the CHOICE of revolver or smartgun to the CoS locker

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -932,6 +932,7 @@
 #include "code\game\objects\items\documents.dm"
 #include "code\game\objects\items\flora.dm"
 #include "code\game\objects\items\glassjar.dm"
+#include "code\game\objects\items\gunboxes.dm"
 #include "code\game\objects\items\holosign_creator.dm"
 #include "code\game\objects\items\instruments.dm"
 #include "code\game\objects\items\latexballoon.dm"

--- a/code/game/objects/items/gunboxes.dm
+++ b/code/game/objects/items/gunboxes.dm
@@ -1,0 +1,16 @@
+/obj/item/gunbox
+	name = "sidearm kit"
+	desc = "A secure box containing a sidearm."
+	icon = 'icons/obj/storage.dmi'
+	icon_state = "excavation"
+
+/obj/item/gunbox/attack_self(mob/user)
+	var/list/options = list()
+	options["Classic - Secure Smartgun"] = list(/obj/item/gun/energy/gun/secure/preauthorized)
+	options["Stylish - Secure Smart Revolver"] = list(/obj/item/gun/energy/revolver/secure/preauthorized)
+	var/choice = input(user, "What is your choice?") as null|anything in options
+	if (choice)
+		var/list/chosen_weapons = options[choice]
+		for (var/new_weapon in chosen_weapons)
+			user.put_in_any_hand_if_possible(new new_weapon(user))
+	qdel(src)

--- a/code/modules/projectiles/guns/energy/secure.dm
+++ b/code/modules/projectiles/guns/energy/secure.dm
@@ -56,6 +56,9 @@
 	req_access = list(list(access_brig, access_heads))
 	authorized_modes = list(ALWAYS_AUTHORIZED, AUTHORIZED)
 
+/obj/item/gun/energy/revolver/secure/preauthorized
+	authorized_modes = list(ALWAYS_AUTHORIZED, AUTHORIZED, AUTHORIZED)
+
 /obj/item/gun/energy/gun/secure/mounted
 	name = "robot energy gun"
 	desc = "A robot-mounted equivalent of the LAEP90-S, which is always registered to its owner."

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -73,7 +73,7 @@
 		/obj/item/storage/belt/holster/security/full,
 		/obj/item/storage/belt/security,
 		/obj/item/device/megaphone,
-		/obj/item/gun/energy/gun/secure/preauthorized,
+		/obj/item/gunbox,
 		/obj/item/melee/telebaton,
 		/obj/item/clothing/accessory/storage/black_vest,
 		/obj/item/device/hailer,


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: SealCure
rscadd: Replaces the pistol in the CoS's locker with an item allowing them to choose between the classic smartgun and the cool stylish smart revolver. Only cool kids will pick the revolver.
/:cl:
I remembered seeing this thing on other servers. You heathens WILL get a CoS revolver and you WILL like it.