### PR TITLE
Change the hidden D3 loot spawn so it doesn't spawn guns

### DIFF
--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -8379,8 +8379,8 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/fore)
 "tm" = (
-/obj/random/loot,
-/obj/random/loot,
+/obj/random/maintenance/clean,
+/obj/random/maintenance/clean,
 /obj/random/trash,
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/fore)


### PR DESCRIPTION
:cl: Mucker
tweak: Guns no longer spawn on a certain hidden D3 loot spawn. 
/:cl: