### PR TITLE
Cable color fixes

### DIFF
--- a/code/modules/power/cable_coil.dm
+++ b/code/modules/power/cable_coil.dm
@@ -72,7 +72,6 @@ GLOBAL_LIST_INIT(cable_default_colors, list(
 
 
 /obj/item/stack/cable_coil/on_update_icon()
-	color = COLOR_MAROON
 	switch (amount)
 		if (1)
 			icon_state = "coil1"

--- a/code/modules/power/cable_coil.dm
+++ b/code/modules/power/cable_coil.dm
@@ -157,8 +157,7 @@ GLOBAL_LIST_INIT(cable_default_colors, list(
 /obj/item/stack/cable_coil/proc/CreateCable(turf/target, mob/living/user, from_dir, to_dir)
 	if(!isturf(target))
 		return
-	var/obj/structure/cable/cable = new (target)
-	cable.set_color(color)
+	var/obj/structure/cable/cable = new (target, color)
 	cable.d1 = from_dir
 	cable.d2 = to_dir
 	cable.add_fingerprint(user)

--- a/code/modules/power/cable_structure.dm
+++ b/code/modules/power/cable_structure.dm
@@ -47,7 +47,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	return ..()
 
 
-/obj/structure/cable/Initialize()
+/obj/structure/cable/Initialize(mapload, _color)
 	. = ..()
 	var/dash = findtext(icon_state, "-")
 	d1 = text2num( copytext( icon_state, 1, dash ) )
@@ -58,6 +58,8 @@ By design, d1 is the smallest direction and d2 is the highest
 	if (level == ATOM_LEVEL_UNDER_TILE)
 		hide(!turf.is_plating() && !turf.is_open())
 	GLOB.cable_list += src
+	if (_color)
+		color = _color
 
 
 /obj/structure/cable/drain_power(drain_check, surge, amount = 0)


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Cable coils no longer reset to red when their icon is updated. This corrects both coils changing when you place a cable, and cut cables being red.
/:cl:

## Other Changes
- Small refactor of cable structure initialization to allow intended color to be passed through to `Initialize()`.

## Bug Fixes
- Fixes #33184
- Fixes #33185