### PR TITLE
Add one-tile jumps/make vox jumps instant

### DIFF
--- a/code/modules/mob/living/maneuvers/_maneuver.dm
+++ b/code/modules/mob/living/maneuvers/_maneuver.dm
@@ -1,7 +1,7 @@
 /singleton/maneuver
 	var/name = "unnamed"
 	var/delay = 2 SECONDS
-	var/cooldown = 10 SECONDS
+	var/cooldown = 5 SECONDS
 	var/stamina_cost = 10
 	var/reflexive_modifier = 1
 

--- a/code/modules/mob/living/maneuvers/maneuver_leap.dm
+++ b/code/modules/mob/living/maneuvers/maneuver_leap.dm
@@ -49,8 +49,37 @@
 /singleton/maneuver/leap/spider/show_initial_message(mob/living/user, atom/target)
 	user.visible_message(SPAN_WARNING("\The [user] reels back and prepares to launch itself at \the [target]!"))
 
+/singleton/maneuver/leap/grab
+	name = "spring leap"
+	stamina_cost = 40
+	reflexive_modifier = 0.5
+	cooldown = 15 SECONDS
+	delay = 0 SECONDS
+
 /singleton/maneuver/leap/grab/end_leap(mob/living/user, atom/target)
 	. = ..()
 	if(ishuman(user) && !user.lying && ismob(target) && user.Adjacent(target))
 		var/mob/living/carbon/human/H = user
 		H.species.attempt_grab(H, target)
+
+/singleton/maneuver/leap/quick
+	name = "quick jump"
+	stamina_cost = 20
+	reflexive_modifier = 0.75
+	cooldown = 10 SECONDS
+	delay = 0 SECONDS
+
+/singleton/maneuver/leap/quick/perform(mob/living/user, atom/target, strength, reflexively = FALSE)
+	. = ..()
+	strength = 1
+	if (.)
+		var/old_pass_flags = user.pass_flags
+		user.pass_flags |= PASS_FLAG_TABLE
+		user.visible_message(SPAN_DANGER("\The [user] takes a flying leap!"))
+		if(reflexively)
+			strength *= reflexive_modifier
+		user.jump_layer_shift()
+		animate(user, pixel_z = 16, time = 3, easing = SINE_EASING | EASE_IN)
+		animate(pixel_z = user.default_pixel_z, time = 3, easing = SINE_EASING | EASE_OUT)
+		user.throw_at(get_turf(target), strength, 1, user, FALSE, new Callback(src, /singleton/maneuver/leap/proc/end_leap, user, target, old_pass_flags))
+		addtimer(new Callback(user, /mob/living/proc/jump_layer_shift_end), 4.5)

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -243,7 +243,10 @@
 	)
 
 	var/standing_jump_range = 2
-	var/list/maneuvers = list(/singleton/maneuver/leap)
+	var/list/maneuvers = list(
+		/singleton/maneuver/leap,
+		/singleton/maneuver/leap/quick
+	)
 
 	var/list/available_cultural_info = list(
 		TAG_CULTURE =   list(CULTURE_OTHER),


### PR DESCRIPTION
:cl:
tweak: Normal jumps cool down in 5 seconds instead of 10.
tweak: Add quick jump for all species (10 second cooldown, instant one tile jump)
tweak: Make vox leap-grabs instant with a 15 second cooldown.
tweak: increase quick jump/leap grab stamina cost.
/:cl:

Requires people to use the "Prepare to Maneuver" verb and select the maneuver before using the hot key.