### PR TITLE
fixes fleet lcdr uniforms

### DIFF
--- a/maps/torch/datums/uniforms_fleet.dm
+++ b/maps/torch/datums/uniforms_fleet.dm
@@ -24,7 +24,7 @@
 
 /singleton/hierarchy/mil_uniform/fleet/com/seniorofficer
 	name = "Fleet senior command"
-	min_rank = 14
+	min_rank = 15
 
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/command
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/command
@@ -103,7 +103,7 @@
 
 /singleton/hierarchy/mil_uniform/fleet/eng/officer/com/seniorofficer
 	name = "Fleet engineering senior command"
-	min_rank = 14
+	min_rank = 15
 
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/command
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/command
@@ -184,7 +184,7 @@
 
 /singleton/hierarchy/mil_uniform/fleet/sec/officer/com/seniorofficer
 	name = "Fleet security senior command"
-	min_rank = 14
+	min_rank = 15
 
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/command
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/command
@@ -258,7 +258,7 @@
 
 /singleton/hierarchy/mil_uniform/fleet/med/officer/com/seniorofficer
 	name = "Fleet medical senior command"
-	min_rank = 14
+	min_rank = 15
 
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/command
 	dress_over = /obj/item/clothing/suit/storage/solgov/dress/fleet/command
@@ -328,7 +328,7 @@
 
 /singleton/hierarchy/mil_uniform/fleet/sup/seniorofficer
 	name = "Fleet supply senior command"
-	min_rank = 14
+	min_rank = 15
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/command
@@ -521,7 +521,7 @@
 
 /singleton/hierarchy/mil_uniform/fleet/spt/seniorofficer
 	name = "Fleet senior command support"
-	min_rank = 14
+	min_rank = 15
 
 	service_hat = /obj/item/clothing/head/solgov/dress/fleet/command
 	service_over = /obj/item/clothing/suit/storage/solgov/service/fleet/command


### PR DESCRIPTION
🆑 
tweak: fleet LCDRs get the right uniforms now
/🆑
I was observing and I noticed that a Fleet LCDR XO had senior officer trim instead of the accurate junior officer trim:
![lcdr ehret unfixed](https://user-images.githubusercontent.com/44277885/222620101-1fce81f3-71b7-4971-9c10-341b894ff8f5.png)

As such, I have fixed it so that they have the accurate trim:

![lcdr ehret fixed](https://user-images.githubusercontent.com/44277885/222620236-b13eebff-7847-4186-a989-7d0db7b5b397.png)
