### PR TITLE
Connection Log Checking Part 2

### DIFF
--- a/code/modules/admin/connectioncheck/connectioncheck_functions.dm
+++ b/code/modules/admin/connectioncheck/connectioncheck_functions.dm
@@ -76,12 +76,9 @@
 			. += list(row)
 
 
-/proc/_find_bans_in_connections(ckey, ip, cid)
+/proc/_find_bans_in_connections(list/connections)
 	RETURN_TYPE(/list)
 	. = list()
-	var/list/connections = _fetch_connections(ckey, ip, cid)
-	if (!length(connections))
-		return
 	for (var/list/connection in connections)
 		. |= _fetch_bans(connection["ckey"], connection["ip"], connection["computerid"])
 

--- a/code/modules/admin/connectioncheck/connectioncheck_functions.dm
+++ b/code/modules/admin/connectioncheck/connectioncheck_functions.dm
@@ -86,6 +86,36 @@
 		. |= _fetch_bans(ckey, ip, cid)
 
 
+/**
+ * Returns a list containing only each unique ckey present in a list of connections provided by `_fetch_connections()`.
+ */
+/proc/_unique_ckeys_from_connections(list/connections)
+	RETURN_TYPE(/list)
+	. = list()
+	for (var/list/connection in connections)
+		. |= connection["ckey"]
+
+
+/**
+ * Returns a list containing only each unique CID present in a list of connections provided by `_fetch_connections()`.
+ */
+/proc/_unique_cids_from_connections(list/connections)
+	RETURN_TYPE(/list)
+	. = list()
+	for (var/list/connection in connections)
+		. |= connection["computerid"]
+
+
+/**
+ * Returns a list containing only each unique IP present in a list of connections provided by `_fetch_connections()`.
+ */
+/proc/_unique_ips_from_connections(list/connections)
+	RETURN_TYPE(/list)
+	. = list()
+	for (var/list/connection in connections)
+		. |= connection["ip"]
+
+
 /client/proc/fetch_connections()
 	RETURN_TYPE(/list)
 	return _fetch_connections(ckey, address, computer_id)

--- a/code/modules/admin/connectioncheck/connectioncheck_functions.dm
+++ b/code/modules/admin/connectioncheck/connectioncheck_functions.dm
@@ -120,7 +120,7 @@
 
 /client/proc/fetch_bans()
 	RETURN_TYPE(/list)
-	return _fetch_bans(ckey, address, computer_id)
+	return _find_bans_in_connections(fetch_connections())
 
 
 /mob/proc/fetch_connections()
@@ -132,9 +132,7 @@
 
 /mob/proc/fetch_bans()
 	RETURN_TYPE(/list)
-	if (client)
-		return client.fetch_bans()
-	return _fetch_bans(ckey ? ckey : last_ckey, lastKnownIP, computer_id)
+	return _find_bans_in_connections(fetch_connections())
 
 
 // Temporary debugging and testing functions

--- a/code/modules/admin/connectioncheck/connectioncheck_functions.dm
+++ b/code/modules/admin/connectioncheck/connectioncheck_functions.dm
@@ -83,7 +83,7 @@
 	if (!length(connections))
 		return
 	for (var/list/connection in connections)
-		. |= _fetch_bans(ckey, ip, cid)
+		. |= _fetch_bans(connection["ckey"], connection["ip"], connection["computerid"])
 
 
 /**

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -150,6 +150,18 @@
 			message_staff("[key_name_admin(src)] has joined the game with an open ticket. Status: [length(T.assigned_admins) ? "Assigned to: [english_list(T.assigned_admin_ckeys())]" : SPAN_DANGER("Unassigned.")]")
 			break
 
+	// Check connections
+	var/list/connections = fetch_connections()
+	var/list/ckeys = _unique_ckeys_from_connections(connections) - ckey
+	if (length(ckeys))
+		log_debug("[key_name_admin(src)] has connection details associated with other ckeys in the log: [english_list(ckeys)]")
+
+	// Check bans
+	var/list/bans = _find_bans_in_connections(connections)
+	ckeys = _unique_ckeys_from_connections(bans)
+	if (length(bans))
+		log_debug("[key_name_admin(src)] has connection details associated with active bans: [english_list(ckeys)]")
+
 	// Change the way they should download resources.
 	if(config.resource_urls && length(config.resource_urls))
 		src.preload_rsc = pick(config.resource_urls)


### PR DESCRIPTION
:cl: SierraKomodo
admin: Connecting clients are now checked for association with other known users and active bans. Any matches are displayed as debug logs for testing purposes.
/:cl: