### PR TITLE
Fixes the smart revolver

### DIFF
--- a/code/modules/projectiles/guns/energy/secure.dm
+++ b/code/modules/projectiles/guns/energy/secure.dm
@@ -48,6 +48,7 @@
 		)
 	modifystate = "energyrevolverstun"
 	item_state = null
+	projectile_type = /obj/item/projectile/beam/stun
 	firemodes = list(
 		list(mode_name="stun", projectile_type=/obj/item/projectile/beam/stun, modifystate="energyrevolverstun"),
 		list(mode_name="shock", projectile_type=/obj/item/projectile/beam/stun/shock, modifystate="energyrevolvershock"),


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Fixes the smart revolver shooting practice beams.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->