### PR TITLE
Bug fixes 2023 04 08

### DIFF
--- a/code/game/objects/items/traitor_plush.dm
+++ b/code/game/objects/items/traitor_plush.dm
@@ -82,7 +82,7 @@
 	return replace_characters(phrase, replacechars)
 
 /obj/item/plushbomb/proc/activate()
-	explosion(src.loc, 3, EX_ACT_LIGHT)
+	explosion(src.loc, 3, EX_ACT_HEAVY)
 	qdel(src)
 
 /obj/item/plushbomb/get_antag_info()

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -26,7 +26,10 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 	var/flush_every_ticks = 30 //Every 30 ticks it will look whether it is ready to flush
 	var/flush_count = 0 //this var adds 1 once per tick. When it reaches flush_every_ticks it resets and tries to flush.
 	var/last_sound = 0
-	var/list/allowed_objects = list(/obj/structure/closet)
+	var/list/allowed_objects = list(
+		/obj/structure/closet,
+		/obj/structure/bigDelivery
+	)
 	active_power_usage = 2200	//the pneumatic pump power. 3 HP ~ 2200W
 	idle_power_usage = 100
 	atom_flags = ATOM_FLAG_CLIMBABLE

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -166,6 +166,7 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 		attackby(AM, user)
 		return
 	else if(!is_type_in_list(AM, allowed_objects))
+		USE_FEEDBACK_FAILURE("\The [AM] doesn't fit in \the [src].")
 		return
 
 	// Checks completed, start inserting


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
balance: Plushie bomb explosions have been bumped up a tier from light to heavy.
bugfix: Fixes an oversight where crates wrapped in paper could not be put in disposal bins.
rscadd: Disposal bins now display a feedback message when trying to disposal a large object that the bins don't accept.
/:cl: