### PR TITLE
Update default IV transfer rate to 1

### DIFF
--- a/code/modules/reagents/reagent_containers/ivbag.dm
+++ b/code/modules/reagents/reagent_containers/ivbag.dm
@@ -9,10 +9,10 @@
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 
 	/// The set of options for the amount of reagents the bag will try to transfer per process.
-	var/static/list/allowed_transfer_amounts = list(2, 1, REM, 0)
+	var/static/list/allowed_transfer_amounts = list(2, 1, 0)
 
 	/// The configured amount of reagents the IV bag will try to transfer per process.
-	var/transfer_amount = 1
+	var/transfer_amount = 2
 
 	/// If this bag is attached to a person, that person.
 	var/mob/living/carbon/human/patient
@@ -251,9 +251,12 @@
 	UpdateTransferAmount(user, src)
 
 
+/obj/item/reagent_containers/ivbag/nanoblood
+	transfer_amount = 1
+
+
 /obj/item/reagent_containers/ivbag/nanoblood/Initialize()
 	. = ..()
-	transfer_amount = REM
 	reagents.add_reagent(/datum/reagent/nanoblood, volume)
 	AddLabel("Nanoblood")
 	UpdateItemSize()


### PR DESCRIPTION
Requested by Nol, due to pending and recent changes that render the 0.2 default useless.

:cl: SierraKomodo
tweak: IV bags now come with a default transfer rate of 2 units (1 unit for nanoblood bags).
rscdel: IV bags can no longer be set to a transfer rate of 0.2 units
/:cl: