### PR TITLE
Adjusts integrated circuit injector targeting

### DIFF
--- a/code/modules/integrated_electronics/subtypes/reagents.dm
+++ b/code/modules/integrated_electronics/subtypes/reagents.dm
@@ -75,7 +75,7 @@
 	desc = "This scary looking thing is able to pump liquids into, or suck liquids out of, whatever it's pointed at."
 	icon_state = "injector"
 	extended_desc = "This autoinjector can push up to 30 units of reagents into another container or someone else outside of the machine. The target \
-	must be adjacent to the machine, and if it is a person, they cannot be wearing thick clothing. Negative given amounts makes the injector suck out reagents instead."
+	must be adjacent to the machine, and if it is a person who is not carrying it in their pockets or belt, they cannot be wearing thick clothing. Negative given amounts makes the injector suck out reagents instead."
 
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	volume = 30
@@ -184,6 +184,12 @@
 		if(isliving(AM))
 			var/mob/living/L = AM
 			var/injection_status = L.can_inject(null, BP_CHEST)
+			if(L.isEquipped(assembly, slot_l_hand))
+				injection_status = L.can_inject(null, BP_L_HAND)
+			if(L.isEquipped(assembly, slot_r_hand))
+				injection_status = L.can_inject(null, BP_R_HAND)
+			if(L.isEquipped(assembly, slot_l_store) || L.isEquipped(assembly, slot_r_store) || L.isEquipped(assembly, slot_belt))
+				injection_status = L.can_inject(null, BP_CHEST, ignore_thick_clothing = TRUE) //The injector has been put under the thick layer
 			log_world("Injection status? [injection_status]")
 			var/injection_delay = 3 SECONDS
 			if(injection_status == INJECTION_PORT)
@@ -217,6 +223,12 @@
 		if(istype(AM, /mob/living/carbon))
 			var/mob/living/carbon/C = AM
 			var/injection_status = C.can_inject(null, BP_CHEST)
+			if(C.isEquipped(assembly, slot_l_hand))
+				injection_status = C.can_inject(null, BP_L_HAND)
+			if(C.isEquipped(assembly, slot_r_hand))
+				injection_status = C.can_inject(null, BP_R_HAND)
+			if(C.isEquipped(assembly, slot_l_store) || C.isEquipped(assembly, slot_r_store) || C.isEquipped(assembly, slot_belt))
+				injection_status = C.can_inject(null, BP_CHEST, ignore_thick_clothing = TRUE)
 			var/injection_delay = 3 SECONDS
 			if(injection_status == INJECTION_PORT)
 				injection_delay += INJECTION_PORT_DELAY

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1349,7 +1349,7 @@
 		W.message = message
 		W.add_fingerprint(src)
 
-/mob/living/carbon/human/can_inject(mob/user, target_zone)
+/mob/living/carbon/human/can_inject(mob/user, target_zone, ignore_thick_clothing)
 	var/obj/item/organ/external/affecting = get_organ(target_zone)
 
 	if(!affecting)
@@ -1361,13 +1361,14 @@
 		return 0
 
 	. = CAN_INJECT
-	for(var/obj/item/clothing/C in list(head, wear_mask, wear_suit, w_uniform, gloves, shoes))
-		if(C && (C.body_parts_covered & affecting.body_part) && (C.item_flags & ITEM_FLAG_THICKMATERIAL))
-			if(istype(C, /obj/item/clothing/suit/space))
-				. = INJECTION_PORT //it was going to block us, but it's a space suit so it doesn't because it has some kind of port
-			else
-				to_chat(user, SPAN_WARNING("There is no exposed flesh or thin material on [src]'s [affecting.name] to inject into."))
-				return 0
+	if(!ignore_thick_clothing)
+		for(var/obj/item/clothing/C in list(head, wear_mask, wear_suit, w_uniform, gloves, shoes))
+			if(C && (C.body_parts_covered & affecting.body_part) && (C.item_flags & ITEM_FLAG_THICKMATERIAL))
+				if(istype(C, /obj/item/clothing/suit/space))
+					. = INJECTION_PORT //it was going to block us, but it's a space suit so it doesn't because it has some kind of port
+				else
+					to_chat(user, SPAN_WARNING("There is no exposed flesh or thin material on [src]'s [affecting.name] to inject into."))
+					return 0
 
 
 /mob/living/carbon/human/print_flavor_text(shrink = 1)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -363,7 +363,7 @@ default behaviour is:
 			return 1
 	return 0
 
-/mob/living/proc/can_inject(mob/user, target_zone)
+/mob/living/proc/can_inject(mob/user, target_zone, ignore_thick_clothing)
 	return 1
 
 /mob/living/proc/get_organ_target()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -172,7 +172,7 @@
 	. = ..()
 
 //can't inject synths
-/mob/living/silicon/can_inject(mob/user, target_zone)
+/mob/living/silicon/can_inject(mob/user, target_zone, ignore_thick_clothing)
 	to_chat(user, SPAN_WARNING("The armoured plating is too tough."))
 	return 0
 


### PR DESCRIPTION
Injectors carried in the hands will try and inject into the hands.
If someone carelessly picks up a malicious circuit, their chest armour won't save them.

Injectors on the belt or in pockets will ignore thickmaterial.
You can put devices in a pocket of your undersuit, so that it will continue to function with armour worn over the top.

[Tested!](https://streamable.com/cso9t3)

(My first coding work in DM after a long time, apologies in advance for errors 👍)

:cl: Fenodyree
tweak: integrated hypo-injectors will inject into the hands if held.
tweak: integrated hypo-injectors will ignore thick material while carried in pockets or on belts.
/:cl:
