### PR TITLE
Set default throwforce to 0

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -7,7 +7,7 @@
 	var/list/matter //Used to store information about the contents of the object.
 	var/w_class // Size of the object.
 	var/unacidable = FALSE //universal "unacidabliness" var, here so you can use it in any obj.
-	var/throwforce = 1
+	var/throwforce = 0
 	var/sharp = FALSE		// whether this object cuts
 	var/edge = FALSE		// whether this object is more likely to dismember
 	var/in_use = 0 // If we have a user using us, this will be set on. We will check if the user has stopped using us, and thus stop updating and LAGGING EVERYTHING!


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Default throwforce value changed from 1 to 0. This fixes random harmless objects causing damage to things when thrown.
/:cl: