### PR TITLE
Fix vending machines not giving cables

### DIFF
--- a/code/game/machinery/vending/tool.dm
+++ b/code/game/machinery/vending/tool.dm
@@ -6,7 +6,7 @@
 	icon_vend = "tool-vend"
 	base_type = /obj/machinery/vending/tool
 	products = list(
-		/obj/random/single/color/cable_coil = 10,
+		/obj/item/stack/cable_coil = 10,
 		/obj/item/crowbar = 5,
 		/obj/item/weldingtool = 3,
 		/obj/item/wirecutters = 5,


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Tool vendors now dispense cable coils again.
/:cl:

As a side effect, dispensed cables will always come out red. Properly fixing vending machines to work with random objects would require a refactor that I don't have the time for right now.

- Fixes #33175