### PR TITLE
Various Pronoun and Faction fixes

### DIFF
--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -64,7 +64,7 @@
 
 	var/list/initial_email_login = list("login" = "", "password" = "")
 
-	var/list/known_mobs
+	var/list/known_mobs = list()
 
 /datum/mind/New(key)
 	src.key = key

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -244,6 +244,7 @@
 			var/datum/dna/dna = usr.dna
 			pai.master = M.real_name
 			pai.master_dna = dna.unique_enzymes
+			pai.faction = M.faction
 			to_chat(pai, SPAN_WARNING("You have been bound to a new master."))
 	if(href_list["request"])
 		src.looking_for_personality = 1

--- a/code/game/objects/items/passport.dm
+++ b/code/game/objects/items/passport.dm
@@ -19,7 +19,7 @@
 		fingerprint = md5(H.dna.uni_identity)
 	else
 		fingerprint = "N/A"
-	info = "\icon[src] [src]:\nName: [H.real_name]\nSpecies: [H.get_species()]\ Pronouns: [H.pronouns]\nAge: [H.age]\nPlace of Birth: [pob]\nFingerprint: [fingerprint]"
+	info = "\icon[src] [src]:\nName: [H.real_name]\nSpecies: [H.get_species()]\nPronouns: [H.pronouns]\nAge: [H.age]\nPlace of Birth: [pob]\nFingerprint: [fingerprint]"
 
 /obj/item/passport/attack_self(mob/user as mob)
 	user.visible_message(

--- a/code/game/objects/items/robot/robot_frame.dm
+++ b/code/game/objects/items/robot/robot_frame.dm
@@ -113,11 +113,15 @@
 		O.set_invisibility(0)
 		O.custom_name = created_name
 		O.updatename("Default")
+		O.faction = user.faction
 		B.mind.transfer_to(O)
-		if(O.mind && O.mind.assigned_role)
-			O.job = O.mind.assigned_role
-		else
-			O.job = "Robot"
+		if(O.mind)
+			O.mind.faction = user.faction
+
+			if(O.mind.assigned_role)
+				O.job = O.mind.assigned_role
+			else
+				O.job = "Robot"
 
 		var/obj/item/robot_parts/chest/chest = parts[BP_CHEST]
 		if (chest && chest.cell)

--- a/code/modules/mob/living/carbon/human/descriptors/_descriptors.dm
+++ b/code/modules/mob/living/carbon/human/descriptors/_descriptors.dm
@@ -43,8 +43,8 @@
 	default_value = Ceil(LAZYLEN(standalone_value_descriptors) * 0.5)
 	..()
 
-/datum/mob_descriptor/proc/get_third_person_message_start(datum/gender/my_gender)
-	return "[my_gender.He] [my_gender.is]"
+/datum/mob_descriptor/proc/get_third_person_message_start(datum/pronouns/my_pronouns)
+	return "[my_pronouns.He] [my_pronouns.is]"
 
 /datum/mob_descriptor/proc/get_first_person_message_start()
 	return "You are"

--- a/code/modules/mob/living/carbon/human/descriptors/descriptors_nabber.dm
+++ b/code/modules/mob/living/carbon/human/descriptors/descriptors_nabber.dm
@@ -25,5 +25,5 @@
 /datum/mob_descriptor/body_length/get_first_person_message_start()
 	return "Your body is"
 
-/datum/mob_descriptor/body_length/get_third_person_message_start(datum/gender/my_gender)
-	return "[my_gender.His] body is"
+/datum/mob_descriptor/body_length/get_third_person_message_start(datum/pronouns/my_pronouns)
+	return "[my_pronouns.His] body is"

--- a/code/modules/mob/living/carbon/human/descriptors/descriptors_skrell.dm
+++ b/code/modules/mob/living/carbon/human/descriptors/descriptors_skrell.dm
@@ -14,14 +14,14 @@
 /datum/mob_descriptor/headtail_length/get_first_person_message_start()
 	. = "Your headtails are"
 
-/datum/mob_descriptor/headtail_length/get_third_person_message_start(datum/gender/my_gender)
-	. = "[my_gender.His] headtails are"
+/datum/mob_descriptor/headtail_length/get_third_person_message_start(datum/pronouns/my_pronouns)
+	. = "[my_pronouns.His] headtails are"
 
-/datum/mob_descriptor/headtail_length/get_comparative_value_string_equivalent(my_value, datum/gender/my_gender, datum/gender/other_gender)
-	. = "indicating [other_gender.he] [other_gender.is] [my_value == 1 ? "male" : "female"] like you"
+/datum/mob_descriptor/headtail_length/get_comparative_value_string_equivalent(my_value, datum/pronouns/my_pronouns, datum/pronouns/other_pronouns)
+	. = "indicating [other_pronouns.he] [other_pronouns.is] [my_value == 1 ? "male" : "female"] like you"
 
-/datum/mob_descriptor/headtail_length/get_comparative_value_string_smaller(value, datum/gender/my_gender, datum/gender/other_gender)
-	. = "indicating [other_gender.he] [other_gender.is] male"
+/datum/mob_descriptor/headtail_length/get_comparative_value_string_smaller(value, datum/pronouns/my_pronouns, datum/pronouns/other_pronouns)
+	. = "indicating [other_pronouns.he] [other_pronouns.is] male"
 
-/datum/mob_descriptor/headtail_length/get_comparative_value_string_larger(value, datum/gender/my_gender, datum/gender/other_gender)
-	. = "indicating [other_gender.he] [other_gender.is] female"
+/datum/mob_descriptor/headtail_length/get_comparative_value_string_larger(value, datum/pronouns/my_pronouns, datum/pronouns/other_pronouns)
+	. = "indicating [other_pronouns.he] [other_pronouns.is] female"

--- a/code/modules/mob/living/carbon/human/descriptors/descriptors_vox.dm
+++ b/code/modules/mob/living/carbon/human/descriptors/descriptors_vox.dm
@@ -31,5 +31,5 @@
 /datum/mob_descriptor/vox_markings/get_first_person_message_start()
 	. = "Your neck markings are"
 
-/datum/mob_descriptor/vox_markings/get_third_person_message_start(datum/gender/my_gender)
-	. = "[my_gender.His] neck markings are"
+/datum/mob_descriptor/vox_markings/get_third_person_message_start(datum/pronouns/my_pronouns)
+	. = "[my_pronouns.His] neck markings are"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -504,7 +504,7 @@
 			if(E)
 				if(hasHUD(user, HUD_MEDICAL))
 					to_chat(usr, "<b>Name:</b> [E.get_name()]")
-					to_chat(usr, "<b>AGAB:</b> [E.get_sex()]")
+					to_chat(usr, "<b>Pronouns:</b> [E.get_sex()]")
 					to_chat(usr, "<b>Species:</b> [E.get_species()]")
 					to_chat(usr, "<b>Blood Type:</b> [E.get_bloodtype()]")
 					to_chat(usr, "<b>Details:</b> [E.get_medRecord()]")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -912,7 +912,8 @@
 
 /mob/living/carbon/human/choose_from_pronouns()
 	if(wear_suit && wear_suit.flags_inv & HIDEJUMPSUIT && ((head && head.flags_inv & HIDEMASK) || wear_mask))
-		return PRONOUNS_THEY_THEM
+		var/datum/pronouns/P = GLOB.pronouns.by_key[PRONOUNS_THEY_THEM]
+		return P
 	return ..()
 
 /mob/living/carbon/human/proc/increase_germ_level(n)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -160,7 +160,6 @@
 			connect_to_ai(new_ai)
 		else
 			lawupdate = FALSE
-
 	playsound(loc, spawn_sound, 75, pitch_toggle)
 
 /mob/living/silicon/robot/fully_replace_character_name(pickedName as text)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -117,9 +117,9 @@
 
 		if(!(M.knows_target(src)) && !isghost(M))
 			for(var/datum/pronouns/entry as anything in GLOB.pronouns.instances)
-				mob_message = replacetext(mob_message, initial(entry.his), "their")
-				mob_message = replacetext(mob_message, initial(entry.him), "them")
-				mob_message = replacetext(mob_message, initial(entry.self), "themselves")
+				mob_message = replacetext(mob_message, " [initial(entry.his)]", " their")
+				mob_message = replacetext(mob_message, " [initial(entry.him)]", " them")
+				mob_message = replacetext(mob_message, " [initial(entry.self)]", " themselves")
 
 		if((!M.is_blind() && M.see_invisible >= src.invisibility) || narrate)
 			M.show_message(mob_message, VISIBLE_MESSAGE, blind_message, AUDIBLE_MESSAGE)
@@ -1240,7 +1240,9 @@
 
 	var/mob/S = src
 	var/mob/U = usr
-
+	if(U == S)
+		to_chat(U, SPAN_WARNING("You can't introduce yourself to yourself!"))
+		return
 	if(get_dist(U, S) > 3)
 		to_chat(U, SPAN_WARNING("You're too far away to properly introduce yourself!"))
 		return

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -10,7 +10,7 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 	blinded = 0
 	anchored = TRUE	//  don't get pushed around
 	universal_speak = TRUE
-
+	pronouns = PRONOUNS_THEY_THEM
 	mob_flags = MOB_FLAG_HOLY_BAD
 	movement_handlers = list(/datum/movement_handler/mob/multiz_connected, /datum/movement_handler/mob/incorporeal)
 

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -136,6 +136,11 @@
 			if(mmi_type)
 				O.mmi = new mmi_type(O)
 				O.mmi.transfer_identity(src)
+		if(O.mind.assigned_job && O.mind.assigned_job.faction)
+			O.faction = O.mind.assigned_job.faction
+			O.mind.faction = O.mind.assigned_job.faction
+		else
+			O.mind.faction = faction
 	else
 		O.key = key
 

--- a/maps/torch/torch_npcs.dm
+++ b/maps/torch/torch_npcs.dm
@@ -8,6 +8,7 @@
 	name = "Warrant Officer Punitelli"
 	real_name = name
 	gender = MALE
+	faction = MOB_FACTION_CREW
 	var/obj/item/clothing/C
 	C = new /obj/item/clothing/under/solgov/utility/expeditionary/monkey(src)
 	equip_to_appropriate_slot(C)


### PR DESCRIPTION
🆑 Jux
bugfix: Borgs and pAIs now adopt faction from their creator. 
bugfix: Joining as a borg now loads faction correctly.
bugfix: Species descriptors that want gender will no longer get fed pronouns.
bugfix: Passports no longer merge pronouns and species.
bugfix: MediHuds now correctly identify pronouns as pronouns.
/🆑

_Potentially_ fixes issues where things like "hits" would be replaced with "hthem", because I can't reproduce, but I'm not positive.

Does NOT fix skrell headtail messages being wrong because when I loaded a commit before pronouns existed those were still broken.

Closes #33200 
Closes #33196 