### PR TITLE
Refac: AI datums to singleton

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -97,12 +97,12 @@ var/global/list/ai_verbs_default = list(
 	var/last_failed_malf_message = null
 	var/last_failed_malf_title = null
 
-	var/datum/ai_icon/selected_sprite			// The selected icon set
+	var/singleton/ai_icon/selected_sprite			// The selected icon set
 	var/carded
 
 	var/multitool_mode = 0
 
-	var/default_ai_icon = /datum/ai_icon/blue
+	var/default_ai_icon = /singleton/ai_icon/blue
 	var/static/list/custom_ai_icons_by_ckey_and_name
 
 /mob/living/silicon/ai/proc/add_ai_verbs()
@@ -268,7 +268,7 @@ var/global/list/ai_verbs_default = list(
 			if(!(dead_icon_state in custom_icon_states))
 				dead_icon_state = ""
 
-			selected_sprite = new/datum/ai_icon("Custom Icon [custom_index++]", alive_icon_state, dead_icon_state, COLOR_WHITE, CUSTOM_ITEM_SYNTH)
+			selected_sprite = new/singleton/ai_icon("Custom Icon [custom_index++]", alive_icon_state, dead_icon_state, COLOR_WHITE, CUSTOM_ITEM_SYNTH)
 			custom_icons += selected_sprite
 	update_icon()
 
@@ -299,9 +299,9 @@ var/global/list/ai_verbs_default = list(
 
 /mob/living/silicon/ai/proc/available_icons()
 	. = list()
-	var/all_ai_icons = GET_SINGLETON_SUBTYPE_MAP(/datum/ai_icon)
+	var/all_ai_icons = GET_SINGLETON_SUBTYPE_MAP(/singleton/ai_icon)
 	for(var/ai_icon_type in all_ai_icons)
-		var/datum/ai_icon/ai_icon = all_ai_icons[ai_icon_type]
+		var/singleton/ai_icon/ai_icon = all_ai_icons[ai_icon_type]
 		if(ai_icon.may_used_by_ai(src))
 			dd_insertObjectList(., ai_icon)
 

--- a/code/modules/mob/living/silicon/ai/icons.dm
+++ b/code/modules/mob/living/silicon/ai/icons.dm
@@ -1,4 +1,4 @@
-/datum/ai_icon
+/singleton/ai_icon
 	var/name
 	var/icon = 'icons/mob/AI.dmi'
 	var/alive_icon
@@ -8,164 +8,164 @@
 	var/dead_icon = "ai-crash"
 	var/dead_light = "#000099"
 
-/datum/ai_icon/New(name, alive_icon, dead_icon, dead_light, icon)
+/singleton/ai_icon/New(name, alive_icon, dead_icon, dead_light, icon)
 	src.name          = name       || src.name
 	src.icon          = icon       || src.icon
 	src.alive_icon    = alive_icon || src.alive_icon
 	src.dead_icon     = dead_icon  || src.dead_icon
 	src.dead_light    = dead_light || src.dead_light
 
-/datum/ai_icon/proc/may_used_by_ai(mob/user)
+/singleton/ai_icon/proc/may_used_by_ai(mob/user)
 	return TRUE
 
-/datum/ai_icon/malf
+/singleton/ai_icon/malf
 	name = "Unlawed"
 	alive_icon = "ai-malf"
 	alive_light = "#45644b"
 
-/datum/ai_icon/malf/New()
+/singleton/ai_icon/malf/New()
 	..()
 	name = "[name] (Malf)"
 
-/datum/ai_icon/malf/may_used_by_ai(mob/living/silicon/ai/AI)
+/singleton/ai_icon/malf/may_used_by_ai(mob/living/silicon/ai/AI)
 	return istype(AI) && AI.is_malf_or_traitor()
 
-/datum/ai_icon/red
+/singleton/ai_icon/red
 	name = "Red"
 	alive_icon = "ai-red"
 	alive_light = "#f04848"
 
-/datum/ai_icon/green
+/singleton/ai_icon/green
 	name = "Green"
 	alive_icon = "ai-wierd"
 	alive_light = "#00ff99"
 
-/datum/ai_icon/blue
+/singleton/ai_icon/blue
 	name = "Blue"
 	alive_icon = "ai"
 	alive_light = "#81ddff"
 
-/datum/ai_icon/angry
+/singleton/ai_icon/angry
 	name = "Angry"
 	alive_icon = "ai-angryface"
 	alive_light = "#ffff33"
 
-/datum/ai_icon/bliss
+/singleton/ai_icon/bliss
 	name = "Bliss"
 	alive_icon = "ai-bliss"
 	alive_light = "#5c7a4a"
 
-/datum/ai_icon/chatterbox
+/singleton/ai_icon/chatterbox
 	name = "Chatterbox"
 	alive_icon = "ai-president"
 	alive_light = "#40666b"
 
-/datum/ai_icon/database
+/singleton/ai_icon/database
 	name = "Database"
 	alive_icon = "ai-database"
 
-/datum/ai_icon/dorf
+/singleton/ai_icon/dorf
 	name = "Dorf"
 	alive_icon = "ai-dorf"
 
-/datum/ai_icon/dugtodeep
+/singleton/ai_icon/dugtodeep
 	name = "Dug Too Deep"
 	alive_icon = "ai-toodeep"
 	alive_light = "#81ddff"
 
-/datum/ai_icon/firewall
+/singleton/ai_icon/firewall
 	name = "Firewall"
 	alive_icon = "ai-magma"
 	alive_light = "#ff4126"
 
-/datum/ai_icon/glitchman
+/singleton/ai_icon/glitchman
 	name = "Glitchman"
 	alive_icon = "ai-glitchman"
 
-/datum/ai_icon/goon
+/singleton/ai_icon/goon
 	name = "Goon"
 	alive_icon = "ai-goon"
 	alive_light = "#3e5c80"
 
-/datum/ai_icon/heartline
+/singleton/ai_icon/heartline
 	name = "Heartline"
 	alive_icon = "ai-heartline"
 	dead_icon = "ai-heartline_dead"
 
-/datum/ai_icon/helios
+/singleton/ai_icon/helios
 	name = "Helios"
 	alive_icon = "ai-helios"
 	alive_light = "#f2cf73"
 
-/datum/ai_icon/inverted
+/singleton/ai_icon/inverted
 	name = "Inverted"
 	alive_icon = "ai-u"
 	alive_light = "#81ddff"
 
-/datum/ai_icon/lonestar
+/singleton/ai_icon/lonestar
 	name = "Lonestar"
 	alive_icon = "ai-lonestar"
 	alive_light = "#58751c"
 
-/datum/ai_icon/matrix
+/singleton/ai_icon/matrix
 	name = "Matrix"
 	alive_icon = "ai-matrix"
 	alive_light = "#449944"
 
-/datum/ai_icon/monochrome
+/singleton/ai_icon/monochrome
 	name = "Monochrome"
 	alive_icon = "ai-mono"
 	alive_light = "#585858"
 
-/datum/ai_icon/nanotrasen
+/singleton/ai_icon/nanotrasen
 	name = "NanoTrasen"
 	alive_icon = "ai-nanotrasen"
 	alive_light = "#000029"
 
-/datum/ai_icon/rainbow
+/singleton/ai_icon/rainbow
 	name = "Rainbow"
 	alive_icon = "ai-clown"
 	alive_light = "#e50213"
 
-/datum/ai_icon/smiley
+/singleton/ai_icon/smiley
 	name = "Smiley"
 	alive_icon = "ai-smiley"
 	alive_light = "#f3dd00"
 
-/datum/ai_icon/soviet
+/singleton/ai_icon/soviet
 	name = "Soviet"
 	alive_icon = "ai-redoctober"
 	alive_light = "#ff4307"
 
-/datum/ai_icon/Static
+/singleton/ai_icon/Static
 	name = "Static"
 	alive_icon = "ai-static"
 	alive_light = "#4784c1"
 
-/datum/ai_icon/text
+/singleton/ai_icon/text
 	name = "Text"
 	alive_icon = "ai-text"
 
-/datum/ai_icon/trapped
+/singleton/ai_icon/trapped
 	name = "Trapped"
 	alive_icon = "ai-hades"
 
-/datum/ai_icon/triumvirate_static
+/singleton/ai_icon/triumvirate_static
 	name = "Triumvirate"
 	alive_icon = "ai-triumvirate"
 	alive_light = "#020b2b"
 
-/datum/ai_icon/triumvirate_static
+/singleton/ai_icon/triumvirate_static
 	name = "Triumvirate Static"
 	alive_icon = "ai-static"
 	alive_light = "#020b2b"
 
-/datum/ai_icon/hotdogger
+/singleton/ai_icon/hotdogger
 	name = "Dancing Hotdog"
 	alive_icon = "ai-hotdog"
 	alive_light = "#81ddff"
 
-/datum/ai_icon/malf/clown
+/singleton/ai_icon/malf/clown
 	name = "Clown"
 	alive_icon = "ai-clown2"
 	alive_light = "#e50213"


### PR DESCRIPTION
When `#define GET_SINGLETON_SUBTYPE_MAP` was born, `/datum` of type `ai_icon` was very jealous of it.
Enormous deprivation was really torturing that `/datum`, but now... I'm here to help it!

<hr />

Casts `/datum/ai_icon` to `/singleton/ai_icon`.

Fixes `Set AI Core Display` verb, because `GET_SINGLETON_SUBTYPE_MAP(/datum/ai_icon)` doesn't work for non-singleton types


Changelog:
```yml
🆑 SuhEugene
bugfix: Set AI Core Display verb now works instead of doing nothing
/🆑
```