### PR TITLE
remove a newline from vote stats

### DIFF
--- a/code/datums/vote/vote.dm
+++ b/code/datums/vote/vote.dm
@@ -137,7 +137,7 @@
 	text += "<b>Votes Per Option:</b>"
 	for(var/R in result)
 		if (result[R] > 0)
-			text += "\n[R]: [result[R]]<br>"
+			text += "\n[R]: [result[R]]"
 	return JOINTEXT(text)
 
 


### PR DESCRIPTION
there was a space in the output that didn't need to be there.

barely user facing so won't bother with a changelog