### PR TITLE
Add round ID to notes

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -266,6 +266,8 @@ var/global/floorIsLava = 0
 /datum/player_info/var/rank //rank of admin who made the notes
 /datum/player_info/var/content // text content of the information
 /datum/player_info/var/timestamp // Because this is bloody annoying
+/// Round ID of the note
+/datum/player_info/var/game_id
 
 #define PLAYER_NOTES_ENTRIES_PER_PAGE 50
 /datum/admins/proc/PlayerNotes()
@@ -389,6 +391,7 @@ var/global/floorIsLava = 0
 					<b>[comment.author || "(not recorded)"]</b>, \
 					<b>[comment.rank || "(not recorded)"]</b>, \
 					on <b>[comment.timestamp || "(not recorded)"]</b>\
+					<br>Round ID: <b>[comment.game_id || "(not recorded)"]</b>\
 				</div>\
 				[remove_button]\
 			</div>\

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -391,7 +391,7 @@ var/global/floorIsLava = 0
 					<b>[comment.author || "(not recorded)"]</b>, \
 					<b>[comment.rank || "(not recorded)"]</b>, \
 					on <b>[comment.timestamp || "(not recorded)"]</b>\
-					<br>Round ID: <b>[comment.game_id || "(not recorded)"]</b>\
+					[comment.game_id ? "<br>Round ID: <b>[comment.game_id]</b>" : null]\
 				</div>\
 				[remove_button]\
 			</div>\

--- a/code/modules/admin/player_notes.dm
+++ b/code/modules/admin/player_notes.dm
@@ -28,6 +28,7 @@
 	var/day_loc = findtext(full_date, time2text(world.timeofday, "DD"))
 
 	var/datum/player_info/P = new
+	P.game_id = game_id
 	if (ismob(user))
 		P.author = user.key
 		P.rank = user.client.holder.rank
@@ -84,6 +85,6 @@
 		dat = "No information found on the given key."
 	else
 		for(var/datum/player_info/I in infos)
-			dat += "[I.content]\nby [I.author] ([I.rank]) on [I.timestamp]\n\n"
+			dat += "[I.content]\nby [I.author] ([I.rank]) on [I.timestamp] ([I.game_id])\n\n"
 
 	return list2params(list(dat))


### PR DESCRIPTION
:cl: SierraKomodo
admin: Notes now include the round ID they were added on. Note this is not retroactive and only applies to notes created after this change went live.
/:cl:

![dreamseeker_MxeeG0p8RQ](https://user-images.githubusercontent.com/11140088/222192640-102e29e7-bd9a-4249-9b24-d986e4f703ce.png)
