### PR TITLE
Reduces renegade skill choices

### DIFF
--- a/code/game/antagonist/station/renegade.dm
+++ b/code/game/antagonist/station/renegade.dm
@@ -21,7 +21,7 @@ GLOBAL_DATUM_INIT(renegades, /datum/antagonist/renegade, new)
 	initial_spawn_req = 1
 	initial_spawn_target = 3
 	antaghud_indicator = "hud_renegade"
-	skill_setter = /datum/antag_skill_setter/station
+	skill_setter = /datum/antag_skill_setter/station/renegade
 
 	var/list/spawn_guns = list(
 		/obj/item/gun/energy/retro,

--- a/code/modules/mob/skills/antag_skill_setter.dm
+++ b/code/modules/mob/skills/antag_skill_setter.dm
@@ -36,6 +36,9 @@
 			skillset.obtain_from_client(job, my_client, 1)
 	skillset.open_ui()
 
+/datum/antag_skill_setter/station/renegade
+	nm_type = /datum/nano_module/skill_ui/antag/rene
+
 //This will obtain skills from the job selection before giving additional buffs.
 /datum/antag_skill_setter/station/offstation
 	nm_type = /datum/nano_module/skill_ui/antag/station/offstation

--- a/code/modules/mob/skills/skill_ui.dm
+++ b/code/modules/mob/skills/skill_ui.dm
@@ -229,6 +229,9 @@ Similar, but for station antags that have jobs.
 */
 /datum/nano_module/skill_ui/antag/station
 	max_choices = list(0, 0, 2, 1, 1)
+
+/datum/nano_module/skill_ui/antag/rene
+	max_choices = list(0, 1, 1, 0, 0)
 /*
 Similar, but for off-station jobs (Bearcat, Verne, survivor etc.).
 */


### PR DESCRIPTION
🆑 Jux
tweak: Renegades now only have one basic and one trained skill choice.
/🆑

So that renegades aren't super-skilled masters of the blade 