### PR TITLE
Adds ability to hug mob holders

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -77,7 +77,16 @@ var/global/list/holder_mob_icon_cache = list()
 	var/obj/item/I = GetIdCard()
 	return I ? I.GetAccess() : ..()
 
-/obj/item/holder/attack_self()
+/obj/item/holder/attack_self(mob/user)
+	if (!ishuman(user))
+		return
+	var/mob/living/carbon/human/H = user
+	for(var/mob/M in contents)
+		H.species.hug(H, M)
+
+/obj/item/holder/MouseDrop(atom/over_atom, atom/source_loc, atom/over_loc, source_control, over_control, list/mouse_params)
+	if(over_atom != usr)
+		return ..()
 	for(var/mob/M in contents)
 		M.show_inv(usr)
 


### PR DESCRIPTION
🆑 Hubblenaut
rscadd: Pets in your hand can now be hugged.
/:cl:

- Moves the call to `show_inv` to `MouseDrop` to make space for hugging.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->