### PR TITLE
Gunbox Fixes

### DIFF
--- a/code/game/objects/items/gunboxes.dm
+++ b/code/game/objects/items/gunboxes.dm
@@ -3,14 +3,17 @@
 	desc = "A secure box containing a sidearm."
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "excavation"
+	var/list/gun_options = list(
+		"Classic - Secure Smartgun" = /obj/item/gun/energy/gun/secure/preauthorized,
+		"Stylish - Secure Smart Revolver" = /obj/item/gun/energy/revolver/secure/preauthorized
+	)
 
 /obj/item/gunbox/attack_self(mob/user)
-	var/list/options = list()
-	options["Classic - Secure Smartgun"] = list(/obj/item/gun/energy/gun/secure/preauthorized)
-	options["Stylish - Secure Smart Revolver"] = list(/obj/item/gun/energy/revolver/secure/preauthorized)
-	var/choice = input(user, "What is your choice?") as null|anything in options
-	if (choice)
-		var/list/chosen_weapons = options[choice]
-		for (var/new_weapon in chosen_weapons)
-			user.put_in_any_hand_if_possible(new new_weapon(user))
-	qdel(src)
+	var/choice = input(user, "What is your choice?") as null|anything in gun_options
+	if (choice && user.use_sanity_check(src))
+		var/new_weapon_path = gun_options[choice]
+		var/obj/item/new_weapon = new new_weapon_path(user.loc)
+		user.drop_from_inventory(src)
+		user.put_in_any_hand_if_possible(new_weapon)
+		to_chat(user, SPAN_NOTICE("You take \the [new_weapon] out of \the [src]."))
+		qdel(src)


### PR DESCRIPTION
Some fixes and refactoring to the COS' gunbox.

## Changelog
:cl: SierraKomodo
bugfix: The gunbox no longer spawns guns inside your mob if your hands are full.
bugfix: The gunbox no longer deletes itself if you cancel the prompt.
/:cl:

## Other Changes
- Moved the `gun_options` list to a var on the gunbox itself.
- Made the gun options a single item instead of a list containing a single item - Lists are unnecessary here.
- Added a `to_chat()` message when extracting a gun.
- Added logic to drop the gunbox before adding the gun to hand, which should prevent the gun appearing on the floor if the user's other hand is full.

## Bug Fixes
- Closes #33133