### PR TITLE
Final Words for Antagonists

### DIFF
--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -50,6 +50,7 @@
 
 	var/faction 			//associated faction
 	var/datum/changeling/changeling		//changeling holder
+	var/last_words 			//last spoken message
 
 	var/rev_cooldown = 0
 

--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -49,8 +49,10 @@
 	var/has_been_rev = 0//Tracks if this mind has been a rev or not
 
 	var/faction 			//associated faction
-	var/datum/changeling/changeling		//changeling holder
-	var/last_words 			//last spoken message
+	var/datum/changeling/changeling		//changeling holde
+
+	///String. Last spoken message.
+	var/last_words
 
 	var/rev_cooldown = 0
 

--- a/code/game/antagonist/antagonist_print.dm
+++ b/code/game/antagonist/antagonist_print.dm
@@ -12,6 +12,8 @@
 		if(ambition)
 			text += "<br>Their goals for today were..."
 			text += "<br>[SPAN_NOTICE("[ambition.summarize()]")]"
+		if(P.current.stat == DEAD && P.last_words)
+			text += "<br><b>Their last words were:</b> '[P.last_words]'"
 		if(!length(global_objectives) && P.objectives && length(P.objectives))
 			var/num = 1
 			for(var/datum/objective/O in P.objectives)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -308,6 +308,9 @@ var/global/list/channel_to_radio_key = new
 				if(O) //It's possible that it could be deleted in the meantime.
 					O.hear_talk(src, stars(message), verb, speaking)
 
+	if(mind)
+		mind.last_words = message
+
 	if(whispering)
 		log_whisper("[name]/[key] : [message]")
 	else


### PR DESCRIPTION
:cl: PurplePineapple
rscadd: A mob's last say message is now recorded in mind. Antagonists have their last words displayed at round end if they die.
/:cl:

For comedic purposes, your final words are now displayed alongside the rest of the antagonist information at the end of a round.
![image](https://user-images.githubusercontent.com/67706292/224729026-e47e090f-8948-404b-bca1-7287aee519ae.png)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->