### PR TITLE
Set return types for global procs

### DIFF
--- a/code/_helpers/areas.dm
+++ b/code/_helpers/areas.dm
@@ -2,6 +2,7 @@
 	List generation helpers
 */
 /proc/get_filtered_areas(list/predicates = list(/proc/is_area_with_turf))
+	RETURN_TYPE(/list)
 	. = list()
 	if(!predicates)
 		return
@@ -12,6 +13,7 @@
 			. += A
 
 /proc/get_area_turfs(area/A, list/predicates)
+	RETURN_TYPE(/list)
 	. = new/list()
 	A = istype(A) ? A : locate(A)
 	if(!A)
@@ -21,6 +23,7 @@
 			. += T
 
 /proc/get_subarea_turfs(area/A, list/predicates)
+	RETURN_TYPE(/list)
 	. = new/list()
 	A = istype(A) ? A.type : A
 	if(!ispath(A))
@@ -32,11 +35,13 @@
 				. += T
 
 /proc/group_areas_by_name(list/predicates)
+	RETURN_TYPE(/list)
 	. = list()
 	for(var/area/A in get_filtered_areas(predicates))
 		group_by(., A.name, A)
 
 /proc/group_areas_by_z_level(list/predicates)
+	RETURN_TYPE(/list)
 	. = list()
 	for(var/area/A in get_filtered_areas(predicates))
 		group_by(., pad_left(num2text(A.z), 3, "0"), A)
@@ -45,21 +50,25 @@
 	Pick helpers
 */
 /proc/pick_subarea_turf(areatype, list/predicates)
+	RETURN_TYPE(/turf)
 	var/list/turfs = get_subarea_turfs(areatype, predicates)
 	if(LAZYLEN(turfs))
 		return pick(turfs)
 
 /proc/pick_area_turf(areatype, list/predicates)
+	RETURN_TYPE(/turf)
 	var/list/turfs = get_area_turfs(areatype, predicates)
 	if(turfs && length(turfs))
 		return pick(turfs)
 
 /proc/pick_area(list/predicates)
+	RETURN_TYPE(/area)
 	var/list/areas = get_filtered_areas(predicates)
 	if(LAZYLEN(areas))
 		. = pick(areas)
 
 /proc/pick_area_and_turf(list/area_predicates, list/turf_predicates)
+	RETURN_TYPE(/turf)
 	var/list/areas = get_filtered_areas(area_predicates)
 	// We loop over all area candidates, until we finally get a valid turf or run out of areas
 	while(!. && length(areas))
@@ -67,6 +76,7 @@
 		. = pick_area_turf(A, turf_predicates)
 
 /proc/pick_area_turf_in_connected_z_levels(list/area_predicates, list/turf_predicates, z_level)
+	RETURN_TYPE(/turf)
 	area_predicates = area_predicates.Copy()
 
 	var/z_levels = GetConnectedZlevels(z_level)
@@ -74,6 +84,7 @@
 	return pick_area_and_turf(area_predicates, turf_predicates)
 
 /proc/pick_area_turf_in_single_z_level(list/area_predicates, list/turf_predicates, z_level)
+	RETURN_TYPE(/turf)
 	area_predicates = area_predicates.Copy()
 	area_predicates[/proc/area_belongs_to_zlevels] = list(z_level)
 	return pick_area_and_turf(area_predicates, turf_predicates)

--- a/code/_helpers/atom_movables.dm
+++ b/code/_helpers/atom_movables.dm
@@ -1,4 +1,5 @@
 /proc/get_turf_pixel(atom/movable/AM)
+	RETURN_TYPE(/turf)
 	if(!istype(AM))
 		return
 
@@ -29,6 +30,7 @@
 
 // Walks up the loc tree until it finds a holder of the given holder_type
 /proc/get_holder_of_type(atom/A, holder_type)
+	RETURN_TYPE(/atom)
 	if(!istype(A)) return
 	for(A, A && !istype(A, holder_type), A=A.loc);
 	return A
@@ -52,6 +54,7 @@
 		do_simple_ranged_interaction()
 
 /proc/get_atom_closest_to_atom(atom/a, list/possibilities)
+	RETURN_TYPE(/atom)
 	if(!possibilities || !length(possibilities))
 		return null
 	var/closest_distance = get_dist(a, possibilities[1])

--- a/code/_helpers/client.dm
+++ b/code/_helpers/client.dm
@@ -17,6 +17,7 @@
 
 /// Get the client associated with ckey text if it is currently connected
 /proc/ckey2client(text)
+	RETURN_TYPE(/client)
 	if (valid_ckey(text))
 		for (var/client/C as anything in GLOB.clients)
 			if (C.ckey == text)
@@ -25,6 +26,7 @@
 
 /// Get the client associated with key text if it is currently connected
 /proc/key2client(text)
+	RETURN_TYPE(/client)
 	if (valid_key(text))
 		for (var/client/C as anything in GLOB.clients)
 			if (C.key == text)
@@ -33,6 +35,7 @@
 
 /// Null, or a client if thing is a client, a mob with a client, a connected ckey, or null
 /proc/resolve_client(client/thing)
+	RETURN_TYPE(/client)
 	if (istype(thing))
 		return thing
 	if (!thing)
@@ -45,6 +48,7 @@
 
 /// Null or a client from the list of connected clients, chosen by actor if actor is valid
 /proc/select_client(client/actor, message = "Connected clients:", title = "Select Client")
+	RETURN_TYPE(/client)
 	actor = resolve_client(actor)
 	if (!actor)
 		return

--- a/code/_helpers/functional.dm
+++ b/code/_helpers/functional.dm
@@ -80,6 +80,7 @@
 
 
 /proc/where(list/list_to_filter, list/predicates, list/extra_predicate_input)
+	RETURN_TYPE(/list)
 	. = list()
 	for(var/entry in list_to_filter)
 		var/predicate_input
@@ -92,6 +93,7 @@
 			. += entry
 
 /proc/map(list/list_to_map, map_proc)
+	RETURN_TYPE(/list)
 	. = list()
 	for(var/entry in list_to_map)
 		. += call(map_proc)(entry)

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -27,18 +27,20 @@
 	return FALSE
 
 /proc/get_area(O)
+	RETURN_TYPE(/area)
 	var/turf/loc = get_turf(O)
 	if(loc)
 		var/area/res = loc.loc
 		.= res
 
 /proc/get_area_name(N) //get area by its name
+	RETURN_TYPE(/area)
 	for(var/area/A in world)
 		if(A.name == N)
 			return A
-	return 0
 
 /proc/get_area_master(const/O)
+	RETURN_TYPE(/area)
 	var/area/A = get_area(O)
 	if (isarea(A))
 		return A
@@ -52,6 +54,7 @@
 // Like view but bypasses luminosity check
 
 /proc/hear(range, atom/source)
+	RETURN_TYPE(/list)
 
 	var/lum = source.luminosity
 	source.luminosity = 6
@@ -83,6 +86,7 @@
 	return level in GLOB.using_map.escape_levels
 
 /proc/circlerange(center=usr,radius=3)
+	RETURN_TYPE(/list)
 
 	var/turf/centerturf = get_turf(center)
 	var/list/turfs = new/list()
@@ -98,6 +102,7 @@
 	return turfs
 
 /proc/circleview(center=usr,radius=3)
+	RETURN_TYPE(/list)
 
 	var/turf/centerturf = get_turf(center)
 	var/list/atoms = new/list()
@@ -113,6 +118,7 @@
 	return atoms
 
 /proc/trange(rad = 0, turf/centre = null) //alternative to range (ONLY processes turfs and thus less intensive)
+	RETURN_TYPE(/list)
 	if(!centre)
 		return
 
@@ -129,6 +135,7 @@
 	return dist
 
 /proc/circlerangeturfs(center=usr,radius=3)
+	RETURN_TYPE(/list)
 	var/turf/centerturf = get_turf(center)
 	. = list()
 	if(!centerturf)
@@ -143,6 +150,7 @@
 			. += T
 
 /proc/circleviewturfs(center=usr,radius=3)		//Is there even a diffrence between this proc and circlerangeturfs()?
+	RETURN_TYPE(/list)
 
 	var/turf/centerturf = get_turf(center)
 	var/list/turfs = new/list()
@@ -164,6 +172,7 @@
 // being unable to hear people due to being in a box within a bag.
 
 /proc/recursive_content_check(atom/O,  list/L = list(), recursion_limit = 3, client_check = 1, sight_check = 1, include_mobs = 1, include_objects = 1)
+	RETURN_TYPE(/list)
 
 	if(!recursion_limit)
 		return L
@@ -192,6 +201,7 @@
 // Returns a list of mobs and/or objects in range of R from source. Used in radio and say code.
 
 /proc/get_mobs_or_objects_in_view(R, atom/source, include_mobs = 1, include_objects = 1)
+	RETURN_TYPE(/list)
 
 	var/turf/T = get_turf(source)
 	var/list/hear = list()
@@ -217,6 +227,7 @@
 
 
 /proc/get_mobs_in_radio_ranges(list/obj/item/device/radio/radios)
+	RETURN_TYPE(/list)
 
 	set background = 1
 
@@ -321,6 +332,7 @@
 		return 0
 
 /proc/get_cardinal_step_away(atom/start, atom/finish) //returns the position of a step from start away from finish, in one of the cardinal directions
+	RETURN_TYPE(/turf)
 	//returns only NORTH, SOUTH, EAST, or WEST
 	var/dx = finish.x - start.x
 	var/dy = finish.y - start.y
@@ -336,6 +348,7 @@
 			return get_step(start, EAST)
 
 /proc/get_mob_by_key(key)
+	RETURN_TYPE(/mob)
 	for(var/mob/M in SSmobs.mob_list)
 		if(M.ckey == lowertext(key))
 			return M
@@ -344,6 +357,7 @@
 
 // Will return a list of active candidates. It increases the buffer 5 times until it finds a candidate which is active within the buffer.
 /proc/get_active_candidates(buffer = 1)
+	RETURN_TYPE(/list)
 
 	var/list/candidates = list() //List of candidate KEYS to assume control of the new larva ~Carn
 	var/i = 0
@@ -356,6 +370,7 @@
 	return candidates
 
 /proc/ScreenText(obj/O, maptext="", screen_loc="CENTER-7,CENTER-7", maptext_height=480, maptext_width=480)
+	RETURN_TYPE(/obj/screen)
 	if(!isobj(O))	O = new /obj/screen/text()
 	O.maptext = maptext
 	O.maptext_height = maptext_height
@@ -402,6 +417,7 @@
 	src.dest_y = dest_y
 
 /proc/projectile_trajectory(src_x, src_y, rotation, angle, power)
+	RETURN_TYPE(/datum/projectile_data)
 
 	// returns the destination (Vx,y) that a projectile shot at [src_x], [src_y], with an angle of [angle],
 	// rotated at [rotation] and with the power of [power]
@@ -428,6 +444,7 @@
 	return hex2num(copytext(hexa,6,8))
 
 /proc/GetHexColors(const/hexa)
+	RETURN_TYPE(/list)
 	return list(
 			GetRedPart(hexa),
 			GetGreenPart(hexa),
@@ -506,6 +523,7 @@
 	return ((temp + T0C))
 
 /proc/getCardinalAirInfo(turf/loc, list/stats=list("temperature"))
+	RETURN_TYPE(/list)
 	var/list/temps = new/list(4)
 	for(var/dir in GLOB.cardinal)
 		var/direction
@@ -550,6 +568,7 @@
 	return (length(GLOB.cult.current_antagonists) > spookiness_threshold)
 
 /proc/getviewsize(view)
+	RETURN_TYPE(/list)
 	var/viewX
 	var/viewY
 	if(isnum(view))

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -86,6 +86,7 @@ var/global/list/string_slot_flags = list(
 //////////////////////////
 
 /proc/get_mannequin(ckey)
+	RETURN_TYPE(/mob/living/carbon/human/dummy/mannequin)
 	if (!GLOB.mannequins[ckey])
 		GLOB.mannequins[ckey] = new /mob/living/carbon/human/dummy/mannequin
 	return GLOB.mannequins[ckey]
@@ -179,12 +180,14 @@ var/global/list/paramslist_cache = list()
 		paramslist_cache[params_data] = .
 
 /proc/key_number_decode(key_number_data)
+	RETURN_TYPE(/list)
 	var/list/L = params2list(key_number_data)
 	for(var/key in L)
 		L[key] = text2num(L[key])
 	return L
 
 /proc/number_list_decode(number_list_data)
+	RETURN_TYPE(/list)
 	var/list/L = params2list(number_list_data)
 	for(var/i in 1 to length(L))
 		L[i] = text2num(L[i])

--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -217,6 +217,7 @@ world
 #define TO_HEX_DIGIT(n) ascii2text((n&15) + ((n&15)<10 ? 48 : 87))
 
 /icon/proc/MakeLying()
+	RETURN_TYPE(/icon)
 	var/icon/I = new(src,dir=SOUTH)
 	I.BecomeLying()
 	return I
@@ -318,6 +319,7 @@ world
  */
 
 /proc/ReadRGB(rgb)
+	RETURN_TYPE(/list)
 	if(!rgb) return
 
 	// interpret the HSV or HSVA value
@@ -368,6 +370,7 @@ world
 	if(usealpha) . += alpha
 
 /proc/ReadHSV(hsv)
+	RETURN_TYPE(/list)
 	if(!hsv) return
 
 	// interpret the HSV or HSVA value
@@ -635,6 +638,7 @@ The _flatIcons list is a cache for generated icon files.
 */
 
 /proc/getFlatIcon(image/A, defdir=2, deficon=null, defstate="", defblend=BLEND_DEFAULT, always_use_defdir = 0)
+	RETURN_TYPE(/icon)
 	// We start with a blank canvas, otherwise some icon procs crash silently
 	var/icon/flat = icon('icons/effects/effects.dmi', "icon_state"="nothing") // Final flattened icon
 	if(!A)
@@ -782,6 +786,7 @@ The _flatIcons list is a cache for generated icon files.
 	return icon(flat, "", SOUTH)
 
 /proc/getIconMask(atom/A)//By yours truly. Creates a dynamic mask for a mob/whatever. /N
+	RETURN_TYPE(/icon)
 	var/icon/alpha_mask = new(A.icon,A.icon_state)//So we want the default icon and icon state of A.
 	for(var/I in A.overlays)//For every image in overlays. var/image/I will not work, don't try it.
 		if(I:layer>A.layer)	continue//If layer is greater than what we need, skip it.
@@ -810,6 +815,7 @@ The _flatIcons list is a cache for generated icon files.
 #define HOLOPAD_LONG_RANGE 2
 
 /proc/getHologramIcon(icon/A, safety=1, noDecolor=FALSE, hologram_color=HOLOPAD_SHORT_RANGE)//If safety is on, a new icon is not created.
+	RETURN_TYPE(/icon)
 	var/icon/flat_icon = safety ? A : new(A)//Has to be a new icon to not constantly change the same icon.
 	if (noDecolor == FALSE)
 		if(hologram_color == HOLOPAD_LONG_RANGE)
@@ -823,6 +829,7 @@ The _flatIcons list is a cache for generated icon files.
 
 //For photo camera.
 /proc/build_composite_icon(atom/A)
+	RETURN_TYPE(/icon)
 	var/icon/composite = icon(A.icon, A.icon_state, A.dir, 1)
 	for(var/O in A.overlays)
 		var/image/I = O
@@ -840,6 +847,7 @@ The _flatIcons list is a cache for generated icon files.
 	return rgb(RGB[1],RGB[2],RGB[3])
 
 /proc/sort_atoms_by_layer(list/atoms)
+	RETURN_TYPE(/list)
 	// Comb sort icons based on levels
 	var/list/result = atoms.Copy()
 	var/gap = length(result)
@@ -864,6 +872,7 @@ cap_mode is capturing mode (optional), user is capturing mob (requred only wehen
 lighting determines lighting capturing (optional), suppress_errors suppreses errors and continues to capture (optional).
 */
 /proc/generate_image(tx as num, ty as num, tz as num, range as num, cap_mode = CAPTURE_MODE_PARTIAL, mob/living/user, lighting = 1, suppress_errors = 1)
+	RETURN_TYPE(/icon)
 	var/list/turfstocapture = list()
 	//Lines below determine what tiles will be rendered
 	for(var/xoff = 0 to range)

--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -120,6 +120,7 @@
  * If either of arguments is not a list, returns null
  */
 /proc/difflist(list/first, list/second, skiprep=0)
+	RETURN_TYPE(/list)
 	if(!islist(first) || !islist(second))
 		return
 	var/list/result = new
@@ -160,6 +161,7 @@ Checks if a list has the same entries and values as an element of big.
  * If either of arguments is not a list, returns null
  */
 /proc/uniquemergelist(list/first, list/second, skiprep=0)
+	RETURN_TYPE(/list)
 	if(!islist(first) || !islist(second))
 		return
 	var/list/result = new
@@ -170,10 +172,12 @@ Checks if a list has the same entries and values as an element of big.
 	return result
 
 /proc/assoc_merge_add(value_a, value_b)
+	RETURN_TYPE(/list)
 	return value_a + value_b
 
 // This proc merges two associative lists
 /proc/merge_assoc_lists(list/a, list/b, merge_method, default_if_null_value = null)
+	RETURN_TYPE(/list)
 	. = list()
 	for(var/key in a)
 		var/a_value = a[key]
@@ -263,6 +267,7 @@ Checks if a list has the same entries and values as an element of big.
 
 //Reverses the order of items in the list
 /proc/reverselist(list/L)
+	RETURN_TYPE(/list)
 	var/list/output = list()
 	if(L)
 		for(var/i = length(L); i >= 1; i--)
@@ -271,6 +276,7 @@ Checks if a list has the same entries and values as an element of big.
 
 //Randomize: Return the list in a random order
 /proc/shuffle(list/L)
+	RETURN_TYPE(/list)
 	if(!L)
 		return
 
@@ -282,18 +288,21 @@ Checks if a list has the same entries and values as an element of big.
 
 //Return a list with no duplicate entries
 /proc/uniquelist(list/L)
+	RETURN_TYPE(/list)
 	. = list()
 	for(var/i in L)
 		. |= i
 
 // Return a list of the values in an assoc list (including null)
 /proc/list_values(list/L)
+	RETURN_TYPE(/list)
 	. = list()
 	for(var/e in L)
 		. += L[e]
 
 //Mergesort: divides up the list into halves to begin the sort
 /proc/sortKey(list/client/L, order = 1)
+	RETURN_TYPE(/list)
 	if(isnull(L) || length(L) < 2)
 		return L
 	var/middle = length(L) / 2 + 1
@@ -301,6 +310,7 @@ Checks if a list has the same entries and values as an element of big.
 
 //Mergsort: does the actual sorting and returns the results back to sortAtom
 /proc/mergeKey(list/client/L, list/client/R, order = 1)
+	RETURN_TYPE(/list)
 	var/Li=1
 	var/Ri=1
 	var/list/result = new()
@@ -318,6 +328,7 @@ Checks if a list has the same entries and values as an element of big.
 
 //Mergesort: divides up the list into halves to begin the sort
 /proc/sortAtom(list/atom/L, order = 1)
+	RETURN_TYPE(/list)
 	if(isnull(L) || length(L) < 2)
 		return L
 	if(null in L)	// Cannot sort lists containing null entries.
@@ -327,6 +338,7 @@ Checks if a list has the same entries and values as an element of big.
 
 //Mergsort: does the actual sorting and returns the results back to sortAtom
 /proc/mergeAtoms(list/atom/L, list/atom/R, order = 1)
+	RETURN_TYPE(/list)
 	var/Li=1
 	var/Ri=1
 	var/list/result = new()
@@ -345,6 +357,7 @@ Checks if a list has the same entries and values as an element of big.
 
 //Mergesort: any value in a list
 /proc/sortList(list/L)
+	RETURN_TYPE(/list)
 	if(length(L) < 2)
 		return L
 	var/middle = length(L) / 2 + 1 // Copy is first,second-1
@@ -352,12 +365,14 @@ Checks if a list has the same entries and values as an element of big.
 
 //Mergsorge: uses sortList() but uses the var's name specifically. This should probably be using mergeAtom() instead
 /proc/sortNames(list/L)
+	RETURN_TYPE(/list)
 	var/list/Q = new()
 	for(var/atom/x in L)
 		Q[x.name] = x
 	return sortList(Q)
 
 /proc/mergeLists(list/L, list/R)
+	RETURN_TYPE(/list)
 	var/Li=1
 	var/Ri=1
 	var/list/result = new()
@@ -374,12 +389,14 @@ Checks if a list has the same entries and values as an element of big.
 
 // List of lists, sorts by element[key] - for things like crew monitoring computer sorting records by name.
 /proc/sortByKey(list/L, key)
+	RETURN_TYPE(/list)
 	if(length(L) < 2)
 		return L
 	var/middle = length(L) / 2 + 1
 	return mergeKeyedLists(sortByKey(L.Copy(0, middle), key), sortByKey(L.Copy(middle), key), key)
 
 /proc/mergeKeyedLists(list/L, list/R, key)
+	RETURN_TYPE(/list)
 	var/Li=1
 	var/Ri=1
 	var/list/result = new()
@@ -399,12 +416,14 @@ Checks if a list has the same entries and values as an element of big.
 
 //Mergesort: any value in a list, preserves key=value structure
 /proc/sortAssoc(list/L)
+	RETURN_TYPE(/list)
 	if(length(L) < 2)
 		return L
 	var/middle = length(L) / 2 + 1 // Copy is first,second-1
 	return mergeAssoc(sortAssoc(L.Copy(0,middle)), sortAssoc(L.Copy(middle))) //second parameter null = to end of list
 
 /proc/mergeAssoc(list/L, list/R)
+	RETURN_TYPE(/list)
 	var/Li=1
 	var/Ri=1
 	var/list/result = new()
@@ -420,6 +439,7 @@ Checks if a list has the same entries and values as an element of big.
 
 //Converts a bitfield to a list of numbers (or words if a wordlist is provided)
 /proc/bitfield2list(bitfield = 0, list/wordlist)
+	RETURN_TYPE(/list)
 	var/list/r = list()
 	if(istype(wordlist,/list))
 		var/max = min(length(wordlist),16)
@@ -459,6 +479,7 @@ Checks if a list has the same entries and values as an element of big.
 
 //Don't use this on lists larger than half a dozen or so
 /proc/insertion_sort_numeric_list_ascending(list/L)
+	RETURN_TYPE(/list)
 	//to_world_log("ascending len input: [length(L)]")
 	var/list/out = list(pop(L))
 	for(var/entry in L)
@@ -476,6 +497,7 @@ Checks if a list has the same entries and values as an element of big.
 	return out
 
 /proc/insertion_sort_numeric_list_descending(list/L)
+	RETURN_TYPE(/list)
 	//to_world_log("descending len input: [length(L)]")
 	var/list/out = insertion_sort_numeric_list_ascending(L)
 	//to_world_log("output: [length(out)]")
@@ -506,12 +528,14 @@ Checks if a list has the same entries and values as an element of big.
 
 
 /proc/dd_sortedObjectList(list/L, cache=list())
+	RETURN_TYPE(/list)
 	if(length(L) < 2)
 		return L
 	var/middle = length(L) / 2 + 1 // Copy is first,second-1
 	return dd_mergeObjectList(dd_sortedObjectList(L.Copy(0,middle), cache), dd_sortedObjectList(L.Copy(middle), cache), cache) //second parameter null = to end of list
 
 /proc/dd_mergeObjectList(list/L, list/R, list/cache)
+	RETURN_TYPE(/list)
 	var/Li=1
 	var/Ri=1
 	var/list/result = new()
@@ -537,6 +561,7 @@ Checks if a list has the same entries and values as an element of big.
 
 // Insert an object into a sorted list, preserving sortedness
 /proc/dd_insertObjectList(list/L, O)
+	RETURN_TYPE(/list)
 	var/min = 1
 	var/max = length(L) + 1
 	var/Oval = O:dd_SortValue()
@@ -559,6 +584,7 @@ Checks if a list has the same entries and values as an element of big.
 			min = mid+1
 
 /proc/dd_sortedtextlist(list/incoming, case_sensitive = 0)
+	RETURN_TYPE(/list)
 	// Returns a new list with the text values sorted.
 	// Use binary search to order by sortValue.
 	// This works by going to the half-point of the list, seeing if the node in question is higher or lower cost,
@@ -618,6 +644,7 @@ Checks if a list has the same entries and values as an element of big.
 
 
 /proc/dd_sortedTextList(list/incoming)
+	RETURN_TYPE(/list)
 	var/case_sensitive = 1
 	return dd_sortedtextlist(incoming, case_sensitive)
 
@@ -637,6 +664,7 @@ Checks if a list has the same entries and values as an element of big.
 //creates every subtype of prototype (excluding prototype) and adds it to list L.
 //if no list/L is provided, one is created.
 /proc/init_subtypes(prototype, list/L)
+	RETURN_TYPE(/list)
 	if(!istype(L))	L = list()
 	for(var/path in subtypesof(prototype))
 		L += new path()
@@ -645,6 +673,7 @@ Checks if a list has the same entries and values as an element of big.
 //creates every subtype of prototype (excluding prototype) and adds it to list L as a type/instance pair.
 //if no list/L is provided, one is created.
 /proc/init_subtypes_assoc(prototype, list/L)
+	RETURN_TYPE(/list)
 	if(!istype(L))	L = list()
 	for(var/path in subtypesof(prototype))
 		L[path] = new path()
@@ -653,6 +682,7 @@ Checks if a list has the same entries and values as an element of big.
 #define listequal(A, B) (length(A) == length(B) && !length(A^B))
 
 /proc/filter_list(list/L, type)
+	RETURN_TYPE(/list)
 	. = list()
 	for(var/entry in L)
 		if(istype(entry, type))
@@ -667,6 +697,7 @@ Checks if a list has the same entries and values as an element of big.
 	values += value
 
 /proc/duplicates(list/L)
+	RETURN_TYPE(/list)
 	. = list()
 	var/list/checked = list()
 	for(var/value in L)
@@ -676,6 +707,7 @@ Checks if a list has the same entries and values as an element of big.
 			checked += value
 
 /proc/assoc_by_proc(list/plain_list, get_initial_value)
+	RETURN_TYPE(/list)
 	. = list()
 	for(var/entry in plain_list)
 		.[call(get_initial_value)(entry)] = entry
@@ -725,6 +757,7 @@ Checks if a list has the same entries and values as an element of big.
 
 //replaces reverseList ~Carnie
 /proc/reverseRange(list/L, start=1, end=0)
+	RETURN_TYPE(/list)
 	if(length(L))
 		start = start % length(L)
 		end = end % (length(L)+1)
@@ -742,6 +775,7 @@ Checks if a list has the same entries and values as an element of big.
 //Copies a list, and all lists inside it recusively
 //Does not copy any other reference type
 /proc/deepCopyList(list/l)
+	RETURN_TYPE(/list)
 	if(!islist(l))
 		return l
 	. = l.Copy()
@@ -759,6 +793,7 @@ Checks if a list has the same entries and values as an element of big.
 
 // Gets the first instance that is of the given type (strictly)
 /proc/get_instance_of_strict_type(list/L, T)
+	RETURN_TYPE(/atom)
 	for(var/key in L)
 		var/atom/A = key
 		if(A.type == T)
@@ -769,6 +804,7 @@ Checks if a list has the same entries and values as an element of big.
  *
  */
 /proc/typecache_filter_list(list/atoms, list/typecache)
+	RETURN_TYPE(/list)
 	. = list()
 	for(var/thing in atoms)
 		var/atom/A = thing
@@ -779,6 +815,7 @@ Checks if a list has the same entries and values as an element of big.
  * Like typesof() or subtypesof(), but returns a typecache instead of a list
  */
 /proc/typecacheof(path, ignore_root_path, only_root_path = FALSE)
+	RETURN_TYPE(/list)
 	if(ispath(path))
 		var/list/types = list()
 		if(only_root_path)

--- a/code/_helpers/maths.dm
+++ b/code/_helpers/maths.dm
@@ -130,6 +130,7 @@
 
 /// A circular random coordinate pair from 0, unit by default, scaled by radius, then rounded if round.
 /proc/CircularRandomCoordinate(radius = 1, round)
+	RETURN_TYPE(/list)
 	var/angle = rand(0, 359)
 	var/x = cos(angle) * radius
 	var/y = sin(angle) * radius
@@ -152,6 +153,7 @@
 * radius outside the scope of the proc, eg as BoundedCircularRandomCoordinate(Frand(1, 3), ...)
 */
 /proc/BoundedCircularRandomCoordinate(radius, center_x, center_y, low_x, low_y, high_x, high_y, round)
+	RETURN_TYPE(/list)
 	var/list/xy = CircularRandomCoordinate(radius, round)
 	var/dx = xy[1]
 	var/dy = xy[2]
@@ -169,12 +171,14 @@
 
 /// Pick a random turf using BoundedCircularRandomCoordinate about x,y on level z
 /proc/CircularRandomTurf(radius, z, center_x, center_y, low_x = 1, low_y = 1, high_x = world.maxx, high_y = world.maxy)
+	RETURN_TYPE(/turf)
 	var/list/xy = BoundedCircularRandomCoordinate(radius, center_x, center_y, low_x, low_y, high_x, high_y, TRUE)
 	return locate(xy[1], xy[2], z)
 
 
 /// Pick a random turf using BoundedCircularRandomCoordinate around the turf of target
 /proc/CircularRandomTurfAround(atom/target, radius, low_x = 1, low_y = 1, high_x = world.maxx, high_y = world.maxy)
+	RETURN_TYPE(/turf)
 	var/turf/turf = get_turf(target)
 	return CircularRandomTurf(radius, turf.z, turf.x, turf.y, low_x, low_y, high_x, high_y)
 

--- a/code/_helpers/matrices.dm
+++ b/code/_helpers/matrices.dm
@@ -48,11 +48,13 @@
 
 //Returns an identity color matrix which does nothing
 /proc/color_identity()
+	RETURN_TYPE(/list)
 	return list(1,0,0, 0,1,0, 0,0,1)
 
 //Moves all colors angle degrees around the color wheel while maintaining intensity of the color and not affecting whites
 //TODO: Need a version that only affects one color (ie shift red to blue but leave greens and blues alone)
 /proc/color_rotation(angle)
+	RETURN_TYPE(/list)
 	if(angle == 0)
 		return color_identity()
 	angle = clamp(angle, -180, 180)
@@ -70,6 +72,7 @@
 
 //Makes everything brighter or darker without regard to existing color or brightness
 /proc/color_brightness(power)
+	RETURN_TYPE(/list)
 	power = clamp(power, -255, 255)
 	power = power/255
 
@@ -90,6 +93,7 @@ var/global/list/delta_index = list(
 
 //Exxagerates or removes brightness
 /proc/color_contrast(value)
+	RETURN_TYPE(/list)
 	value = round(clamp(value, -100, 100))
 	if(value == 0)
 		return color_identity()
@@ -111,6 +115,7 @@ var/global/list/delta_index = list(
 
 //Exxagerates or removes colors
 /proc/color_saturation(value as num)
+	RETURN_TYPE(/list)
 	if(value == 0)
 		return color_identity()
 	value = clamp(value, -100, 100)
@@ -132,6 +137,7 @@ var/global/list/delta_index = list(
 //Given 2 matrices mxn and nxp (row major) it multiplies their members and return an mxp matrix
 //Do make sure your lists actually have this many elements
 /proc/multiply_matrices(list/A, list/B, m, n, p)
+	RETURN_TYPE(/list)
 	var/list/result = new (m * p)
 
 	if(length(A) == m*n && length(B) == n*p)

--- a/code/_helpers/medical_scans.dm
+++ b/code/_helpers/medical_scans.dm
@@ -1,4 +1,5 @@
 /mob/living/carbon/human/proc/get_raw_medical_data(tag = FALSE)
+	RETURN_TYPE(/list)
 	var/mob/living/carbon/human/H = src
 	var/list/scan = list()
 
@@ -107,6 +108,7 @@
 	return scan
 
 /proc/display_medical_data_header(list/scan, skill_level = SKILL_DEFAULT)
+	RETURN_TYPE(/list)
 	//In case of problems, abort.
 	var/dat = list()
 
@@ -128,6 +130,7 @@
 	return dat
 
 /proc/display_medical_data_health(list/scan, skill_level = SKILL_DEFAULT)
+	RETURN_TYPE(/list)
 	//In case of problems, abort.
 	if(!scan["name"])
 		return "<center>[SPAN_BAD("<strong>SCAN READOUT ERROR.</strong>")]</center>"

--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -13,6 +13,7 @@
 #define blocked_mult(blocked) max(1 - (blocked/100), 0)
 
 /proc/mobs_in_view(range, source)
+	RETURN_TYPE(/list)
 	var/list/mobs = list()
 	for(var/atom/movable/AM in view(range, source))
 		var/M = AM.get_mob()
@@ -229,6 +230,7 @@
 		target.do_unique_target_user = null
 
 /proc/able_mobs_in_oview(origin)
+	RETURN_TYPE(/list)
 	var/list/mobs = list()
 	for(var/mob/living/M in oview(origin)) // Only living mobs are considered able.
 		if(!M.is_physically_disabled())
@@ -273,6 +275,7 @@
 
 //Find a dead mob with a brain and client.
 /proc/find_dead_player(find_key, include_observers = 0)
+	RETURN_TYPE(/mob)
 	if(isnull(find_key))
 		return
 

--- a/code/_helpers/sorts/TimSort.dm
+++ b/code/_helpers/sorts/TimSort.dm
@@ -1,5 +1,6 @@
 //TimSort interface
 /proc/sortTim(list/L, cmp=/proc/cmp_numeric_asc, associative, fromIndex=1, toIndex=0)
+	RETURN_TYPE(/list)
 	if(L && length(L) >= 2)
 		fromIndex = fromIndex % length(L)
 		toIndex = toIndex % (length(L)+1)

--- a/code/_helpers/sorts/__main.dm
+++ b/code/_helpers/sorts/__main.dm
@@ -33,6 +33,7 @@ var/global/datum/sortInstance/sortInstance = new()
 
 
 /datum/sortInstance/proc/timSort(start, end)
+	RETURN_TYPE(/list)
 	runBases.Cut()
 	runLens.Cut()
 
@@ -571,6 +572,7 @@ reverse a descending sequence without violating stability.
 
 
 /datum/sortInstance/proc/mergeSort(start, end)
+	RETURN_TYPE(/list)
 	var/remaining = end - start
 
 	//If array is small, do an insertion sort

--- a/code/_helpers/species.dm
+++ b/code/_helpers/species.dm
@@ -5,6 +5,7 @@
 
 /// Null, or a species if thing is a species, a species path, or a species name
 /proc/resolve_species(datum/species/thing)
+	RETURN_TYPE(/datum/species)
 	if (ispath(thing, /datum/species))
 		thing = initial(thing.name)
 	if (istext(thing))

--- a/code/_helpers/time.dm
+++ b/code/_helpers/time.dm
@@ -203,6 +203,7 @@ var/global/round_start_time = 0
 	return weekdays.Find(time2text(world.timeofday, "DDD"))
 
 /proc/current_month_and_day()
+	RETURN_TYPE(/list)
 	var/time_string = time2text(world.realtime, "MM-DD")
 	var/time_list = splittext(time_string, "-")
 	return list(text2num(time_list[1]), text2num(time_list[2]))

--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -1,6 +1,7 @@
 // Returns the atom sitting on the turf.
 // For example, using this on a disk, which is in a bag, on a mob, will return the mob because it's on the turf.
 /proc/get_atom_on_turf(atom/movable/M)
+	RETURN_TYPE(/atom)
 	var/atom/mloc = M
 	while(mloc && mloc.loc && !isturf(mloc.loc))
 		mloc = mloc.loc
@@ -15,6 +16,7 @@
 // Picks a turf without a mob from the given list of turfs, if one exists.
 // If no such turf exists, picks any random turf from the given list of turfs.
 /proc/pick_mobless_turf_if_exists(list/start_turfs)
+	RETURN_TYPE(/turf)
 	if(!length(start_turfs))
 		return null
 
@@ -28,6 +30,7 @@
 	return pick(available_turfs)
 
 /proc/get_random_edge_turf(dir, clearance = TRANSITIONEDGE + 1, Z)
+	RETURN_TYPE(/turf)
 	if(!dir)
 		return
 
@@ -42,6 +45,7 @@
 			return locate(clearance, rand(clearance, world.maxy - clearance), Z)
 
 /proc/get_random_turf_in_range(atom/origin, outer_range, inner_range)
+	RETURN_TYPE(/turf)
 	origin = get_turf(origin)
 	if(!origin)
 		return
@@ -56,6 +60,7 @@
 		return pick(turfs)
 
 /proc/screen_loc2turf(text, turf/origin)
+	RETURN_TYPE(/turf)
 	if(!origin)
 		return null
 	var/tZ = splittext(text, ",")
@@ -130,6 +135,7 @@
 //Returns an assoc list that describes how turfs would be changed if the
 //turfs in turfs_src were translated by shifting the src_origin to the dst_origin
 /proc/get_turf_translation(turf/src_origin, turf/dst_origin, list/turfs_src)
+	RETURN_TYPE(/list)
 	var/list/turf_map = list()
 	for(var/turf/source in turfs_src)
 		var/x_pos = (source.x - src_origin.x)
@@ -161,6 +167,7 @@
 
 //Transports a turf from a source turf to a target turf, moving all of the turf's contents and making the target a copy of the source.
 /proc/transport_turf_contents(turf/source, turf/target)
+	RETURN_TYPE(/turf)
 
 	var/turf/new_turf = target.ChangeTurf(source.type, 1, 1)
 	new_turf.transport_properties_from(source)
@@ -192,6 +199,7 @@
 */
 
 /proc/get_turfs_in_range(turf/center, range, list/predicates)
+	RETURN_TYPE(/list)
 	. = list()
 
 	if (!istype(center))
@@ -206,6 +214,7 @@
 */
 
 /proc/pick_turf_in_range(turf/center, range, list/turf_predicates)
+	RETURN_TYPE(/list)
 	var/list/turfs = get_turfs_in_range(center, range, turf_predicates)
 	if (length(turfs))
 		return pick(turfs)

--- a/code/_helpers/type2type.dm
+++ b/code/_helpers/type2type.dm
@@ -9,6 +9,7 @@
  */
 
 /proc/text2numlist(text, delimiter="\n")
+	RETURN_TYPE(/list)
 	var/list/num_list = list()
 	for(var/x in splittext(text, delimiter))
 		num_list += text2num(x)
@@ -16,6 +17,7 @@
 
 // Splits the text of a file at seperator and returns them in a list.
 /proc/file2list(filename, seperator="\n")
+	RETURN_TYPE(/list)
 	return splittext(file2text(filename) || "", seperator)
 
 // Turns a direction into text
@@ -182,6 +184,7 @@
 	return ((y) % 4 == 0 && ((y) % 100 != 0 || (y) % 400 == 0))
 
 /proc/atomtypes2nameassoclist(list/atom_types)
+	RETURN_TYPE(/list)
 	. = list()
 	for(var/atom_type in atom_types)
 		var/atom/A = atom_type
@@ -189,8 +192,10 @@
 	. = sortAssoc(.)
 
 /proc/atomtype2nameassoclist(atom_type)
+	RETURN_TYPE(/list)
 	return atomtypes2nameassoclist(typesof(atom_type))
 
 //Splits the text of a file at seperator and returns them in a list.
 /world/proc/file2list(filename, seperator="\n")
+	RETURN_TYPE(/list)
 	return splittext(file2text(filename), seperator)

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -3,6 +3,7 @@
  */
 
 /proc/subtypesof(datum/thing)
+	RETURN_TYPE(/list)
 	if (ispath(thing))
 		return typesof(thing) - thing
 	if (istype(thing))
@@ -64,6 +65,7 @@
 
 //Returns location. Returns null if no location was found.
 /proc/get_teleport_loc(turf/location,mob/target,distance = 1, density = FALSE, errorx = 0, errory = 0, eoffsetx = 0, eoffsety = 0)
+	RETURN_TYPE(/turf)
 /*
 Location where the teleport begins, target that will teleport, distance to go, density checking 0/1(yes/no).
 Random error in tile placement x, error in tile placement y, and block offset.
@@ -198,6 +200,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	return x!=0?x/abs(x):0
 
 /proc/getline(atom/M,atom/N)//Ultra-Fast Bresenham Line-Drawing Algorithm
+	RETURN_TYPE(/list)
 	var/px=M.x		//starting x
 	var/py=M.y
 	var/line[] = list(locate(px,py,M.z))
@@ -230,6 +233,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 #define LOCATE_COORDS(X, Y, Z) locate(clamp(X, 1, world.maxx), clamp(Y, 1, world.maxy), Z)
 /proc/getcircle(turf/center, radius) //Uses a fast Bresenham rasterization algorithm to return the turfs in a thin circle.
+	RETURN_TYPE(/list)
 	if(!radius) return list(center)
 
 	var/x = 0
@@ -320,6 +324,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 //When an AI is activated, it can choose from a list of non-slaved borgs to have as a slave.
 /proc/freeborg(z)
+	RETURN_TYPE(/mob/living/silicon/robot)
 	var/list/zs = get_valid_silicon_zs(z)
 
 	var/select = null
@@ -336,6 +341,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 //When a borg is activated, it can choose which AI it wants to be slaved to
 /proc/active_ais(z)
+	RETURN_TYPE(/list)
 	var/list/zs = get_valid_silicon_zs(z)
 
 	. = list()
@@ -347,6 +353,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 //Find an active ai with the least borgs. VERBOSE PROCNAME HUH!
 /proc/select_active_ai_with_fewest_borgs(z)
+	RETURN_TYPE(/mob/living/silicon/ai)
 	var/mob/living/silicon/ai/selected
 	var/list/active = active_ais(z)
 	for(var/mob/living/silicon/ai/A in active)
@@ -356,6 +363,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	return selected
 
 /proc/select_active_ai(mob/user, z)
+	RETURN_TYPE(/mob/living/silicon/ai)
 	var/list/ais = active_ais(z)
 	if(length(ais))
 		if(user?.client)
@@ -364,11 +372,13 @@ Turf and target are seperate in case you want to teleport some distance from a t
 			. = pick(ais)
 
 /proc/get_valid_silicon_zs(z)
+	RETURN_TYPE(/list)
 	if(z)
 		return GetConnectedZlevels(z)
 	return list() //We return an empty list, because we are apparently in nullspace
 
 /proc/get_sorted_mobs()
+	RETURN_TYPE(/list)
 	var/list/old_list = getmobs()
 	var/list/AI_list = list()
 	var/list/Dead_list = list()
@@ -398,7 +408,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 //Returns a list of all mobs with their name
 /proc/getmobs()
-
+	RETURN_TYPE(/list)
 	var/list/mobs = sortmobs()
 	var/list/names = list()
 	var/list/creatures = list()
@@ -423,10 +433,12 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	return creatures
 
 /proc/get_follow_targets()
+	RETURN_TYPE(/list)
 	return follow_repository.get_follow_targets()
 
 //Orders mobs by type then by name
 /proc/sortmobs()
+	RETURN_TYPE(/list)
 	var/list/moblist = list()
 	var/list/sortmob = sortAtom(SSmobs.mob_list)
 	for(var/mob/observer/eye/M in sortmob)
@@ -467,7 +479,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 // returns the turf located at the map edge in the specified direction relative to A
 // used for mass driver
 /proc/get_edge_target_turf(atom/A, direction)
-
+	RETURN_TYPE(/turf)
 	var/turf/target = locate(A.x, A.y, A.z)
 	if(!A || !target)
 		return 0
@@ -491,7 +503,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 // note range is non-pythagorean
 // used for disposal system
 /proc/get_ranged_target_turf(atom/A, direction, range)
-
+	RETURN_TYPE(/turf)
 	var/x = A.x
 	var/y = A.y
 	if(direction & NORTH)
@@ -509,6 +521,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 // returns turf relative to A offset in dx and dy tiles
 // bound to map limits
 /proc/get_offset_target_turf(atom/A, dx, dy)
+	RETURN_TYPE(/turf)
 	var/x = min(world.maxx, max(1, A.x + dx))
 	var/y = min(world.maxy, max(1, A.y + dy))
 	return locate(x,y,A.z)
@@ -537,6 +550,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
  * Returns a list of atoms.
  */
 /atom/proc/GetAllContents(searchDepth = 5)
+	RETURN_TYPE(/list)
 	var/list/toReturn = list()
 
 	for(var/atom/part in contents)
@@ -574,6 +588,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	return cant_pass
 
 /proc/get_step_towards2(atom/ref , atom/trg)
+	RETURN_TYPE(/turf)
 	var/base_dir = get_dir(ref, get_step_towards(ref,trg))
 	var/turf/temp = get_step_towards(ref,trg)
 
@@ -609,6 +624,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 //Takes: Area type as text string or as typepath OR an instance of the area.
 //Returns: A list of all areas of that type in the world.
 /proc/get_areas(areatype)
+	RETURN_TYPE(/list)
 	if(!areatype) return null
 	if(istext(areatype)) areatype = text2path(areatype)
 	if(isarea(areatype))
@@ -623,6 +639,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 //Takes: Area type as a typepath OR an instance of the area.
 //Returns: A list of all atoms	(objs, turfs, mobs) in areas of that type of that type in the world.
 /proc/get_area_all_atoms(areatype)
+	RETURN_TYPE(/list)
 	if(!areatype)
 		return null
 	if(isarea(areatype))
@@ -677,6 +694,7 @@ GLOBAL_LIST_INIT(duplicate_object_disallowed_vars, list(
 
 
 /proc/clone_atom(obj/original, copy_vars, atom/loc)
+	RETURN_TYPE(/obj)
 	if (!original)
 		return
 	if (loc && !isloc(loc))
@@ -710,6 +728,7 @@ GLOBAL_LIST_INIT(duplicate_object_disallowed_vars, list(
  * Returns List (`/atom`). A list containing all atoms that were created at the target area during the process.
  */
 /area/proc/copy_contents_to(area/target, plating_required)
+	RETURN_TYPE(/list)
 	if (!target || !src)
 		return
 	var/list/turfs_src = get_area_turfs(type)
@@ -783,6 +802,7 @@ GLOBAL_LIST_INIT(duplicate_object_disallowed_vars, list(
 	return (rand(1,value)==value)
 
 /proc/view_or_range(distance = world.view , center = usr , type)
+	RETURN_TYPE(/list)
 	switch(type)
 		if("view")
 			. = view(distance,center)
@@ -791,6 +811,7 @@ GLOBAL_LIST_INIT(duplicate_object_disallowed_vars, list(
 	return
 
 /proc/oview_or_orange(distance = world.view , center = usr , type)
+	RETURN_TYPE(/list)
 	switch(type)
 		if("view")
 			. = oview(distance,center)
@@ -799,6 +820,7 @@ GLOBAL_LIST_INIT(duplicate_object_disallowed_vars, list(
 	return
 
 /proc/get_mob_with_client_list()
+	RETURN_TYPE(/list)
 	var/list/mobs = list()
 	for(var/mob/M in SSmobs.mob_list)
 		if (M.client)
@@ -829,6 +851,7 @@ GLOBAL_LIST_INIT(duplicate_object_disallowed_vars, list(
 	return null
 
 /proc/get_turf_or_move(turf/location)
+	RETURN_TYPE(/turf)
 	return get_turf(location)
 
 
@@ -1014,6 +1037,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 
 //Version of view() which ignores darkness, because BYOND doesn't have it.
 /proc/dview(range = world.view, center, invis_flags = 0)
+	RETURN_TYPE(/list)
 	if(!center)
 		return
 

--- a/code/_helpers/vector.dm
+++ b/code/_helpers/vector.dm
@@ -110,6 +110,7 @@ return_location()
 	return sqrt(((offset_x / 32) ** 2) + ((offset_y / 32) ** 2))
 
 /datum/plot_vector/proc/return_location(datum/vector_loc/data)
+	RETURN_TYPE(/datum/vector_loc)
 	if(!data)
 		data = new()
 	data.loc = locate(round(loc_x / world.icon_size, 1), round(loc_y / world.icon_size, 1), loc_z)
@@ -132,4 +133,5 @@ return_turf()
 	var/pixel_y
 
 /datum/vector_loc/proc/return_turf()
+	RETURN_TYPE(/turf)
 	return loc

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -439,6 +439,7 @@ GLOBAL_LIST_INIT(click_catchers, create_click_catcher())
 	return QDEL_HINT_LETMELIVE
 
 /proc/create_click_catcher()
+	RETURN_TYPE(/list)
 	. = list()
 	for(var/i = 0, i<15, i++)
 		for(var/j = 0, j<15, j++)

--- a/code/controllers/subsystems/initialization/materials.dm
+++ b/code/controllers/subsystems/initialization/materials.dm
@@ -51,6 +51,7 @@ SUBSYSTEM_DEF(materials)
 		log_error("Unable to acquire material by name '[name]'")
 
 /proc/material_display_name(name)
+	RETURN_TYPE(/material)
 	var/material/material = SSmaterials.get_material_by_name(name)
 	if(material)
 		return material.display_name

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -74,6 +74,7 @@ SUBSYSTEM_DEF(mapping)
 			away_sites_templates[MT.name] = MT
 
 /proc/generateMapList(filename)
+	RETURN_TYPE(/list)
 	var/list/potentialMaps = list()
 	var/list/Lines = world.file2list(filename)
 	if(!length(Lines))

--- a/code/datums/extensions/extensions.dm
+++ b/code/datums/extensions/extensions.dm
@@ -39,12 +39,14 @@
 		source.extensions[extension_base_type] = extension_data
 
 /proc/get_or_create_extension(datum/source, datum/extension/extension_type)
+	RETURN_TYPE(/datum/extension)
 	var/base_type = initial(extension_type.base_type)
 	if(!has_extension(source, base_type))
 		set_extension(arglist(args))
 	return get_extension(source, base_type)
 
 /proc/get_extension(datum/source, base_type)
+	RETURN_TYPE(/datum/extension)
 	if(!source.extensions)
 		return
 	. = source.extensions[base_type]
@@ -60,6 +62,7 @@
 	return !!(source.extensions && source.extensions[base_type])
 
 /proc/construct_extension_instance(extension_type, datum/source, list/arguments)
+	RETURN_TYPE(/datum/extension)
 	arguments = list(source) + arguments
 	return new extension_type(arglist(arguments))
 

--- a/code/datums/extensions/label.dm
+++ b/code/datums/extensions/label.dm
@@ -72,6 +72,7 @@
 
 
 /proc/get_attached_labels(atom/source)
+	RETURN_TYPE(/list)
 	if (has_extension(source, /datum/extension/labels))
 		var/datum/extension/labels/labels = get_extension(source, /datum/extension/labels)
 		if (length(labels.labels))

--- a/code/datums/extensions/state_machine.dm
+++ b/code/datums/extensions/state_machine.dm
@@ -7,6 +7,7 @@ var/global/list/state_machines = list()
 		return islist(machines) && machines[base_type]
 
 /proc/add_state_machine(datum/holder, base_type, fsm_type)
+	RETURN_TYPE(/datum/state_machine)
 	if(istype(holder) && base_type)
 		var/holder_ref = "\ref[holder]"
 		var/list/machines = global.state_machines[holder_ref]

--- a/code/datums/mutable_appearance.dm
+++ b/code/datums/mutable_appearance.dm
@@ -6,6 +6,7 @@
 
 // Helper similar to image()
 /proc/mutable_appearance(icon, icon_state, color, flags = DEFAULT_APPEARANCE_FLAGS | RESET_COLOR | RESET_ALPHA, plane = FLOAT_PLANE, layer = FLOAT_LAYER)
+	RETURN_TYPE(/mutable_appearance)
 	var/mutable_appearance/MA = new()
 	MA.icon = icon
 	MA.icon_state = icon_state

--- a/code/datums/outfits/equipment/backpacks.dm
+++ b/code/datums/outfits/equipment/backpacks.dm
@@ -179,6 +179,7 @@
 * Helpers *
 **********/
 /proc/get_default_outfit_backpack()
+	RETURN_TYPE(/singleton/backpack_outfit)
 	var backpacks = GET_SINGLETON_SUBTYPE_MAP(/singleton/backpack_outfit)
 	for(var/backpack in backpacks)
 		var/singleton/backpack_outfit/bo = backpacks[backpack]

--- a/code/datums/repositories/client.dm
+++ b/code/datums/repositories/client.dm
@@ -56,6 +56,7 @@ var/global/repository/client/client_repository = new()
 	return " \[[C.holder.rank]\]"
 
 /proc/client_by_ckey(ckey)
+	RETURN_TYPE(/client)
 	for(var/client/C)
 		if(C.ckey == ckey)
 			return C

--- a/code/datums/repositories/follow.dm
+++ b/code/datums/repositories/follow.dm
@@ -51,6 +51,7 @@ var/global/repository/follow/follow_repository = new()
 			return followed_subtypes[follow_type]
 
 /repository/follow/proc/get_follow_targets()
+	RETURN_TYPE(/list)
 	if(cache && cache.is_valid())
 		return cache.data
 	// The previous cache entry should have no further references and will thus be GCd eventually without qdel

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -150,6 +150,7 @@ var/global/datum/uplink/uplink = new()
 * Support procs *
 ****************/
 /proc/get_random_uplink_items(obj/item/device/uplink/U, remaining_TC, loc)
+	RETURN_TYPE(/list)
 	var/list/bought_items = list()
 	while(remaining_TC)
 		var/datum/uplink_random_selection/uplink_selection = get_uplink_random_selection_by_type(/datum/uplink_random_selection/default)

--- a/code/datums/weakref.dm
+++ b/code/datums/weakref.dm
@@ -3,6 +3,7 @@
 
 //obtain a weak reference to a datum
 /proc/weakref(datum/D)
+	RETURN_TYPE(/weakref)
 	if(!istype(D))
 		return
 	if(QDELETED(D))

--- a/code/game/antagonist/_antagonist_setup.dm
+++ b/code/game/antagonist/_antagonist_setup.dm
@@ -14,6 +14,7 @@
 
 // Global procs.
 /proc/get_antag_data(antag_type)
+	RETURN_TYPE(/datum/antagonist)
 	if(GLOB.all_antag_types_[antag_type])
 		return GLOB.all_antag_types_[antag_type]
 	else
@@ -42,12 +43,14 @@
 			antag.update_all_icons()
 
 /proc/get_antags(atype)
+	RETURN_TYPE(/list)
 	var/datum/antagonist/antag = GLOB.all_antag_types_[atype]
 	if(antag && islist(antag.current_antagonists))
 		return antag.current_antagonists
 	return list()
 
 /proc/player_is_antag(datum/mind/player, only_offstation_roles = 0)
+	RETURN_TYPE(/datum/antagonist)
 	var/list/all_antag_types = GLOB.all_antag_types_
 	for(var/antag_type in all_antag_types)
 		var/datum/antagonist/antag = all_antag_types[antag_type]

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -75,6 +75,7 @@
 	return (flags & (ANTAG_OVERRIDE_MOB|ANTAG_OVERRIDE_JOB))
 
 /proc/all_random_antag_types()
+	RETURN_TYPE(/list)
 	// No caching as the ANTAG_RANDOM_EXCEPTED flag can be added/removed mid-round.
 	var/list/antag_candidates = GLOB.all_antag_types_.Copy()
 	for(var/datum/antagonist/antag in antag_candidates)

--- a/code/game/area/area_access.dm
+++ b/code/game/area/area_access.dm
@@ -5,6 +5,7 @@
 
 // Given two areas, find the minimal req_access needed such that (return value) + (area access) >= (other area access) and vice versa
 /proc/req_access_diff(area/first, area/second)
+	RETURN_TYPE(/list)
 	if(!length(first.req_access))
 		return second.req_access.Copy()
 	if(!length(second.req_access))
@@ -17,6 +18,7 @@
 
 // Given two areas, find the minimal req_access needed such that req_access >= (area access) + (other area access)
 /proc/req_access_union(area/first, area/second)
+	RETURN_TYPE(/list)
 	if(!length(first.req_access))
 		return second.req_access.Copy()
 	if(!length(second.req_access))
@@ -28,6 +30,7 @@
 // Comes up with the minimal thing to add to the first argument so that the new list guarantees that the access requirement in the second argument is satisfied.
 // Second argument is a number access code or list thereof (like an entry in req_access); the typecasting is false.
 /proc/get_minimal_requirement(list/req_access, list/requirement)
+	RETURN_TYPE(/list)
 	if(!requirement)
 		return
 	if(!islist(requirement))

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/HELPERS.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/HELPERS.dm
@@ -153,6 +153,7 @@
 // Parameters: None
 // Description: Returns a list of all unhacked APCs. APCs on station Zs are on top of the list.
 /proc/get_unhacked_apcs(mob/living/silicon/ai/user)
+	RETURN_TYPE(/list)
 	var/list/station_apcs = list()
 	var/list/offstation_apcs = list()
 
@@ -171,6 +172,7 @@
 
 // Helper procs which return lists of relevant mobs.
 /proc/get_unlinked_cyborgs(mob/living/silicon/ai/A)
+	RETURN_TYPE(/list)
 	if(!A || !istype(A))
 		return
 
@@ -184,11 +186,13 @@
 	return L
 
 /proc/get_linked_cyborgs(mob/living/silicon/ai/A)
+	RETURN_TYPE(/list)
 	if(!A || !istype(A))
 		return
 	return A.connected_robots
 
 /proc/get_other_ais(mob/living/silicon/ai/A)
+	RETURN_TYPE(/list)
 	if(!A || !istype(A))
 		return
 
@@ -208,6 +212,7 @@
 	admin_attack_log(A, null, message, null, message)
 
 /proc/check_for_interception()
+	RETURN_TYPE(/mob/living/silicon/ai)
 	for(var/mob/living/silicon/ai/A in SSmobs.mob_list)
 		if(A.intercepts_communication)
 			return A

--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -83,6 +83,7 @@ var/global/list/meteors_cataclysm = list(\
 	return
 
 /proc/spaceDebrisStartLoc(startSide, Z)
+	RETURN_TYPE(/turf)
 	var/starty
 	var/startx
 	switch(startSide)
@@ -102,6 +103,7 @@ var/global/list/meteors_cataclysm = list(\
 	return T
 
 /proc/spaceDebrisFinishLoc(startSide, Z)
+	RETURN_TYPE(/turf)
 	var/endy
 	var/endx
 	switch(startSide)

--- a/code/game/jobs/access.dm
+++ b/code/game/jobs/access.dm
@@ -89,6 +89,7 @@
 
 var/global/list/datum/access/priv_all_access_datums
 /proc/get_all_access_datums()
+	RETURN_TYPE(/list)
 	if(!priv_all_access_datums)
 		priv_all_access_datums = init_subtypes(/datum/access)
 		priv_all_access_datums = dd_sortedObjectList(priv_all_access_datums)
@@ -97,6 +98,7 @@ var/global/list/datum/access/priv_all_access_datums
 
 var/global/list/datum/access/priv_all_access_datums_id
 /proc/get_all_access_datums_by_id()
+	RETURN_TYPE(/list)
 	if(!priv_all_access_datums_id)
 		priv_all_access_datums_id = list()
 		for(var/datum/access/A in get_all_access_datums())
@@ -106,6 +108,7 @@ var/global/list/datum/access/priv_all_access_datums_id
 
 var/global/list/datum/access/priv_all_access_datums_region
 /proc/get_all_access_datums_by_region()
+	RETURN_TYPE(/list)
 	if(!priv_all_access_datums_region)
 		priv_all_access_datums_region = list()
 		for(var/datum/access/A in get_all_access_datums())
@@ -116,6 +119,7 @@ var/global/list/datum/access/priv_all_access_datums_region
 	return priv_all_access_datums_region.Copy()
 
 /proc/get_access_ids(access_types = ACCESS_TYPE_ALL)
+	RETURN_TYPE(/list)
 	var/list/L = new()
 	for(var/datum/access/A in get_all_access_datums())
 		if(A.access_type & access_types)
@@ -124,6 +128,7 @@ var/global/list/datum/access/priv_all_access_datums_region
 
 var/global/list/priv_all_access
 /proc/get_all_accesses()
+	RETURN_TYPE(/list)
 	if(!priv_all_access)
 		priv_all_access = get_access_ids()
 
@@ -131,6 +136,7 @@ var/global/list/priv_all_access
 
 var/global/list/priv_station_access
 /proc/get_all_station_access()
+	RETURN_TYPE(/list)
 	if(!priv_station_access)
 		priv_station_access = get_access_ids(ACCESS_TYPE_STATION)
 
@@ -138,6 +144,7 @@ var/global/list/priv_station_access
 
 var/global/list/priv_centcom_access
 /proc/get_all_centcom_access()
+	RETURN_TYPE(/list)
 	if(!priv_centcom_access)
 		priv_centcom_access = get_access_ids(ACCESS_TYPE_CENTCOM)
 
@@ -145,6 +152,7 @@ var/global/list/priv_centcom_access
 
 var/global/list/priv_syndicate_access
 /proc/get_all_syndicate_access()
+	RETURN_TYPE(/list)
 	if(!priv_syndicate_access)
 		priv_syndicate_access = get_access_ids(ACCESS_TYPE_SYNDICATE)
 
@@ -152,6 +160,7 @@ var/global/list/priv_syndicate_access
 
 var/global/list/priv_region_access
 /proc/get_region_accesses(code)
+	RETURN_TYPE(/list)
 	if(code == ACCESS_REGION_ALL)
 		return get_all_station_access()
 
@@ -200,6 +209,7 @@ var/global/list/priv_region_access
 	return AS[id]
 
 /proc/get_all_centcom_jobs()
+	RETURN_TYPE(/list)
 	return list("VIP Guest",
 		"Custodian",
 		"Thunderdome Overseer",
@@ -254,6 +264,7 @@ var/global/list/priv_region_access
 	return missing_id_name
 
 /proc/get_all_job_icons() //For all existing HUD icons
+	RETURN_TYPE(/list)
 	return SSjobs.titles_to_datums + list("Prisoner")
 
 /obj/proc/GetJobName() //Used in secHUD icon generation

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -3,6 +3,7 @@
 GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 
 /proc/cache_circuits_by_build_path()
+	RETURN_TYPE(/list)
 	. = list()
 	for(var/board_path in subtypesof(/obj/item/stock_parts/circuitboard))
 		var/obj/item/stock_parts/circuitboard/board = board_path //fake type

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -192,6 +192,7 @@
 	ai_camera_list()
 
 /proc/camera_sort(list/L)
+	RETURN_TYPE(/list)
 	var/obj/machinery/camera/a
 	var/obj/machinery/camera/b
 

--- a/code/game/machinery/status_display_ai.dm
+++ b/code/game/machinery/status_display_ai.dm
@@ -29,6 +29,7 @@ var/global/list/ai_status_emotions = list(
 	)
 
 /proc/get_ai_emotions(ckey)
+	RETURN_TYPE(/list)
 	var/list/emotions = new
 	for(var/emotion_name in ai_status_emotions)
 		var/datum/ai_emotion/emotion = ai_status_emotions[emotion_name]

--- a/code/game/movietitles.dm
+++ b/code/game/movietitles.dm
@@ -91,6 +91,7 @@ GLOBAL_LIST(end_titles)
 	return ..()
 
 /proc/generate_titles()
+	RETURN_TYPE(/list)
 	var/list/titles = list()
 	var/list/cast = list()
 	var/list/chunk = list()

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -157,6 +157,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 
 //and to shortcut all that
 /proc/sparks(n = 3, c = 0, loca)
+	RETURN_TYPE(/datum/effect/effect/system/spark_spread)
 	var/datum/effect/effect/system/spark_spread/S = new
 	S.set_up(n, c, loca)
 	S.start()

--- a/code/game/objects/items/devices/scanners/mining.dm
+++ b/code/game/objects/items/devices/scanners/mining.dm
@@ -80,6 +80,7 @@
 
 //Returns list of two elements, 1 is text output, 2 is amoutn of GEP data
 /proc/mineral_scan_results(turf/simulated/target)
+	RETURN_TYPE(/list)
 	var/list/metals = list(
 		ORE_SURFACE = 0,
 		ORE_PRECIOUS = 0,

--- a/code/game/objects/items/devices/scanners/reagents.dm
+++ b/code/game/objects/items/devices/scanners/reagents.dm
@@ -18,6 +18,7 @@
 	user.show_message(SPAN_NOTICE(scan_data))
 
 /proc/reagent_scan_results(obj/O, details = 0)
+	RETURN_TYPE(/list)
 	if(isnull(O.reagents))
 		return list("No significant chemical agents found in [O].")
 	if(length(O.reagents.reagent_list) == 0)

--- a/code/game/objects/items/devices/scanners/xenobio.dm
+++ b/code/game/objects/items/devices/scanners/xenobio.dm
@@ -28,6 +28,7 @@
 	user.show_message(SPAN_NOTICE(scan_data))
 
 /proc/list_gases(gases)
+	RETURN_TYPE(/list)
 	. = list()
 	for(var/g in gases)
 		. += "[gas_data.name[g]] ([gases[g]]%)"

--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -228,6 +228,7 @@
 
 var/global/list/id_card_states
 /proc/id_card_states()
+	RETURN_TYPE(/list)
 	if(!id_card_states)
 		id_card_states = list()
 		for(var/path in typesof(/obj/item/card/id))

--- a/code/game/objects/items/weapons/material/coins.dm
+++ b/code/game/objects/items/weapons/material/coins.dm
@@ -246,6 +246,7 @@
 
 /// Create a new random simple coin at loc and return it.
 /proc/new_simple_coin(loc)
+	RETURN_TYPE(/obj/item/material/coin)
 	var/static/list/simple_coins = subtypesof(/obj/item/material/coin) - typesof(/obj/item/material/coin/challenge)
 	var/obj/item/material/coin = pick(simple_coins)
 	coin = new coin (loc)

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -1223,6 +1223,7 @@ var/global/list/multi_point_spawns
 
 
 /proc/get_random_useful_type()
+	RETURN_TYPE(/obj)
 	var/static/list/options = list(
 		/obj/random/crayon,
 		/obj/item/pen,
@@ -1238,6 +1239,7 @@ var/global/list/multi_point_spawns
 
 
 /proc/get_random_junk_type()
+	RETURN_TYPE(/obj)
 	var/static/list/options = ((\
 		typesof(/obj/item/trash/cigbutt) +\
 		subtypesof(/obj/item/trash)) - list(

--- a/code/game/turfs/turf_ao.dm
+++ b/code/game/turfs/turf_ao.dm
@@ -28,6 +28,7 @@
 		CALCULATE_NEIGHBORS(src, ao_neighbors, T, AO_TURF_CHECK(T))
 
 /proc/make_ao_image(corner, i, px = 0, py = 0, pz = 0, pw = 0)
+	RETURN_TYPE(/image)
 	var/list/cache = SSao.image_cache
 	var/cstr = "[corner]"
 	var/key = "[cstr]-[i]-[px]/[py]/[pz]/[pw]"

--- a/code/modules/admin/ticket.dm
+++ b/code/modules/admin/ticket.dm
@@ -100,6 +100,7 @@ var/global/list/ticket_panels = list()
 		. |= assigned_admin.key
 
 /proc/get_open_ticket_by_client(datum/client_lite/owner)
+	RETURN_TYPE(/datum/ticket)
 	for(var/datum/ticket/ticket in tickets)
 		if(ticket.owner.ckey == owner.ckey && (ticket.status == TICKET_OPEN || ticket.status == TICKET_ASSIGNED))
 			return ticket // there should only be one open ticket by a client at a time, so no need to keep looking

--- a/code/modules/admin/verbs/adminjump.dm
+++ b/code/modules/admin/verbs/adminjump.dm
@@ -69,6 +69,7 @@
 	log_and_message_admins("jumped to coordinates [tx], [ty], [tz]")
 
 /proc/sorted_client_keys()
+	RETURN_TYPE(/list)
 	return sortKey(GLOB.clients.Copy())
 
 /client/proc/jumptokey(client/C in sorted_client_keys())

--- a/code/modules/admin/verbs/mapping.dm
+++ b/code/modules/admin/verbs/mapping.dm
@@ -319,6 +319,7 @@ var/global/list/debug_verbs = list (
 	log_debug("There are [count] objects of type [type_path] in the game world")
 
 /proc/get_zas_image(turf/T, icon_state)
+	RETURN_TYPE(/image)
 	return image_repository.atom_image(T, 'icons/misc/debug_group.dmi', icon_state, plane = DEFAULT_PLANE, layer = ABOVE_TILE_LAYER)
 
 //Special for Cakey

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -37,6 +37,7 @@ var/global/list/_client_preferences_by_key
 var/global/list/_client_preferences_by_type
 
 /proc/get_client_preferences()
+	RETURN_TYPE(/list)
 	if(!_client_preferences)
 		_client_preferences = list()
 		for(var/ct in subtypesof(/datum/client_preference))
@@ -46,6 +47,7 @@ var/global/list/_client_preferences_by_type
 	return _client_preferences
 
 /proc/get_client_preference(datum/client_preference/preference)
+	RETURN_TYPE(/datum/client_preference)
 	if(istype(preference))
 		return preference
 	if(ispath(preference))
@@ -53,6 +55,7 @@ var/global/list/_client_preferences_by_type
 	return get_client_preference_by_key(preference)
 
 /proc/get_client_preference_by_key(preference)
+	RETURN_TYPE(/datum/client_preference)
 	if(!_client_preferences_by_key)
 		_client_preferences_by_key = list()
 		for(var/ct in get_client_preferences())
@@ -61,6 +64,7 @@ var/global/list/_client_preferences_by_type
 	return _client_preferences_by_key[preference]
 
 /proc/get_client_preference_by_type(preference)
+	RETURN_TYPE(/datum/client_preference)
 	if(!_client_preferences_by_type)
 		_client_preferences_by_type = list()
 		for(var/ct in get_client_preferences())

--- a/code/modules/client/preferences_spawnpoints.dm
+++ b/code/modules/client/preferences_spawnpoints.dm
@@ -1,6 +1,7 @@
 GLOBAL_VAR(spawntypes)
 
 /proc/spawntypes()
+	RETURN_TYPE(/list)
 	if(!GLOB.spawntypes)
 		GLOB.spawntypes = list()
 		for(var/type in typesof(/datum/spawnpoint)-/datum/spawnpoint)

--- a/code/modules/client/preferences_toggle.dm
+++ b/code/modules/client/preferences_toggle.dm
@@ -1,6 +1,7 @@
 var/global/list/client_preference_stats_
 
 /proc/client_preference_stats_for_usr(mob/user = usr)
+	RETURN_TYPE(/list)
 	. = list()
 	if(!user)
 		return

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -40,6 +40,7 @@
 
 
 /proc/create_account(account_name = "Default account name", owner_name, starting_funds = 0, account_type = ACCOUNT_TYPE_PERSONAL, obj/machinery/computer/account_database/source_db)
+	RETURN_TYPE(/datum/money_account)
 
 	//create a new account
 	var/datum/money_account/M = new()
@@ -93,11 +94,13 @@
 
 //this returns the first account datum that matches the supplied accnum/pin combination, it returns null if the combination did not match any account
 /proc/attempt_account_access(attempt_account_number, attempt_pin_number, security_level_passed = 0)
+	RETURN_TYPE(/datum/money_account)
 	var/datum/money_account/D = get_account(attempt_account_number)
 	if(D && D.security_level <= security_level_passed && (!D.security_level || D.remote_access_pin == attempt_pin_number) )
 		return D
 
 /proc/get_account(account_number)
+	RETURN_TYPE(/datum/money_account)
 	for(var/datum/money_account/D in all_money_accounts)
 		if(D.account_number == account_number)
 			return D

--- a/code/modules/events/event_dynamic.dm
+++ b/code/modules/events/event_dynamic.dm
@@ -93,6 +93,7 @@ var/global/list/event_last_fired = list()
 // with a specific role.
 // Note that this isn't sorted by department, because e.g. having a roboticist shouldn't make meteors spawn.
 /proc/number_active_with_role()
+	RETURN_TYPE(/list)
 	var/list/active_with_role = list()
 	active_with_role["Engineer"] = 0
 	active_with_role["Medical"] = 0

--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -4,11 +4,13 @@
 var/global/list/ghost_traps
 
 /proc/get_ghost_trap(trap_key)
+	RETURN_TYPE(/datum/ghosttrap)
 	if(!ghost_traps)
 		populate_ghost_traps()
 	return ghost_traps[trap_key]
 
 /proc/get_ghost_traps()
+	RETURN_TYPE(/list)
 	if(!ghost_traps)
 		populate_ghost_traps()
 	return ghost_traps

--- a/code/modules/mechs/mech_icon.dm
+++ b/code/modules/mechs/mech_icon.dm
@@ -1,4 +1,5 @@
 /proc/get_mech_image(decal, cache_key, cache_icon, image_colour, overlay_layer = FLOAT_LAYER)
+	RETURN_TYPE(/image)
 	var/use_key = "[cache_key]-[cache_icon]-[overlay_layer]-[decal ? decal : "none"]-[image_colour ? image_colour : "none"]"
 	if(!GLOB.mech_image_cache[use_key])
 		var/image/I = image(icon = cache_icon, icon_state = cache_key)
@@ -26,6 +27,7 @@
 	return GLOB.mech_image_cache[use_key]
 
 /proc/get_mech_images(list/components = list(), overlay_layer = FLOAT_LAYER)
+	RETURN_TYPE(/list)
 	var/list/all_images = list()
 	for(var/obj/item/mech_component/comp in components)
 		all_images += get_mech_image(comp.decal, comp.icon_state, comp.on_mech_icon, comp.color, overlay_layer)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -11,6 +11,7 @@ GLOBAL_LIST_EMPTY(overlay_icon_cache)
 GLOBAL_LIST_EMPTY(species_icon_template_cache)
 
 /proc/overlay_image(icon, icon_state, color, flags, plane, layer)
+	RETURN_TYPE(/image)
 	var/image/ret = image(icon,icon_state)
 	if(plane)
 		ret.plane = plane

--- a/code/modules/mob/living/silicon/robot/drone/drone.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone.dm
@@ -1,5 +1,6 @@
 var/global/list/mob_hat_cache = list()
 /proc/get_hat_icon(obj/item/hat, offset_x = 0, offset_y = 0)
+	RETURN_TYPE(/image)
 	var/t_state = hat.icon_state
 	if(hat.item_state_slots && hat.item_state_slots[slot_head_str])
 		t_state = hat.item_state_slots[slot_head_str]

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -184,6 +184,7 @@ var/global/list/organ_rel_size = list(
 //Replaces some of the characters with *, used in whispers. pr = probability of no star.
 //Will try to preserve HTML formatting. re_encode controls whether the returned text is HTML encoded outside tags.
 /proc/stars(n, pr = 25, re_encode = 1)
+	RETURN_TYPE(/list)
 	if (pr < 0)
 		return null
 	else if (pr >= 100)
@@ -208,6 +209,7 @@ var/global/list/organ_rel_size = list(
 
 //Ingnores the possibility of breaking tags.
 /proc/stars_no_html(text, pr, re_encode)
+	RETURN_TYPE(/list)
 	text = html_decode(text) //We don't want to screw up escaped characters
 	. = list()
 	for(var/i = 1, i <= length_char(text), i++)
@@ -397,6 +399,7 @@ var/global/list/intents = list(I_HELP,I_DISARM,I_GRAB,I_HURT)
 			M.show_message(SPAN_INFO("[icon2html(icon, M)] [message]"), 1)
 
 /proc/mobs_in_area(area/A)
+	RETURN_TYPE(/list)
 	var/list/mobs = new
 	for(var/mob/living/M in SSmobs.mob_list)
 		if(get_area(M) == A)

--- a/code/modules/mob/observer/freelook/chunk.dm
+++ b/code/modules/mob/observer/freelook/chunk.dm
@@ -176,6 +176,7 @@
 	return
 
 /proc/seen_turfs_in_range(source, range)
+	RETURN_TYPE(/list)
 	var/turf/pos = get_turf(source)
 	if(pos)
 		. = hear(range, pos)

--- a/code/modules/mob/observer/virtual/helpers.dm
+++ b/code/modules/mob/observer/virtual/helpers.dm
@@ -14,6 +14,7 @@
 * Range Helpers *
 ****************/
 /proc/clients_in_range(atom/movable/center_vmob)
+	RETURN_TYPE(/list)
 	. = list()
 
 	ACQUIRE_VIRTUAL_OR_TURF(center_vmob)
@@ -23,6 +24,7 @@
 			. |= C
 
 /proc/hearers_in_range(atom/movable/center_vmob, hearing_range = world.view)
+	RETURN_TYPE(/list)
 	. = list()
 
 	ACQUIRE_VIRTUAL_OR_TURF(center_vmob)
@@ -31,6 +33,7 @@
 			. |= v_mob.host
 
 /proc/viewers_in_range(atom/movable/center_vmob)
+	RETURN_TYPE(/list)
 	. = list()
 
 	ACQUIRE_VIRTUAL_OR_TURF(center_vmob)
@@ -47,6 +50,7 @@
 
 // Gets the hosts of all the virtual mobs that can hear the given movable atom (or rather, it's virtual mob or turf in that existence order)
 /proc/all_hearers(atom/movable/heard_vmob, range = world.view)
+	RETURN_TYPE(/list)
 	. = list()
 
 	ACQUIRE_VIRTUAL_OR_TURF(heard_vmob)
@@ -67,6 +71,7 @@
 
 // Gets the hosts of all virtual mobs that can see the given atom movable as well as its turf
 /proc/all_viewers(mob/observer/virtual/viewed_atom)
+	RETURN_TYPE(/list)
 	. = list()
 
 	viewed_atom = istype(viewed_atom) ? viewed_atom.host : viewed_atom
@@ -84,6 +89,7 @@
 // This proc returns all hosts of virtual mobs in the given atom's view range (using its turf), ignoring invisibility, VIRUAL_ABILITY_SEE, and most other restrictions.
 // In most cases you actually want the all_* procs above. This helper was designed with LOOC in mind.
 /proc/hosts_in_view_range(atom/movable/viewing_atom)
+	RETURN_TYPE(/list)
 	. = list()
 
 	ACQUIRE_VIRTUAL_OR_TURF(viewing_atom)

--- a/code/modules/modular_computers/file_system/manifest.dm
+++ b/code/modules/modular_computers/file_system/manifest.dm
@@ -114,6 +114,7 @@
 	return filtered_entries
 
 /proc/filtered_nano_crew_manifest(list/filter, blacklist = FALSE)
+	RETURN_TYPE(/list)
 	var/list/filtered_entries = list()
 	for(var/datum/computer_file/report/crew_record/CR in department_crew_manifest(filter, blacklist))
 		filtered_entries.Add(list(list(
@@ -141,6 +142,7 @@
 		)
 
 /proc/flat_nano_crew_manifest()
+	RETURN_TYPE(/list)
 	. = list()
 	. += filtered_nano_crew_manifest(null, TRUE)
 	. += silicon_nano_crew_manifest(SSjobs.titles_by_department(MSC))

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -136,6 +136,7 @@ GLOBAL_VAR_INIT(arrest_security_status, "Arrest")
 
 // Gets crew records filtered by set of positions
 /proc/department_crew_manifest(list/filter_positions, blacklist = FALSE)
+	RETURN_TYPE(/list)
 	var/list/matches = list()
 	for(var/datum/computer_file/report/crew_record/CR in GLOB.all_crew_records)
 		var/rank = CR.get_job()
@@ -162,6 +163,7 @@ GLOBAL_VAR_INIT(arrest_security_status, "Arrest")
 	return dat
 
 /proc/get_crewmember_record(name)
+	RETURN_TYPE(/datum/computer_file/report/crew_record)
 	name = sanitize(name)
 	for(var/datum/computer_file/report/crew_record/CR in GLOB.all_crew_records)
 		if(sanitize(CR.get_name()) == name)

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -29,18 +29,21 @@ var/global/list/z_levels = list()// Each bit re... haha just kidding this is a l
 
 // Thankfully, no bitwise magic is needed here.
 /proc/GetAbove(atom/atom)
+	RETURN_TYPE(/turf)
 	var/turf/turf = get_turf(atom)
 	if(!turf)
 		return null
 	return HasAbove(turf.z) ? get_step(turf, UP) : null
 
 /proc/GetBelow(atom/atom)
+	RETURN_TYPE(/turf)
 	var/turf/turf = get_turf(atom)
 	if(!turf)
 		return null
 	return HasBelow(turf.z) ? get_step(turf, DOWN) : null
 
 /proc/GetConnectedZlevels(z)
+	RETURN_TYPE(/list)
 	. = list(z)
 	for(var/level = z, HasBelow(level), level--)
 		. |= level-1
@@ -51,6 +54,7 @@ var/global/list/z_levels = list()// Each bit re... haha just kidding this is a l
 	return zA == zB || (zB in GetConnectedZlevels(zA))
 
 /proc/get_zstep(ref, dir)
+	RETURN_TYPE(/turf)
 	if(dir == UP)
 		. = GetAbove(ref)
 	else if (dir == DOWN)

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -211,6 +211,7 @@
 	return data
 
 /proc/blood_splatter(target,datum/reagent/blood/source,large,spray_dir)
+	RETURN_TYPE(/obj/effect/decal/cleanable/blood)
 
 	var/obj/effect/decal/cleanable/blood/B
 	var/decal_type = /obj/effect/decal/cleanable/blood/splatter

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -41,6 +41,7 @@ var/global/list/cached_space = list()
 	return 1
 
 /proc/get_deepspace(x,y)
+	RETURN_TYPE(/obj/effect/overmap/visitable/sector/temporary)
 	var/turf/map = locate(x,y,GLOB.using_map.overmap_z)
 	var/obj/effect/overmap/visitable/sector/temporary/res
 	for(var/obj/effect/overmap/visitable/sector/temporary/O in map)

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -319,6 +319,7 @@ GLOBAL_LIST_EMPTY(admin_departments)
 
 /// Retrieves a list of all fax machines matching the given department tag.
 /proc/get_fax_machines_by_department(department)
+	RETURN_TYPE(/list)
 	if (!department)
 		department = "Unknown"
 	var/list/faxes = list()

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -165,6 +165,7 @@
 // excluding source, that match the direction d
 // if unmarked==1, only return those with no powernet
 /proc/power_list(turf/T, source, d, unmarked=0, cable_only = 0)
+	RETURN_TYPE(/list)
 	. = list()
 
 	var/reverse = d ? GLOB.reverse_dir[d] : 0
@@ -222,6 +223,7 @@
 
 //Merge two powernets, the bigger (in cable length term) absorbing the other
 /proc/merge_powernets(datum/powernet/net1, datum/powernet/net2)
+	RETURN_TYPE(/datum/powernet)
 	if(!net1 || !net2) //if one of the powernet doesn't exist, return
 		return
 

--- a/code/modules/psionics/complexus/complexus.dm
+++ b/code/modules/psionics/complexus/complexus.dm
@@ -45,6 +45,7 @@
 	return _aura_image
 
 /proc/create_aura_image(newloc)
+	RETURN_TYPE(/image)
 	var/image/aura_image = image(loc = newloc, icon = 'icons/effects/psi_aura_small.dmi', icon_state = "aura")
 	aura_image.blend_mode = BLEND_MULTIPLY
 	aura_image.appearance_flags = DEFAULT_APPEARANCE_FLAGS | NO_CLIENT_COLOR | RESET_COLOR | RESET_ALPHA | RESET_TRANSFORM

--- a/code/modules/random_map/drop/drop_types.dm
+++ b/code/modules/random_map/drop/drop_types.dm
@@ -1,6 +1,7 @@
 var/global/list/datum/supply_drop_loot/supply_drop
 
 /proc/supply_drop_random_loot_types()
+	RETURN_TYPE(/list)
 	if(!supply_drop)
 		supply_drop = init_subtypes(/datum/supply_drop_loot)
 		supply_drop = dd_sortedObjectList(supply_drop)

--- a/code/modules/reagents/reagent_containers/food/lunch.dm
+++ b/code/modules/reagents/reagent_containers/food/lunch.dm
@@ -106,31 +106,37 @@ var/global/list/lunchables_ethanol_reagents_ = list(
 											)
 
 /proc/lunchables_lunches()
+	RETURN_TYPE(/list)
 	if(!(lunchables_lunches_[lunchables_lunches_[1]]))
 		lunchables_lunches_ = init_lunchable_list(lunchables_lunches_)
 	return lunchables_lunches_
 
 /proc/lunchables_snacks()
+	RETURN_TYPE(/list)
 	if(!(lunchables_snacks_[lunchables_snacks_[1]]))
 		lunchables_snacks_ = init_lunchable_list(lunchables_snacks_)
 	return lunchables_snacks_
 
 /proc/lunchables_drinks()
+	RETURN_TYPE(/list)
 	if(!(lunchables_drinks_[lunchables_drinks_[1]]))
 		lunchables_drinks_ = init_lunchable_list(lunchables_drinks_)
 	return lunchables_drinks_
 
 /proc/lunchables_drink_reagents()
+	RETURN_TYPE(/list)
 	if(!(lunchables_drink_reagents_[lunchables_drink_reagents_[1]]))
 		lunchables_drink_reagents_ = init_lunchable_reagent_list(lunchables_drink_reagents_, /datum/reagent/drink)
 	return lunchables_drink_reagents_
 
 /proc/lunchables_ethanol_reagents()
+	RETURN_TYPE(/list)
 	if(!(lunchables_ethanol_reagents_[lunchables_ethanol_reagents_[1]]))
 		lunchables_ethanol_reagents_ = init_lunchable_reagent_list(lunchables_ethanol_reagents_, /datum/reagent/ethanol)
 	return lunchables_ethanol_reagents_
 
 /proc/init_lunchable_list(list/lunches)
+	RETURN_TYPE(/list)
 	. = list()
 	for(var/lunch in lunches)
 		var/obj/O = lunch
@@ -138,6 +144,7 @@ var/global/list/lunchables_ethanol_reagents_ = list(
 	return sortAssoc(.)
 
 /proc/init_lunchable_reagent_list(list/banned_reagents, reagent_types)
+	RETURN_TYPE(/list)
 	. = list()
 	for(var/reagent_type in subtypesof(reagent_types))
 		if(reagent_type in banned_reagents)

--- a/code/modules/research/designs/_designs.dm
+++ b/code/modules/research/designs/_designs.dm
@@ -67,6 +67,7 @@ other types of metals and chemistry for reagents).
 GLOBAL_LIST_INIT(build_path_to_design_datum_path, populate_design_datum_index())
 
 /proc/populate_design_datum_index()
+	RETURN_TYPE(/list)
 	. = list()
 	for(var/path in typesof(/datum/design))
 		var/datum/design/fake_design = path

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -469,6 +469,7 @@
 */
 
 /proc/dirs_to_corner_states(list/dirs)
+	RETURN_TYPE(/list)
 	if(!istype(dirs)) return
 
 	var/list/ret = list(NORTHWEST, SOUTHEAST, NORTHEAST, SOUTHWEST)

--- a/code/modules/xenoarcheaology/finds/find_spawning.dm
+++ b/code/modules/xenoarcheaology/finds/find_spawning.dm
@@ -1,4 +1,5 @@
 /proc/get_archeological_find_by_findtype(find_type)
+	RETURN_TYPE(/obj/item/archaeological_find)
 	for(var/T in typesof(/obj/item/archaeological_find))
 		var/obj/item/archaeological_find/F = T
 		if(find_type == initial(F.find_type))

--- a/code/procs/hud.dm
+++ b/code/procs/hud.dm
@@ -57,6 +57,7 @@ the HUD updates properly! */
 	var/turf/Turf
 
 /proc/arrange_hud_process(mob/M, mob/Alt, list/hud_list)
+	RETURN_TYPE(/datum/arranged_hud_process)
 	hud_list |= M
 	var/datum/arranged_hud_process/P = new
 	P.Client = M.client
@@ -83,9 +84,11 @@ the HUD updates properly! */
 	GLOB.jani_hud_users -= src
 
 /mob/proc/in_view(turf/T)
+	RETURN_TYPE(/list)
 	return view(T)
 
 /mob/observer/eye/in_view(turf/T)
+	RETURN_TYPE(/list)
 	var/list/viewed = new
 	for(var/mob/living/carbon/human/H in SSmobs.mob_list)
 		if(get_dist(H, T) <= 7)

--- a/code/procs/radio.dm
+++ b/code/procs/radio.dm
@@ -37,6 +37,7 @@
 	var/list/receiver_reception = new
 
 /proc/get_message_server(z)
+	RETURN_TYPE(/obj/machinery/message_server)
 	if(message_servers)
 		var/list/zlevels = GLOB.using_map.contact_levels
 		if(z)
@@ -60,6 +61,7 @@
 	return TELECOMMS_RECEPTION_NONE
 
 /proc/get_reception(atom/sender, receiver, message = "", do_sleep = 1)
+	RETURN_TYPE(/datum/reception)
 	var/datum/reception/reception = new
 
 	// check if telecomms I/O route 1459 is stable
@@ -73,6 +75,7 @@
 	return reception
 
 /proc/get_receptions(atom/sender, list/atom/receivers, do_sleep = 1)
+	RETURN_TYPE(/datum/receptions)
 	var/datum/receptions/receptions = new
 	receptions.message_server = get_message_server()
 

--- a/code/unit_tests/mob_tests.dm
+++ b/code/unit_tests/mob_tests.dm
@@ -65,6 +65,7 @@
 var/global/default_mobloc = null
 
 /proc/create_test_mob_with_mind(turf/mobloc = null, mobtype = /mob/living/carbon/human)
+	RETURN_TYPE(/list)
 	var/list/test_result = list("result" = FAILURE, "msg"    = "", "mobref" = null)
 
 	if(isnull(mobloc))

--- a/code/unit_tests/unit_test.dm
+++ b/code/unit_tests/unit_test.dm
@@ -118,6 +118,7 @@ var/global/ascii_reset = "[ascii_esc]\[0m"
  */
 
 /proc/get_test_datums()
+	RETURN_TYPE(/list)
 	. = list()
 	for(var/test in subtypesof(/datum/unit_test))
 		var/datum/unit_test/d = test

--- a/code/unit_tests/zas_tests.dm
+++ b/code/unit_tests/zas_tests.dm
@@ -42,6 +42,7 @@
 //	The primary helper proc.
 //
 /proc/test_air_in_area(test_area, expectation = UT_NORMAL)
+	RETURN_TYPE(/list)
 	var/test_result = list("result" = FAILURE, "msg"    = "")
 
 	var/area/A = locate(test_area)

--- a/maps/mapsystem/maps.dm
+++ b/maps/mapsystem/maps.dm
@@ -308,6 +308,7 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 
 /* It is perfectly possible to create loops with TEMPLATE_FLAG_ALLOW_DUPLICATES and force/allow. Don't. */
 /proc/resolve_site_selection(datum/map_template/ruin/away_site/site, list/selected, list/available, list/unavailable, list/by_type)
+	RETURN_TYPE(/list)
 	var/spawn_cost = 0
 	var/player_cost = 0
 	if (site in selected)


### PR DESCRIPTION
NUFC

Makes use of spacemandmm's `RETURN_TYPE()` call to provide some type hinting for certain global procs, so you can do things like `get_area().powered()` and not have the linter scream at you.