### PR TITLE
Make Solars All-Access

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -1808,7 +1808,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/engineering{
 	icon_state = "closed";
-	name = "Starboard Solar Access"
+	name = "Starboard Solar Access";
+	req_access = list(list("ACCESS_TORCH_CREW"));
+	autoset_access = 0
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -6122,7 +6124,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(list("ACCESS_TORCH_CREW"));
+	autoset_access = 0
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -11034,7 +11039,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/engineering{
 	icon_state = "closed";
-	name = "Port Solar Access"
+	name = "Port Solar Access";
+	req_access = list(list("ACCESS_TORCH_CREW"));
+	autoset_access = 0
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -15233,7 +15240,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(list("ACCESS_TORCH_CREW"));
+	autoset_access = 0
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/seconddeck/aftport)
 "OL" = (
@@ -16823,7 +16833,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	req_access = list(list("ACCESS_TORCH_CREW"));
+	autoset_access = 0
+	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/seconddeck/central)

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -5915,7 +5915,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/airlock/hatch/maintenance,
+/obj/machinery/door/airlock/hatch/maintenance{
+	req_access = list(list("ACCESS_TORCH_CREW"));
+	autoset_access = 0
+	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/maintenance/bridge/aftport)
@@ -8806,7 +8809,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
 	icon_state = "closed";
-	name = "Bridge Solar Access"
+	name = "Bridge Solar Access";
+	req_access = list(list("ACCESS_TORCH_CREW"));
+	autoset_access = 0
 	},
 /obj/structure/cable{
 	d1 = 4;


### PR DESCRIPTION
:cl:
tweak: Make all solar doors all-access.
tweak: Make maintenance doors leading to Solars from main hallways all-access.
/:cl:

![image](https://user-images.githubusercontent.com/50071611/229509933-e47f4fde-25f4-454d-9a97-2318c822fd04.png)

and

![image](https://user-images.githubusercontent.com/50071611/229510061-2d570563-de64-48c3-8188-22bd0aceb1eb.png)

are the three maintenance access that have been made all access. During low pop when there's no engineer, it gets kind of bad when you're effectively playing on a time-limit, unless you break character to bust into solars or have an admin do it for you.
This allows for anyone to activate solars.

It does allow all-access to a small portion of the maintenance areas, but maintenance has doors everywhere else, which restrict a lot of it, anyhow.

