### PR TITLE
Crafting tweaks/fixes

### DIFF
--- a/code/modules/crafting/_crafting_holder.dm
+++ b/code/modules/crafting/_crafting_holder.dm
@@ -8,6 +8,7 @@
 	var/mob/M = target.loc
 	if(istype(M))
 		M.drop_from_inventory(target)
+		M.put_in_hands(src)
 	target.forceMove(src)
 	current_crafting_stage = initial_stage
 	update_icon()
@@ -44,6 +45,8 @@
 		if(ismob(src.loc))
 			var/mob/M = src.loc
 			M.drop_from_inventory(src)
+			if(isitem(product))
+				M.put_in_hands(product)
 		qdel_self()
 	else
 		current_crafting_stage = next_stage

--- a/code/modules/crafting/_crafting_stage.dm
+++ b/code/modules/crafting/_crafting_stage.dm
@@ -26,11 +26,11 @@
 			return next_stage
 
 /singleton/crafting_stage/proc/progress_to(obj/item/thing, mob/user, obj/item/target)
-	. = is_appropriate_tool(thing) && consume(user, thing, target)
+	. = is_appropriate_tool(thing, user) && consume(user, thing, target)
 	if(.)
 		on_progress(user)
 
-/singleton/crafting_stage/proc/is_appropriate_tool(obj/item/thing)
+/singleton/crafting_stage/proc/is_appropriate_tool(obj/item/thing, mob/user = null)
 	. = istype(thing, completion_trigger_type)
 
 /singleton/crafting_stage/proc/consume(mob/user, obj/item/thing, obj/item/target)
@@ -68,12 +68,12 @@
 	var/obj/item/stack/material/M = thing
 	. = istype(M) && (!stack_material || M.material.name == stack_material) && ..()
 
-/singleton/crafting_stage/welding/consume(mob/user, obj/item/thing, obj/item/target)
-	var/obj/item/weldingtool/T = thing
-	. = istype(T) && T.remove_fuel(0, user) && T.isOn()
-
 /singleton/crafting_stage/welding
 	consume_completion_trigger = FALSE
+
+/singleton/crafting_stage/welding/is_appropriate_tool(obj/item/thing, mob/user)
+	var/obj/item/weldingtool/T = thing
+	. = istype(T) && T.remove_fuel(1, user) && T.isOn()
 
 /singleton/crafting_stage/welding/on_progress(mob/user)
 	..()
@@ -82,12 +82,12 @@
 /singleton/crafting_stage/screwdriver
 	consume_completion_trigger = FALSE
 
+/singleton/crafting_stage/screwdriver/is_appropriate_tool(obj/item/thing)
+	. = isScrewdriver(thing)
+
 /singleton/crafting_stage/screwdriver/on_progress(mob/user)
 	..()
 	playsound(user.loc, 'sound/items/Screwdriver.ogg', 100, 1)
-
-/singleton/crafting_stage/screwdriver/progress_to(obj/item/thing, mob/user)
-	. = ..() && isScrewdriver(thing)
 
 /singleton/crafting_stage/tape
 	consume_completion_trigger = FALSE


### PR DESCRIPTION
:cl: rootoo807
bugfix: Cans and bottles are no longer deleted when clicked on with other items.
tweak: Welding steps in crafting now use 1 welding fuel.
/:cl:

Tweaks how crafting checks for welders+screwdrivers. Also, puts newly-spawned crafted items in-hand if they were crafted in-hand rather than dropping them on the floor.

Fixes #32480, fixes #32950, fixes #32360, fixes #28203