### PR TITLE
Add `use_*` to `/mob`

### DIFF
--- a/code/__defines/feedback.dm
+++ b/code/__defines/feedback.dm
@@ -10,6 +10,8 @@
 #define USE_FEEDBACK_FAILURE(MSG) FEEDBACK_FAILURE(user, MSG)
 /// ID card lacks access
 #define USE_FEEDBACK_ID_CARD_DENIED(REFUSER, ID_CARD) USE_FEEDBACK_FAILURE("\The [REFUSER] refuses [ID_CARD].")
+/// Item stack did not have enough items. `STACK` is assumed to be of type `/obj/item/stack`.
+#define USE_FEEDBACK_STACK_NOT_ENOUGH(STACK, NEEDED_AMT, ACTION) USE_FEEDBACK_FAILURE("You need at least [NEEDED_AMT] [NEEDED_AMT == 1 ? STACK.singular_name : STACK.plural_name] of \the [STACK] [ACTION]")
 
 /// Feedback messages intended for use in `use_grab()` overrides. These assume the presence of the `grab` variable.
 #define USE_FEEDBACK_GRAB_FAILURE(MSG) FEEDBACK_FAILURE(grab.assailant, MSG)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -248,6 +248,14 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	return FALSE
 
 
+/mob/living/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	// Legacy mob attack code is handled by the weapon
+	if (weapon.attack(src, user, user.zone_sel ? user.zone_sel.selecting : ran_zone()))
+		return TRUE
+
+	return ..()
+
+
 /**
  * Interaction handler for using an item on this atom with a non-harm intent, or if `use_weapon()` did not resolve an
  * action. Generally, this is for any standard interactions with items.
@@ -287,13 +295,6 @@ avoid code duplication. This includes items that may sometimes act as a standard
  */
 /atom/proc/attackby(obj/item/W, mob/user, click_params)
 	return FALSE
-
-
-/mob/living/attackby(obj/item/W, mob/user, click_params)
-	// Legacy mob attack code is handled by the weapon
-	if (W.attack(src, user, user.zone_sel ? user.zone_sel.selecting : ran_zone()))
-		return TRUE
-	return ..()
 
 
 /**

--- a/code/modules/mechs/mech_construction.dm
+++ b/code/modules/mechs/mech_construction.dm
@@ -87,14 +87,17 @@
 				SPAN_NOTICE("\The [user] begins trying to install \the [system] into \the [src]."),
 				SPAN_NOTICE("You begin trying to install \the [system] into \the [src].")
 			)
-			if(!do_after(user, delay, src, DO_PUBLIC_UNIQUE) || user.get_active_hand() != system)
+			if(!do_after(user, delay, src, DO_PUBLIC_UNIQUE) || user.get_active_hand() != system || !user.use_sanity_check(src, system, SANITY_CHECK_TOOL_UNEQUIP))
 				return FALSE
 
 			if(hardpoints_locked || hardpoints[system_hardpoint])
 				return FALSE
 
 			if(user.unEquip(system))
-				to_chat(user, SPAN_NOTICE("You install \the [system] in \the [src]'s [system_hardpoint]."))
+				user.visible_message(
+					SPAN_NOTICE("\The [user] installs \the [system] into \the [src]'s [system_hardpoint]."),
+					SPAN_NOTICE("You install \the [system] in \the [src]'s [system_hardpoint].")
+				)
 				playsound(user.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 			else return FALSE
 

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -316,154 +316,221 @@
 	remove_pilot(user)
 	return 1
 
-/mob/living/exosuit/attackby(obj/item/thing, mob/user)
 
-	if(user.a_intent != I_HURT && istype(thing, /obj/item/mech_equipment))
-		if(hardpoints_locked)
-			to_chat(user, SPAN_WARNING("Hardpoint system access is disabled."))
-			return
+/mob/living/exosuit/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Cable Coil - Repair burn damage
+	if (isCoil(tool))
+		if (!getFireLoss())
+			USE_FEEDBACK_FAILURE("\The [src] has no electrical damage to repair.")
+			return TRUE
+		var/list/damaged_parts = list()
+		for (var/obj/item/mech_component/component in list(arms, legs, body, head))
+			if (component?.burn_damage)
+				damaged_parts += component
+		var/obj/item/mech_component/input_fix = input(user, "Which component would you like to fix?", "\The [src] - Fix Component") as null|anything in damaged_parts
+		if (!input_fix || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (!input_fix.brute_damage)
+			USE_FEEDBACK_FAILURE("\The [src]'s [input_fix.name] no longer needs repair.")
+			return TRUE
+		input_fix.repair_burn_generic(tool, user)
+		return TRUE
 
-		var/obj/item/mech_equipment/realThing = thing
-		if(realThing.owner)
-			return
+	// Crowbar - Force open locked cockpit
+	if (isCrowbar(tool))
+		if (!body)
+			USE_FEEDBACK_FAILURE("\The [src] has no cockpit to force.")
+			return TRUE
+		if (!hatch_locked)
+			USE_FEEDBACK_FAILURE("\The [src]'s cockpit isn't locked. You don't need to force it.")
+			return TRUE
+		user.visible_message(
+			SPAN_WARNING("\The [user] starts forcing \the [src]'s emergency [body.hatch_descriptor] release using \a [tool]."),
+			SPAN_WARNING("You start forcing \the [src]'s emergency [body.hatch_descriptor] release using \the [tool].")
+		)
+		var/delay = min(50 * user.skill_delay_mult(SKILL_DEVICES), 50 * user.skill_delay_mult(SKILL_EVA))
+		if (!do_after(user, delay, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (!body)
+			USE_FEEDBACK_FAILURE("\The [src] has no cockpit to force.")
+			return TRUE
+		playsound(src, 'sound/machines/bolts_up.ogg', 25, TRUE)
+		hatch_locked = FALSE
+		hatch_closed = FALSE
+		for (var/mob/pilot in pilots)
+			eject(pilot, TRUE)
+		hud_open.update_icon()
+		update_icon()
+		user.visible_message(
+			SPAN_WARNING("\The [user] forces \the [src]'s emergency [body.hatch_descriptor] release using \a [tool]."),
+			SPAN_WARNING("You force \the [src]'s emergency [body.hatch_descriptor] release using \the [tool].")
+		)
+		return TRUE
 
+	// Exosuit Customization Kit - Customize the exosuit
+	if (istype(tool, /obj/item/device/kit/paint))
+		var/obj/item/device/kit/paint/paint = tool
+		SetName(paint.new_name)
+		desc = paint.new_desc
+		for (var/obj/item/mech_component/component in list(arms, legs, head, body))
+			component.decal = paint.new_icon
+		if (paint.new_icon_file)
+			icon = paint.new_icon_file
+		update_icon()
+		paint.use(1, user)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] opens \the [tool] and spends some quality time customising \the [src]."),
+			SPAN_NOTICE("You open \the [tool] and spend some quality time customising \the [src].")
+		)
+		return TRUE
+
+	// Mech Equipment - Install equipment
+	if (istype(tool, /obj/item/mech_equipment))
+		if (hardpoints_locked)
+			USE_FEEDBACK_FAILURE("\The [src]'s hardpoint system is locked.")
+			return TRUE
+		var/obj/item/mech_equipment/mech_equipment = tool
+		if (mech_equipment.owner)
+			USE_FEEDBACK_FAILURE("\The [tool] is already owned by \the [mech_equipment.owner]. This might be a bug.")
+			return TRUE
 		var/free_hardpoints = list()
-		for(var/hardpoint in hardpoints)
-			if(hardpoints[hardpoint] == null)
+		for (var/hardpoint in hardpoints)
+			if (hardpoints[hardpoint] == null && (!length(mech_equipment.restricted_hardpoints) || (hardpoint in mech_equipment.restricted_hardpoints)))
 				free_hardpoints += hardpoint
-		var/to_place = input("Where would you like to install it?") as null|anything in (realThing.restricted_hardpoints & free_hardpoints)
-		if(!to_place)
-			to_chat(user, SPAN_WARNING("There is no room to install \the [thing]."))
-		if(install_system(thing, to_place, user))
+		if (!length(free_hardpoints))
+			USE_FEEDBACK_FAILURE("\The [src] has no free hardpoints for \the [tool].")
+			return TRUE
+		var/input = input(user, "Where would you like to install \the [tool]?", "\The [src] - Hardpoint Installation") as null|anything in free_hardpoints
+		if (!input || !user.use_sanity_check(src, tool, SANITY_CHECK_TOOL_UNEQUIP))
+			return TRUE
+		if (hardpoints[input] != null)
+			USE_FEEDBACK_FAILURE("\The [input] slot on \the [src] is no longer free. It has \a [hardpoints[input]] attached.")
+			return TRUE
+		install_system(tool, input, user)
+		return TRUE
+
+	// Multitool - Remove component
+	if (isMultitool(tool))
+		if (hardpoints_locked)
+			USE_FEEDBACK_FAILURE("\The [src]'s hardpoint system is locked.")
+			return TRUE
+		var/list/parts = list()
+		for (var/hardpoint in hardpoints)
+			if (hardpoints[hardpoint])
+				parts += hardpoint
+		var/input = input(user, "Which component would you like to remove?", "\The [src] - Remove Hardpoint") as null|anything in parts
+		if (!input || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (hardpoints[input] == null)
+			USE_FEEDBACK_FAILURE("\The [src] not longer has a component in the [input] slot.")
+			return TRUE
+		remove_system(input, user)
+		return TRUE
+
+	// Power Cell - Install cell
+	if (istype(tool, /obj/item/cell))
+		if (!maintenance_protocols)
+			USE_FEEDBACK_FAILURE("\The [src]'s maintenance protocols must be enabled to install \the [tool].")
+			return TRUE
+		if (!body?.cell)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [body.cell] installed.")
+			return TRUE
+		if (!user.unEquip(tool, body))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		body.cell = tool
+		playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs \a [tool] into \the [src]."),
+			SPAN_NOTICE("You install \the [tool] into \the [src].")
+		)
+		return TRUE
+
+	// Robot Analyzer - Scan mech
+	if (istype(tool, /obj/item/device/robotanalyzer))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] scans \the [src] with \a [tool]."),
+			SPAN_NOTICE("You scan \the [src] with \the [tool].")
+		)
+		to_chat(user, SPAN_INFO("Diagnostic Report for \the [src]:"))
+		for (var/obj/item/mech_component/component in list(arms, legs, body, head))
+			if (component)
+				component.return_diagnostics(user)
+		return TRUE
+
+	// Screwdriver - Remove cell
+	if (isScrewdriver(tool))
+		if (!maintenance_protocols)
+			USE_FEEDBACK_FAILURE("\The [src]'s maintenance protocols must be enabled to access the power cell.")
+			return TRUE
+		if (!body?.cell)
+			USE_FEEDBACK_FAILURE("\The [src] has no power cell to remove.")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts removing \the [src]'s power cell with \a [tool]."),
+			SPAN_NOTICE("You start removing \the [src]'s power cell with \the [tool].")
+		)
+		var/delay = 2 SECONDS * user.skill_delay_mult(SKILL_DEVICES)
+		if (!do_after(user, delay, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
 			return
-		to_chat(user, SPAN_WARNING("\The [thing] could not be installed in that hardpoint."))
-		return
+		if (!maintenance_protocols)
+			USE_FEEDBACK_FAILURE("\The [src]'s maintenance protocols must be enabled to access the power cell.")
+			return TRUE
+		if (!body?.cell)
+			USE_FEEDBACK_FAILURE("\The [src] has no power cell to remove.")
+			return TRUE
+		user.put_in_hands(body.cell)
+		power = MECH_POWER_OFF
+		hud_power_control.update_icon()
+		body.cell = null
+		user.visible_message(
+			SPAN_NOTICE("\The [user] removes \the [src]'s power cell with \a [tool]."),
+			SPAN_NOTICE("You remove \the [src]'s power cell with \the [tool].")
+		)
+		return TRUE
 
-	else if(istype(thing, /obj/item/device/kit/paint))
-		user.visible_message(SPAN_NOTICE("\The [user] opens \the [thing] and spends some quality time customising \the [src]."))
-		var/obj/item/device/kit/paint/P = thing
-		SetName(P.new_name)
-		desc = P.new_desc
-		for(var/obj/item/mech_component/comp in list(arms, legs, head, body))
-			comp.decal = P.new_icon
-		if(P.new_icon_file)
-			icon = P.new_icon_file
-		queue_icon_update()
-		P.use(1, user)
-		return 1
+	// Welding Tool - Repair physical damage
+	if (isWelder(tool))
+		if (!getBruteLoss())
+			USE_FEEDBACK_FAILURE("\The [src] has no physical damage to repair.")
+			return TRUE
+		var/list/damaged_parts = list()
+		for (var/obj/item/mech_component/component in list(arms, legs, body, head))
+			if (component?.brute_damage)
+				damaged_parts += component
+		var/obj/item/mech_component/input_fix = input(user, "Which component would you like to fix?", "\The [src] - Fix Component") as null|anything in damaged_parts
+		if (!input_fix || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (!input_fix.brute_damage)
+			USE_FEEDBACK_FAILURE("\The [src]'s [input_fix.name] no longer needs repair.")
+			return TRUE
+		input_fix.repair_brute_generic(tool, user)
+		return TRUE
 
-	else
-		if(user.a_intent != I_HURT)
-			if(isMultitool(thing))
-				if(hardpoints_locked)
-					to_chat(user, SPAN_WARNING("Hardpoint system access is disabled."))
-					return
+	// Wrench - Toggle securing bolts
+	if (isWrench(tool))
+		if (!maintenance_protocols)
+			USE_FEEDBACK_FAILURE("\The [src]'s maintenance protocols must be enabled to access the securing bolts.")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts removing \the [src]'s securing bolts with \a [tool]."),
+			SPAN_NOTICE("You start removing \the [src]'s securing bolts with \the [tool].")
+		)
+		var/delay = 6 SECONDS * user.skill_delay_mult(SKILL_DEVICES)
+		if (!do_after(user, delay, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (!maintenance_protocols)
+			USE_FEEDBACK_FAILURE("\The [src]'s maintenance protocols must be enabled to access the securing bolts.")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] removes \the [src]'s securing bolts with \a [tool], dismantling it."),
+			SPAN_NOTICE("You remove \the [src]'s securing bolts with \the [tool], dismantling it.")
+		)
+		dismantle()
+		return TRUE
 
-				var/list/parts = list()
-				for(var/hardpoint in hardpoints)
-					if(hardpoints[hardpoint])
-						parts += hardpoint
-
-				var/to_remove = input("Which component would you like to remove") as null|anything in parts
-
-				if(remove_system(to_remove, user))
-					return
-				to_chat(user, SPAN_WARNING("\The [src] has no hardpoint systems to remove."))
-				return
-			else if(isWrench(thing))
-				if(!maintenance_protocols)
-					to_chat(user, SPAN_WARNING("The securing bolts are not visible while maintenance protocols are disabled."))
-					return
-
-				visible_message(SPAN_WARNING("\The [user] begins unwrenching the securing bolts holding \the [src] together."))
-				var/delay = 6 SECONDS * user.skill_delay_mult(SKILL_DEVICES)
-				if(!do_after(user, delay, src, DO_PUBLIC_UNIQUE) || !maintenance_protocols)
-					return
-				visible_message(SPAN_NOTICE("\The [user] loosens and removes the securing bolts, dismantling \the [src]."))
-				dismantle()
-				return
-			else if(isWelder(thing))
-				if(!getBruteLoss())
-					return
-				var/list/damaged_parts = list()
-				for(var/obj/item/mech_component/MC in list(arms, legs, body, head))
-					if(MC && MC.brute_damage)
-						damaged_parts += MC
-				var/obj/item/mech_component/to_fix = input(user,"Which component would you like to fix") as null|anything in damaged_parts
-				if(CanPhysicallyInteract(user) && !QDELETED(to_fix) && (to_fix in src) && to_fix.brute_damage)
-					to_fix.repair_brute_generic(thing, user)
-				return
-			else if(isCoil(thing))
-				if(!getFireLoss())
-					return
-				var/list/damaged_parts = list()
-				for(var/obj/item/mech_component/MC in list(arms, legs, body, head))
-					if(MC && MC.burn_damage)
-						damaged_parts += MC
-				var/obj/item/mech_component/to_fix = input(user,"Which component would you like to fix") as null|anything in damaged_parts
-				if(CanPhysicallyInteract(user) && !QDELETED(to_fix) && (to_fix in src) && to_fix.burn_damage)
-					to_fix.repair_burn_generic(thing, user)
-				return
-			else if(isScrewdriver(thing))
-				if(!maintenance_protocols)
-					to_chat(user, SPAN_WARNING("The cell compartment remains locked while maintenance protocols are disabled."))
-					return
-				if(!body || !body.cell)
-					to_chat(user, SPAN_WARNING("There is no cell here for you to remove!"))
-					return
-				var/delay = 2 SECONDS * user.skill_delay_mult(SKILL_DEVICES)
-				if(!do_after(user, delay, src, DO_PUBLIC_UNIQUE) || !maintenance_protocols || !body || !body.cell)
-					return
-
-				user.put_in_hands(body.cell)
-				to_chat(user, SPAN_NOTICE("You remove \the [body.cell] from \the [src]."))
-				playsound(user.loc, 'sound/items/Crowbar.ogg', 50, 1)
-				visible_message(SPAN_NOTICE("\The [user] pries out \the [body.cell] using \the [thing]."))
-				power = MECH_POWER_OFF
-				hud_power_control.queue_icon_update()
-				body.cell = null
-				return
-			else if(isCrowbar(thing))
-				if(!hatch_locked)
-					to_chat(user, SPAN_NOTICE("The cockpit isn't locked. There is no need for this."))
-					return
-				if(!body) //Error
-					return
-				var/delay = min(50 * user.skill_delay_mult(SKILL_DEVICES), 50 * user.skill_delay_mult(SKILL_EVA))
-				visible_message(SPAN_NOTICE("\The [user] starts forcing the \the [src]'s emergency [body.hatch_descriptor] release using \the [thing]."))
-				if(!do_after(user, delay, src, DO_PUBLIC_UNIQUE))
-					return
-				visible_message(SPAN_NOTICE("\The [user] forces \the [src]'s [body.hatch_descriptor] open using the \the [thing]."))
-				playsound(user.loc, 'sound/machines/bolts_up.ogg', 25, 1)
-				hatch_locked = FALSE
-				hatch_closed = FALSE
-				for(var/mob/pilot in pilots)
-					eject(pilot, silent = 1)
-				hud_open.queue_icon_update()
-				queue_icon_update()
-				return
-			else if(istype(thing, /obj/item/cell))
-				if(!maintenance_protocols)
-					to_chat(user, SPAN_WARNING("The cell compartment remains locked while maintenance protocols are disabled."))
-					return
-				if(!body || body.cell)
-					to_chat(user, SPAN_WARNING("There is already a cell in there!"))
-					return
-
-				if(user.unEquip(thing))
-					thing.forceMove(body)
-					body.cell = thing
-					to_chat(user, SPAN_NOTICE("You install \the [body.cell] into \the [src]."))
-					playsound(user.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-					visible_message(SPAN_NOTICE("\The [user] installs \the [body.cell] into \the [src]."))
-				return
-			else if(istype(thing, /obj/item/device/robotanalyzer))
-				to_chat(user, SPAN_NOTICE("Diagnostic Report for \the [src]:"))
-				for(var/obj/item/mech_component/MC in list(arms, legs, body, head))
-					if(MC)
-						MC.return_diagnostics(user)
-				return
 	return ..()
+
 
 /mob/living/exosuit/attack_hand(mob/user)
 	// Drag the pilot out if possible.

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -130,10 +130,11 @@
 	.[CODEX_INTERACTION_EMAG] += "<p>Causes \the [initial(name)] to attack and arrest anyone around it, except the person who emagged it.</p>"
 
 
-/mob/living/bot/secbot/use_weapon(obj/item/weapon, mob/user, list/click_params)
-	var/previous_health = health
-	. = ..()
-	if (. && health < previous_health)
+/mob/living/bot/secbot/post_use_item(obj/item/tool, mob/user, interaction_handled, use_call, click_params)
+	..()
+
+	// React to attack
+	if (use_call == "weapon")
 		react_to_attack(user)
 
 

--- a/code/modules/mob/living/carbon/alien/diona/nymph_attacks.dm
+++ b/code/modules/mob/living/carbon/alien/diona/nymph_attacks.dm
@@ -15,16 +15,25 @@
 
 	return ..()
 
-/mob/living/carbon/alien/diona/attackby(obj/item/W, mob/user)
-	if(user.a_intent == I_HELP && istype(W, /obj/item/clothing/head))
-		if(hat)
-			to_chat(user, SPAN_WARNING("\The [src] is already wearing \the [hat]."))
-			return
-		user.unEquip(W)
-		wear_hat(W)
-		user.visible_message(SPAN_NOTICE("\The [user] puts \the [W] on \the [src]."))
-		return
+
+/mob/living/carbon/alien/diona/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Hat - Equip hat
+	if (istype(tool, /obj/item/clothing/head))
+		if (hat)
+			USE_FEEDBACK_FAILURE("\The [src] is already wearing \a [hat].")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		wear_hat(tool)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] puts \a [tool] on \the [src]."),
+			SPAN_NOTICE("You put \the [tool] on \the [src].")
+		)
+		return TRUE
+
 	return ..()
+
 
 /mob/living/carbon/alien/diona/UnarmedAttack(atom/A)
 

--- a/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
+++ b/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
@@ -299,18 +299,31 @@
 				visible_message(SPAN_DANGER("[M] has attempted to punch [src]!"))
 	return
 
-/mob/living/carbon/slime/attackby(obj/item/W, mob/user)
-	if(W.force > 0)
+
+/mob/living/carbon/slime/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	// Handle 'damage' (Except you can't hit a slime)
+	if (weapon.force)
+		user.setClickCooldown(user.get_attack_speed(weapon))
+		user.do_attack_animation(src)
+		user.visible_message(
+			SPAN_DANGER("\The [user] swings \a [weapon] at \the [src], but it just passes through!"),
+			SPAN_DANGER("You swing \the [weapon] at \the [src], but it just passes through!")
+		)
+		return TRUE
+
+	return ..()
+
+
+/mob/living/carbon/slime/post_use_item(obj/item/tool, mob/user, interaction_handled, use_call, click_params)
+	..()
+
+	// React to attacks
+	if (use_call == "weapon")
 		attacked += 10
-		if(!(stat) && prob(25)) //Only run this check if we're alive or otherwise motile, otherwise surgery will be agonizing for xenobiologists.
-			to_chat(user, SPAN_DANGER("\The [W] passes right through \the [src]!"))
-			return
+		if (Victim && prob(tool.force * 5))
+			Feedstop()
+			step_away(src, user)
 
-	. = ..()
-
-	if(Victim && prob(W.force * 5))
-		Feedstop()
-		step_away(src, user)
 
 /mob/living/carbon/slime/restrained()
 	return 0

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -612,31 +612,30 @@ var/global/list/ai_verbs_default = list(
 		camera_light_on = world.timeofday + 1 * 20 // Update the light every 2 seconds.
 
 
-/mob/living/silicon/ai/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/aicard))
-
-		var/obj/item/aicard/card = W
+/mob/living/silicon/ai/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Intellicard - Swap AI
+	if (istype(tool, /obj/item/aicard))
+		var/obj/item/aicard/card = tool
 		card.grab_ai(src, user)
+		return TRUE
 
-	else if(isWrench(W))
-		if(anchored)
-			user.visible_message(SPAN_NOTICE("\The [user] starts to unbolt \the [src] from the plating..."))
-			if(!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-				user.visible_message(SPAN_NOTICE("\The [user] decides not to unbolt \the [src]."))
-				return
-			user.visible_message(SPAN_NOTICE("\The [user] finishes unfastening \the [src]!"))
-			anchored = FALSE
-			return
-		else
-			user.visible_message(SPAN_NOTICE("\The [user] starts to bolt \the [src] to the plating..."))
-			if(!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-				user.visible_message(SPAN_NOTICE("\The [user] decides not to bolt \the [src]."))
-				return
-			user.visible_message(SPAN_NOTICE("\The [user] finishes fastening down \the [src]!"))
-			anchored = TRUE
-			return
-	else
-		return ..()
+	// Wrench - Toggle anchored
+	if (isWrench(tool))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts [anchored ? "unbolting" : "bolting"] \the [src] from the floor with \a [tool]."),
+			SPAN_NOTICE("You start [anchored ? "unbolting" : "bolting"] \the [src] from the floor with \the [tool].")
+		)
+		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		anchored = !anchored
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [anchored ? "bolts" : "unbolts"] \the [src] from the floor with \a [tool]."),
+			SPAN_NOTICE("You [anchored ? "bolts" : "unbolts"] \the [src] from the floor with \the [tool].")
+		)
+		return
+
+	return ..()
+
 
 /mob/living/silicon/ai/proc/control_integrated_radio()
 	set name = "Radio Settings"

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -260,25 +260,39 @@ GLOBAL_LIST_INIT(possible_say_verbs, list(
 		icon_state = resting ? "[chassis]_rest" : "[chassis]"
 		to_chat(src, SPAN_NOTICE("You are now [resting ? "resting" : "getting up"]"))
 
-//Overriding this will stop a number of headaches down the track.
-/mob/living/silicon/pai/attackby(obj/item/W, mob/user)
-	var/obj/item/card/id/card = W.GetIdCard()
-	if(card && user.a_intent == I_HELP)
-		var/list/new_access = card.GetAccess()
-		idcard.access = new_access
-		visible_message(SPAN_NOTICE("[user] slides [W] across [src]."))
-		to_chat(src, SPAN_NOTICE("Your access has been updated!"))
-		return FALSE // don't continue processing click callstack.
-	if(W.force)
-		visible_message(SPAN_DANGER("[user] attacks [src] with [W]!"))
-		adjustBruteLoss(W.force)
-		updatehealth()
-	else
-		visible_message(SPAN_WARNING("[user] bonks [src] harmlessly with [W]."))
 
-	spawn(1)
-		if(stat != 2) fold()
-	return
+/mob/living/silicon/pai/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	// Damage handling
+	if (weapon.force)
+		user.setClickCooldown(user.get_attack_speed(weapon))
+		user.do_attack_animation(src)
+		playsound(src, weapon.hitsound, 75, TRUE)
+		user.visible_message(
+			SPAN_DANGER("\The [user] hits \the [src] with \a [weapon]!"),
+			SPAN_DANGER("You hit \the [src] with \the [weapon]!")
+		)
+		adjustBruteLoss(weapon.force)
+		updatehealth()
+		return TRUE
+
+	return ..()
+
+
+/mob/living/silicon/pai/use_tool(obj/item/tool, mob/user, list/click_params)
+	// ID Card - Set pAI access
+	var/obj/item/card/id/id = tool.GetIdCard()
+	if (istype(id))
+		var/id_name = GET_ID_NAME(id, tool)
+		var/list/new_access = id.GetAccess()
+		idcard.access = new_access
+		user.visible_message(
+			SPAN_NOTICE("\The [user] scans \a [tool] over \the [src], updating \his access."),
+			SPAN_NOTICE("You scan [id_name] over \the [src], updating \his access.")
+		)
+		return TRUE
+
+	return ..()
+
 
 /mob/living/silicon/pai/attack_hand(mob/user as mob)
 	visible_message(SPAN_DANGER("[user] boops [src] on the head."))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -461,205 +461,374 @@
 	if(prob(75) && Proj.damage > 0) spark_system.start()
 	return 2
 
-/mob/living/silicon/robot/attackby(obj/item/W as obj, mob/user as mob)
 
-	if(istype(W, /obj/item/inducer)) return // inducer.dm afterattack handles this
-	if (istype(W, /obj/item/handcuffs)) // fuck i don't even know why isrobot() in handcuff code isn't working so this will have to do
-		return
+/mob/living/silicon/robot/use_user(obj/item/tool, list/click_params)
+	// Welding Tool - Block self repair
+	if (isWelder(tool))
+		FEEDBACK_FAILURE(src, "You lack the reach to be able to repair yourself.")
+		return TRUE
 
-	if(opened) // Are they trying to insert something?
-		for(var/V in components)
-			var/datum/robot_component/C = components[V]
-			if(!C.installed && C.accepts_component(W))
-				if(!user.unEquip(W))
-					return
-				C.installed = 1
-				C.wrapped = W
-				C.install()
-				W.forceMove(null)
+	return ..()
 
-				var/obj/item/robot_parts/robot_component/WC = W
-				if(istype(WC))
-					C.brute_damage = WC.brute
-					C.electronics_damage = WC.burn
 
-				to_chat(usr, SPAN_NOTICE("You install the [W.name]."))
-				return
+/mob/living/silicon/robot/post_use_item(obj/item/tool, mob/user, interaction_handled, use_call, click_params)
+	..()
 
-	if(isWelder(W) && user.a_intent != I_HURT)
-		if (src == user)
-			to_chat(user, SPAN_WARNING("You lack the reach to be able to repair yourself."))
-			return
+	// Spark when hit
+	if (use_call == "weapon")
+		spark_system.start()
 
-		if (!getBruteLoss())
-			to_chat(user, "Nothing to fix here!")
-			return
-		var/obj/item/weldingtool/WT = W
-		if (WT.remove_fuel(0))
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-			adjustBruteLoss(-30)
-			updatehealth()
-			add_fingerprint(user)
-			for(var/mob/O in viewers(user, null))
-				O.show_message(text(SPAN_WARNING("[user] has fixed some of the dents on [src]!")), 1)
-		else
-			to_chat(user, "Need more welding fuel!")
-			return
 
-	else if(istype(W, /obj/item/stack/cable_coil) && (wiresexposed || istype(src,/mob/living/silicon/robot/drone)))
+/mob/living/silicon/robot/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Components - Attempt to install
+	for (var/key in components)
+		var/datum/robot_component/component = components[key]
+		if (component.accepts_component(tool))
+			if (!opened)
+				USE_FEEDBACK_FAILURE("\The [src]'s maintenance hatch must be open before you can install \the [tool].")
+				return TRUE
+			if (component.installed)
+				USE_FEEDBACK_FAILURE("\The [src] already has \a [component.wrapped] installed in \the [component] slot.")
+				return TRUE
+			if (!user.unEquip(tool, component))
+				FEEDBACK_UNEQUIP_FAILURE(user, tool)
+				return TRUE
+			component.installed = TRUE
+			component.wrapped = tool
+			component.install()
+			if (istype(tool, /obj/item/robot_parts/robot_component))
+				var/obj/item/robot_parts/robot_component/component_tool = tool
+				component.brute_damage = component_tool.brute
+				component.electronics_damage = component_tool.burn
+			user.visible_message(
+				SPAN_NOTICE("\The [user] installs \a [tool] into \the [src]."),
+				SPAN_NOTICE("You install \the [tool] into \the [src].")
+			)
+			return TRUE
+		// Intentionally allows other interactions here, if there was no valid component
+
+	// Cable Coil - Repair burn damage
+	if (isCoil(tool))
+		if (!wiresexposed)
+			USE_FEEDBACK_FAILURE("\The [src]'s wires must be exposed to repair electronics damage.")
+			return TRUE
 		if (!getFireLoss())
-			to_chat(user, "Nothing to fix here!")
-			return
-		var/obj/item/stack/cable_coil/coil = W
-		if (coil.use(1))
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-			adjustFireLoss(-30)
-			updatehealth()
-			for(var/mob/O in viewers(user, null))
-				O.show_message(text(SPAN_WARNING("[user] has fixed some of the burnt wires on [src]!")), 1)
+			USE_FEEDBACK_FAILURE("\The [src] has no electronics damage to repair.")
+			return TRUE
+		var/obj/item/stack/cable_coil/cable = tool
+		if (!cable.can_use(1))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(cable, 1, "to repair \the [src]'s electronics damage.")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts repairing some of the electronics in \the [src] with some [cable.plural_name] of \a [cable]."),
+			SPAN_NOTICE("You start repairing some of the electronics in \the [src] with some [cable.plural_name] of \the [cable]."),
+		)
+		if (!do_after(user, 1 SECOND, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check())
+			return TRUE
+		if (!wiresexposed)
+			USE_FEEDBACK_FAILURE("\The [src]'s wires must be exposed to repair electronics damage.")
+			return TRUE
+		if (!getFireLoss())
+			USE_FEEDBACK_FAILURE("\The [src] has no electronics damage to repair.")
+			return TRUE
+		if (!cable.can_use(1))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(cable, 1, "to repair \the [src]'s electronics damage.")
+			return TRUE
+		cable.use(1)
+		adjustFireLoss(-30)
+		updatehealth()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] repairs some of the electronics in \the [src] with some [cable.plural_name] of \a [cable]."),
+			SPAN_NOTICE("You repair some of the electronics in \the [src] with some [cable.plural_name] of \the [cable]."),
+		)
+		return TRUE
 
-	else if(isCrowbar(W) && user.a_intent != I_HURT)	// crowbar means open or close the cover - we all know what a crowbar is by now
-		if(opened)
-			if(cell)
-				user.visible_message(SPAN_NOTICE("\The [user] begins clasping shut \the [src]'s maintenance hatch."), SPAN_NOTICE("You begin closing up \the [src]."))
-				if(do_after(user, 5 SECONDS, src, DO_PUBLIC_UNIQUE))
-					to_chat(user, SPAN_NOTICE("You close \the [src]'s maintenance hatch."))
-					opened = FALSE
-					update_icon()
-
-			else if(wiresexposed && wires.IsAllCut())
-				//Cell is out, wires are exposed, remove MMI, produce damaged chassis, baleet original mob.
-				if(!mmi)
-					to_chat(user, "\The [src] has no brain to remove.")
-					return
-
-				user.visible_message(SPAN_NOTICE("\The [user] begins ripping [mmi] from [src]."), SPAN_NOTICE("You jam the crowbar into the robot and begin levering [mmi]."))
-				if(do_after(user, 5 SECONDS, src, DO_PUBLIC_UNIQUE))
-					dismantle(user)
-
-			else
-				// Okay we're not removing the cell or an MMI, but maybe something else?
-				var/list/removable_components = list()
-				for(var/V in components)
-					if(V == "power cell") continue
-					var/datum/robot_component/C = components[V]
-					if(C.installed == 1 || C.installed == -1)
-						removable_components += V
-
-				var/remove = input(user, "Which component do you want to pry out?", "Remove Component") as null|anything in removable_components
-				if(!remove)
-					return
-				var/datum/robot_component/C = components[remove]
-				var/obj/item/robot_parts/robot_component/I = C.wrapped
-				to_chat(user, "You remove \the [I].")
-				if(istype(I))
-					I.brute = C.brute_damage
-					I.burn = C.electronics_damage
-
-				I.forceMove(loc)
-
-				if(C.installed == 1)
-					C.uninstall()
-				C.installed = 0
-
-		else
-			if(locked)
-				to_chat(user, "The cover is locked and cannot be opened.")
-			else
-				user.visible_message(SPAN_NOTICE("\The [user] begins prying open \the [src]'s maintenance hatch."), SPAN_NOTICE("You start opening \the [src]'s maintenance hatch."))
-				if(do_after(user, 5 SECONDS, src, DO_PUBLIC_UNIQUE))
-					to_chat(user, SPAN_NOTICE("You open \the [src]'s maintenance hatch."))
-					opened = TRUE
-					update_icon()
-
-	// If the robot is having something inserted which will remain inside it, self-inserting must be handled before exiting to avoid logic errors. Use the handle_selfinsert proc.
-	else if (istype(W, /obj/item/stock_parts/matter_bin) && opened) // Installing/swapping a matter bin
-		if(!user.unEquip(W, src))
-			return
-		if(storage)
-			to_chat(user, "You replace \the [storage] with \the [W]")
-			storage.dropInto(loc)
-			storage = null
-		else
-			to_chat(user, "You install \the [W]")
-		storage = W
-		handle_selfinsert(W, user)
-		recalculate_synth_capacities()
-
-	else if (istype(W, /obj/item/cell) && opened)	// trying to put a cell inside
-		var/datum/robot_component/C = components["power cell"]
-		if(wiresexposed)
-			to_chat(user, "Close the panel first.")
-		else if(cell)
-			to_chat(user, "There is a power cell already installed.")
-		else if(W.w_class != ITEM_SIZE_NORMAL)
-			to_chat(user, "\The [W] is too [W.w_class < ITEM_SIZE_NORMAL? "small" : "large"] to fit here.")
-		else if(user.unEquip(W, src))
-			cell = W
-			handle_selfinsert(W, user) //Just in case.
-			to_chat(user, "You insert the power cell.")
-			C.installed = 1
-			C.wrapped = W
-			C.install()
-			// This means that removing and replacing a power cell will repair the mount.
-			C.brute_damage = 0
-			C.electronics_damage = 0
-
-	else if(isWirecutter(W) || isMultitool(W))
-		if (wiresexposed)
-			wires.Interact(user)
-		else
-			to_chat(user, "You can't reach the wiring.")
-	else if(isScrewdriver(W) && opened && !cell)	// haxing
-		wiresexposed = !wiresexposed
-		to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"].")
-		update_icon()
-
-	else if(istype(W, /obj/item/screwdriver) && opened && cell)	// radio
-		if(silicon_radio)
-			silicon_radio.attackby(W,user)//Push it to the radio to let it handle everything
-		else
-			to_chat(user, "Unable to locate a radio.")
-		update_icon()
-
-	else if(istype(W, /obj/item/device/encryptionkey) && opened)
-		if(silicon_radio)//sanityyyyyy
-			silicon_radio.attackby(W,user)//GTFO, you have your own procs
-		else
-			to_chat(user, "Unable to locate a radio.")
-	else if (istype(W, /obj/item/card/id)||istype(W, /obj/item/modular_computer)||istype(W, /obj/item/card/robot))			// trying to unlock the interface with an ID card
-		if(emagged)//still allow them to open the cover
-			to_chat(user, "The interface seems slightly damaged")
-		if(opened)
-			to_chat(user, "You must close the cover to swipe an ID card.")
-		else
-			if(allowed(usr))
-				locked = !locked
-				to_chat(user, "You [ locked ? "lock" : "unlock"] [src]'s interface.")
+	// Crowbar
+	// - Toggle cover
+	// - Remove MMI
+	// - Remove components
+	if (isCrowbar(tool))
+		if (opened)
+			// Close cover
+			if (cell)
+				user.visible_message(
+					SPAN_NOTICE("\The [user] starts closing \the [src]'s maintenance hatch with \a [tool]."),
+					SPAN_NOTICE("You start closing \the [src]'s maintenance hatch with \a [tool]."),
+				)
+				if (!do_after(user, 5 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+					return TRUE
+				if (!opened)
+					USE_FEEDBACK_FAILURE("\The [src]'s maintenance hatch is already closed.")
+					return TRUE
+				if (!cell)
+					USE_FEEDBACK_FAILURE("\The [src]'s cell needs to remain in place to close \his maintenance hatch.")
+					return TRUE
+				opened = FALSE
 				update_icon()
-			else
-				to_chat(user, SPAN_WARNING("Access denied."))
-	else if(istype(W, /obj/item/borg/upgrade))
-		var/obj/item/borg/upgrade/U = W
-		if(!opened)
-			to_chat(usr, "You must access the borgs internals!")
-		else if(!src.module && U.require_module)
-			to_chat(usr, "The borg must choose a module before he can be upgraded!")
-		else if(U.locked)
-			to_chat(usr, "The upgrade is locked and cannot be used yet!")
-		else
-			if(U.action(src))
-				if(!user.unEquip(U, src))
-					return
-				to_chat(usr, "You apply the upgrade to [src]!")
-				handle_selfinsert(W, user)
-			else
-				to_chat(usr, "Upgrade error!")
+				user.visible_message(
+					SPAN_NOTICE("\The [user] closes \the [src]'s maintenance hatch with \a [tool]."),
+					SPAN_NOTICE("You close \the [src]'s maintenance hatch with \a [tool]."),
+				)
+				return TRUE
 
-	else
-		if( !(istype(W, /obj/item/device/robotanalyzer) || istype(W, /obj/item/device/scanner/health)) )
-			spark_system.start()
-		return ..()
+			// Remove MMI
+			if (wiresexposed && wires.IsAllCut())
+				if (!mmi)
+					USE_FEEDBACK_FAILURE("\The [src] has no brain to remove.")
+					return TRUE
+				user.visible_message(
+					SPAN_NOTICE("\The [user] starts removing \the [src]'s [mmi.name] with \a [tool]."),
+					SPAN_NOTICE("You start removing \the [src]'s [mmi.name] with \a [tool]."),
+				)
+				if (!do_after(user, 5 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+					return TRUE
+				if (!mmi)
+					USE_FEEDBACK_FAILURE("\The [src] has no longer has a brain to remove.")
+					return TRUE
+				user.visible_message(
+					SPAN_NOTICE("\The [user] removes \the [src]'s [mmi.name] with \a [tool]."),
+					SPAN_NOTICE("You remove \the [src]'s [mmi.name] with \a [tool]."),
+				)
+				dismantle(user)
+				return TRUE
+
+			// Remove component
+			var/list/removable_components = list()
+			for (var/key in components)
+				if (key == "power cell")
+					continue
+				var/datum/robot_component/component = components[key]
+				if (component.installed != 0)
+					removable_components += key
+			if (!length(removable_components))
+				USE_FEEDBACK_FAILURE("\The [src] has no components to remove.")
+				return TRUE
+			var/input = input(user, "Whick component do you want to pry out?", "[name] - Remove Component") as null|anything in removable_components
+			if (!input || !user.use_sanity_check(src, tool))
+				return TRUE
+			var/datum/robot_component/component = components[input]
+			if (component.installed == 0)
+				USE_FEEDBACK_FAILURE("\The [src] no longer has \a [input] to remove.")
+				return TRUE
+			var/obj/item/robot_parts/robot_component/removed_component = component.wrapped
+			if (istype(removed_component))
+				removed_component.brute = component.brute_damage
+				removed_component.burn = component.electronics_damage
+			removed_component.forceMove(loc)
+			if (component.installed == 1)
+				component.uninstall()
+			component.installed = 0
+			component.wrapped = null
+			user.visible_message(
+				SPAN_NOTICE("\The [user] removes \a [removed_component] from \the [src]'s [component.name] slot with \a [tool]."),
+				SPAN_NOTICE("You remove \a [removed_component] from \the [src]'s [component.name] slot with \the [tool].")
+			)
+			return TRUE
+
+		// Open the panel
+		if (locked)
+			USE_FEEDBACK_FAILURE("\The [src]'s maintenance hatch is locked and cannot be opened.")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts prying open \the [src]'s maintenance hatch with \a [tool]."),
+			SPAN_NOTICE("You start prying open \the [src]'s maintenance hatch with \a [tool].")
+		)
+		if (!do_after(user, 5 SECONDS, src, DO_PUBLIC_UNIQUE) || user.use_sanity_check(src, tool))
+			return TRUE
+		if (locked)
+			USE_FEEDBACK_FAILURE("\The [src]'s maintenance hatch is locked and cannot be opened.")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] pries open \the [src]'s maintenance hatch with \a [tool]."),
+			SPAN_NOTICE("You pry open \the [src]'s maintenance hatch with \a [tool].")
+		)
+		opened = TRUE
+		update_icon()
+		return TRUE
+
+	// Encryption key - Passthrough to radio
+	if (istype(tool, /obj/item/device/encryptionkey))
+		if (!opened)
+			USE_FEEDBACK_FAILURE("\The [src]'s maintenance panel must be opened before you can access the radio.")
+			return TRUE
+		if (tool.resolve_attackby(src, user, click_params))
+			return TRUE
+
+	// ID Card - Toggle panel lock
+	var/obj/item/card/id/id = tool.GetIdCard()
+	if (istype(id))
+		var/id_name = GET_ID_NAME(id, tool)
+		if (emagged)
+			to_chat(user, SPAN_WARNING("\The [src]'s panel lock seems slightly damaged."))
+		if (opened)
+			USE_FEEDBACK_FAILURE("\The [src]'s cover must be closed before you can lock it.")
+			return TRUE
+		if (!check_access(id))
+			USE_FEEDBACK_ID_CARD_DENIED(src, id_name)
+			return TRUE
+		locked = !locked
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] scans \a [tool] over \the [src]'s maintenance hatch, toggling it [locked ? "locked" : "unlocked"]."),
+			SPAN_NOTICE("You scan [id_name] over \the [src]'s maintenance hatch, toggling it [locked ? "locked" : "unlocked"]."),
+			range = 1
+		)
+		return TRUE
+
+	// Matter Bin - Install/swap matter bin
+	if (istype(tool, /obj/item/stock_parts/matter_bin))
+		if (!opened)
+			USE_FEEDBACK_FAILURE("\The [src]'s maintenance hatch must be opened before you can install \the [tool].")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		if (storage)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] replaces \the [src]'s [storage.name] with \a [tool]."),
+				SPAN_NOTICE("You replace \the [src]'s [storage.name] with \the [tool].")
+			)
+			storage.dropInto(loc)
+		else
+			user.visible_message(
+				SPAN_NOTICE("\The [user] installs \a [tool] into \the [src]."),
+				SPAN_NOTICE("You install \a [tool] into \the [src].")
+			)
+		storage = tool
+		handle_selfinsert(tool, user)
+		recalculate_synth_capacities()
+		return TRUE
+
+	// Multitool, Wirecutters - Wire panel
+	if (isMultitool(tool) || isWirecutter(tool))
+		if (!wiresexposed)
+			USE_FEEDBACK_FAILURE("\The [src]'s wiring must be exposed before you can access them.")
+			return TRUE
+		wires.Interact(user)
+		return TRUE
+
+	// Power Cell - Install cell
+	if (istype(tool, /obj/item/cell))
+		if (!opened)
+			USE_FEEDBACK_FAILURE("\The [src]'s maintenance hatch must be opened before you can install \the [tool].")
+			return TRUE
+		if (cell)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [cell] installed.")
+			return TRUE
+		if (wiresexposed)
+			USE_FEEDBACK_FAILURE("\The [src]'s wiring panel must be closed before you can install \the [tool].")
+			return TRUE
+		if (tool.w_class != ITEM_SIZE_NORMAL)
+			USE_FEEDBACK_FAILURE("\The [tool] is too [tool.w_class < ITEM_SIZE_NORMAL ? "small" : "large"] to fit in \the [src].")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		var/datum/robot_component/component = components["power cell"]
+		cell = tool
+		handle_selfinsert(cell, user)
+		component.installed = 1
+		component.wrapped = tool
+		component.install()
+		component.brute_damage = 0
+		component.electronics_damage = 0
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs \a [tool] into \the [src]."),
+			SPAN_NOTICE("You install \a [tool] into \the [src].")
+		)
+		return TRUE
+
+	// Robot Upgrade Module - Apply upgrade
+	if (istype(tool, /obj/item/borg/upgrade))
+		if (!opened)
+			USE_FEEDBACK_FAILURE("\The [src]'s maintenance hatch must be opened before you can install \the [tool].")
+			return TRUE
+		var/obj/item/borg/upgrade/upgrade = tool
+		if (!module && upgrade.require_module)
+			USE_FEEDBACK_FAILURE("\The [src] must choose a module before \the [tool] can be installed.")
+			return TRUE
+		if (upgrade.locked)
+			USE_FEEDBACK_FAILURE("\The [tool] is locked and cannot be used.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		if (!upgrade.action(src))
+			return TRUE
+		handle_selfinsert(tool, user)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs \a [tool] into \the [src]."),
+			SPAN_NOTICE("You install \a [tool] into \the [src].")
+		)
+		return TRUE
+
+	// Screwdriver
+	// - Toggle wire panel
+	// - Passthrough to radio
+	if (isScrewdriver(tool))
+		if (!opened)
+			USE_FEEDBACK_FAILURE("\The [src]'s maintenance panel must be opened before you can access the wiring or radio.")
+			return TRUE
+		var/input = input(user, "What would you like to access?", "[name] - Screwdriver Access") as null|anything in list("Wiring", "Radio")
+		if (!input || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (!opened)
+			USE_FEEDBACK_FAILURE("\The [src]'s maintenance panel must be opened before you can access the wiring or radio.")
+			return TRUE
+		switch (input)
+			// Passthrough to radio
+			if ("Radio")
+				if (!silicon_radio)
+					USE_FEEDBACK_FAILURE("\The [src] doesn't have a radio to access.")
+					return TRUE
+				var/result = tool.resolve_attackby(silicon_radio, user, click_params)
+				if (result)
+					update_icon()
+			// Toggle wire panel
+			if ("Wiring")
+				if (cell)
+					USE_FEEDBACK_FAILURE("\The [src]'s power cell must be removed before you can access the wiring.")
+					return TRUE
+				wiresexposed = !wiresexposed
+				update_icon()
+				user.visible_message(
+					SPAN_NOTICE("\The [user] [wiresexposed ? "exposes" : "unexposes"] \the [src]'s wiring with \a [tool]."),
+					SPAN_NOTICE("You [wiresexposed ? "expose" : "unexpose"] \the [src]'s wiring with \the [tool].")
+				)
+		return TRUE
+
+	// Welding Tool - Repair brute damage
+	if (isWelder(tool))
+		if (!getBruteLoss())
+			USE_FEEDBACK_FAILURE("\The [src] has no physical damage to repair.")
+			return TRUE
+		var/obj/item/weldingtool/welder = tool
+		if (!welder.can_use(1, user, "to repair \the [src]'s physical damage."))
+			return TRUE
+		playsound(src, 'sound/items/Welder.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts repairing some of the dents on \the [src] with \a [tool]."),
+			SPAN_NOTICE("You start repairing some of the dents on \the [src] with \the [tool]."),
+		)
+		if (!do_after(user, 1 SECOND, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check())
+			return TRUE
+		if (!getBruteLoss())
+			USE_FEEDBACK_FAILURE("\The [src] has no physical damage to repair.")
+			return TRUE
+		if (!welder.can_use(1, user, "to repair \the [src]'s physical damage."))
+			return TRUE
+		welder.remove_fuel(1, user)
+		adjustBruteLoss(-30)
+		updatehealth()
+		playsound(src, 'sound/items/Welder.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] repairs some of the dents on \the [src] with \a [tool]."),
+			SPAN_NOTICE("You repair some of the dents on \the [src] with \the [tool]."),
+		)
+		return TRUE
+
+	return ..()
+
 
 /mob/living/silicon/robot/proc/handle_selfinsert(obj/item/W, mob/user)
 	if ((user == src) && istype(get_active_hand(),/obj/item/gripper))
@@ -1086,7 +1255,6 @@
 	return ..()
 
 /mob/living/silicon/robot/proc/dismantle(mob/user)
-	to_chat(user, SPAN_NOTICE("You damage some parts of the chassis, but eventually manage to rip out the central processor."))
 	var/obj/item/robot_parts/robot_suit/C = new dismantle_type(loc)
 	C.dismantled_from(src)
 	qdel(src)

--- a/code/modules/mob/living/simple_animal/defense.dm
+++ b/code/modules/mob/living/simple_animal/defense.dm
@@ -59,56 +59,79 @@
 
 	return
 
-/mob/living/simple_animal/attackby(obj/item/O, mob/user)
-	if(istype(O, /obj/item/stack/medical))
-		if(stat != DEAD)
-			var/obj/item/stack/medical/MED = O
-			if(!MED.animal_heal)
-				to_chat(user, SPAN_NOTICE("That [MED] won't help \the [src] at all!"))
-				return
-			if(health < maxHealth)
-				if(MED.can_use(1))
-					adjustBruteLoss(-MED.animal_heal)
-					visible_message(SPAN_NOTICE("[user] applies the [MED] on [src]."))
-					MED.use(1)
-		else
-			to_chat(user, SPAN_NOTICE("\The [src] is dead, medical items won't bring \him back to life."))
-		return
 
-	if(istype(O, /obj/item/device/flash))
-		if(stat != DEAD)
-			O.attack(src, user, user.zone_sel ? user.zone_sel.selecting : ran_zone())
-			return
+/mob/living/simple_animal/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	// Attempt attack
+	var/result = weapon.attack(src, user, user.zone_sel ? user.zone_sel.selecting : ran_zone())
+	if (result && ai_holder)
+		ai_holder.react_to_attack(user)
+		return TRUE
 
-	if(meat_type && (stat == DEAD) && meat_amount)
-		if(istype(O, /obj/item/material/knife/kitchen/cleaver))
-			var/victim_turf = get_turf(src)
-			if(!locate(/obj/structure/table, victim_turf))
-				to_chat(user, SPAN_NOTICE("You need to place \the [src] on a table to butcher it."))
-				return
-			var/time_to_butcher = (mob_size)
-			to_chat(user, SPAN_NOTICE("You begin harvesting \the [src]."))
-			if(do_after(user, time_to_butcher, src, DO_PUBLIC_UNIQUE))
-				if(prob(user.skill_fail_chance(SKILL_COOKING, 60, SKILL_ADEPT)))
-					to_chat(user, SPAN_NOTICE("You botch harvesting \the [src], and ruin some of the meat in the process."))
-					subtract_meat(user)
-					return
-				else
-					harvest(user, user.get_skill_value(SKILL_COOKING))
-					return
-			else
-				to_chat(user, SPAN_NOTICE("Your hand slips with your movement, and some of the meat is ruined."))
-				subtract_meat(user)
-				return
+	return ..()
 
-	else
-		if(!O.force)
-			visible_message(SPAN_NOTICE("[user] gently taps [src] with \the [O]."))
-		else
-			O.attack(src, user, user.zone_sel ? user.zone_sel.selecting : ran_zone())
 
-			if (ai_holder)
-				ai_holder.react_to_attack(user)
+/mob/living/simple_animal/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Butcher's Cleaver - Butcher dead mob
+	if (istype(tool, /obj/item/material/knife/kitchen/cleaver))
+		if (stat != DEAD)
+			USE_FEEDBACK_FAILURE("\The [src] must be dead before you can butcher \him.")
+			return TRUE
+		if (!meat_type || !meat_amount)
+			USE_FEEDBACK_FAILURE("\The [src] can't be butchered.")
+			return TRUE
+		var/turf/turf = get_turf(src)
+		if (!locate(/obj/structure/table, turf))
+			USE_FEEDBACK_FAILURE("You need to place \the [src] on a table to butcher \him.")
+			return TRUE
+		var/time_to_butcher = mob_size
+		user.visible_message(
+			SPAN_WARNING("\The [user] begins butchering \the [src]'s corpse with \a [tool]."),
+			SPAN_WARNING("You begin \the [src]'s corpse with \the [tool].")
+		)
+		if (!do_after(user, time_to_butcher, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check())
+			USE_FEEDBACK_FAILURE("Some of \the [src]'s meat is ruined.")
+			subtract_meat(user)
+			return TRUE
+		if (prob(user.skill_fail_chance(SKILL_COOKING, 60, SKILL_ADEPT)))
+			subtract_meat(user)
+			user.visible_message(
+				SPAN_WARNING("\The [user] botches harvesting \the [src], and ruins some of the meat in the process."),
+				SPAN_WARNING("You botch harvesting \the [src], and ruins some of the meat in the process.")
+			)
+			return TRUE
+		harvest(user, user.get_skill_value(SKILL_COOKING))
+		user.visible_message(
+			SPAN_WARNING("\The [user] harvests some meat from \the [src] with \a [tool]."),
+			SPAN_WARNING("You harvest some meat from \the [src] with \the [tool].")
+		)
+		return TRUE
+
+	// Medical - Attempt healing
+	if (istype(tool, /obj/item/stack/medical))
+		if (stat == DEAD)
+			USE_FEEDBACK_FAILURE("\The [src] is dead, medical items won't bring \him back to life.")
+			return TRUE
+		if (health >= maxHealth)
+			USE_FEEDBACK_FAILURE("\The [src] doesn't need any healing.")
+			return TRUE
+		var/obj/item/stack/medical/medical = tool
+		if (!medical.animal_heal)
+			USE_FEEDBACK_FAILURE("\The [medical] won't help \the [src].")
+			return TRUE
+		if (!medical.use(1))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(medical, 1, "to heal \the [src].")
+			return TRUE
+		adjustBruteLoss(-medical.animal_heal)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] applies a [medical.singular_name] from \a [medical.name] to \the [src]'s injuries."),
+			SPAN_NOTICE("You apply a [medical.singular_name] from \the [medical.name] to \the [src]'s injuries."),
+			exclude_mobs = list(src)
+		)
+		to_chat(src, SPAN_NOTICE("\The [user] applies a [medical.singular_name] from \a [medical.name] to your injuries."),)
+		return TRUE
+
+	return ..()
+
 
 /mob/living/simple_animal/hit_with_weapon(obj/item/O, mob/living/user, effective_force, hit_zone)
 

--- a/code/modules/mob/living/simple_animal/friendly/alien.dm
+++ b/code/modules/mob/living/simple_animal/friendly/alien.dm
@@ -22,20 +22,29 @@
 	ai_holder = /datum/ai_holder/simple_animal/passive
 	var/num_meat = 5
 
-/mob/living/simple_animal/passive/meatbeast/attackby(obj/item/O, mob/living/user)
-	if(stat == CONSCIOUS && is_sharp(O) && (user.a_intent == I_HELP))
-		if(num_meat >= 1)
-			user.visible_message(
-				SPAN_NOTICE("\The [user] harvests meat from [src]"),
-				SPAN_NOTICE("You harvest meat from [src]")
-			)
-			--num_meat
-			new meat_type(get_turf(src))
-			playsound(user, 'sound/weapons/bladeslice.ogg', 15, 1)
-		else
-			to_chat(user, SPAN_NOTICE("Meat protrusions on \the [src] are still growing."))
-	else
-		..()
+
+/mob/living/simple_animal/passive/meatbeast/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Sharp item - Harvest meat
+	if (is_sharp(tool))
+		if (stat)
+			USE_FEEDBACK_FAILURE("\The [src] is not conscious and not in a state to be harvested.")
+			return TRUE
+		if (num_meat <= 0)
+			USE_FEEDBACK_FAILURE("\The [src]'s met protrusions are still growing.")
+			return TRUE
+		num_meat--
+		var/obj/item/meat = new meat_type(loc)
+		playsound(user, 'sound/weapons/bladeslice.ogg', 15, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] harvests some [meat.name] from \the [src] with \a [tool]."),
+			SPAN_NOTICE("You harvest some [meat.name] from \the [src] with \the [tool]."),
+			exclude_mobs = list(src)
+		)
+		to_chat(src, SPAN_NOTICE("\The [user] harvests some [meat.name] from you with \a [tool]."))
+		return TRUE
+
+	return ..()
+
 
 /mob/living/simple_animal/passive/meatbeast/Life()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/corgi.dm
+++ b/code/modules/mob/living/simple_animal/friendly/corgi.dm
@@ -96,18 +96,33 @@
 	name = "Corgi meat"
 	desc = "Tastes like... well you know..."
 
-/mob/living/simple_animal/passive/corgi/attackby(obj/item/O as obj, mob/user as mob)  //Marker -Agouri
-	if(istype(O, /obj/item/newspaper))
-		if(!stat)
-			for(var/mob/M in viewers(user, null))
-				if ((M.client && !( M.blinded )))
-					M.show_message(SPAN_NOTICE("[user] baps [name] on the nose with the rolled up [O]"))
-			spawn(0)
-				for(var/i in list(1,2,4,8,4,2,1,2))
-					set_dir(i)
-					sleep(1)
-	else
-		..()
+
+/mob/living/simple_animal/passive/corgi/get_interactions_info()
+	. = ..()
+	.["Newspaper"] = "<p>On harm intent, disciplines \the [initial(name)]. Bad dog!</p>"
+
+
+/mob/living/simple_animal/passive/corgi/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	// Newspaper - Bap on the nose
+	if (istype(weapon, /obj/item/newspaper))
+		user.setClickCooldown(user.get_attack_speed(weapon))
+		user.do_attack_animation(src)
+		user.visible_message(
+			SPAN_WARNING("\The [user] baps \the [src] on the nose with a rolled up [weapon.name]!"),
+			SPAN_DANGER("You bap \the [src] on the nose with the rolled up [weapon.name]!"),
+			exclude_mobs = list(src)
+		)
+		if (stat)
+			return TRUE
+		to_chat(src, SPAN_DANGER("\The [user] baps you on the nose with a rolle up [weapon.name]!"))
+		spawn(0)
+			for(var/i in list(1,2,4,8,4,2,1,2))
+				set_dir(i)
+				sleep(1)
+		return TRUE
+
+	return ..()
+
 
 /mob/living/simple_animal/passive/corgi/regenerate_icons()
 	overlays = list()

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/webslinger.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/webslinger.dm
@@ -184,9 +184,10 @@
 		var/tally = W.stacks * 2
 		return . + tally
 
-/mob/living/attackby(obj/item/I, mob/user)
-	for (var/obj/aura/web/W in auras)
-		W.remove_webbing(user)
-		return
+/mob/living/use_tool(obj/item/tool, mob/user, list/click_params)
+	if (length(auras))
+		for (var/obj/aura/web/web in auras)
+			web.remove_webbing(user)
+			return TRUE
 
 	return ..()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -252,19 +252,20 @@
 			drop_held_item(0)
 	return
 
-//Mobs with objects
-/mob/living/simple_animal/hostile/retaliate/parrot/attackby(obj/item/O as obj, mob/user as mob)
-	..()
-	if(!stat && !client && !istype(O, /obj/item/stack/medical))
-		if(O.force)
-			if(parrot_state == PARROT_PERCH)
-				parrot_sleep_dur = parrot_sleep_max //Reset it's sleep timer if it was perched
 
-			parrot_interest = user
-			parrot_state = PARROT_SWOOP | PARROT_FLEE
-			icon_state = "[icon_set]_fly"
-			drop_held_item(0)
-	return
+/mob/living/simple_animal/hostile/retaliate/parrot/post_use_item(obj/item/tool, mob/user, interaction_handled, use_call, click_params)
+	..()
+
+	// React to being hit
+	if ((use_call == "weapon" || use_call == "attackby") && !stat && !client)
+		if (parrot_state == PARROT_PERCH)
+			parrot_sleep_dur = parrot_sleep_max //Reset it's sleep timer if it was perched
+
+		parrot_interest = user
+		parrot_state = PARROT_SWOOP | PARROT_FLEE
+		icon_state = "[icon_set]_fly"
+		drop_held_item(FALSE)
+
 
 //Bullets
 /mob/living/simple_animal/hostile/retaliate/parrot/bullet_act(obj/item/projectile/Proj)

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -45,20 +45,40 @@
 	weapon2 = /obj/item/shield/energy
 	status_flags = 0
 
-/mob/living/simple_animal/hostile/syndicate/melee/attackby(obj/item/O as obj, mob/user as mob)
-	if(O.force)
-		if(prob(80))
-			var/damage = O.force
-			if (O.damtype == DAMAGE_PAIN)
-				damage = 0
-			health -= damage
-			visible_message(SPAN_DANGER("\The [src] has been attacked with \the [O] by \the [user]."))
-		else
-			visible_message(SPAN_DANGER("\The [src] blocks the [O] with its shield!"))
-		//user.do_attack_animation(src)
-	else
-		to_chat(usr, SPAN_WARNING("This weapon is ineffective, it does no damage."))
-		visible_message(SPAN_WARNING("\The [user] gently taps \the [src] with \the [O]."))
+
+/mob/living/simple_animal/hostile/syndicate/melee/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	if (!weapon.force)
+		return ..()
+
+	// Shield check
+	if (!prob(80))
+		user.visible_message(
+			SPAN_WARNING("\The [user] swings \a [weapon] at \the [src], but they block it with their shield!"),
+			SPAN_WARNING("You swing \the [weapon] at \the [src], but they block it with their shield!"),
+			exclude_mobs = list(src)
+		)
+		to_chat(src, SPAN_WARNING("\The [user] swings \a [weapon] at you, but you block it with your shield!"))
+		return TRUE
+
+	// Block pain damage
+	if (weapon.damtype == DAMAGE_PAIN)
+		user.visible_message(
+			SPAN_WARNING("\The [user] swings \a [weapon] at \the [src], but it has no effect!"),
+			SPAN_WARNING("You swing \the [weapon] at \the [src], but it has no effect!"),
+			exclude_mobs = list(src)
+		)
+		to_chat(src, SPAN_WARNING("\The [user] swings \a [weapon] at you, but it has no effect!"))
+		return TRUE
+
+	// Apply damage
+	health -= weapon.force
+	user.visible_message(
+		SPAN_WARNING("\The [user] swings \a [weapon] at \the [src]!"),
+		SPAN_DANGER("You swing \the [weapon] at \the [src]!"),
+		exclude_mobs = list(src)
+	)
+	to_chat(src, SPAN_DANGER("\The [user] swings \a [weapon] at you!"))
+	return TRUE
 
 
 /mob/living/simple_animal/hostile/syndicate/melee/bullet_act(obj/item/projectile/Proj)

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -44,7 +44,7 @@ exactly 25 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 5 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 352 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 351 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 0 "anchored = 0/1" 'anchored\s*=\s*\d' -P
 exactly 2 "density = 0/1" 'density\s*=\s*\d' -P
@@ -53,7 +53,7 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 5 "uses of .len" '\.len\b' -P
-exactly 574 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 556 "attackby() override" '\/attackby\((.*)\)'  -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 num=`find ./html/changelogs -not -name "*.yml" | wc -l`


### PR DESCRIPTION
Updates all `/mob` attackby overrides to `use_*` instead, including the tweaks provided in other open PRs.

## Changelog
:cl: SierraKomodo
refactor: Updates all `/mob` attackby overrides to `use_*` instead, including the tweaks provided in other open PRs.
tweak: Removing webbing from other mobs with an item in your hand now requires you to be on a non-harm intent. If on harm intent, you'll just hit them instead. Now you can take advantage of that webbed up victim you wanted to kill anyway!
tweak: Security bots now react to being attacked with a melee weapon/tool, even if the attack does no damage.
tweak: Attacking simple mobs with melee weapons/tools now requires being on harm intent.
tweak: Repairing cyborgs with a welding tool or cable coil now requires 1 units of fuel per repair and includes a 1 second timer.
tweak: Using a screwdriver on a borg now gives you the option of accessing the wiring or radio, instead of the decision being decided by the presence of a power cell. Opening the wiring panel still requires the power cell to be removed first.
tweak: Various tool based interactions with mobs now all include failure feedback messages, and visual messages on success.
tweak: pAIs no longer fold when attacked.
/:cl:

## Dependencies
- #33101
- #33102