### PR TITLE
Can anchor proc

### DIFF
--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -263,6 +263,12 @@
 	if(CanUseTopic(user, DefaultTopicState()) > STATUS_CLOSE)
 		return interface_interact(user)
 
+
+/obj/machinery/post_anchor_change()
+	..()
+	power_change()
+
+
 /**
  * If you want to have interface interactions handled for you conveniently, use this.
  * Return `TRUE` for handled.

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -59,16 +59,6 @@
 	return TRUE
 
 
-/obj/machinery/jukebox/attackby(obj/item/I, mob/user)
-	if (isWrench(I))
-		add_fingerprint(user)
-		wrench_floor_bolts(user, 0)
-		power_change()
-		return
-	return ..()
-
-
-
 /obj/machinery/jukebox/old
 	name = "space jukebox"
 	desc = "A battered and hard-loved jukebox in some forgotten style, carefully restored to some semblance of working condition."

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -297,8 +297,7 @@
 				to_chat(user, SPAN_NOTICE("Some items were refused."))
 
 	else if ((obj_flags & OBJ_FLAG_ANCHORABLE) && isWrench(O))
-		wrench_floor_bolts(user)
-		power_change()
+		return ..()
 
 	else
 		to_chat(user, SPAN_NOTICE("\The [src] smartly refuses [O]."))

--- a/code/game/machinery/vending/_vending.dm
+++ b/code/game/machinery/vending/_vending.dm
@@ -180,9 +180,7 @@
 	if ((. = component_attackby(item, user)))
 		return
 	if ((obj_flags & OBJ_FLAG_ANCHORABLE) && isWrench(item))
-		wrench_floor_bolts(user)
-		power_change()
-		return
+		return ..()
 
 
 /obj/machinery/vending/MouseDrop_T(obj/item/item, mob/living/user)

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -67,10 +67,18 @@
 		become_airtight()
 		return
 	if (isWrench(W))
-		if (airtight)
-			to_chat(user,"You have to readjust the airflow before unwrenching \the [src].")
-			return
-		wrench_floor_bolts(user)
+		return ..()
+
+
+/obj/structure/plasticflaps/can_anchor(obj/item/tool, mob/user, silent)
+	. = ..()
+	if (!.)
+		return
+	if (airtight)
+		if (!silent)
+			USE_FEEDBACK_FAILURE("You have to readjust the airflow before unwrenching \the [src].")
+		return FALSE
+
 
 /obj/structure/plasticflaps/ex_act(severity)
 	switch(severity)

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -53,7 +53,7 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 5 "uses of .len" '\.len\b' -P
-exactly 557 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 556 "attackby() override" '\/attackby\((.*)\)'  -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 num=`find ./html/changelogs -not -name "*.yml" | wc -l`


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
refactor: Anchoring/unanchoring objects with a wrench has been refactored with some standardized sanity checks.
/:cl:

## Other Changes
- Added `/obj/proc/can_anchor()`.
- Added `/obj/proc/post_anchor_change()`.
- Added `use_sanity_check()` to `wrench_floor_bolts()`.
