### PR TITLE
More Connection Checker Fixes

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -87,6 +87,8 @@ var/global/floorIsLava = 0
 		<A href='?src=\ref[src];newban=\ref[M];last_key=[last_ckey]'>Ban</A> |
 		<A href='?src=\ref[src];jobban2=\ref[M]'>Jobban</A> |
 		<A href='?src=\ref[src];notes=show;mob=\ref[M]'>Notes</A> |
+		<A HREF='?src=\ref[src];connections=\ref[M]'>Check Connections</A> |
+		<A HREF='?src=\ref[src];bans=\ref[M]'>Check Bans</A> |
 	"}
 
 	if (!istype(M, /mob/new_player) && !istype(M, /mob/observer))
@@ -96,8 +98,6 @@ var/global/floorIsLava = 0
 		body += "<A HREF='?src=\ref[src];sendtoprison=\ref[M]'>Prison</A> | "
 		body += "<A HREF='?src=\ref[src];reloadsave=\ref[M]'>Reload Save</A> | "
 		body += "<A HREF='?src=\ref[src];reloadchar=\ref[M]'>Reload Character</A> | "
-		body += "<A HREF='?src=\ref[src];connections=\ref[M]'>Check Connections</A> | "
-		body += "<A HREF='?src=\ref[src];bans=\ref[M]'>Check Bans</A> | "
 		var/muted = M.client.prefs.muted
 		body += {"<br><b>Mute: </b>
 			\[<A href='?src=\ref[src];mute=\ref[M];mute_type=[MUTE_IC]'><span style='font-color: [(muted & MUTE_IC)?"red":"blue"]'>IC</span></a> |

--- a/code/modules/admin/connectioncheck/connectioncheck_functions.dm
+++ b/code/modules/admin/connectioncheck/connectioncheck_functions.dm
@@ -220,7 +220,7 @@
 
 
 /proc/_debug_fetch_bans(ckey, ip, cid, include_inactive = FALSE)
-	var/list/result = _fetch_bans(ckey, ip, cid, include_inactive)
+	var/list/result = _find_bans_in_connections(_fetch_connections(ckey, ip, cid), include_inactive)
 	var/table = {"
 		<table>
 			<thead>


### PR DESCRIPTION
Guess who forgot to actually open this PR.

## Changelog
:cl: SierraKomodo
admin: 'Check Connections' and 'Check Bans' buttons in the Player Panel are now always visible, even if a mob's client is disconnected or ghosted.
bugfix: The 'Check Bans' button in the Player Panel now shows all related bans, making it consistant with the admin log on connect.
/:cl:

## Other Changes
- Added `include_inactive` parameter to `/proc/_find_bans_in_connections()`, passed on directly to `/proc/_fetch_bans()`.