### PR TITLE
Move aura interaction checks to separate procs

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -388,11 +388,20 @@
 #define STASIS_CRYOBAG  "cryobag"
 #define STASIS_COLD     "cold"
 
-#define AURA_CANCEL 1
-#define AURA_FALSE  2
+// Aura check result flags for `/obj/aura/proc/aura_check_*()`.
+/// Halts further checking of any other auras on the mob.
+#define AURA_CANCEL FLAG(0)
+/// Causes the calling `aura_check()` proc to return `FALSE`.
+#define AURA_FALSE  FLAG(1)
+
+// Aura type options for `/mob/living/proc/aura_check()`.
+/// Aura checks for projectile impacts. Generally called by `/obj/item/projectile/proc/attack_mob()`. Results in `/obj/aura/proc/aura_check_bullet()`.
 #define AURA_TYPE_BULLET "Bullet"
+/// Aura checks for physical weapon attacks. Generally called by `/obj/item/proc/attack()`. Results in `/obj/aura/proc/aura_check_weapon()`.
 #define AURA_TYPE_WEAPON "Weapon"
+/// Aura checks for thrown atom impacts. Generally called by `/mob/living/hitby()`. Results in `/obj/aura/proc/aura_check_thrown()`.
 #define AURA_TYPE_THROWN "Thrown"
+/// Aura checks during mob life. Generally called by `/mob/living/Life()`. Results in `/obj/aura/proc/aura_check_life()`.
 #define AURA_TYPE_LIFE   "Life"
 
 #define SPECIES_BLOOD_DEFAULT 560

--- a/code/game/objects/auras/aura.dm
+++ b/code/game/objects/auras/aura.dm
@@ -24,33 +24,74 @@ They should also be used for when you want to effect the ENTIRE mob, like having
 /obj/aura/proc/removed()
 	user = null
 
-/obj/aura/proc/life_tick()
-	return 0
+/**
+ * Called during the associated mob's life checks.
+ *
+ * Called by `/mob/living/proc/aura_check()` when `type` == `AURA_TYPE_LIFE`.
+ *
+ * Returns bitfield (Any of `AURA_*`). See `code\__defines\mobs.dm`.
+ */
+/obj/aura/proc/aura_check_life()
+	return EMPTY_BITFIELD
 
-/obj/aura/attackby(obj/item/I, mob/user)
-	return 0
+/**
+ * Called when the associated mob is attacked with a weapon.
+ *
+ * Called by `/mob/living/proc/aura_check()` when `type` == `AURA_TYPE_WEAPON`.
+ *
+ * **Parameters**:
+ * - `weapon` - Item used to attack the mob.
+ * - `attacker` - The attacking mob.
+ * - `click_params` - List of click parameters.
+ *
+ * Returns bitfield (Any of `AURA_*`). See `code\__defines\mobs.dm`.
+ */
+/obj/aura/proc/aura_check_weapon(obj/item/weapon, mob/attacker, click_params)
+	return EMPTY_BITFIELD
 
-/obj/aura/bullet_act(obj/item/projectile/P, def_zone)
-	return 0
+/**
+ * Called when the associated mob is impacted by a projectile.
+ *
+ * Called by `/mob/living/proc/aura_check()` when `type` == `AURA_TYPE_BULLET`.
+ *
+ * **Parameters**:
+ * - `proj` - The impacting projectile
+ * - `def_zone` - Body part target zone that was impacted
+ *
+ * Returns bitfield (Any of `AURA_*`). See `code\__defines\mobs.dm`.
+ */
+/obj/aura/proc/aura_check_bullet(obj/item/projectile/proj, def_zone)
+	return EMPTY_BITFIELD
 
-/obj/aura/hitby()
-	return 0
+/**
+ * Called when the associated mob is hit by a thrown atom.
+ *
+ * Called by `/mob/living/proc/aura_check()` when `type` == `AURA_TYPE_THROWN`.
+ *
+ * **Parameters**:
+ * - `thrown_atom` - The atom impacting the mob.
+ * - `thrown_datum` - The thrownthing datum associated with the thrown atom.
+ *
+ * Returns bitfield (Any of `AURA_*`). See `code\__defines\mobs.dm`.
+ */
+/obj/aura/proc/aura_check_thrown(atom/movable/thrown_atom, datum/thrownthing/thrown_datum)
+	return EMPTY_BITFIELD
 
 /obj/aura/debug
-	var/returning = 0
+	var/returning = EMPTY_BITFIELD
 
-/obj/aura/debug/attackby(obj/item/I, mob/user)
-	log_debug("Attackby for \ref[src]: [I], [user]")
+/obj/aura/debug/aura_check_weapon(obj/item/weapon, mob/attacker, click_params)
+	log_debug("Aura Check Weapon for \ref[src]: [weapon], [attacker]")
 	return returning
 
-/obj/aura/debug/bullet_act(obj/item/projectile/P, def_zone)
-	log_debug("Bullet Act for \ref[src]: [P], [def_zone]")
+/obj/aura/debug/aura_check_bullet(obj/item/projectile/proj, def_zone)
+	log_debug("Aura Check Bullet for \ref[src]: [proj], [def_zone]")
 	return returning
 
-/obj/aura/debug/life_tick()
-	log_debug("Life tick")
+/obj/aura/debug/aura_check_life()
+	log_debug("Aura Check Life for \ref[src]")
 	return returning
 
-/obj/aura/debug/hitby(atom/movable/M, datum/thrownthing/TT)
-	log_debug("Hit By for \ref[src]: [M], [TT.speed]")
+/obj/aura/debug/aura_check_thrown(atom/movable/thrown_atom, datum/thrownthing/thrown_datum)
+	log_debug("Aura Check Thrown for \ref[src]: [thrown_atom], [thrown_datum.speed]")
 	return returning

--- a/code/game/objects/auras/blueforge_aura.dm
+++ b/code/game/objects/auras/blueforge_aura.dm
@@ -4,13 +4,13 @@
 	icon_state = "eyes_blueforged_s"
 	layer = MOB_LAYER
 
-/obj/aura/blueforge_aura/life_tick()
+/obj/aura/blueforge_aura/aura_check_life()
 	user.adjustToxLoss(-10)
-	return 0
+	return EMPTY_BITFIELD
 
-/obj/aura/blueforge_aura/bullet_act(obj/item/projectile/P)
-	if (P.damtype == DAMAGE_BURN)
-		P.damage *=2
-	else if(P.agony || P.stun)
+/obj/aura/blueforge_aura/aura_check_bullet(obj/item/projectile/proj, def_zone	)
+	if (proj.damtype == DAMAGE_BURN)
+		proj.damage *= 2
+	else if (proj.agony || proj.stun)
 		return AURA_FALSE
-	return 0
+	return EMPTY_BITFIELD

--- a/code/game/objects/auras/personal_shields/personal_shield.dm
+++ b/code/game/objects/auras/personal_shields/personal_shield.dm
@@ -6,8 +6,8 @@
 	playsound(user,'sound/weapons/flash.ogg',35,1)
 	to_chat(user,SPAN_NOTICE("You feel your body prickle as \the [src] comes online."))
 
-/obj/aura/personal_shield/bullet_act(obj/item/projectile/P, def_zone)
-	user.visible_message(SPAN_WARNING("\The [user]'s [src.name] flashes before \the [P] can hit them!"))
+/obj/aura/personal_shield/aura_check_bullet(obj/item/projectile/proj, def_zone)
+	user.visible_message(SPAN_WARNING("\The [user]'s [name] flashes before \the [proj] can hit them!"))
 	new /obj/effect/temporary(get_turf(src), 2 SECONDS,'icons/obj/machines/shielding.dmi',"shield_impact")
 	playsound(user,'sound/effects/basscannon.ogg',35,1)
 	return AURA_FALSE|AURA_CANCEL
@@ -20,7 +20,7 @@
 /obj/aura/personal_shield/device
 	var/obj/item/device/personal_shield/shield
 
-/obj/aura/personal_shield/device/bullet_act()
+/obj/aura/personal_shield/device/aura_check_bullet(obj/item/projectile/proj, def_zone)
 	. = ..()
 	if(shield)
 		shield.take_charge()

--- a/code/game/objects/auras/radiant_aura.dm
+++ b/code/game/objects/auras/radiant_aura.dm
@@ -13,8 +13,8 @@
 	to_chat(user, SPAN_WARNING("Your protective aura dissipates, leaving you feeling cold and unsafe."))
 	..()
 
-/obj/aura/radiant_aura/bullet_act(obj/item/projectile/P, def_zone)
-	if(P.damage_flags() & DAMAGE_FLAG_LASER)
-		user.visible_message(SPAN_WARNING("\The [P] refracts, bending into \the [user]'s aura."))
+/obj/aura/radiant_aura/aura_check_bullet(obj/item/projectile/proj, def_zone)
+	if (HAS_FLAGS(proj.damage_flags(), DAMAGE_FLAG_LASER))
+		user.visible_message(SPAN_WARNING("\The [proj] refracts, bending into \the [user]'s aura."))
 		return AURA_FALSE
-	return 0
+	return EMPTY_BITFIELD

--- a/code/game/objects/auras/shadowling_aura.dm
+++ b/code/game/objects/auras/shadowling_aura.dm
@@ -14,9 +14,9 @@
 		user.mutations -= MUTATION_SPACERES
 	..()
 
-/obj/aura/shadowling_aura/bullet_act(obj/item/projectile/P)
-	if(P.damage_flags() & DAMAGE_FLAG_LASER)
-		P.damage *= 2
-	if(P.agony)
-		P.agony *= 2
-	return 0
+/obj/aura/shadowling_aura/aura_check_bullet(obj/item/projectile/proj, def_zone)
+	if (HAS_FLAGS(proj.damage_flags(), DAMAGE_FLAG_LASER))
+		proj.damage *= 2
+	if (proj.agony)
+		proj.agony *= 2
+	return EMPTY_BITFIELD

--- a/code/game/objects/auras/starlight.dm
+++ b/code/game/objects/auras/starlight.dm
@@ -5,16 +5,16 @@
 	color = "#33cc33"
 	layer = MOB_LAYER
 
-/obj/aura/starborn/bullet_act(obj/item/projectile/P, def_zone)
-	if (P.damage_type == DAMAGE_BURN)
-		user.visible_message(SPAN_WARNING("\The [P] seems to only make \the [user] stronger."))
-		user.adjustBruteLoss(-P.damage)
+/obj/aura/starborn/aura_check_bullet(obj/item/projectile/proj, def_zone)
+	if (proj.damage_type == DAMAGE_BURN)
+		user.visible_message(SPAN_WARNING("\The [proj] seems to only make \the [user] stronger."))
+		user.adjustBruteLoss(-proj.damage)
 		return AURA_FALSE
-	return 0
+	return EMPTY_BITFIELD
 
-/obj/aura/starborn/attackby(obj/item/I, mob/i_user)
-	if(I.damtype == DAMAGE_BURN)
-		to_chat(i_user, SPAN_WARNING("\The [I] seems to only feed into \the [user]'s flames."))
-		user.adjustBruteLoss(-I.force)
+/obj/aura/starborn/aura_check_weapon(obj/item/weapon, mob/attacker, click_params)
+	if (weapon.damtype == DAMAGE_BURN)
+		user.visible_message(SPAN_WARNING("\The [weapon] seems to only feed into \the [user]'s flames."))
+		user.adjustBruteLoss(-weapon.force)
 		return AURA_FALSE
-	return 0
+	return EMPTY_BITFIELD

--- a/code/modules/augment/passive/nanoaura.dm
+++ b/code/modules/augment/passive/nanoaura.dm
@@ -57,9 +57,9 @@
 	to_chat(loc, SPAN_NOTICE("Your skin tingles as the nanites spread over your body."))
 
 
-/obj/aura/nanoaura/bullet_act(obj/item/projectile/P, def_zone)
+/obj/aura/nanoaura/aura_check_bullet(obj/item/projectile/proj, def_zone)
 	if (!active)
-		return
+		return EMPTY_BITFIELD
 	if (unit.charges > 0)
 		user.visible_message(SPAN_WARNING("The nanomachines harden as a response to physical trauma!"))
 		playsound(user, 'sound/effects/basscannon.ogg',35,1)
@@ -68,6 +68,7 @@
 			to_chat(user, SPAN_DANGER("Warning: Critical damage treshold passed. Shut down unit to avoid further damage"))
 		return AURA_FALSE | AURA_CANCEL
 	unit.catastrophic_failure()
+	return EMPTY_BITFIELD
 
 
 /obj/aura/nanoaura/Destroy()

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -55,6 +55,30 @@
 /mob/living/get_bullet_impact_effect_type(def_zone)
 	return BULLET_IMPACT_MEAT
 
+/**
+ * Checks the mob for auras and interactions of the given type.
+ *
+ * Calls one of the `aura_check_*` procs for each aura in the mobs `auras` list, based on type provided.
+ * All parameters after `type` are passed on to the called proc.
+ *
+ * **Parameters**:
+ * - `type` (String - One of `AURA_TYPE_*`) - The type of check to be performed any any found auras.
+ * - Additional parameters depend on aura type:
+ *   - `AURA_TYPE_WEAPON (obj/item/weapon, mob/user, click_params)`:
+ *     - `weapon` - The item used to attack/interact with the mob.
+ *     - `attacker` - The mob performing the attack/interaction.
+ *     - `click_params` - List of click parameters.
+ *   - `AURA_TYPE_BULLET (obj/item/projectile/proj, def_zone)`:
+ *     - `proj` - Projectile impacting the mob.
+ *     - `def_zone` - Impacted body part target zone.
+ *   - `AURA_TYPE_THROWN (atom/movable/thrown_atom, datum/thrownthing/thrown_datum)`:
+ *     - `thrown_atom` - Atom impacting the mob.
+ *     - `thrown_datum` - thrownthing datum instance for the throw chain.
+ *   - `AURA_TYPE_LIFE` (No additional parameters)
+ *
+ * Returns boolean - `TRUE` if no auras were found or if no auras passed `AURA_FALSE` in their checks.
+ * Generally, a `FALSE` return value means the aura blocks further interaction.
+ */
 /mob/living/proc/aura_check(type)
 	if(!auras)
 		return TRUE
@@ -62,16 +86,16 @@
 	var/list/newargs = args - args[1]
 	for(var/a in auras)
 		var/obj/aura/aura = a
-		var/result = 0
+		var/result = EMPTY_BITFIELD
 		switch(type)
 			if(AURA_TYPE_WEAPON)
-				result = aura.attackby(arglist(newargs))
+				result = aura.aura_check_weapon(arglist(newargs))
 			if(AURA_TYPE_BULLET)
-				result = aura.bullet_act(arglist(newargs))
+				result = aura.aura_check_bullet(arglist(newargs))
 			if(AURA_TYPE_THROWN)
-				result = aura.hitby(arglist(newargs))
+				result = aura.aura_check_thrown(arglist(newargs))
 			if(AURA_TYPE_LIFE)
-				result = aura.life_tick()
+				result = aura.aura_check_life()
 		if(result & AURA_FALSE)
 			. = FALSE
 		if(result & AURA_CANCEL)

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/webslinger.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/webslinger.dm
@@ -114,15 +114,15 @@
 		Destroy()
 
 
-/obj/aura/web/bullet_act(obj/item/projectile/P, def_zone)
+/obj/aura/web/aura_check_bullet(obj/item/projectile/proj, def_zone)
 	. = ..()
-	if (istype(P, /obj/item/projectile/webball))
+	if (istype(proj, /obj/item/projectile/webball))
 		add_stack()
 
-/obj/aura/web/hitby(atom/movable/AM, datum/thrownthing/TT)
+/obj/aura/web/aura_check_thrown(atom/movable/thrown_atom, datum/thrownthing/thrown_datum)
 	. = ..()
-	if (isliving(AM))
-		remove_webbing(AM)
+	if (isliving(thrown_atom))
+		remove_webbing(thrown_atom)
 
 /obj/aura/web/proc/remove_webbing(mob/living/M)
 	if (!M)

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -53,7 +53,7 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 5 "uses of .len" '\.len\b' -P
-exactly 608 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 603 "attackby() override" '\/attackby\((.*)\)'  -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 num=`find ./html/changelogs -not -name "*.yml" | wc -l`


### PR DESCRIPTION
Originally was going to replace the attackby overrides, then realised auras aren't even using those procs in the originally intended manner, so now there's new procs instead.

Replaces all aura attackbys with the new `aura_check_*` procs, and updates them to meet current coding standards.

NUFC