### PR TITLE
Fix geosample errors for pitchblende

### DIFF
--- a/code/modules/materials/definitions/materials_mineral.dm
+++ b/code/modules/materials/definitions/materials_mineral.dm
@@ -12,7 +12,7 @@
 		"thousand" = 999,
 		"million" = 704
 		)
-	xarch_source_mineral = "potassium"
+	xarch_source_mineral = /datum/reagent/potassium
 	ore_icon_overlay = "nugget"
 	chem_products = list(
 		/datum/reagent/radium = 10,


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Running the geosample scanner on pitchblende no longer gets stuck in an infinite runtime-error loop.
/:cl: