### PR TITLE
Fix buckling while handcuffed

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -145,7 +145,7 @@
 		buckled_mob = null
 		return FALSE
 	if (user)
-		if (user.incapacitated())
+		if (user.incapacitated(INCAPACITATION_DISABLED))
 			if (!silent)
 				to_chat(user, SPAN_WARNING("You're in no condition to unbuckle things right now."))
 			return FALSE


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Unbuckling while handcuffed no longer tells you success, then failure, then does nothing - It now actually unbuckles you.
/:cl: