### PR TITLE
Restricts some pets to only HoS/Passenger/CL/SCGR

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/pet.dm
+++ b/code/modules/client/preference_setup/loadout/lists/pet.dm
@@ -75,7 +75,7 @@
 
 /datum/gear/pet
 	display_name = "pet selection"
-	description = "A variety of creatures indentured for comfort and amusement."
+	description = "A variety of small creatures indentured for comfort and amusement. Usually considered pests, most of the lower echelon of the crew have been silently allowed to keep them."
 	path = /obj/item/holder/gear
 	custom_setup_proc = /obj/item/holder/gear/proc/LoadoutCustomSetup
 	cost = 5
@@ -83,13 +83,45 @@
 /datum/gear/pet/New()
 	..()
 	var/list/options = list()
-	options["kitten"] = /obj/item/holder/gear/kitten
 	options["lizard"] = /obj/item/holder/gear/lizard
 	options["mouse, brown"] = /obj/item/holder/gear/mouse_brown
 	options["mouse, grey"] = /obj/item/holder/gear/mouse_gray
 	options["mouse, white"] = /obj/item/holder/gear/mouse_white
 	options["rat"]	= /obj/item/holder/gear/mouse_rat
 	options["diona nymph"] = /obj/item/holder/gear/nymph
+
+	gear_tweaks += new /datum/gear_tweak/path (options)
+
+/datum/gear/rpet
+	display_name = "pet selection, restricted"
+	description = "A variety of creatures indentured for comfort and amusement. These are pets considered common on planets, however, only allowed to the higher echelons of the crew on this vessel."
+	path = /obj/item/holder/gear
+	custom_setup_proc = /obj/item/holder/gear/proc/LoadoutCustomSetup
+	cost = 5
+	allowed_roles = list(
+		/datum/job/captain,
+		/datum/job/hop,
+		/datum/job/rd,
+		/datum/job/cmo,
+		/datum/job/chief_engineer,
+		/datum/job/hos,
+		/datum/job/liaison,
+		/datum/job/representative,
+		/datum/job/assistant,
+		/datum/job/merchant,
+		/datum/job/submap/colonist,
+		/datum/job/submap/colonist2,
+		/datum/job/submap/scavver_pilot,
+		/datum/job/submap/scavver_doctor,
+		/datum/job/submap/scavver_engineer,
+		/datum/job/submap/bearcat_captain,
+		/datum/job/submap/pod
+	)
+
+/datum/gear/rpet/New()
+	..()
+	var/list/options = list()
+	options["kitten"] = /obj/item/holder/gear/kitten
 	options["puppy"] = /obj/item/holder/gear/puppy
 	options["opossum"] = /obj/item/holder/gear/opossum
 	options["snake"] = /obj/item/holder/gear/snake


### PR DESCRIPTION
:cl:
tweak: Opossum, Snakes, Puppy and Kittens are now restricted to head of staff/passenger/CL/SCGR
/:cl:

as discussed before plenty of times in maine/code on discord.
big animals are likely to be a commodity and privilege. and have more needs to maintain.
smaller animals are likely still allowed.

holopet project after this.