### PR TITLE
Revert moving `attack` to `use_weapon`

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -248,14 +248,6 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	return FALSE
 
 
-/mob/living/use_weapon(obj/item/weapon, mob/user, list/click_params)
-	// Legacy mob attack code is handled by the weapon
-	if (weapon.attack(src, user, user.zone_sel ? user.zone_sel.selecting : ran_zone()))
-		return TRUE
-
-	return ..()
-
-
 /**
  * Interaction handler for using an item on this atom with a non-harm intent, or if `use_weapon()` did not resolve an
  * action. Generally, this is for any standard interactions with items.
@@ -295,6 +287,14 @@ avoid code duplication. This includes items that may sometimes act as a standard
  */
 /atom/proc/attackby(obj/item/W, mob/user, click_params)
 	return FALSE
+
+
+/mob/living/attackby(obj/item/W, mob/user, click_params)
+	// Legacy mob attack code is handled by the weapon
+	if (W.attack(src, user, user.zone_sel ? user.zone_sel.selecting : ran_zone()))
+		return TRUE
+
+	return ..()
 
 
 /**

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -53,7 +53,7 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 5 "uses of .len" '\.len\b' -P
-exactly 556 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 557 "attackby() override" '\/attackby\((.*)\)'  -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 num=`find ./html/changelogs -not -name "*.yml" | wc -l`


### PR DESCRIPTION
ihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcodeihateattackcode

:cl: SierraKomodo
bugfix: Legacy non-harmful mob interactions no longer require harm intent to occur.
/:cl: