### PR TITLE
Add `use_*` to `/atom/movable`

### DIFF
--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -164,8 +164,9 @@
 
 	return ..()
 
-/atom/movable/openspace/mimic/attackby(obj/item/W, mob/user)
-	to_chat(user, SPAN_NOTICE("\The [src] is too far away."))
+/atom/movable/openspace/mimic/can_use_item(obj/item/tool, mob/user, click_params)
+	USE_FEEDBACK_FAILURE("\The [src] is too far away.")
+	return FALSE
 
 /atom/movable/openspace/mimic/attack_hand(mob/user)
 	to_chat(user, SPAN_NOTICE("You cannot reach \the [src] from here."))
@@ -196,8 +197,9 @@
 	mouse_opacity = 0
 	z_flags = ZMM_IGNORE // Only one of these should ever be visible at a time, the mimic logic will handle that.
 
-/atom/movable/openspace/turf_proxy/attackby(obj/item/W, mob/user)
-	loc.attackby(W, user)
+/atom/movable/openspace/turf_proxy/use_tool(obj/item/tool, mob/user, list/click_params)
+	SHOULD_CALL_PARENT(FALSE)
+	return tool.resolve_attackby(loc, user, click_params)
 
 /atom/movable/openspace/turf_proxy/attack_hand(mob/user as mob)
 	loc.attack_hand(user)
@@ -223,8 +225,9 @@
 	ASSERT(isturf(loc))
 	delegate = loc:below
 
-/atom/movable/openspace/turf_mimic/attackby(obj/item/W, mob/user)
-	loc.attackby(W, user)
+/atom/movable/openspace/turf_mimic/use_tool(obj/item/tool, mob/user, list/click_params)
+	SHOULD_CALL_PARENT(FALSE)
+	return tool.resolve_attackby(loc, user, click_params)
 
 /atom/movable/openspace/turf_mimic/attack_hand(mob/user as mob)
 	to_chat(user, SPAN_NOTICE("You cannot reach \the [src] from here."))

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -53,7 +53,7 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 5 "uses of .len" '\.len\b' -P
-exactly 577 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 574 "attackby() override" '\/attackby\((.*)\)'  -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 num=`find ./html/changelogs -not -name "*.yml" | wc -l`


### PR DESCRIPTION
Fairly straightforward, only needed small changes here.

## Changelog
NUFC

## Dependences
- #33101

## Other Changes
- Forwarded all use calls for `/turf_proxy` and `/turf_mimic` open space subtypes to `loc` - Matches prior `attackby()` overrides.
- Overrode `/mimic/can_use_item()` open space subtype to always return `FALSE` - Matches prior `attackby()` override.