### PR TITLE
Lets ed209s accept stunrevolvers

### DIFF
--- a/code/modules/crafting/crafting_ed209.dm
+++ b/code/modules/crafting/crafting_ed209.dm
@@ -27,7 +27,7 @@
 	next_stages = list(/singleton/crafting_stage/ed209_armour)
 
 /singleton/crafting_stage/ed209_armour
-	completion_trigger_type = /obj/item/clothing/accessory/armor_plate
+	completion_trigger_type = /obj/item/organ/internal/augment/armor
 	progress_message = "You layer the armour plating over the frame."
 	item_icon_state = "ed209_4"
 	next_stages = list(/singleton/crafting_stage/welding/ed209)
@@ -45,6 +45,7 @@
 
 /singleton/crafting_stage/ed209_proximity
 	progress_message = "You add the proximity sensor to the frame."
+	completion_trigger_type = /obj/item/device/assembly/prox_sensor
 	next_stages = list(/singleton/crafting_stage/wiring/ed209)
 	item_icon_state = "ed209_6"
 
@@ -57,7 +58,7 @@
 /singleton/crafting_stage/ed209_taser
 	progress_message = "You add the taser to the frame."
 	next_stages = list(/singleton/crafting_stage/screwdriver/ed209)
-	completion_trigger_type = /obj/item/gun/energy/taser
+	completion_trigger_type = /obj/item/gun/energy/stunrevolver
 	item_icon_state = "ed209_7"
 
 /singleton/crafting_stage/screwdriver/ed209

--- a/code/modules/mob/living/bot/ed209bot.dm
+++ b/code/modules/mob/living/bot/ed209bot.dm
@@ -43,7 +43,7 @@
 	visible_message(SPAN_WARNING("[src] blows apart!"))
 	var/turf/Tsec = get_turf(src)
 
-	var/obj/item/gun/energy/taser/G = new /obj/item/gun/energy/taser(Tsec)
+	var/obj/item/gun/energy/stunrevolver/G = new /obj/item/gun/energy/stunrevolver(Tsec)
 	G.power_supply.charge = 0
 	if(prob(50))
 		new /obj/item/robot_parts/l_leg(Tsec)


### PR DESCRIPTION
:cl:
tweak: Allows ED209s to accept stun revolvers. Making them actually constructable.
tweak: Lets ED209s use the subdermal armour plating from mechfabs.
/:cl:

also fixes a weird bug in the crafting step where it could accept anything as a prox sensor.