### PR TITLE
Buckling fixes

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -528,7 +528,6 @@ SUBSYSTEM_DEF(jobs)
 		var/obj/item/organ/external/r_foot = H.get_organ(BP_R_FOOT)
 		if(!l_foot || !r_foot)
 			var/obj/structure/bed/chair/wheelchair/W = new /obj/structure/bed/chair/wheelchair(H.loc)
-			H.buckled = W
 			H.UpdateLyingBuckledAndVerbStatus()
 			W.set_dir(H.dir)
 			W.buckle_mob(H)

--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -178,6 +178,8 @@
  * Returns boolean. Whether or not the buckling was successful.
  */
 /obj/proc/AttemptBuckle(mob/living/target, mob/living/user, silent = FALSE)
+	if (!istype(target))
+		return FALSE
 	if (target == user || target.a_intent == I_HELP)
 		return user_buckle_mob(target, user, silent)
 	if (!can_buckle(target, user, silent))


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Interactions that require drop+dropping an item on another item should now work again, if they were broken.
bugfix: Spawning in a wheelchair no longer places you in a broken half-buckled state.
/:cl:

## Other Changes
- Adds a type check to `AttemptBuckle` that ensures `target` is of the expected type.
