### PR TITLE
Protolathe canBuild math fix

### DIFF
--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -147,10 +147,10 @@
 
 /obj/machinery/r_n_d/protolathe/proc/canBuild(datum/design/D)
 	for(var/M in D.materials)
-		if(materials[M] < D.materials[M])
+		if(materials[M] < D.materials[M] * mat_efficiency)
 			return 0
 	for(var/C in D.chemicals)
-		if(!reagents.has_reagent(C, D.chemicals[C]))
+		if(!reagents.has_reagent(C, D.chemicals[C] * mat_efficiency))
 			return 0
 	return 1
 


### PR DESCRIPTION
Fixes incorrect calculation of the materials needed by the protolathe to build design

🆑
bugfix: Fixes incorrect calculation of the materials needed by the protolathe to build design
/🆑

