### PR TITLE
Automatic gun safety on holstering

### DIFF
--- a/code/datums/extensions/holster/holster.dm
+++ b/code/datums/extensions/holster/holster.dm
@@ -45,6 +45,11 @@
 			playsound(get_turf(atom_holder), sound_in, 50)
 		if(istype(user))
 			user.stop_aiming(no_message=1)
+		if(istype(I, /obj/item/gun))
+			var/obj/item/gun/G = I
+			G.check_accidents(user)
+			if(user.a_intent == I_HELP && G.has_safety && !G.safety_state && user.skill_check(SKILL_WEAPONS, SKILL_EXPERT))
+				G.toggle_safety(user)
 		holstered = I
 		storage.handle_item_insertion(holstered, 1)
 		holstered.add_fingerprint(user)
@@ -77,7 +82,7 @@
 			if(istype(holstered, /obj/item/gun))
 				var/obj/item/gun/G = holstered
 				G.check_accidents(user)
-				if(G.safety() && !user.skill_fail_prob(SKILL_WEAPONS, 100, SKILL_EXPERT, 0.5)) //Experienced shooter will disable safety before shooting.
+				if(G.safety() && user.skill_check(SKILL_WEAPONS, SKILL_EXPERT)) // Experienced shooter will disable safety before shooting.
 					G.toggle_safety(user)
 			usr.visible_message(
 				SPAN_DANGER("\The [user] draws \the [holstered], ready to go!"),

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -230,7 +230,7 @@
 		return
 
 	if(safety())
-		if(user.a_intent == I_HURT && !user.skill_fail_prob(SKILL_WEAPONS, 100, SKILL_EXPERT, 0.5)) //reflex un-safeying
+		if(user.a_intent == I_HURT && user.skill_check(SKILL_WEAPONS, SKILL_EXPERT))
 			toggle_safety(user)
 		else
 			handle_click_safety(user)


### PR DESCRIPTION
🆑 Hubblenaut
tweak: When having the required weapons skill, guns will automatically have their safety turned on when holstered.
tweak: Skill-based toggling of the gun-safety when drawing/shooting a gun is no longer chance-based.
/:cl:

About the second tweak:
The probabilistic nature of quickdrawing guns resulted in players simply avoiding the gun safety mechanic altogether by keeping their guns stored with the safety toggled off.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->