### PR TITLE
Chemistry iv bags

### DIFF
--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -80,7 +80,8 @@
 	accepted_types = list(
 		/obj/item/reagent_containers/glass,
 		/obj/item/storage/pill_bottle,
-		/obj/item/reagent_containers/pill
+		/obj/item/reagent_containers/pill,
+		/obj/item/reagent_containers/ivbag
 	)
 
 /obj/machinery/smartfridge/secure/virology

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -21703,6 +21703,7 @@
 	dir = 10
 	},
 /obj/structure/table/standard,
+/obj/item/storage/box/bloodpacks,
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
 "lAC" = (


### PR DESCRIPTION
Now you can host blood drives. Or pre-fill them with meds if you want to go that route.

## Changelog
:cl: SierraKomodo
tweak: The chemistry fridge now accepts IV bags.
maptweak: Medbay now has a box of empty IV bags in the ETC.
/:cl:

## Dependencies
- #33190