### PR TITLE
Decreases material bat max force

### DIFF
--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -140,7 +140,7 @@
 	attack_verb = list("smashed", "beaten", "slammed", "smacked", "struck", "battered", "bonked")
 	hitsound = 'sound/weapons/genhit3.ogg'
 	default_material = MATERIAL_MAPLE
-	max_force = 40	//for wielded
+	max_force = 30	//for wielded
 	force_multiplier = 1.1           // 22 when wielded with weight 20 (steel)
 	unwielded_force_divisor = 0.7 // 15 when unwielded based on above.
 	attack_cooldown_modifier = 1


### PR DESCRIPTION
:cl: Ryan180602
tweak: Decreases material bat max force to 30 from 40.
/:cl:

No reason as to why a titanium bat can break bones and organs in one hit through body armour. 