### PR TITLE
Connection checker fixes

### DIFF
--- a/code/modules/admin/connectioncheck/connectioncheck_functions.dm
+++ b/code/modules/admin/connectioncheck/connectioncheck_functions.dm
@@ -53,7 +53,8 @@
 	var/DBQuery/query = dbcon.NewQuery("\
 		SELECT `bantime`, `bantype`, `reason`, `job`, `duration`, `expiration_time`, `ckey`, `ip`, `computerid`, `a_ckey`, `unbanned`\
 			FROM `erro_ban`\
-			WHERE `ckey` = '[ckey]' OR `ip` = '[ip]' OR `computerid` = '[cid]'\
+			WHERE `bantype` IN ('PERMABAN', 'TEMPBAN') AND \
+			(`ckey` = '[ckey]' OR `ip` = '[ip]' OR `computerid` = '[cid]')\
 	")
 	query.Execute()
 	var/now = time2text(world.realtime, "YYYY-MM-DD hh:mm:ss")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -150,18 +150,6 @@
 			message_staff("[key_name_admin(src)] has joined the game with an open ticket. Status: [length(T.assigned_admins) ? "Assigned to: [english_list(T.assigned_admin_ckeys())]" : SPAN_DANGER("Unassigned.")]")
 			break
 
-	// Check connections
-	var/list/connections = fetch_connections()
-	var/list/ckeys = _unique_ckeys_from_connections(connections) - ckey
-	if (length(ckeys))
-		log_and_message_staff(SPAN_INFO("[key_name_admin(src)] has connection details associated with other ckeys in the log: [english_list(ckeys)]"))
-
-	// Check bans
-	var/list/bans = _find_bans_in_connections(connections)
-	ckeys = _unique_ckeys_from_connections(bans)
-	if (length(bans))
-		log_and_message_staff(SPAN_DANGER("[key_name_admin(src)] has connection details associated with active bans: [english_list(ckeys)]"))
-
 	// Change the way they should download resources.
 	if(config.resource_urls && length(config.resource_urls))
 		src.preload_rsc = pick(config.resource_urls)
@@ -225,6 +213,20 @@
 
 	if(holder)
 		src.control_freak = 0 //Devs need 0 for profiler access
+
+	// This turns out to be a touch too much when a bunch of people are connecting at once from a restart during init.
+	if (GAME_STATE & RUNLEVELS_DEFAULT)
+		// Check connections
+		var/list/connections = fetch_connections()
+		var/list/ckeys = _unique_ckeys_from_connections(connections) - ckey
+		if (length(ckeys))
+			log_and_message_staff(SPAN_INFO("[key_name_admin(src)] has connection details associated with other ckeys in the log: [english_list(ckeys)]"))
+
+		// Check bans
+		var/list/bans = _find_bans_in_connections(connections)
+		ckeys = _unique_ckeys_from_connections(bans)
+		if (length(bans))
+			log_and_message_staff(SPAN_DANGER("[key_name_admin(src)] has connection details associated with active bans: [english_list(ckeys)]"))
 
 	//////////////
 	//DISCONNECT//

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -154,13 +154,13 @@
 	var/list/connections = fetch_connections()
 	var/list/ckeys = _unique_ckeys_from_connections(connections) - ckey
 	if (length(ckeys))
-		log_debug("[key_name_admin(src)] has connection details associated with other ckeys in the log: [english_list(ckeys)]")
+		log_and_message_staff(SPAN_INFO("[key_name_admin(src)] has connection details associated with other ckeys in the log: [english_list(ckeys)]"))
 
 	// Check bans
 	var/list/bans = _find_bans_in_connections(connections)
 	ckeys = _unique_ckeys_from_connections(bans)
 	if (length(bans))
-		log_debug("[key_name_admin(src)] has connection details associated with active bans: [english_list(ckeys)]")
+		log_and_message_staff(SPAN_DANGER("[key_name_admin(src)] has connection details associated with active bans: [english_list(ckeys)]"))
 
 	// Change the way they should download resources.
 	if(config.resource_urls && length(config.resource_urls))

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -216,17 +216,18 @@
 
 	// This turns out to be a touch too much when a bunch of people are connecting at once from a restart during init.
 	if (GAME_STATE & RUNLEVELS_DEFAULT)
-		// Check connections
-		var/list/connections = fetch_connections()
-		var/list/ckeys = _unique_ckeys_from_connections(connections) - ckey
-		if (length(ckeys))
-			log_and_message_staff(SPAN_INFO("[key_name_admin(src)] has connection details associated with other ckeys in the log: [english_list(ckeys)]"))
+		spawn()
+			// Check connections
+			var/list/connections = fetch_connections()
+			var/list/ckeys = _unique_ckeys_from_connections(connections) - ckey
+			if (length(ckeys))
+				log_and_message_staff(SPAN_INFO("[key_name_admin(src)] has connection details associated with other ckeys in the log: [english_list(ckeys)]"))
 
-		// Check bans
-		var/list/bans = _find_bans_in_connections(connections)
-		ckeys = _unique_ckeys_from_connections(bans)
-		if (length(bans))
-			log_and_message_staff(SPAN_DANGER("[key_name_admin(src)] has connection details associated with active bans: [english_list(ckeys)]"))
+			// Check bans
+			var/list/bans = _find_bans_in_connections(connections)
+			ckeys = _unique_ckeys_from_connections(bans)
+			if (length(bans))
+				log_and_message_staff(SPAN_DANGER("[key_name_admin(src)] has connection details associated with active bans: [english_list(ckeys)]"))
 
 	//////////////
 	//DISCONNECT//

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -44,7 +44,7 @@ exactly 25 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 5 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 351 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 352 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 0 "anchored = 0/1" 'anchored\s*=\s*\d' -P
 exactly 2 "density = 0/1" 'density\s*=\s*\d' -P


### PR DESCRIPTION
Worked better than expected.

:cl: SierraKomodo
admin: Associated ban checks now ignore job bans.
admin: Logs for connections and bans found on clients now appear as staff logs instead of debug logs. Messages for found bans are in red.
admin: Checks on connecting clients are now skipped if the server is performing initialization, to avoid causing connection failures or other lag-related issues.
/:cl: