### PR TITLE
Adds player panel buttons to look up mob connections information

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -96,6 +96,8 @@ var/global/floorIsLava = 0
 		body += "<A HREF='?src=\ref[src];sendtoprison=\ref[M]'>Prison</A> | "
 		body += "<A HREF='?src=\ref[src];reloadsave=\ref[M]'>Reload Save</A> | "
 		body += "<A HREF='?src=\ref[src];reloadchar=\ref[M]'>Reload Character</A> | "
+		body += "<A HREF='?src=\ref[src];connections=\ref[M]'>Check Connections</A> | "
+		body += "<A HREF='?src=\ref[src];bans=\ref[M]'>Check Bans</A> | "
 		var/muted = M.client.prefs.muted
 		body += {"<br><b>Mute: </b>
 			\[<A href='?src=\ref[src];mute=\ref[M];mute_type=[MUTE_IC]'><span style='font-color: [(muted & MUTE_IC)?"red":"blue"]'>IC</span></a> |

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1072,6 +1072,18 @@
 			return
 		P.copy_to(H)
 
+	else if (href_list["connections"])
+		if (!check_rights(R_ADMIN))
+			return
+		var/mob/target = locate(href_list["connections"])
+		target.debug_fetch_connections()
+
+	else if (href_list["bans"])
+		if (!check_rights(R_ADMIN))
+			return
+		var/mob/target = locate(href_list["bans"])
+		target.debug_fetch_bans()
+
 	else if (href_list["cloneother"])
 		if (!check_rights(R_DEBUG))
 			return


### PR DESCRIPTION
:cl: SierraKomodo
admin: Added buttons to the Player Panel to look up matching known prior connections and matching active bans for a given mob. Currently intended for ease of debug use, but should be accurate for admin purposes. Requires ADMIN perms for now.
/:cl: