### PR TITLE
Various Grab & Buckle Fixes

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -279,15 +279,15 @@
 	if (buckle_pixel_shift)
 		if (M == buckled_mob)
 			animate(M, 0.5 SECONDS, TRUE, LINEAR_EASING,
-				pixel_x = M.default_pixel_x + buckle_pixel_shift[1],
-				pixel_y = M.default_pixel_y + buckle_pixel_shift[2],
-				pixel_z = M.default_pixel_z + buckle_pixel_shift[3]
+				pixel_x = M.pixel_x + buckle_pixel_shift[1],
+				pixel_y = M.pixel_y + buckle_pixel_shift[2],
+				pixel_z = M.pixel_z + buckle_pixel_shift[3]
 			)
 		else
 			animate(M, 0.5 SECONDS, TRUE, LINEAR_EASING,
-				pixel_x = M.default_pixel_x,
-				pixel_y = M.default_pixel_y,
-				pixel_z = M.default_pixel_z
+				pixel_x = M.pixel_x - buckle_pixel_shift[1],
+				pixel_y = M.pixel_y - buckle_pixel_shift[2],
+				pixel_z = M.pixel_z - buckle_pixel_shift[3]
 			)
 
 

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -172,6 +172,16 @@
 	admin_attack_log(G.assailant, G.affecting, "[action]s their victim", "was [action]ed", "used [action] on")
 
 
+#define GRAB_ADJUST_ANIMATE(X, Y) animate(\
+	affecting,\
+	pixel_x = G.affecting.pixel_x - adjust_x + X,\
+	pixel_y = G.affecting.pixel_y - adjust_y + Y,\
+	5, 1, LINEAR_EASING\
+);\
+adjust_x = X;\
+adjust_y = Y;
+
+
 /datum/grab/proc/adjust_position(obj/item/grab/G)
 	var/mob/living/carbon/human/affecting = G.affecting
 	var/mob/living/carbon/human/assailant = G.assailant
@@ -182,48 +192,19 @@
 		adir = assailant.dir
 		affecting.set_dir(assailant.dir)
 
-	switch(adir)
-		if(NORTH)
-			animate(
-				affecting,
-				pixel_x = G.affecting.pixel_x - adjust_x,
-				pixel_y = G.affecting.pixel_y - adjust_y - shift,
-				5, 1, LINEAR_EASING
-			)
-			adjust_x = 0
-			adjust_y = -shift
-			G.draw_affecting_under()
-		if(SOUTH)
-			animate(
-				affecting,
-				pixel_x = G.affecting.pixel_x - adjust_x,
-				pixel_y = G.affecting.pixel_y - adjust_y + shift,
-				5, 1, LINEAR_EASING
-			)
-			adjust_x = 0
-			adjust_y = shift
-			G.draw_affecting_over()
-		if(WEST)
-			animate(
-				affecting,
-				pixel_x = G.affecting.pixel_x - adjust_x + shift,
-				pixel_y = G.affecting.pixel_y - adjust_y,
-				5, 1, LINEAR_EASING
-			)
-			adjust_x = shift
-			adjust_y = 0
-			G.draw_affecting_under()
-		if(EAST)
-			animate(
-				affecting,
-				pixel_x = G.affecting.pixel_x - adjust_x - shift,
-				pixel_y = G.affecting.pixel_y - adjust_y,
-				5, 1, LINEAR_EASING
-			)
-			adjust_x = -shift
-			adjust_y = 0
-			G.draw_affecting_under()
+	var/x_shift = 0
+	var/y_shift = 0
+	if (HAS_FLAGS(adir, NORTH))
+		y_shift = -shift
+	if (HAS_FLAGS(adir, SOUTH))
+		y_shift = shift
+	if (HAS_FLAGS(adir, WEST))
+		x_shift = shift
+	if (HAS_FLAGS(adir, EAST))
+		x_shift = -shift
+	GRAB_ADJUST_ANIMATE(x_shift, y_shift)
 
+	G.draw_affecting_under()
 	affecting.reset_plane_and_layer()
 
 /datum/grab/proc/reset_position(obj/item/grab/G)

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -55,6 +55,11 @@
 	var/grab_action = "grab intent"
 	var/harm_action = "harm intent"
 
+	/// Integer. The amount of pixel adjustment made on the X axis. Used to revert the shift.
+	var/adjust_x = 0
+	/// Integer. The amount of pixel adjustment made on the Y axis. Used to revert the shift.
+	var/adjust_y = 0
+
 /*
 	These procs shouldn't be overriden in the children unless you know what you're doing with them; they handle important core functions.
 	Even if you do override them, you should likely be using ..() if you want the behaviour to function properly. That is, of course,
@@ -179,16 +184,44 @@
 
 	switch(adir)
 		if(NORTH)
-			animate(affecting, pixel_x = 0, pixel_y =-shift, 5, 1, LINEAR_EASING)
+			animate(
+				affecting,
+				pixel_x = G.affecting.pixel_x - adjust_x,
+				pixel_y = G.affecting.pixel_y - adjust_y - shift,
+				5, 1, LINEAR_EASING
+			)
+			adjust_x = 0
+			adjust_y = -shift
 			G.draw_affecting_under()
 		if(SOUTH)
-			animate(affecting, pixel_x = 0, pixel_y = shift, 5, 1, LINEAR_EASING)
+			animate(
+				affecting,
+				pixel_x = G.affecting.pixel_x - adjust_x,
+				pixel_y = G.affecting.pixel_y - adjust_y + shift,
+				5, 1, LINEAR_EASING
+			)
+			adjust_x = 0
+			adjust_y = shift
 			G.draw_affecting_over()
 		if(WEST)
-			animate(affecting, pixel_x = shift, pixel_y = 0, 5, 1, LINEAR_EASING)
+			animate(
+				affecting,
+				pixel_x = G.affecting.pixel_x - adjust_x + shift,
+				pixel_y = G.affecting.pixel_y - adjust_y,
+				5, 1, LINEAR_EASING
+			)
+			adjust_x = shift
+			adjust_y = 0
 			G.draw_affecting_under()
 		if(EAST)
-			animate(affecting, pixel_x =-shift, pixel_y = 0, 5, 1, LINEAR_EASING)
+			animate(
+				affecting,
+				pixel_x = G.affecting.pixel_x - adjust_x - shift,
+				pixel_y = G.affecting.pixel_y - adjust_y,
+				5, 1, LINEAR_EASING
+			)
+			adjust_x = -shift
+			adjust_y = 0
 			G.draw_affecting_under()
 
 	affecting.reset_plane_and_layer()
@@ -196,8 +229,14 @@
 /datum/grab/proc/reset_position(obj/item/grab/G)
 	var/mob/living/carbon/human/affecting = G.affecting
 
-	if(!affecting.buckled)
-		animate(affecting, pixel_x = 0, pixel_y = 0, 4, 1, LINEAR_EASING)
+	animate(
+		affecting,
+		pixel_x = G.affecting.pixel_x - adjust_x,
+		pixel_y = G.affecting.pixel_y - adjust_y,
+		4, 1, LINEAR_EASING
+	)
+	adjust_x = 0
+	adjust_y = 0
 	affecting.reset_plane_and_layer()
 
 // This is called whenever the assailant moves.


### PR DESCRIPTION
Separated from the general bug fixes PR as there's the possibility of unfun brokenness with these fixes.

## Changelog
:cl: SierraKomodo
bugfix: Mobs no longer become stuck in a certain pixel offset when buckled while in a grab.
refactor: Mild rework of how pixel shifting when grabbed works.
tweak: Pixel adjustments for grabs now also appear for diagonal directions, and reset if the grabee and grabber are on the same tile.
/:cl:

## Bug Fixes
- Fixes #33234

## Other Changes
- Added `adjust_x` and `adjust_y` vars to `/obj/item/grab`, used for tracking and resetting pixel offset adjustments from grabs.
- Pixel offsets for grabs and buckles are now relative to the current offset, instead of absolute based on the default offset (Or assuming offset's already at default).