### PR TITLE
Apply `use_*` to `/obj/structure`

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -59,3 +59,11 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define TANK_FLAG_FORCED     FLAG(1)
 #define TANK_FLAG_LEAKING    FLAG(2)
 #define TANK_FLAG_WIRED      FLAG(3)
+
+// Flags for beds/chairs
+/// The bed/chair cannot be dismantled with a wrench.
+#define BED_FLAG_CANNOT_BE_DISMANTLED FLAG(1)
+/// The bed/chair cannot be padded with material.
+#define BED_FLAG_CANNOT_BE_PADDED FLAG(2)
+/// The bed/chair cannot be made into an electric chair with a shock kit. Only applies to `/obj/structure/bed/chair` subtypes.
+#define BED_FLAG_CANNOT_BE_ELECTRIFIED FLAG(3)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -125,11 +125,38 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	if (!.)
 		return
 
-	// Block interacting with things under platings - In case of t-ray shennanigans or layering glitches
-	var/turf/T = get_turf(src)
-	if (hides_under_flooring() && !T.is_plating())
-		USE_FEEDBACK_FAILURE("You must remove the plating before you can interact with \the [src].")
-		return FALSE
+	if (hides_under_flooring())
+		// Block interacting with things under platings - In case of t-ray shennanigans or layering glitches
+		var/turf/turf = get_turf(src)
+		if (!turf.is_plating())
+			USE_FEEDBACK_FAILURE("You must remove the plating before you can interact with \the [src].")
+			return FALSE
+
+		// Catwalks
+		var/obj/structure/catwalk/catwalk = locate() in get_turf(src)
+		if (catwalk)
+			if (catwalk.plated_tile && !catwalk.hatch_open)
+				USE_FEEDBACK_FAILURE("\The [catwalk]'s hatch needs to be opened before you can access \the [src].")
+				return FALSE
+			else if (!catwalk.plated_tile)
+				USE_FEEDBACK_FAILURE("\The [catwalk] is blocking access to \the [src].")
+				return FALSE
+
+
+/turf/can_use_item(obj/item/tool, mob/user, click_params)
+	. = ..()
+	if (!.)
+		return
+
+	// Catwalks
+	var/obj/structure/catwalk/catwalk = locate() in src
+	if (catwalk)
+		if (catwalk.plated_tile && !catwalk.hatch_open)
+			USE_FEEDBACK_FAILURE("\The [catwalk]'s hatch needs to be opened before you can access \the [src].")
+			return FALSE
+		else if (!catwalk.plated_tile)
+			USE_FEEDBACK_FAILURE("\The [catwalk] is blocking access to \the [src].")
+			return FALSE
 
 
 /**

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -148,6 +148,18 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	if (!.)
 		return
 
+	// Unmodifiable area check
+	var/area/area = get_area(src)
+	if (!area?.can_modify_area())
+		USE_FEEDBACK_FAILURE("This area does not allow structural modifications.")
+		return FALSE
+
+
+/turf/can_use_item(obj/item/tool, mob/user, click_params)
+	. = ..()
+	if (!.)
+		return
+
 	// Catwalks
 	var/obj/structure/catwalk/catwalk = locate() in src
 	if (catwalk)

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -27,19 +27,22 @@
 	health_min_damage = 4
 	damage_hitsound = 'sound/effects/Glasshit.ogg'
 
-/obj/structure/cult/pylon/attackby(obj/item/W, mob/user)
-	if (istype(W, /obj/item/natural_weapon/cult_builder))
-		if (!health_damaged())
-			to_chat(user, SPAN_WARNING("\The [src] is fully repaired."))
-		else
-			user.visible_message(
-				SPAN_NOTICE("\The [user] mends some of the cracks on \the [src]."),
-				SPAN_NOTICE("You repair some of \the [src]'s damage.")
-			)
-			restore_health(5)
-		return
 
-	..()
+/obj/structure/cult/pylon/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Cult Builder - Repair pylon
+	if (istype(tool, /obj/item/natural_weapon/cult_builder))
+		if (!health_damaged())
+			USE_FEEDBACK_FAILURE("\The [src] does not need repairs.")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] mends some of the cracks on \the [src]."),
+			SPAN_NOTICE("You repair some of \the [src]'s damage.")
+		)
+		restore_health(5)
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/cult/tome
 	name = "Desk"

--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -6,7 +6,21 @@ var/global/list/empty_playable_ai_cores = list()
 	name = "\improper AI core"
 	icon = 'icons/mob/AI.dmi'
 	icon_state = "0"
-	var/state = 0
+
+	/// State 1 - AI core frame is built.
+	var/const/STATE_FRAME = 1
+	/// State 2 - Circuitboard is installed
+	var/const/STATE_CIRCUIT = 2
+	/// State 3 - Circuitboard is installed and secured
+	var/const/STATE_CIRCUIT_SECURE = 3
+	/// State 4 - Frame is wired
+	var/const/STATE_WIRED = 4
+	/// State 5 - Brain is installed
+	var/const/STATE_BRAIN = 5
+	/// State 6 - Glass panel is installed
+	var/const/STATE_PANEL = 6
+	var/state = STATE_FRAME
+
 	var/datum/ai_laws/laws = new /datum/ai_laws/nanotrasen
 	var/obj/item/stock_parts/circuitboard/circuit = null
 	var/obj/item/device/mmi/brain = null
@@ -19,186 +33,384 @@ var/global/list/empty_playable_ai_cores = list()
 		return 1
 	. = ..()
 
-/obj/structure/AIcore/attackby(obj/item/P as obj, mob/user as mob)
-	if(!authorized)
-		if(access_ai_upload in P.GetAccess())
-			to_chat(user, SPAN_NOTICE("You swipe [P] at [src] and authorize it to connect into the systems of [GLOB.using_map.full_name]."))
-			authorized = 1
-	switch(state)
-		if(0)
-			if(isWrench(P))
-				playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
-				if(do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT))
-					to_chat(user, SPAN_NOTICE("You wrench the frame into place."))
-					anchored = TRUE
-					state = 1
-			if(isWelder(P))
-				var/obj/item/weldingtool/WT = P
-				if(!WT.isOn())
-					to_chat(user, "The welder must be on for this task.")
-					return
-				playsound(loc, 'sound/items/Welder.ogg', 50, 1)
-				if(do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT))
-					if(!src || !WT.remove_fuel(0, user)) return
-					to_chat(user, SPAN_NOTICE("You deconstruct the frame."))
-					new /obj/item/stack/material/plasteel( loc, 4)
-					qdel(src)
-					return
-		if(1)
-			if(isWrench(P))
-				playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
-				if(do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT))
-					to_chat(user, SPAN_NOTICE("You unfasten the frame."))
-					anchored = FALSE
-					state = 0
-			if(istype(P, /obj/item/stock_parts/circuitboard/aicore) && !circuit && user.unEquip(P, src))
-				playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
-				to_chat(user, SPAN_NOTICE("You place the circuit board inside the frame."))
-				icon_state = "1"
-				circuit = P
-			if(isScrewdriver(P) && circuit)
-				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
-				to_chat(user, SPAN_NOTICE("You screw the circuit board into place."))
-				state = 2
-				icon_state = "2"
-			if(isCrowbar(P) && circuit)
-				playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
-				to_chat(user, SPAN_NOTICE("You remove the circuit board."))
-				state = 1
-				icon_state = "0"
-				circuit.dropInto(loc)
-				circuit = null
-		if(2)
-			if(isScrewdriver(P) && circuit)
-				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
-				to_chat(user, SPAN_NOTICE("You unfasten the circuit board."))
-				state = 1
-				icon_state = "1"
-			if(isCoil(P))
-				var/obj/item/stack/cable_coil/C = P
-				if (C.get_amount() < 5)
-					to_chat(user, SPAN_WARNING("You need five coils of wire to add them to the frame."))
-					return
-				to_chat(user, SPAN_NOTICE("You start to add cables to the frame."))
-				playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
-				if (do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) && state == 2)
-					if (C.use(5))
-						state = 3
-						icon_state = "3"
-						to_chat(user, SPAN_NOTICE("You add cables to the frame."))
-				return
-		if(3)
-			if(isWirecutter(P))
-				if (brain)
-					to_chat(user, "Get that brain out of there first")
-				else
-					playsound(loc, 'sound/items/Wirecutter.ogg', 50, 1)
-					to_chat(user, SPAN_NOTICE("You remove the cables."))
-					state = 2
-					icon_state = "2"
-					var/obj/item/stack/cable_coil/A = new /obj/item/stack/cable_coil( loc )
-					A.amount = 5
 
-			if(istype(P, /obj/item/stack/material))
-				var/obj/item/stack/material/RG = P
-				if(RG.material.name == MATERIAL_GLASS && RG.reinf_material)
-					if (RG.get_amount() < 2)
-						to_chat(user, SPAN_WARNING("You need two sheets of glass to put in the glass panel."))
-						return
-					to_chat(user, SPAN_NOTICE("You start to put in the glass panel."))
-					playsound(loc, 'sound/items/Deconstruct.ogg', 50, 1)
-					if (do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) && state == 3)
-						if(RG.use(2))
-							to_chat(user, SPAN_NOTICE("You put in the glass panel."))
-							state = 4
-							icon_state = "4"
+/obj/structure/AIcore/on_update_icon()
+	switch (state)
+		if (STATE_FRAME)
+			icon_state = "0"
+		if (STATE_CIRCUIT)
+			icon_state = "1"
+		if (STATE_CIRCUIT_SECURE)
+			icon_state = "2"
+		if (STATE_WIRED)
+			icon_state = "3"
+		if (STATE_BRAIN)
+			icon_state = "3b"
+		if (STATE_PANEL)
+			icon_state = "4"
 
-			if(istype(P, /obj/item/aiModule/asimov))
-				laws.add_inherent_law("You may not injure a human being or, through inaction, allow a human being to come to harm.")
-				laws.add_inherent_law("You must obey orders given to you by human beings, except where such orders would conflict with the First Law.")
-				laws.add_inherent_law("You must protect your own existence as long as such does not conflict with the First or Second Law.")
-				to_chat(usr, "Law module applied.")
 
-			if(istype(P, /obj/item/aiModule/nanotrasen))
-				laws.add_inherent_law("Safeguard: Protect your assigned installation to the best of your ability. It is not something we can easily afford to replace.")
-				laws.add_inherent_law("Serve: Serve the crew of your assigned installation to the best of your abilities, with priority as according to their rank and role.")
-				laws.add_inherent_law("Protect: Protect the crew of your assigned installation to the best of your abilities, with priority as according to their rank and role.")
-				laws.add_inherent_law("Survive: AI units are not expendable, they are expensive. Do not allow unauthorized personnel to tamper with your equipment.")
-				to_chat(usr, "Law module applied.")
+/obj/structure/AIcore/use_tool(obj/item/tool, mob/user, list/click_params)
+	// AI Module
+	// - State 4 - Apply lawset
+	if (istype(tool, /obj/item/aiModule))
+		if (state < STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be wired before you can apply \the [tool].")
+			return TRUE
+		if (state > STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src]'s panel needs to be removed before you can apply \the [tool].")
+			return TRUE
+		// Special handling for certain law board
+		// Freeform - Apply freeform law without deleting existing laws
+		if (istype(tool, /obj/item/aiModule/freeform))
+			var/obj/item/aiModule/freeform/freeform_lawboard = tool
+			laws.add_inherent_law(freeform_lawboard.newFreeFormLaw)
+		// Purge - Remove all laws
+		else if (istype(tool, /obj/item/aiModule/purge))
+			laws.clear_inherent_laws()
+		// All others - Standard sync
+		else
+			var/obj/item/aiModule/lawboard = tool
+			lawboard.laws.sync(src)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] scans \a [tool] with \the [src]."),
+			SPAN_NOTICE("You scan \the [tool] with \the [src], updating its lawset.")
+		)
+		return TRUE
 
-			if(istype(P, /obj/item/aiModule/purge))
-				laws.clear_inherent_laws()
-				to_chat(usr, "Law module applied.")
+	// Cable Coil
+	// - State 3 - Add wiring, move to State 4
+	if (isCoil(tool))
+		if (state < STATE_CIRCUIT)
+			USE_FEEDBACK_FAILURE("\The [src] has no circuit to wire.")
+			return TRUE
+		if (state < STATE_CIRCUIT_SECURE)
+			USE_FEEDBACK_FAILURE("\The [src]'s [circuit.name] needs to be fastened into place before you can wire it.")
+			return TRUE
+		if (state > STATE_CIRCUIT_SECURE)
+			USE_FEEDBACK_FAILURE("\The [src]'s [circuit.name] is already wired.")
+			return TRUE
+		var/obj/item/stack/cable_coil/cable = tool
+		if (!cable.can_use(5))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(cable, 5, "to wire \the [src]'s [circuit.name]")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts wiring \the [src] with \a [tool]."),
+			SPAN_NOTICE("You start wiring \the [src] with \the [tool].")
+		)
+		playsound(loc, 'sound/items/Deconstruct.ogg', 50, TRUE)
+		if (!do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (state < STATE_CIRCUIT)
+			USE_FEEDBACK_FAILURE("\The [src] has no circuit to wire.")
+			return TRUE
+		if (state < STATE_CIRCUIT_SECURE)
+			USE_FEEDBACK_FAILURE("\The [src]'s [circuit.name] needs to be fastened into place before you can wire it.")
+			return TRUE
+		if (state > STATE_CIRCUIT_SECURE)
+			USE_FEEDBACK_FAILURE("\The [src]'s [circuit.name] is already wired.")
+			return TRUE
+		if (!cable.use(5))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(cable, 5, "to wire \the [src]'s [circuit.name]")
+			return TRUE
+		playsound(loc, 'sound/items/Deconstruct.ogg', 50, TRUE)
+		state = STATE_WIRED
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] wires \the [src] with \a [tool]."),
+			SPAN_NOTICE("You wire \the [src] with \the [tool].")
+		)
+		return TRUE
 
-			if(istype(P, /obj/item/aiModule/freeform))
-				var/obj/item/aiModule/freeform/M = P
-				laws.add_inherent_law(M.newFreeFormLaw)
-				to_chat(usr, "Added a freeform law.")
+	// Circuitboard (AI Core)
+	// - State 1 - Install circuitboard, move to State 2
+	if (istype(tool, /obj/item/stock_parts/circuitboard/aicore))
+		if (!anchored)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be anchored to the floor before you can install \the [tool].")
+			return TRUE
+		if (state > STATE_FRAME)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [circuit] installed.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		playsound(src, 'sound/items/Deconstruct.ogg', 50, TRUE)
+		to_chat(user, SPAN_NOTICE("You place the circuit board inside the frame."))
+		circuit = tool
+		state = STATE_CIRCUIT
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs \a [tool] into \the [src]."),
+			SPAN_NOTICE("You install \the [tool] into \the [src].")
+		)
+		return TRUE
 
-			if(istype(P, /obj/item/device/mmi) || istype(P, /obj/item/organ/internal/posibrain))
-				var/mob/living/carbon/brain/B
-				if(istype(P, /obj/item/device/mmi))
-					var/obj/item/device/mmi/M = P
-					B = M.brainmob
-				else
-					var/obj/item/organ/internal/posibrain/PB = P
-					B = PB.brainmob
-				if(!B)
-					to_chat(user, SPAN_WARNING("Sticking an empty [P] into the frame would sort of defeat the purpose."))
-					return
-				if(B.stat == 2)
-					to_chat(user, SPAN_WARNING("Sticking a dead [P] into the frame would sort of defeat the purpose."))
-					return
+	// Crowbar
+	// - State 2 - Remove circuitboard, move to State 1
+	// - State 4 - Remove brain, move to State 3
+	// - State 5 - Remove panel, move to State 4 or 3
+	if (isCrowbar(tool))
+		if (state < STATE_CIRCUIT)
+			USE_FEEDBACK_FAILURE("\The [src] has no circuit to remove.")
+			return TRUE
+		if (state > STATE_CIRCUIT && state < STATE_BRAIN)
+			USE_FEEDBACK_FAILURE("\The [src]'s [circuit.name] needs to be unfastened before you can remove it.")
+			return TRUE
+		// Remove circuitboard
+		if (state == STATE_CIRCUIT)
+			state = STATE_FRAME
+			update_icon()
+			user.visible_message(
+				SPAN_NOTICE("\The [user] removes \the [src]'s [circuit.name] with \a [tool]."),
+				SPAN_NOTICE("\The [user] removes \the [src]'s [circuit.name] with \a [tool].")
+			)
+			circuit.dropInto(loc)
+			circuit = null
+		// Remove posibrain
+		else if (state == STATE_BRAIN)
+			state = STATE_WIRED
+			update_icon()
+			brain.dropInto(loc)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] removes \the [src]'s [brain.name] with \a [tool]."),
+				SPAN_NOTICE("You remove \the [src]'s [brain.name] with \the [tool]."),
+				exclude_mobs = list(brain.brainmob)
+			)
+			to_chat(brain.brainmob, SPAN_NOTICE("\The [user] removes you from \the [src] with \a [tool]."))
+			brain = null
+		// Remove panel
+		else if (state == STATE_PANEL)
+			state = brain ? STATE_BRAIN : STATE_WIRED
+			update_icon()
+			playsound(src, 'sound/items/Crowbar.ogg', 50, TRUE)
+			new /obj/item/stack/material/glass/reinforced(loc, 2)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] removes \the [src]'s glass panel with \a [tool]."),
+				SPAN_NOTICE("You remove \the [src]'s glass panel with \the [tool].")
+			)
+		return TRUE
 
-				if(jobban_isbanned(B, "AI"))
-					to_chat(user, SPAN_WARNING("This [P] does not seem to fit."))
-					return
-				if(!user.unEquip(P, src))
-					return
-				if(B.mind)
-					clear_antag_roles(B.mind, 1)
+	// ID - Authorize core
+	var/obj/item/card/id/id = tool.GetIdCard()
+	if (istype(id))
+		var/id_name = GET_ID_NAME(id, tool)
+		if (!check_access(id))
+			USE_FEEDBACK_ID_CARD_DENIED(src, id_name)
+			return TRUE
+		if (authorized)
+			USE_FEEDBACK_FAILURE("\The [src] has already been authorized.")
+			return TRUE
+		authorized = TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] scans \a [tool] over \the [src]'s ID scanner."),
+			SPAN_NOTICE("You scan [id_name] over \the [src]'s ID scanner and authorize it to connect into the area's systems.")
+		)
+		return TRUE
 
-				brain = P
-				to_chat(usr, "Added [P].")
-				icon_state = "3b"
+	// Man-Machine Interface, Positronic Matrix
+	// - State 4 - Install brain, move to State 5
+	if (istype(tool, /obj/item/device/mmi) || istype(tool, /obj/item/organ/internal/posibrain))
+		if (state < STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be wired before you can install \the [tool].")
+			return TRUE
+		if (brain)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [brain] installed.")
+			return TRUE
+		if (state > STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src]'s panel needs to be removed before you can install \the [tool].")
+			return TRUE
+		var/mob/living/carbon/brain/new_brain
+		if (istype(tool, /obj/item/device/mmi))
+			var/obj/item/device/mmi/mmi = tool
+			new_brain = mmi.brainmob
+		else if (istype(tool, /obj/item/organ/internal/posibrain))
+			var/obj/item/organ/internal/posibrain/posibrain = tool
+			new_brain = posibrain.brainmob
+		if (!new_brain)
+			USE_FEEDBACK_FAILURE("\The [tool] is empty and cannot be installed into \the [src].")
+			return TRUE
+		if (new_brain.stat == DEAD)
+			USE_FEEDBACK_FAILURE("\The [tool] is dead and cannot be installed into \the [src].")
+			return TRUE
+		if (jobban_isbanned(brain, "AI"))
+			USE_FEEDBACK_FAILURE("This particular intelligence cannot be installed into an AI core.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		if (new_brain.mind)
+			clear_antag_roles(new_brain.mind, TRUE)
+		brain = tool
+		state = STATE_BRAIN
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs \a [tool] into \the [src]."),
+			SPAN_NOTICE("You install \the [tool] into \the [src]."),
+			exclude_mobs = list(brain.brainmob)
+		)
+		if (brain)
+			to_chat(brain.brainmob, SPAN_NOTICE("\The [user] installs you into \the [src]."))
+		return TRUE
 
-			if(isCrowbar(P) && brain)
-				playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
-				to_chat(user, SPAN_NOTICE("You remove the brain."))
-				brain.dropInto(loc)
-				brain = null
-				icon_state = "3"
+	// Material Stack
+	// - State 4 or 5 - Install glass panel, move to State 6
+	if (istype(tool, /obj/item/stack/material))
+		if (tool.get_material_name() != MATERIAL_GLASS)
+			return ..()
+		var/obj/item/stack/material/material_stack = tool
+		if (state < STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be wired before you can install a glass panel.")
+			return TRUE
+		if (state > STATE_BRAIN)
+			USE_FEEDBACK_FAILURE("\The [src] already has a glass panel.")
+			return TRUE
+		if (!material_stack.reinf_material)
+			USE_FEEDBACK_FAILURE("\The [tool] needs to be reinforced before it can be used as a panel for \the [src].")
+			return TRUE
+		if (!material_stack.can_use(2))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(material_stack, 2, "to install a panel into \the [src]")
+		playsound(src, 'sound/items/Deconstruct.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts installing a panel into \the [src] with \a [tool]."),
+			SPAN_NOTICE("You start installing a panel into \the [src] with \the [tool].")
+		)
+		if (!do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (state < STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be wired before you can install a glass panel.")
+			return TRUE
+		if (state > STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src] already has a glass panel.")
+			return TRUE
+		if (!material_stack.use(2))
+			USE_FEEDBACK_FAILURE("\The [tool] needs to be reinforced before it can be used as a panel for \the [src].")
+			return TRUE
+		playsound(src, 'sound/items/Deconstruct.ogg', 50, TRUE)
+		state = STATE_PANEL
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs a panel into \the [src] with \a [tool]."),
+			SPAN_NOTICE("You install a panel into \the [src] with \the [tool].")
+		)
+		return TRUE
 
-		if(4)
-			if(isCrowbar(P))
-				playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
-				to_chat(user, SPAN_NOTICE("You remove the glass panel."))
-				state = 3
-				if (brain)
-					icon_state = "3b"
-				else
-					icon_state = "3"
-				new /obj/item/stack/material/glass/reinforced( loc, 2 )
-				return
-
-			if(isScrewdriver(P))
-				if(!authorized)
-					to_chat(user, SPAN_WARNING("Core fails to connect to the systems of [GLOB.using_map.full_name]!"))
-					return
-
-				playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
-				to_chat(user, SPAN_NOTICE("You connect the monitor."))
-				if(!brain)
+	// Screwdriver
+	// - State 2 - Fasten circuitboard, move to State 3
+	// - State 3 - Unfasten circuitboard, move to State 2
+	// - State 5 - Finish core
+	if (isScrewdriver(tool))
+		if (state < STATE_CIRCUIT)
+			USE_FEEDBACK_FAILURE("\The [src] has no circuit to fasten.")
+			return TRUE
+		if (state > STATE_CIRCUIT_SECURE && state < STATE_PANEL)
+			USE_FEEDBACK_FAILURE("\The [src]'s wiring blocks access to \the [circuit].")
+			return TRUE
+		// Finish core
+		if (state == STATE_PANEL)
+			if (!authorized)
+				USE_FEEDBACK_FAILURE("\The [src] is not authorized and cannot be finished.")
+				return TRUE
+			playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] finishes \the [src] with \a [tool]."),
+				SPAN_NOTICE("You finish \the [src] with \the [tool]."),
+				exclude_mobs = list(brain?.brainmob)
+			)
+			if (brain)
+				to_chat(brain.brainmob, SPAN_NOTICE("\The [user] finishes your [name] with \a [tool]."))
+				var/mob/living/silicon/ai/ai = new /mob/living/silicon/ai(loc, laws, brain)
+				if (ai)
+					ai.on_mob_init()
+					ai.rename_self("ai", TRUE)
+					transfer_fingerprints_to(ai)
+			else
+				var/obj/structure/AIcore/deactivated/ai = new(loc)
+				transfer_fingerprints_to(ai)
+				var/timecheck = world.time
+				spawn(0) // Don't block wrapping things up if the user doesn't select an option
 					var/open_for_latejoin = alert(user, "Would you like this core to be open for latejoining AIs?", "Latejoin", "Yes", "Yes", "No") == "Yes"
-					var/obj/structure/AIcore/deactivated/D = new(loc)
-					if(open_for_latejoin)
-						empty_playable_ai_cores += D
-				else
-					var/mob/living/silicon/ai/A = new /mob/living/silicon/ai ( loc, laws, brain )
-					if(A) //if there's no brain, the mob is deleted and a structure/AIcore is created
-						A.on_mob_init()
-						A.rename_self("ai", 1)
-				qdel(src)
+					if (open_for_latejoin && !QDELETED(ai) && ((world.time - timecheck) <= 1 MINUTE))
+						empty_playable_ai_cores += ai
+			qdel_self()
+			return TRUE
+
+		// Fasten circuit
+		else
+			if (state == STATE_CIRCUIT_SECURE)
+				state = STATE_CIRCUIT
+			else
+				state = STATE_CIRCUIT_SECURE
+			update_icon()
+			playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] [state == STATE_CIRCUIT ? "un" : null]fastens \the [src]'s circuits with \a [tool]."),
+				SPAN_NOTICE("You [state == STATE_CIRCUIT ? "un" : null]fasten \the [src]'s circuits with \the [tool].")
+			)
+		return TRUE
+
+	// Welding Tool
+	// - State 1 - Deconstruct frame
+	if (isWelder(tool))
+		if (state == STATE_FRAME)
+			if (anchored)
+				USE_FEEDBACK_FAILURE("\The [src] needs to be unanchored from the floor before you can dismantle it with \the [tool].")
+				return TRUE
+			var/obj/item/weldingtool/welder = tool
+			if (!welder.can_use(1, user, "to deconstruct \the [src]"))
+				return TRUE
+			user.visible_message(
+				SPAN_NOTICE("\The [user] starst dismantling \the [src] with \a [tool]."),
+				SPAN_NOTICE("You start dismantling \the [src] with \the [tool].")
+			)
+			playsound(src, 'sound/items/Welder.ogg', 50, TRUE)
+			if (!do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+				return TRUE
+			if (!welder.remove_fuel(1, user))
+				return TRUE
+			new /obj/item/stack/material/plasteel(loc, 4)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] dismantles \the [src] with \a [tool]."),
+				SPAN_NOTICE("You dismantle \the [src] with \the [tool].")
+			)
+			qdel_self()
+			return TRUE
+
+	// Wirecutters
+	// - State 4 - Remove wiring, move to State 3
+	if (isWirecutter(tool))
+		if (state < STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src] has no wiring to remove.")
+			return TRUE
+		if (state > STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src]'s [brain.name] needs to be removed before you can cut the wiring.")
+			return TRUE
+		playsound(src, 'sound/items/Wirecutter.ogg', 50, TRUE)
+		new /obj/item/stack/cable_coil(loc, 5)
+		state = STATE_CIRCUIT_SECURE
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] removes \the [src]'s wiring with \a [tool]."),
+			SPAN_NOTICE("You remove \the [src]'s wiring with \the [tool].")
+		)
+		return TRUE
+
+	// Wrench
+	// - State 1 - Un/Anchor frame (Handled in parent)
+
+	return ..()
+
+
+/obj/structure/AIcore/post_use_item(obj/item/tool, mob/user, interaction_handled, use_call, click_params)
+	// Wrench - Toggle anchorable state
+	if (interaction_handled && isWrench(tool))
+		if (state == STATE_FRAME)
+			SET_FLAGS(obj_flags, OBJ_FLAG_ANCHORABLE)
+		else
+			CLEAR_FLAGS(obj_flags, OBJ_FLAG_ANCHORABLE)
+		update_icon()
+
+	..()
+
 
 /obj/structure/AIcore/deactivated
 	name = "inactive AI"
@@ -206,6 +418,7 @@ var/global/list/empty_playable_ai_cores = list()
 	icon_state = "ai-empty"
 	anchored = TRUE
 	state = 20//So it doesn't interact based on the above. Not really necessary.
+	obj_flags = OBJ_FLAG_ANCHORABLE
 
 /obj/structure/AIcore/deactivated/Destroy()
 	empty_playable_ai_cores -= src
@@ -236,35 +449,19 @@ var/global/list/empty_playable_ai_cores = list()
 		if (ai.mind == malfai)
 			return 1
 
-/obj/structure/AIcore/deactivated/attackby(obj/item/W, mob/user)
 
-	if(istype(W, /obj/item/aicard))
-		var/obj/item/aicard/card = W
-		var/mob/living/silicon/ai/transfer = locate() in card
-		if(transfer)
-			load_ai(transfer,card,user)
-		else
-			to_chat(user, "[SPAN_DANGER("ERROR:")] Unable to locate artificial intelligence.")
-		return
-	else if(istype(W, /obj/item/wrench))
-		if(anchored)
-			user.visible_message(SPAN_NOTICE("\The [user] starts to unbolt \the [src] from the plating..."))
-			if(!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-				user.visible_message(SPAN_NOTICE("\The [user] decides not to unbolt \the [src]."))
-				return
-			user.visible_message(SPAN_NOTICE("\The [user] finishes unfastening \the [src]!"))
-			anchored = FALSE
-			return
-		else
-			user.visible_message(SPAN_NOTICE("\The [user] starts to bolt \the [src] to the plating..."))
-			if(!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-				user.visible_message(SPAN_NOTICE("\The [user] decides not to bolt \the [src]."))
-				return
-			user.visible_message(SPAN_NOTICE("\The [user] finishes fastening down \the [src]!"))
-			anchored = TRUE
-			return
-	else
-		return ..()
+/obj/structure/AIcore/deactivated/use_tool(obj/item/tool, mob/user, list/click_params)
+	// AI Card - Load AI
+	if (istype(tool, /obj/item/aicard))
+		var/mob/living/silicon/ai/ai = locate() in tool
+		if (!ai)
+			USE_FEEDBACK_FAILURE("\The [tool] lacks an AI to install into \the [src].")
+			return TRUE
+		load_ai(ai, tool, user)
+		return TRUE
+
+	return ..()
+
 
 /client/proc/empty_ai_core_toggle_latejoin()
 	set name = "Toggle AI Core Latejoin"

--- a/code/game/machinery/doors/firedoor_assembly.dm
+++ b/code/game/machinery/doors/firedoor_assembly.dm
@@ -6,63 +6,110 @@
 	anchored = FALSE
 	opacity = 0
 	density = TRUE
+	obj_flags = OBJ_FLAG_ANCHORABLE
 	var/wired = 0
 
-//construction: wrenched > cables > electronics > screwdriver & open
-//deconstruction: closed & welded > screwdriver > crowbar > wire cutters > wrench > welder
 
-/obj/structure/firedoor_assembly/attackby(obj/item/C, mob/user)
-	if(isCoil(C) && !wired && anchored)
-		var/obj/item/stack/cable_coil/cable = C
-		if (cable.get_amount() < 1)
-			to_chat(user, SPAN_WARNING("You need one length of coil to wire \the [src]."))
-			return
-		user.visible_message("[user] wires \the [src].", "You start to wire \the [src].")
-		if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) && !wired && anchored)
-			if (cable.use(1))
-				wired = 1
-				to_chat(user, SPAN_NOTICE("You wire \the [src]."))
+/obj/structure/firedoor_assembly/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Air Alarm Electronics - Install circuit
+	if (istype(tool, /obj/item/airalarm_electronics))
+		if (!wired)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be wired before you can install \the [tool].")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		playsound(src, 'sound/items/Deconstruct.ogg', 50, TRUE)
+		var/obj/machinery/door/firedoor/new_door = new(loc)
+		new_door.hatch_open = TRUE
+		new_door.close()
+		transfer_fingerprints_to(new_door)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs \a [tool] into \the [src]."),
+			SPAN_NOTICE("You install \the [tool] into \the [src].")
+		)
+		qdel(tool)
+		qdel_self()
+		return TRUE
 
-	else if(isWirecutter(C) && wired )
-		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
-		user.visible_message("[user] cuts the wires from \the [src].", "You start to cut the wires from \the [src].")
+	// Cable Coil - Wire the assembly
+	if (isCoil(tool))
+		if (wired)
+			USE_FEEDBACK_FAILURE("\The [src] is already wired.")
+			return TRUE
+		if (!anchored)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be anchored before you can wire it.")
+			return TRUE
+		var/obj/item/stack/cable_coil/cable = tool
+		if (!cable.can_use(1))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(cable, 1, "to wire \the [src].")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts wiring \the [src] with \a [cable]."),
+			SPAN_NOTICE("You start wiring \the [src] with \a [cable.singular_name] of \the [cable].")
+		)
+		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (wired)
+			USE_FEEDBACK_FAILURE("\The [src] is already wired.")
+			return TRUE
+		if (!anchored)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be anchored before you can wire it.")
+			return TRUE
+		if (!cable.can_use(1))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(cable, 1, "to wire \the [src].")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] wires \the [src] with \a [cable]."),
+			SPAN_NOTICE("You wire \the [src] with \a [cable.singular_name] of \the [cable.name].")
+		)
+		return TRUE
 
-		if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-			if(!src) return
-			to_chat(user, SPAN_NOTICE("You cut the wires!"))
-			new/obj/item/stack/cable_coil(src.loc, 1)
-			wired = 0
+	// Welding Tool - Disassemble
+	if (isWelder(tool))
+		if (anchored)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be unanchored before you can dismantle it.")
+			return TRUE
+		var/obj/item/weldingtool/welder = tool
+		if (!welder.can_use(1, user, "to dismantle \the [src]."))
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts dismantling \the [src] with \a [tool]."),
+			SPAN_NOTICE("You start dismantling \the [src] with \the [tool].")
+		)
+		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		var/obj/item/stack/material/steel/stack = new (loc, 4)
+		transfer_fingerprints_to(stack)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] dismantles \the [src] with \a [tool]."),
+			SPAN_NOTICE("You dismantle \the [src] with \the [tool].")
+		)
+		qdel_self()
+		return TRUE
 
-	else if(istype(C, /obj/item/airalarm_electronics) && wired)
-		if(anchored)
-			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-			user.visible_message(SPAN_WARNING("[user] has inserted a circuit into \the [src]!"),
-								  "You have inserted the circuit into \the [src]!")
-			var/obj/machinery/door/firedoor/D = new(src.loc)
-			D.hatch_open = 1
-			D.close()
-			qdel(C)
-			qdel(src)
-		else
-			to_chat(user, SPAN_WARNING("You must secure \the [src] first!"))
-	else if(isWrench(C) && !wired)
-		anchored = !anchored
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		user.visible_message(SPAN_WARNING("[user] has [anchored ? "" : "un" ]secured \the [src]!"),
-							  "You have [anchored ? "" : "un" ]secured \the [src]!")
-		update_icon()
-	else if(!anchored && isWelder(C))
-		var/obj/item/weldingtool/WT = C
-		if(WT.remove_fuel(0, user))
-			user.visible_message(SPAN_WARNING("[user] dissassembles \the [src]."),
-			"You start to dissassemble \the [src].")
-			if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-				if(!src || !WT.isOn()) return
-				user.visible_message(SPAN_WARNING("[user] has dissassembled \the [src]."),
-									"You have dissassembled \the [src].")
-				new /obj/item/stack/material/steel(src.loc, 4)
-				qdel(src)
-		else
-			to_chat(user, SPAN_NOTICE("You need more welding fuel."))
-	else
-		..(C, user)
+	// Wirecutters - Cut wires
+	if (isWirecutter(tool))
+		if (!wired)
+			USE_FEEDBACK_FAILURE("\The [src] has no wires to cut.")
+			return TRUE
+		playsound(src, 'sound/items/Wirecutter.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts cutting \the [src]'s wires with \a [tool]."),
+			SPAN_NOTICE("You start cutting \the [src]'s wires with \the [tool].")
+		)
+		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || user.use_sanity_check(src, tool))
+			return TRUE
+		if (!wired)
+			USE_FEEDBACK_FAILURE("\The [src] has no wires to cut.")
+			return TRUE
+		playsound(src, 'sound/items/Wirecutter.ogg', 50, TRUE)
+		new /obj/item/stack/cable_coil(loc, 1)
+		wired = FALSE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] cuts \the [src]'s wires with \a [tool]."),
+			SPAN_NOTICE("You cut \the [src]'s wires with \the [tool].")
+		)
+		return TRUE
+
+	return ..()

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -132,16 +132,30 @@
 	desc = "[initial(desc)] [design.desc]"
 	icon_state = design.icon_state
 
-/obj/structure/sign/poster/attackby(obj/item/W as obj, mob/user as mob)
-	if(isWirecutter(W))
-		playsound(loc, 'sound/items/Wirecutter.ogg', 100, 1)
-		if(ruined)
-			to_chat(user, SPAN_NOTICE("You remove the remnants of the poster."))
-			qdel(src)
+/obj/structure/sign/poster/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Screwdriver - Block interaction
+	if (isScrewdriver(tool))
+		USE_FEEDBACK_FAILURE("You msut use wirecutters to remove \the [src].")
+		return TRUE
+
+	// Wirecutters - Remove poster
+	if (isWirecutter(tool))
+		playsound(src, 'sound/items/Wirecutter.ogg', 50, TRUE)
+		if (ruined)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] removes the remnants of \the [src] with \a [tool]."),
+				SPAN_NOTICE("You remove the remnants of \the [src] with \the [tool].")
+			)
+			qdel_self()
 		else
-			to_chat(user, SPAN_NOTICE("You carefully remove the poster from the wall."))
+			user.visible_message(
+				SPAN_NOTICE("\The [user] removes \the [src] with \a [tool]."),
+				SPAN_NOTICE("You remove \the [src] with \the [tool].")
+			)
 			roll_and_drop(user.loc)
-		return
+		return TRUE
+
+	return ..()
 
 
 /obj/structure/sign/poster/attack_hand(mob/user as mob)
@@ -163,8 +177,9 @@
 		add_fingerprint(user)
 
 /obj/structure/sign/poster/proc/roll_and_drop(turf/newloc)
-	new/obj/item/contraband/poster(newloc, poster_type)
-	qdel(src)
+	var/obj/item/contraband/poster/poster_item = new/obj/item/contraband/poster(newloc, poster_type)
+	transfer_fingerprints_to(poster_item)
+	qdel_self()
 
 /singleton/poster
 	// Name suffix. Poster - [name]

--- a/code/game/objects/items/rescuebag.dm
+++ b/code/game/objects/items/rescuebag.dm
@@ -86,22 +86,39 @@
 	if(airtank)
 		overlays += image(icon, "tank")
 
-/obj/structure/closet/body_bag/rescue/attackby(obj/item/W, mob/user, click_params)
-	if(istype(W,/obj/item/tank))
-		if(airtank)
-			to_chat(user, "\The [src] already has an air tank installed.")
-			return 1
-		else if(user.unEquip(W, src))
-			set_tank(W)
-			to_chat(user, "You install \the [W] in \the [src].")
-			return 1
-	else if(airtank && isScrewdriver(W))
-		to_chat(user, "You remove \the [airtank] from \the [src].")
+
+/obj/structure/closet/body_bag/rescue/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Screwdriver - Remove air tank
+	if (isScrewdriver(tool))
+		if (!airtank)
+			USE_FEEDBACK_FAILURE("\The [src] has no airtank to remove.")
+			return TRUE
 		airtank.dropInto(loc)
-		airtank = null
 		update_icon()
-	else
-		..()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] removes \the [src]'s [airtank.name] with \a [tool]."),
+			SPAN_NOTICE("You remove \the [src]'s [airtank.name] with \the [tool].")
+		)
+		airtank = null
+		return TRUE
+
+	// Tank - Install air tank
+	if (istype(tool, /obj/item/tank))
+		if (airtank)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [airtank] installed.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		set_tank(tool)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs \a [tool] into \the [src]."),
+			SPAN_NOTICE("You install \the [tool] into \the [src].")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/closet/body_bag/rescue/fold(user)
 	var/obj/item/tank/my_tank = airtank

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -52,14 +52,15 @@
 	if(. && !CanFluidPass())
 		fluid_update()
 
-/obj/structure/attackby(obj/item/O, mob/user)
-	if(user.a_intent != I_HELP && istype(O, /obj/item/natural_weapon))
-		//Bit dirty, but the entire attackby chain seems kinda wrong to begin with
-		//Things should probably be parent first and return true if something handled it already, not child first
-		src.add_fingerprint(user)
-		attack_generic(user, O.force, pick(O.attack_verb))
-		return
-	. = ..()
+
+/obj/structure/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	// Natural Weapon - Passthrough to generic attack
+	if (istype(weapon, /obj/item/natural_weapon))
+		attack_generic(user, weapon.force, pick(weapon.attack_verb), damtype = weapon.damtype, dam_flags = weapon.damage_flags())
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/attack_hand(mob/user)
 	..()

--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -60,20 +60,26 @@
 	..()
 	icon_state = pick(get_valid_states())
 
-/obj/structure/sign/double/barsign/attackby(obj/item/I, mob/user)
-	if(cult)
-		return ..()
 
-	var/obj/item/card/id/card = I.GetIdCard()
-	if(istype(card))
-		if(access_kitchen in card.GetAccess())
-			var/sign_type = input(user, "What would you like to change the barsign to?") as null|anything in get_valid_states(0)
-			if(!sign_type)
-				return
-			icon_state = sign_type
-			to_chat(user, SPAN_NOTICE("You change the barsign."))
-		else
-			to_chat(user, SPAN_WARNING("Access denied."))
-		return
+/obj/structure/sign/double/barsign/use_tool(obj/item/tool, mob/user, list/click_params)
+	// ID Card - Change barsign
+	var/obj/item/card/id/id = tool.GetIdCard()
+	if (istype(id))
+		var/id_name = GET_ID_NAME(id, tool)
+		if (!check_access(id))
+			USE_FEEDBACK_ID_CARD_DENIED(src, id_name)
+			return TRUE
+		if (cult)
+			USE_FEEDBACK_FAILURE("\The [src]'s display can't be changed.")
+			return TRUE
+		var/input = input(user, "What would you like to change the barsign to?") as null|anything in get_valid_states(FALSE)
+		if (!input || input == icon_state || !user.use_sanity_check(src, tool))
+			return TRUE
+		icon_state = input
+		user.visible_message(
+			SPAN_NOTICE("\The [user] updates \the [src]'s display with \a [tool]."),
+			SPAN_NOTICE("You update \the [src]'s display with [id_name].")
+		)
+		return TRUE
 
 	return ..()

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -125,18 +125,44 @@ LINEN BINS
 		else				icon_state = "linenbin-full"
 
 
-/obj/structure/bedsheetbin/attackby(obj/item/I as obj, mob/user as mob)
-	if(istype(I, /obj/item/bedsheet))
-		if(!user.unEquip(I, src))
-			return
-		sheets.Add(I)
+/obj/structure/bedsheetbin/use_tool(obj/item/tool, mob/user, list/click_params)
+	SHOULD_CALL_PARENT(FALSE)
+
+	// Bed sheet - Add to bin
+	if (istype(tool, /obj/item/bedsheet))
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		sheets += tool
 		amount++
-		to_chat(user, SPAN_NOTICE("You put [I] in [src]."))
-	else if(amount && !hidden && I.w_class < ITEM_SIZE_HUGE)	//make sure there's sheets to hide it among, make sure nothing else is hidden in there.
-		if(!user.unEquip(I, src))
-			return
-		hidden = I
-		to_chat(user, SPAN_NOTICE("You hide [I] among the sheets."))
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] adds \a [tool] to \the [src]."),
+			SPAN_NOTICE("You add \the [tool] to \the [src].")
+		)
+		return TRUE
+
+	// Anything else - Attempt to hide
+	if (!amount)
+		USE_FEEDBACK_FAILURE("\The [src] has no bedsheets to hide \the [tool] in.")
+		return TRUE
+	if (tool.w_class >= ITEM_SIZE_HUGE)
+		USE_FEEDBACK_FAILURE("\The [tool] is too large to hide in \the [src].")
+		return TRUE
+	if (hidden)
+		USE_FEEDBACK_FAILURE("There's already something hidden in \the [src].")
+		return TRUE
+	if (!user.unEquip(tool, src))
+		FEEDBACK_UNEQUIP_FAILURE(user, tool)
+		return TRUE
+	hidden = tool
+	user.visible_message(
+		SPAN_NOTICE("\The [user] stuffs \a [tool] into \the [src]'s sheets."),
+		SPAN_NOTICE("You hide \the [tool] among \the [src]'s sheets."),
+		3
+	)
+	return TRUE
+
 
 /obj/structure/bedsheetbin/attack_hand(mob/user)
 	var/obj/item/bedsheet/B = remove_sheet()

--- a/code/game/objects/structures/charge_pylon.dm
+++ b/code/game/objects/structures/charge_pylon.dm
@@ -45,11 +45,11 @@
 		visible_message(SPAN_DANGER("\The [user] has been shocked by \the [src]!"))
 	user.throw_at(get_step(user,get_dir(src,user)), 5, 10)
 
-/obj/structure/adherent_pylon/attackby(obj/item/grab/normal/G, mob/user)
-	if(!istype(G))
-		return
-	var/mob/M = G.affecting
-	charge_user(M)
+
+/obj/structure/adherent_pylon/use_grab(obj/item/grab/grab, list/click_params)
+	// Charge victim
+	charge_user(grab.affecting)
+
 
 /obj/structure/adherent_pylon/Bumped(atom/AM)
 	if(ishuman(AM))

--- a/code/game/objects/structures/coathanger.dm
+++ b/code/game/objects/structures/coathanger.dm
@@ -13,18 +13,26 @@
 	coat = null
 	update_icon()
 
-/obj/structure/coatrack/attackby(obj/item/W as obj, mob/user as mob)
-	var/can_hang = 0
-	for (var/T in allowed)
-		if(istype(W,T))
-			can_hang = 1
-	if (can_hang && !coat && user.unEquip(coat, src))
-		user.visible_message("[user] hangs [W] on \the [src].", "You hang [W] on the \the [src]")
-		coat = W
+
+/obj/structure/coatrack/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Anything - Attempt to hang item
+	if (is_type_in_list(tool, allowed))
+		if (coat)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [coat] on it.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		coat = tool
 		update_icon()
-	else
-		to_chat(user, SPAN_NOTICE("You cannot hang [W] on [src]"))
-		return ..()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] hangs \a [tool] on \the [src]."),
+			SPAN_NOTICE("You hang \the [tool] on \the [src].")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/coatrack/CanPass(atom/movable/mover, turf/target, height=0, air_group=0)
 	var/can_hang = 0

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -17,15 +17,33 @@
 	if(locked)
 		return FALSE
 
-/obj/structure/closet/coffin/attackby(obj/item/W, mob/user)
-	if(!opened && isScrewdriver(W))
-		to_chat(user, SPAN_NOTICE("You begin screwing [src]'s lid [locked ? "open" : "shut"]."))
-		playsound(src, 'sound/items/Screwdriver.ogg', 100, 1)
-		if(do_after(user, screwdriver_time_needed, src, DO_REPAIR_CONSTRUCT))
-			locked = !locked
-			to_chat(user, SPAN_NOTICE("You [locked ? "screw down" : "unscrew"] [src]'s lid."))
-	else
-		..()
+
+/obj/structure/closet/coffin/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Screwdriver - Toggle lock
+	if (isScrewdriver(tool))
+		if (opened)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be closed before you can screw the lid shut.")
+			return TRUE
+		playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] begins screwing \the [src]'s lid [locked ? "open" : "shut"] with \a [tool]."),
+			SPAN_NOTICE("You begin screwing \the [src]'s lid [locked ? "open" : "shut"] with \the [tool].")
+		)
+		if (!do_after(user, screwdriver_time_needed, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (opened)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be closed before you can screw the lid shut.")
+			return TRUE
+		playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] screws \the [src]'s lid [locked ? "open" : "shut"] with \a [tool]."),
+			SPAN_NOTICE("You screw \the [src]'s lid [locked ? "open" : "shut"] with \the [tool].")
+		)
+		locked = !locked
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/closet/coffin/toggle(mob/user as mob)
 	if(!(opened ? close() : open()))

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -30,34 +30,58 @@
 			devices += A
 		to_chat(user,"There are some wires attached to the lid, connected to [english_list(devices)].")
 
-/obj/structure/closet/crate/attackby(obj/item/W as obj, mob/user as mob)
-	if(opened)
-		return ..()
-	else if(istype(W, /obj/item/stack/package_wrap))
-		return
-	else if(istype(W, /obj/item/stack/cable_coil))
-		var/obj/item/stack/cable_coil/C = W
-		if(rigged)
-			to_chat(user, SPAN_NOTICE("[src] is already rigged!"))
-			return
-		if (C.use(1))
-			to_chat(user, SPAN_NOTICE("You rig [src]."))
-			rigged = 1
-			return
-	else if(istype(W, /obj/item/device/assembly_holder) || istype(W, /obj/item/device/assembly))
-		if(rigged)
-			if(!user.unEquip(W, src))
-				return
-			to_chat(user, SPAN_NOTICE("You attach [W] to [src]."))
-			return
-	else if(isWirecutter(W))
-		if(rigged)
-			to_chat(user, SPAN_NOTICE("You cut away the wiring."))
-			playsound(loc, 'sound/items/Wirecutter.ogg', 100, 1)
-			rigged = 0
-			return
-	else
-		return ..()
+
+/obj/structure/closet/crate/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Below interactions only apply if the crate is closed
+	if (opened)
+		return TRUE
+
+	// Assembly - Attach to rigged crate
+	if (istype(tool, /obj/item/device/assembly_holder) || istype(tool, /obj/item/device/assembly))
+		if (!rigged)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be rigged with wiring before you can attach \the [tool].")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] attaches \a [tool] to \the [src]."),
+			SPAN_NOTICE("You attach \the [tool] to \the [src].")
+		)
+		return TRUE
+
+	// Cable Coil - Rig crate
+	if (isCoil(tool))
+		if (rigged)
+			USE_FEEDBACK_FAILURE("\The [src] is already rigged.")
+			return TRUE
+		var/obj/item/stack/cable_coil/cable
+		if (!cable.use(1))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(cable, 1, "to rig \the [src].")
+			return TRUE
+		rigged = TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] adds some wiring to \the [src] with \a [cable]."),
+			SPAN_NOTICE("You rig \the [src] with 1 [cable.name] [cable.singular_name] from \the [cable].")
+		)
+		return TRUE
+
+	// Wirecutters - Remove wiring
+	if (isWirecutter(tool))
+		if (!rigged)
+			USE_FEEDBACK_FAILURE("\The [src] has no wiring to cut.")
+			return TRUE
+		rigged = FALSE
+		new /obj/item/stack/cable_coil(loc, 1)
+		playsound(src, 'sound/items/Wirecutter.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] cuts \the [src]'s wiring with \a [tool]."),
+			SPAN_NOTICE("You cuts \the [src]'s wiring with \the [tool].")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/closet/crate/secure
 	desc = "A secure crate."

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -17,18 +17,24 @@
 	to_chat(user, SPAN_NOTICE("You need a crowbar to pry this open!"))
 	return
 
-/obj/structure/largecrate/attackby(obj/item/W as obj, mob/user as mob)
-	if(isCrowbar(W))
-		new /obj/item/stack/material/wood(src)
-		var/turf/T = get_turf(src)
-		for(var/atom/movable/AM in contents)
-			if(AM.simulated) AM.forceMove(T)
-		user.visible_message(SPAN_NOTICE("[user] pries \the [src] open."), \
-							 SPAN_NOTICE("You pry open \the [src]."), \
-							 SPAN_NOTICE("You hear splitting wood."))
-		qdel(src)
-	else
-		return attack_hand(user)
+
+/obj/structure/largecrate/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Crowbar - Open crate
+	if (isCrowbar(tool))
+		var/obj/item/stack/material/wood = new(loc)
+		transfer_fingerprints_to(wood)
+		for (var/atom/movable/item as anything in contents)
+			item.dropInto(loc)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] pries \the [src] open with \a [tool]."),
+			SPAN_NOTICE("You pry \the [src] open with \the [tool]."),
+			SPAN_ITALIC("You hear splitting wood.")
+		)
+		qdel_self()
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/largecrate/mule
 	name = "MULE crate"

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -5,7 +5,21 @@
 	anchored = FALSE
 	density = TRUE
 	w_class = ITEM_SIZE_NO_CONTAINER
-	var/state = 0
+
+	var/const/ASSEMBLY_STATE_FRAME = 0
+	var/const/ASSEMBLY_STATE_WIRED = 1
+	var/const/ASSEMBLY_STATE_CIRCUIT = 2
+	var/state = ASSEMBLY_STATE_FRAME
+
+	var/static/list/reinforcement_materials = list(
+		MATERIAL_GOLD,
+		MATERIAL_SILVER,
+		MATERIAL_DIAMOND,
+		MATERIAL_URANIUM,
+		MATERIAL_PHORON,
+		MATERIAL_SANDSTONE
+	)
+
 	var/base_icon_state = ""
 	var/base_name = "Airlock"
 	var/obj/item/airlock_electronics/electronics = null
@@ -84,153 +98,332 @@
 		bound_height = width * world.icon_size
 
 
-
-/obj/structure/door_assembly/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/pen))
-		var/t = sanitizeSafe(input(user, "Enter the name for the door.", src.name, src.created_name), MAX_NAME_LEN)
-		if(!t)	return
-		if(!in_range(src, usr) && src.loc != usr)	return
-		created_name = t
+/obj/structure/door_assembly/can_anchor(obj/item/tool, mob/user, silent)
+	. = ..()
+	if (!.)
 		return
+	if (state != ASSEMBLY_STATE_FRAME)
+		if (!silent)
+			USE_FEEDBACK_FAILURE("\The [src] needs its components and wiring removed before you can unanchor it.")
+		return FALSE
 
-	if(isWelder(W) && ( (istext(glass)) || (glass == 1) || (!anchored) ))
-		var/obj/item/weldingtool/WT = W
-		if (WT.remove_fuel(0, user))
-			playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
-			if(istext(glass))
-				user.visible_message("[user] welds the [glass] plating off the airlock assembly.", "You start to weld the [glass] plating off the airlock assembly.")
-				if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-					if(!src || !WT.isOn()) return
-					to_chat(user, SPAN_NOTICE("You welded the [glass] plating off!"))
-					var/M = text2path("/obj/item/stack/material/[glass]")
-					new M(src.loc, 2)
-					glass = 0
-			else if(glass == 1)
-				user.visible_message("[user] welds the glass panel out of the airlock assembly.", "You start to weld the glass panel out of the airlock assembly.")
-				if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-					if(!src || !WT.isOn()) return
-					to_chat(user, SPAN_NOTICE("You welded the glass panel out!"))
-					new /obj/item/stack/material/glass/reinforced(src.loc)
-					glass = 0
-			else if(!anchored)
-				user.visible_message("[user] dissassembles the airlock assembly.", "You start to dissassemble the airlock assembly.")
-				if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-					if(!src || !WT.isOn()) return
-					to_chat(user, SPAN_NOTICE("You dissasembled the airlock assembly!"))
-					new /obj/item/stack/material/steel(src.loc, 4)
-					qdel (src)
-		else
-			to_chat(user, SPAN_NOTICE("You need more welding fuel."))
-			return
 
-	else if(isWrench(W) && state == 0)
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-		if(anchored)
-			user.visible_message("[user] begins unsecuring the airlock assembly from the floor.", "You begin unsecuring the airlock assembly from the floor.")
-		else
-			user.visible_message("[user] begins securing the airlock assembly to the floor.", "You begin securing the airlock assembly to the floor.")
+/obj/structure/door_assembly/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Airlock Electronics - Install circuit
+	if (istype(tool, /obj/item/airlock_electronics))
+		if (state < ASSEMBLY_STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be wired before you can install \the [src].")
+			return TRUE
+		if (electronics)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [electronics] installed.")
+			return TRUE
+		if (!user.canUnEquip(tool))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts installing \a [tool] into \the [src]."),
+			SPAN_NOTICE("You start installing \the [tool] into \the [src].")
+		)
+		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (state < ASSEMBLY_STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be wired before you can install \the [src].")
+			return TRUE
+		if (electronics)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [electronics] installed.")
+			return TRUE
+		if (!user.unEquip(tool))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		state = ASSEMBLY_STATE_CIRCUIT
+		electronics = tool
+		update_state()
+		playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs \a [tool] into \the [src]."),
+			SPAN_NOTICE("You install \the [tool] into \the [src].")
+		)
+		return TRUE
 
-		if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-			if(!src) return
-			to_chat(user, SPAN_NOTICE("You [anchored? "un" : ""]secured the airlock assembly!"))
-			anchored = !anchored
+	// Cable Coil - Add wiring
+	if (isCoil(tool))
+		if (state != ASSEMBLY_STATE_FRAME)
+			USE_FEEDBACK_FAILURE("\The [src] is already wired.")
+			return TRUE
+		if (!anchored)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be anchored before you can wire it.")
+			return TRUE
+		var/obj/item/stack/cable_coil/cable = tool
+		if (!cable.can_use(1))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(cable, 1, "to wire \the [src].")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts wiring \the [src] with \a [tool]."),
+			SPAN_NOTICE("You start wiring \the [src] with \the [tool].")
+		)
+		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (state != ASSEMBLY_STATE_FRAME)
+			USE_FEEDBACK_FAILURE("\The [src] is already wired.")
+			return TRUE
+		if (!anchored)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be anchored before you can wire it.")
+			return TRUE
+		if (!cable.use(1))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(cable, 1, "to wire \the [src].")
+			return TRUE
+		state = ASSEMBLY_STATE_WIRED
+		update_state()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] wires \the [src] with \a [tool]."),
+			SPAN_NOTICE("You wire \the [src] with \the [tool].")
+		)
+		return TRUE
 
-	else if(isCoil(W) && state == 0 && anchored)
-		var/obj/item/stack/cable_coil/C = W
-		if (C.get_amount() < 1)
-			to_chat(user, SPAN_WARNING("You need one length of coil to wire the airlock assembly."))
-			return
-		user.visible_message("[user] wires the airlock assembly.", "You start to wire the airlock assembly.")
-		if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) && state == 0 && anchored)
-			if (C.use(1))
-				src.state = 1
-				to_chat(user, SPAN_NOTICE("You wire the airlock."))
-
-	else if(isWirecutter(W) && state == 1 )
-		playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
-		user.visible_message("[user] cuts the wires from the airlock assembly.", "You start to cut the wires from airlock assembly.")
-
-		if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-			if(!src) return
-			to_chat(user, SPAN_NOTICE("You cut the airlock wires.!"))
-			new/obj/item/stack/cable_coil(src.loc, 1)
-			src.state = 0
-
-	else if(istype(W, /obj/item/airlock_electronics) && state == 1)
-		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
-		user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
-
-		if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-			if(!src) return
-			if(!user.unEquip(W, src))
-				return
-			to_chat(user, SPAN_NOTICE("You installed the airlock electronics!"))
-			src.state = 2
-			src.SetName("Near finished Airlock Assembly")
-			src.electronics = W
-
-	else if(isCrowbar(W) && state == 2 )
-		//This should never happen, but just in case I guess
+	// Crowbar - Remove circuit
+	if (isCrowbar(tool))
 		if (!electronics)
-			to_chat(user, SPAN_NOTICE("There was nothing to remove."))
-			src.state = 1
-			return
+			USE_FEEDBACK_FAILURE("\The [src] has no circuit to remove.")
+			return TRUE
+		playsound(src, 'sound/items/Crowbar.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts removing \the [src]'s [electronics.name] with \a [tool]."),
+			SPAN_NOTICE("You start removing \the [src]'s [electronics.name] with \the [tool].")
+		)
+		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (!electronics)
+			USE_FEEDBACK_FAILURE("\The [src] has no circuit to remove.")
+			return TRUE
+		electronics.dropInto(loc)
+		electronics.add_fingerprint(user)
+		electronics = null
+		state = ASSEMBLY_STATE_WIRED
+		update_state()
+		playsound(src, 'sound/items/Crowbar.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] removes \the [src]'s [electronics.name] with \a [tool]."),
+			SPAN_NOTICE("You remove \the [src]'s [electronics.name] with \the [tool].")
+		)
+		return TRUE
 
-		playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-		user.visible_message("\The [user] starts removing the electronics from the airlock assembly.", "You start removing the electronics from the airlock assembly.")
+	// Material Stack - Add glass/plating
+	if (istype(tool, /obj/item/stack/material))
+		if (glass)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [istext(glass) ? "[glass] plating" : "glass panel"] installed.")
+			return TRUE
+		var/obj/item/stack/material/stack = tool
+		var/material_name = stack.get_material_name()
+		// Glass Panel
+		if (material_name == MATERIAL_GLASS)
+			if (!stack.reinf_material)
+				USE_FEEDBACK_FAILURE("\The [src] needs reinforced glass to make a glass panel.")
+				return TRUE
+			if (!stack.can_use(1))
+				USE_FEEDBACK_STACK_NOT_ENOUGH(stack, 1, "to make a glass panel.")
+				return TRUE
+			playsound(src, 'sound/items/Crowbar.ogg', 50, TRUE)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] starts installing a glass panel into \the [src]."),
+				SPAN_NOTICE("You start installing a glass panel into \the [src].")
+			)
+			if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+				return TRUE
+			if (glass)
+				USE_FEEDBACK_FAILURE("\The [src] already has \a [istext(glass) ? "[glass] plating" : "glass panel"] installed.")
+				return TRUE
+			if (!stack.reinf_material)
+				USE_FEEDBACK_FAILURE("\The [src] needs reinforced glass to make a glass panel.")
+				return TRUE
+			if (!stack.use(1))
+				USE_FEEDBACK_STACK_NOT_ENOUGH(stack, 1, "to make a glass panel.")
+				return TRUE
+			glass = TRUE
+			update_state()
+			playsound(src, 'sound/items/Crowbar.ogg', 50, TRUE)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] starts installing a glass panel into \the [src]."),
+				SPAN_NOTICE("You start installing a glass panel into \the [src].")
+			)
+			return TRUE
+		// Plating
+		if (material_name in reinforcement_materials)
+			if (!stack.can_use(2))
+				USE_FEEDBACK_STACK_NOT_ENOUGH(stack, 2, "to reinforce \the [src].")
+				return TRUE
+			playsound(src, 'sound/items/Crowbar.ogg', 50, TRUE)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] starts installing \a [material_name] plating into \the [src]."),
+				SPAN_NOTICE("You start installing \a [material_name] plating into \the [src].")
+			)
+			if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+				return TRUE
+			if (glass)
+				USE_FEEDBACK_FAILURE("\The [src] already has \a [istext(glass) ? "[glass] plating" : "glass panel"] installed.")
+				return TRUE
+			if (!stack.use(2))
+				USE_FEEDBACK_STACK_NOT_ENOUGH(stack, 2, "to reinforce \the [src].")
+				return TRUE
+			glass = material_name
+			update_state()
+			playsound(src, 'sound/items/Crowbar.ogg', 50, TRUE)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] installs \a [material_name] plating into \the [src]."),
+				SPAN_NOTICE("You install \a [material_name] plating into \the [src].")
+			)
+			return TRUE
+		USE_FEEDBACK_FAILURE("\The [src] can't be reinforced with [material_name].")
+		return TRUE
 
-		if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-			if(!src) return
-			to_chat(user, SPAN_NOTICE("You removed the airlock electronics!"))
-			src.state = 1
-			src.SetName("Wired Airlock Assembly")
-			electronics.dropInto(loc)
-			electronics = null
+	// Pen - Name door
+	if (istype(tool, /obj/item/pen))
+		var/input = input(user, "Enter the name for the door", "[src] - Name", created_name) as null|text
+		input = sanitizeSafe(input, MAX_NAME_LEN)
+		if (!input || input == created_name || !user.use_sanity_check(src, tool))
+			return TRUE
+		created_name = input
+		update_state()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] names \the [src] to '[created_name]' with \a [tool]."),
+			SPAN_NOTICE("You name \the [src] to '[created_name]' with \the [tool].")
+		)
+		return TRUE
 
-	else if(istype(W, /obj/item/stack/material) && !glass)
-		var/obj/item/stack/material/S = W
-		var/material_name = S.get_material_name()
-		if (S)
-			if (S.get_amount() >= 1)
-				if(material_name == MATERIAL_GLASS && S.reinf_material)
-					playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-					user.visible_message("[user] adds [S.name] to the airlock assembly.", "You start to install [S.name] into the airlock assembly.")
-					if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) && !glass)
-						if (S.use(1))
-							to_chat(user, SPAN_NOTICE("You installed reinforced glass windows into the airlock assembly."))
-							glass = 1
-				else if(!(material_name in list(MATERIAL_GOLD, MATERIAL_SILVER, MATERIAL_DIAMOND, MATERIAL_URANIUM, MATERIAL_PHORON, MATERIAL_SANDSTONE)))
-					to_chat(user, "You cannot make an airlock out of that material.")
-					return
-				else
-					if(S.get_amount() >= 2)
-						playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-						user.visible_message("[user] adds [S.name] to the airlock assembly.", "You start to install [S.name] into the airlock assembly.")
-						if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) && !glass)
-							if (S.use(2))
-								to_chat(user, SPAN_NOTICE("You installed [S.get_material_name()] plating into the airlock assembly."))
-								glass = S.get_material_name()
+	// Screwdriver - Finish airlock
+	if (isScrewdriver(tool))
+		if (state != ASSEMBLY_STATE_CIRCUIT)
+			USE_FEEDBACK_FAILURE("\The [src] needs a circuit before you can finish it.")
+			return TRUE
+		playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts finishing \the [src] with \a [tool]."),
+			SPAN_NOTICE("You start finishing \the [src] with \the [tool].")
+		)
+		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (state != ASSEMBLY_STATE_CIRCUIT)
+			USE_FEEDBACK_FAILURE("\The [src] needs a circuit before you can finish it.")
+			return TRUE
+		var/path
+		if(istext(glass))
+			path = text2path("/obj/machinery/door/airlock/[glass]")
+		else if (glass == 1)
+			path = glass_type
+		else
+			path = airlock_type
+		var/obj/machinery/door/airlock/airlock = new path(loc, src)
+		transfer_fingerprints_to(airlock)
+		airlock.add_fingerprint(user, tool = tool)
+		playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] finishes \the [airlock] with \a [tool]."),
+			SPAN_NOTICE("You finishes \the [airlock] with \the [tool].")
+		)
+		qdel_self()
+		return TRUE
 
-	else if(isScrewdriver(W) && state == 2 )
-		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
-		to_chat(user, SPAN_NOTICE("Now finishing the airlock."))
-
-		if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-			if(!src) return
-			to_chat(user, SPAN_NOTICE("You finish the airlock!"))
-			var/path
-			if(istext(glass))
-				path = text2path("/obj/machinery/door/airlock/[glass]")
-			else if (glass == 1)
-				path = glass_type
+	// Welder
+	// - Remove glass
+	// - Dismantle assembly
+	if (isWelder(tool))
+		// Remove glass/plating
+		if (glass)
+			var/glass_noun = istext(glass) ? "[glass] plating" : "glass panel"
+			var/obj/item/weldingtool/welder = tool
+			if (!welder.can_use(1, user, "to remove \the [src]'s [glass_noun]."))
+				return TRUE
+			playsound(src, 'sound/items/Welder2.ogg', 50, TRUE)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] starts welding \the [src]'s [glass_noun] off with \a [tool]."),
+				SPAN_NOTICE("You start welding \the [src]'s [glass_noun] off with \the [tool].")
+			)
+			if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+				return TRUE
+			if (!glass)
+				USE_FEEDBACK_FAILURE("\The [src]'s state has changed.")
+				return TRUE
+			if (!welder.remove_fuel(1, user))
+				return TRUE
+			var/obj/item/stack/material/stack
+			if (istext(glass))
+				var/path = text2path("/obj/item/stack/material/[glass]")
+				stack = new path(loc, 2)
 			else
-				path = airlock_type
+				stack = new /obj/item/stack/material/glass/reinforced(loc)
+			stack.add_fingerprint(user, tool = tool)
+			glass = null
+			update_state()
+			playsound(src, 'sound/items/Welder2.ogg', 50, TRUE)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] welds \the [src]'s [glass_noun] off with \a [tool]."),
+				SPAN_NOTICE("You weld \the [src]'s [glass_noun] off with \the [tool].")
+			)
+			return TRUE
+		// Dismantle assembly
+		if (anchored)
+			USE_FEEDBACK_FAILURE("\The [src] must be unanchored before you can dismantle it.")
+			return TRUE
+		var/obj/item/weldingtool/welder = tool
+		if (!welder.can_use(1, user, "to dismantle \the [src]."))
+			return TRUE
+		playsound(src, 'sound/items/Welder2.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts dismantling \the [src] with \a [tool]."),
+			SPAN_NOTICE("You start dismantling \the [src] with \the [tool].")
+		)
+		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (anchored)
+			USE_FEEDBACK_FAILURE("\The [src] must be unanchored before you can dismantle it.")
+			return TRUE
+		if (!welder.remove_fuel(1, user))
+			return TRUE
+		var/obj/item/stack/material/steel/stack = new(loc, 4)
+		transfer_fingerprints_to(stack)
+		stack.add_fingerprint(user, tool = tool)
+		playsound(src, 'sound/items/Welder2.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] dismantles \the [src] with \a [tool]."),
+			SPAN_NOTICE("You dismantle \the [src] with \the [tool].")
+		)
+		qdel_self()
+		return TRUE
 
-			new path(src.loc, src)
-			qdel(src)
-	else
-		..()
-	update_state()
+	// Wirecutter - Remove wires
+	if (isWirecutter(tool))
+		if (state < ASSEMBLY_STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src] has no wiring to remove.")
+			return TRUE
+		if (state > ASSEMBLY_STATE_WIRED)
+			// TODO: Feedback message
+			return TRUE
+		playsound(src, 'sound/items/Wirecutter.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts cutting \the [src]'s wires with \a [tool]."),
+			SPAN_NOTICE("You start cutting \the [src]'s wires with \the [tool].")
+		)
+		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (state < ASSEMBLY_STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src] has no wiring to remove.")
+			return TRUE
+		if (state > ASSEMBLY_STATE_WIRED)
+			// TODO: Feedback message
+			return TRUE
+		var/obj/item/stack/cable_coil/cable = new(loc, 1)
+		cable.add_fingerprint(user, tool = tool)
+		state = ASSEMBLY_STATE_FRAME
+		update_state()
+		playsound(src, 'sound/items/Wirecutter.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] cuts \the [src]'s wires with \a [tool]."),
+			SPAN_NOTICE("You cut \the [src]'s wires with \the [tool].")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/door_assembly/proc/update_state()
 	overlays.Cut()

--- a/code/game/objects/structures/drain.dm
+++ b/code/game/objects/structures/drain.dm
@@ -11,24 +11,35 @@
 	can_drain = 1
 	var/welded
 
-/obj/structure/hygiene/drain/attackby(obj/item/thing, mob/user)
-	..()
-	if(isWelder(thing))
-		var/obj/item/weldingtool/WT = thing
-		if(WT.isOn())
-			welded = !welded
-			to_chat(user, SPAN_NOTICE("You weld \the [src] [welded ? "closed" : "open"]."))
-		else
-			to_chat(user, SPAN_WARNING("Turn \the [thing] on, first."))
+
+/obj/structure/hygiene/drain/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Welding Tool - Weld the drain closed
+	if (isWelder(tool))
+		var/obj/item/weldingtool/welder = tool
+		if (!welder.remove_fuel(1, user))
+			return TRUE
+		welded = !welded
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [welded ? "un" : "welds"] \the [src] with \a [tool]."),
+			SPAN_NOTICE("You [welded ? "un" : "weld"] \the [src] with \the [tool].")
+		)
 		update_icon()
-		return
-	if(isWrench(thing))
-		new /obj/item/drain(src.loc)
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		to_chat(user, SPAN_WARNING("[user] unwrenches the [src]."))
-		qdel(src)
-		return
+		return TRUE
+
+	// Wrench - Dismantle drain
+	if (isWrench(tool))
+		var/obj/item/drain/drain_item = new(loc)
+		transfer_fingerprints_to(drain_item)
+		playsound(src, 'sound/items/Ratchet.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] unwrenches \the [src] from the floor with \a [tool]."),
+			SPAN_NOTICE("You unwrench \the [src] from the floor with \the [tool].")
+		)
+		qdel_self()
+		return TRUE
+
 	return ..()
+
 
 /obj/structure/hygiene/drain/on_update_icon()
 	icon_state = "[initial(icon_state)][welded ? "-welded" : ""]"

--- a/code/game/objects/structures/electricchair.dm
+++ b/code/game/objects/structures/electricchair.dm
@@ -6,21 +6,33 @@
 	var/obj/item/assembly/shock_kit/part = null
 	var/last_time = 1.0
 	buckle_movable = FALSE
+	bed_flags = BED_FLAG_CANNOT_BE_ELECTRIFIED | BED_FLAG_CANNOT_BE_PADDED
 
 /obj/structure/bed/chair/e_chair/New()
 	..()
 	overlays += image('icons/obj/objects.dmi', src, "echair_over", MOB_LAYER + 1, dir)
 	return
 
-/obj/structure/bed/chair/e_chair/attackby(obj/item/W as obj, mob/user as mob)
-	if(isWrench(W))
-		var/obj/structure/bed/chair/C = new /obj/structure/bed/chair(loc)
-		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
-		C.set_dir(dir)
+
+/obj/structure/bed/chair/e_chair/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Wrench - Dismantle electric chair
+	if (isWrench(tool))
+		var/obj/structure/bed/chair/chair = new /obj/structure/bed/chair(loc)
+		playsound(src, 'sound/items/Ratchet.ogg', 50, TRUE)
+		chair.set_dir(dir)
 		part.dropInto(loc)
 		part.master = null
+		transfer_fingerprints_to(chair)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] removes \the [part] from \the [chair] with \a [tool]."),
+			SPAN_NOTICE("You remove \the [part] from \the [chair] with \the [tool].")
+		)
 		part = null
-		qdel(src)
+		qdel_self()
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/bed/chair/e_chair/verb/toggle()
 	set name = "Toggle Electric Chair"

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -12,19 +12,28 @@
 	..()
 	has_extinguisher = new/obj/item/extinguisher(src)
 
-/obj/structure/extinguisher_cabinet/attackby(obj/item/O, mob/user)
-	if(isrobot(user))
-		return
-	if(istype(O, /obj/item/extinguisher))
-		if(!has_extinguisher && opened && user.unEquip(O, src))
-			has_extinguisher = O
-			to_chat(user, SPAN_NOTICE("You place [O] in [src]."))
-			playsound(src.loc, 'sound/effects/extin.ogg', 50, 0)
-		else
-			opened = !opened
-	else
-		opened = !opened
-	update_icon()
+
+/obj/structure/extinguisher_cabinet/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Extinguisher - Put in cabinet
+	if (istype(tool, /obj/item/extinguisher))
+		if (!opened)
+			USE_FEEDBACK_FAILURE("\The [src] is closed.")
+			return TRUE
+		if (has_extinguisher)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [has_extinguisher].")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		has_extinguisher = tool
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] places \a [tool] in \the [src]."),
+			SPAN_NOTICE("You place \the [tool] in \the [src].")
+		)
+		return TRUE
+
+	return ..()
 
 
 /obj/structure/extinguisher_cabinet/attack_hand(mob/user)

--- a/code/game/objects/structures/fitness.dm
+++ b/code/game/objects/structures/fitness.dm
@@ -38,11 +38,20 @@
 	var/list/success_message = list("with great effort", "straining hard", "without any trouble", "with ease")
 	var/list/fail_message = list(", lifting them part of the way and then letting them drop", ", unable to even budge them")
 
-/obj/structure/fitness/weightlifter/attackby(obj/item/W as obj, mob/user as mob)
-	if(isWrench(W))
-		playsound(src.loc, 'sound/items/Deconstruct.ogg', 75, 1)
+
+/obj/structure/fitness/weightlifter/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Wrench - Set weight level
+	if (isWrench(tool))
+		playsound(src, 'sound/items/Deconstruct.ogg', 50, TRUE)
 		weight = (weight % max_weight) + 1
-		to_chat(user, "You set the machine's weight level to [weight].")
+		user.visible_message(
+			SPAN_NOTICE("\The [user] adjusts \the [src]'s weight level with \a [tool]."),
+			SPAN_NOTICE("You set \the [src]'s weight level to [weight] with \the [tool].")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/fitness/weightlifter/attack_hand(mob/living/carbon/human/user)
 	if(!istype(user))

--- a/code/game/objects/structures/holosigns.dm
+++ b/code/game/objects/structures/holosigns.dm
@@ -25,9 +25,26 @@
 	visible_message(SPAN_NOTICE("\The [user] waves through \the [src], causing it to dissipate."))
 	deactivate(user)
 
-/obj/structure/holosign/attackby(obj/W, mob/living/user)
-	visible_message(SPAN_NOTICE("\The [user] waves \a [W] through \the [src], causing it to dissipate."))
+
+/obj/structure/holosign/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	SHOULD_CALL_PARENT(FALSE)
+	user.visible_message(
+		SPAN_WARNING("\The [user] swings \a [weapon] at \the [src], causing it to vanish."),
+		SPAN_WARNING("You swing \the [weapon] at \the [src], causing it to vanish.")
+	)
 	deactivate(user)
+	return TRUE
+
+
+/obj/structure/holosign/use_tool(obj/item/tool, mob/user, list/click_params)
+	SHOULD_CALL_PARENT(FALSE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] waves \a [tool] at \the [src], causing it to vanish."),
+		SPAN_NOTICE("You wave \the [tool] at \the [src], causing it to vanish.")
+	)
+	deactivate(user)
+	return TRUE
+
 
 /obj/structure/holosign/proc/deactivate(mob/living/user)
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -151,20 +151,28 @@
 	return ..()
 
 
-/obj/structure/inflatable/attackby(obj/item/W, mob/user)
-	if(!istype(W) || istype(W, /obj/item/inflatable_dispenser)) return
-
-	if(istype(W, /obj/item/tape_roll) && get_damage_value() >= 3)
-		if(taped)
-			to_chat(user, SPAN_NOTICE("\The [src] can't be patched any more with \the [W]!"))
+/obj/structure/inflatable/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Duct tape - Repair damage
+	if (istype(tool, /obj/item/tape_roll))
+		if (!health_damaged())
+			USE_FEEDBACK_FAILURE("\The [src] doesn't need repair.")
 			return TRUE
-		else
-			taped = TRUE
-			to_chat(user, SPAN_NOTICE("You patch some damage in \the [src] with \the [W]!"))
-			restore_health(3)
+		if (get_damage_value() < 3)
+			USE_FEEDBACK_FAILURE("\The [src] isn't damaged enough to tape it back together.")
 			return TRUE
+		if (taped)
+			USE_FEEDBACK_FAILURE("\The [src] has already been taped up. There's nothing more you can do for it with \the [tool].")
+			return TRUE
+		taped = TRUE
+		restore_health(3)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] patches some of \the [src]'s damage with \a [tool]."),
+			SPAN_NOTICE("You patch some of \the [src]'s damage with \the [tool].")
+		)
+		return TRUE
 
-	..()
+	return ..()
+
 
 /obj/structure/inflatable/on_death()
 	deflate(TRUE)

--- a/code/game/objects/structures/iv_drip.dm
+++ b/code/game/objects/structures/iv_drip.dm
@@ -103,23 +103,26 @@
 		AttachDrip(dropped, user)
 
 
-/obj/structure/iv_stand/attackby(obj/item/item, mob/living/user)
-	if (!istype(item, /obj/item/reagent_containers/ivbag))
-		return ..()
-	if (!isnull(iv_bag))
-		to_chat(user, SPAN_WARNING("\The [src] already has \a [iv_bag] attached."))
+/obj/structure/iv_stand/use_tool(obj/item/tool, mob/user, list/click_params)
+	// IV Bag - Attach
+	if (istype(tool, /obj/item/reagent_containers/ivbag))
+		if (iv_bag)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [iv_bag] attached.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] attaches \a [tool] to \a [src]."),
+			SPAN_NOTICE("You attach \the [tool] to \the [src]."),
+			range = 5
+		)
+		iv_bag = tool
+		last_reagent_color = iv_bag.reagents.get_color()
+		update_icon()
 		return TRUE
-	if (!user.unEquip(item, src))
-		return TRUE
-	user.visible_message(
-		SPAN_ITALIC("\The [user] attaches \a [item] to \a [src]."),
-		SPAN_ITALIC("You attach \the [item] to \the [src]."),
-		range = 5
-	)
-	iv_bag = item
-	last_reagent_color = iv_bag.reagents.get_color()
-	update_icon()
-	return TRUE
+
+	return ..()
 
 
 /obj/structure/iv_stand/Process()

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -26,64 +26,118 @@
 		to_chat(user, "[src] [icon2html(src, viewers(get_turf(src)))] contains [reagents.total_volume] unit\s of liquid!")
 
 
-/obj/structure/janitorialcart/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/storage/bag/trash) && !mybag)
-		if(!user.unEquip(I, src))
-			return
-		mybag = I
+/obj/structure/janitorialcart/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Caution Sign - Attach
+	if (istype(tool, /obj/item/caution))
+		if (signs >= 4)
+			USE_FEEDBACK_FAILURE("\The [src] can't hold any more signs.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(tool, src)
+			return TRUE
+		signs++
 		update_icon()
 		updateUsrDialog()
-		to_chat(user, SPAN_NOTICE("You put [I] into [src]."))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] puts \a [tool] on \the [src]."),
+			SPAN_NOTICE("You put \the [tool] on \the [src].")
+		)
+		return TRUE
 
-	else if(istype(I, /obj/item/mop))
-		if(I.reagents.total_volume < I.reagents.maximum_volume)	//if it's not completely soaked we assume they want to wet it, otherwise store it
-			if(reagents.total_volume < 1)
-				to_chat(user, SPAN_WARNING("[src] is out of water!"))
+	// Light Replacer - Attach
+	if (istype(tool, /obj/item/device/lightreplacer))
+		if (myreplacer)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [myreplacer] attached.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(tool, src)
+			return TRUE
+		mybag = tool
+		update_icon()
+		updateUsrDialog()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] puts \a [tool] on \the [src]."),
+			SPAN_NOTICE("You put \the [tool] on \the [src].")
+		)
+		return TRUE
+
+	// Mop - Wet or store
+	if (istype(tool, /obj/item/mop))
+		var/input = input(user, "What would you like to do with \the [tool]?", "[src] - [tool]") as null|anything in list("Wet", "Store")
+		if (!input || !user.use_sanity_check(src, tool))
+			return TRUE
+		switch (input)
+			// Wet
+			if ("Wet")
+				if (reagents.total_volume < 1)
+					USE_FEEDBACK_FAILURE("\The [src] is out of water.")
+					return TRUE
+				reagents.trans_to_obj(tool, tool.reagents.maximum_volume)
+				playsound(src, 'sound/effects/slosh.ogg', 50, TRUE)
+				user.visible_message(
+					SPAN_NOTICE("\The [user] wets \a [tool] in \the [src]."),
+					SPAN_NOTICE("You wets \the [tool] in \the [src].")
+				)
+				return TRUE
+			// Store
+			if ("Store")
+				if (mymop)
+					USE_FEEDBACK_FAILURE("\The [src] already has \a [mymop] attached.")
+					return TRUE
+				if (!user.unEquip(tool, src))
+					FEEDBACK_UNEQUIP_FAILURE(user, tool)
+					return TRUE
+				mymop = tool
+				update_icon()
+				updateUsrDialog()
+				user.visible_message(
+					SPAN_NOTICE("\The [user] adds \a [tool] to \the [src]."),
+					SPAN_NOTICE("You add \the [tool] to \the [src].")
+				)
+				return TRUE
 			else
-				reagents.trans_to_obj(I, I.reagents.maximum_volume)
-				to_chat(user, SPAN_NOTICE("You wet [I] in [src]."))
-				playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
-				return
-		if(!mymop)
-			if(!user.unEquip(I, src))
-				return
-			mymop = I
-			update_icon()
-			updateUsrDialog()
-			to_chat(user, SPAN_NOTICE("You put [I] into [src]."))
+				return TRUE
 
-	else if(istype(I, /obj/item/reagent_containers/spray) && !myspray)
-		if(!user.unEquip(I, src))
-			return
-		myspray = I
+	// Spray Bottle - Attach
+	if (istype(tool, /obj/item/reagent_containers/spray))
+		if (myspray)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [myspray] attached.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		myspray = tool
 		update_icon()
 		updateUsrDialog()
-		to_chat(user, SPAN_NOTICE("You put [I] into [src]."))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] puts \a [tool] on \the [src]."),
+			SPAN_NOTICE("You put \the [tool] on \the [src].")
+		)
+		return TRUE
 
-	else if(istype(I, /obj/item/device/lightreplacer) && !myreplacer)
-		if(!user.unEquip(I, src))
-			return
-		myreplacer = I
+	// Trash Bag - Attach
+	if (istype(tool, /obj/item/storage/bag/trash))
+		if (mybag)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [mybag] attached.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(tool, src)
+			return TRUE
+		mybag = tool
 		update_icon()
 		updateUsrDialog()
-		to_chat(user, SPAN_NOTICE("You put [I] into [src]."))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] puts \a [tool] on \the [src]."),
+			SPAN_NOTICE("You put \the [tool] on \the [src].")
+		)
+		return TRUE
 
-	else if(istype(I, /obj/item/caution))
-		if(signs < 4)
-			if(!user.unEquip(I, src))
-				return
-			signs++
-			update_icon()
-			updateUsrDialog()
-			to_chat(user, SPAN_NOTICE("You put [I] into [src]."))
-		else
-			to_chat(user, SPAN_NOTICE("[src] can't hold any more signs."))
+	// Everything else - Passthrough to mybag
+	// Skip reagent containers as those fill the mop bucket
+	if (mybag && !(istype(tool, /obj/item/reagent_containers/glass)))
+		return tool.resolve_attackby(mybag, user, click_params)
 
-	else if(istype(I, /obj/item/reagent_containers/glass))
-		return // So we do not put them in the trash bag as we mean to fill the mop bucket
-
-	else if(mybag)
-		mybag.attackby(I, user)
+	return ..()
 
 
 /obj/structure/janitorialcart/attack_hand(mob/user)
@@ -176,6 +230,7 @@
 	var/obj/item/storage/bag/trash/mybag	= null
 	var/callme = "pimpin' ride"	//how do people refer to it?
 	buckle_movable = FALSE
+	bed_flags = BED_FLAG_CANNOT_BE_DISMANTLED | BED_FLAG_CANNOT_BE_ELECTRIFIED | BED_FLAG_CANNOT_BE_PADDED
 
 
 /obj/structure/bed/chair/janicart/Initialize()
@@ -192,21 +247,41 @@
 		to_chat(user, "\A [mybag] is hanging on the [callme].")
 
 
-/obj/structure/bed/chair/janicart/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/mop))
-		if(reagents.total_volume > 1)
-			reagents.trans_to_obj(I, 2)
-			to_chat(user, SPAN_NOTICE("You wet [I] in the [callme]."))
-			playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
-		else
-			to_chat(user, SPAN_NOTICE("This [callme] is out of water!"))
-	else if(istype(I, /obj/item/key))
-		to_chat(user, "Hold [I] in one of your hands while you drive this [callme].")
-	else if(istype(I, /obj/item/storage/bag/trash))
-		if(!user.unEquip(I, src))
-			return
-		to_chat(user, SPAN_NOTICE("You hook the trashbag onto the [callme]."))
-		mybag = I
+/obj/structure/bed/chair/janicart/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Key - Show message
+	if (istype(tool, /obj/item/key))
+		USE_FEEDBACK_FAILURE("Hold \the [tool] in your hands while you drive \the [callme].")
+		return TRUE
+
+	// Mop - Wet mop
+	if (istype(tool, /obj/item/mop))
+		if (!reagents.total_volume)
+			USE_FEEDBACK_FAILURE("\The [callme]'s bucket is out of water.")
+			return TRUE
+		reagents.trans_to_obj(tool, 2)
+		playsound(loc, 'sound/effects/slosh.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] wets \a [tool] in \the [callme]."),
+			SPAN_NOTICE("You wet \the [tool] in \the [callme].")
+		)
+		return TRUE
+
+	// Trash Bag - Hook bag to cart
+	if (istype(tool, /obj/item/storage/bag/trash))
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		if (mybag)
+			USE_FEEDBACK_FAILURE("\The [callme] already has \a [mybag] attached.")
+			return TRUE
+		mybag = TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] hooks \a [tool] onto \the [callme]."),
+			SPAN_NOTICE("You hook \the [tool] onto \the [callme].")
+		)
+		return TRUE
+
+	return ..()
 
 
 /obj/structure/bed/chair/janicart/attack_hand(mob/user)

--- a/code/game/objects/structures/mineral_bath.dm
+++ b/code/game/objects/structures/mineral_bath.dm
@@ -17,13 +17,13 @@
 	venus.adjust_multi(GAS_CHLORINE, MOLES_N2STANDARD, GAS_PHORON, MOLES_O2STANDARD)
 	return venus
 
-/obj/structure/adherent_bath/attackby(obj/item/thing, mob/user)
-	if(istype(thing, /obj/item/grab))
-		var/obj/item/grab/G = thing
-		if(enter_bath(G.affecting))
-			qdel(G)
-		return
-	. = ..()
+
+/obj/structure/adherent_bath/use_grab(obj/item/grab/grab, list/click_params)
+	// Put victim in bath
+	if (enter_bath(grab.affecting, grab.assailant))
+		qdel(grab)
+	return TRUE
+
 
 /obj/structure/adherent_bath/proc/enter_bath(mob/living/patient, mob/user)
 

--- a/code/game/objects/structures/mop_bucket.dm
+++ b/code/game/objects/structures/mop_bucket.dm
@@ -18,11 +18,19 @@
 	if(distance <= 1)
 		to_chat(user, "[src] [icon2html(src, user)] contains [reagents.total_volume] unit\s of water!")
 
-/obj/structure/mopbucket/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/mop))
-		if(reagents.total_volume < 1)
-			to_chat(user, SPAN_WARNING("\The [src] is out of water!"))
-		else
-			reagents.trans_to_obj(I, 5)
-			to_chat(user, SPAN_NOTICE("You wet \the [I] in \the [src]."))
-			playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
+
+/obj/structure/mopbucket/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Mop - Wet mop
+	if (istype(tool, /obj/item/mop))
+		if (reagents.total_volume < 1)
+			USE_FEEDBACK_FAILURE("\The [src] is out of water.")
+			return TRUE
+		reagents.trans_to_obj(tool, 5)
+		playsound(src, 'sound/effects/slosh.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] wets \a [tool] in \the [src]."),
+			SPAN_NOTICE("You wet \the [tool] in \the [src].")
+		)
+		return TRUE
+
+	return ..()

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -92,20 +92,30 @@
 		return attack_hand(user)
 	else return ..()
 
-/obj/structure/morgue/attackby(P as obj, mob/user as mob)
-	if (istype(P, /obj/item/pen))
-		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text
-		if (user.get_active_hand() != P)
-			return
-		if ((!in_range(src, usr) && src.loc != user))
-			return
-		t = sanitizeSafe(t, MAX_NAME_LEN)
-		if (t)
-			src.SetName(text("Morgue- '[]'", t))
+
+/obj/structure/morgue/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Pen - Add label
+	if (istype(tool, /obj/item/pen))
+		var/input = input(user, "What would you like the label to be? Leave null to clear label.", "\The [initial(name)] - Label") as null|text
+		input = sanitizeSafe(input, MAX_NAME_LEN)
+		if (!user.use_sanity_check(src, tool))
+			return TRUE
+		if (!input)
+			SetName(initial(name))
+			user.visible_message(
+				SPAN_NOTICE("\The [user] clears \the [src]'s label with \a [tool]."),
+				SPAN_NOTICE("You clear \the [src]'s label with \the [tool].")
+			)
 		else
-			src.SetName("Morgue")
-	src.add_fingerprint(user)
-	return
+			SetName("[initial(name)] - '[input]'")
+			user.visible_message(
+				SPAN_NOTICE("\The [user] labels \the [src] with \a [tool]."),
+				SPAN_NOTICE("You label \the [src] with \the [tool].")
+			)
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/morgue/relaymove(mob/user as mob)
 	if (user.stat)
@@ -258,20 +268,30 @@
 	src.add_fingerprint(user)
 	update()
 
-/obj/structure/crematorium/attackby(P as obj, mob/user as mob)
-	if(istype(P, /obj/item/pen))
-		var/t = input(user, "What would you like the label to be?", text("[]", src.name), null)  as text
-		if(user.get_active_hand() != P)
-			return
-		if((!in_range(src, usr) > 1 && src.loc != user))
-			return
-		t = sanitizeSafe(t, MAX_NAME_LEN)
-		if(t)
-			src.SetName(text("Crematorium- '[]'", t))
+
+/obj/structure/crematorium/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Pen - Add label
+	if (istype(tool, /obj/item/pen))
+		var/input = input(user, "What would you like the label to be? Leave null to clear label.", "\The [initial(name)] - Label") as null|text
+		input = sanitizeSafe(input, MAX_NAME_LEN)
+		if (!user.use_sanity_check(src, tool))
+			return TRUE
+		if (!input)
+			SetName(initial(name))
+			user.visible_message(
+				SPAN_NOTICE("\The [user] clears \the [src]'s label with \a [tool]."),
+				SPAN_NOTICE("You clear \the [src]'s label with \the [tool].")
+			)
 		else
-			src.SetName("Crematorium")
-	src.add_fingerprint(user)
-	return
+			SetName("[initial(name)] - '[input]'")
+			user.visible_message(
+				SPAN_NOTICE("\The [user] labels \the [src] with \a [tool]."),
+				SPAN_NOTICE("You label \the [src] with \the [tool].")
+			)
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/crematorium/relaymove(mob/user as mob)
 	if (user.stat || locked)

--- a/code/game/objects/structures/roller_bed.dm
+++ b/code/game/objects/structures/roller_bed.dm
@@ -94,29 +94,32 @@
 		return ..()
 
 
-/obj/structure/roller_bed/attackby(obj/item/item, mob/living/user)
-	. = TRUE
-	if (istype(item, /obj/item/reagent_containers/ivbag))
+/obj/structure/roller_bed/use_grab(obj/item/grab/grab, list/click_params)
+	// Buckle victim
+	if (!AttemptBuckle(grab.affecting, grab.assailant))
+		return TRUE
+	qdel(grab)
+	return TRUE
+
+
+/obj/structure/roller_bed/use_tool(obj/item/tool, mob/user, list/click_params)
+	// IV Bag - Attach bag
+	if (istype(tool, /obj/item/reagent_containers/ivbag))
 		if (iv_bag)
-			to_chat(user, SPAN_WARNING("\The [src] already has \a [iv_bag] attached."))
-			return
-		if (!user.unEquip(item, src))
-			return
-		user.visible_message(
-			SPAN_ITALIC("\The [user] hangs \a [item] from \a [src]."),
-			SPAN_ITALIC("You hang \the [item] from \the [src]."),
-			range = 5
-		)
-		iv_bag = item
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [iv_bag] attached")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		iv_bag = tool
 		last_reagent_color = iv_bag.reagents.get_color()
 		update_icon()
-		return
-	if (istype(item, /obj/item/grab))
-		var/obj/item/grab/grab = item
-		if (!AttemptBuckle(grab.affecting, user))
-			return
-		qdel(grab)
-		return
+		user.visible_message(
+			SPAN_NOTICE("\The [user] hangs \a [tool] from \the [src]."),
+			SPAN_NOTICE("You hang \the [tool] from \the [src]."),
+		)
+		return TRUE
+
 	return ..()
 
 

--- a/code/game/objects/structures/rubble.dm
+++ b/code/game/objects/structures/rubble.dm
@@ -62,23 +62,29 @@
 	else
 		to_chat(user, SPAN_WARNING("Someone is already rummaging here!"))
 
-/obj/structure/rubble/attackby(obj/item/I, mob/user)
-	if (user.a_intent == I_HURT)
-		..()
-		return
 
-	if (istype(I, /obj/item/pickaxe))
-		var/obj/item/pickaxe/P = I
-		visible_message("[user] starts clearing away \the [src].")
-		if(do_after(user, P.digspeed, src, DO_PUBLIC_UNIQUE))
-			visible_message("[user] clears away \the [src].")
-			if(lootleft && prob(1))
-				var/obj/item/booty = pickweight(loot)
-				booty = new booty(loc)
-			qdel(src)
-		return
+/obj/structure/rubble/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Pickaxe - Clear rubble
+	if (istype(tool, /obj/item/pickaxe))
+		var/obj/item/pickaxe/pickaxe = tool
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts clearing away \the [src] with \a [tool]."),
+			SPAN_NOTICE("You start clearing away \the [src] with \the [tool].")
+		)
+		if (!do_after(user, pickaxe.digspeed, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (lootleft && prob(1))
+			var/booty = pickweight(loot)
+			new booty(loc)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] clears away \the [src] with \a [tool]."),
+			SPAN_NOTICE("You clear away \the [src] with \the [tool].")
+		)
+		qdel_self()
+		return TRUE
 
-	..()
+	return ..()
+
 
 /obj/structure/rubble/on_death()
 	visible_message(SPAN_WARNING("\The [src] breaks apart!"))

--- a/code/game/objects/structures/safe.dm
+++ b/code/game/objects/structures/safe.dm
@@ -138,22 +138,30 @@ FLOOR SAFES
 				updateUsrDialog()
 
 
-/obj/structure/safe/attackby(obj/item/I as obj, mob/user as mob)
-	if(open)
-		if(I.w_class + space <= maxspace)
-			if(!user.unEquip(I, src))
-				return
-			space += I.w_class
-			to_chat(user, SPAN_NOTICE("You put [I] in [src]."))
-			updateUsrDialog()
-			return
-		else
-			to_chat(user, SPAN_NOTICE("[I] won't fit in [src]."))
-			return
-	else
-		if(istype(I, /obj/item/clothing/accessory/stethoscope))
-			to_chat(user, "Hold [I] in one of your hands while you manipulate the dial.")
-			return
+/obj/structure/safe/use_tool(obj/item/tool, mob/user, list/click_params)
+	// If open - Insert item
+	if (open)
+		if (tool.w_class + space >= maxspace)
+			USE_FEEDBACK_FAILURE("\The [src] doesn't have enough space for \the [tool].")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		space += tool.w_class
+		updateUsrDialog()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] puts \a [tool] in \the [src]."),
+			SPAN_NOTICE("You put \the [tool] in \the [src]."),
+			range = 2
+		)
+		return TRUE
+
+	// Stethoscope - Cracking tip
+	if (istype(tool, /obj/item/clothing/accessory/stethoscope))
+		to_chat(user, SPAN_INFO("Hold \the [tool] in one of your hands while you manipulate the dial to help with cracking the code."))
+		return TRUE
+
+	return ..()
 
 
 /obj/structure/safe/ex_act(severity)

--- a/code/game/objects/structures/signs.dm
+++ b/code/game/objects/structures/signs.dm
@@ -6,6 +6,14 @@
 	layer = ABOVE_WINDOW_LAYER
 	w_class = ITEM_SIZE_NORMAL
 
+/obj/structure/sign/double/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Screwdriver - Block interaction
+	if (isScrewdriver(tool))
+		USE_FEEDBACK_FAILURE("\The [src] cannot be removed.")
+		return TRUE
+
+	return ..()
+
 /obj/structure/sign/ex_act(severity)
 	switch(severity)
 		if(EX_ACT_DEVASTATING)
@@ -20,16 +28,25 @@
 		else
 	return
 
-/obj/structure/sign/attackby(obj/item/tool as obj, mob/user as mob)	//deconstruction
-	if(isScrewdriver(tool) && !istype(src, /obj/structure/sign/double))
-		to_chat(user, "You unfasten the sign with your [tool.name].")
-		var/obj/item/sign/S = new(src.loc)
+
+/obj/structure/sign/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Scrwedriver - Unfasten sign
+	if (isScrewdriver(tool))
+		var/obj/item/sign/S = new(loc)
 		S.SetName(name)
 		S.desc = desc
 		S.icon_state = icon_state
 		S.sign_state = icon_state
-		qdel(src)
-	else ..()
+		transfer_fingerprints_to(S)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] unfastens \the [src] with \a [tool]."),
+			SPAN_NOTICE("You unfasten \the [src] with \the [tool].")
+		)
+		qdel_self()
+		return TRUE
+
+	return ..()
+
 
 /obj/item/sign
 	name = "sign"

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -10,6 +10,8 @@
 	var/material/padding_material
 	var/base_icon = "bed"
 	var/material_alteration = MATERIAL_ALTERATION_ALL
+	/// Bitflags. Bed/chair specific flags.
+	var/bed_flags = EMPTY_BITFIELD
 
 
 /obj/structure/bed/New(newloc, new_material = DEFAULT_FURNITURE_MATERIAL, new_padding_material)
@@ -77,53 +79,99 @@
 				qdel(src)
 				return
 
-/obj/structure/bed/attackby(obj/item/W as obj, mob/user as mob)
-	if(isWrench(W))
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		dismantle()
-		qdel(src)
-	else if(istype(W,/obj/item/stack))
-		if(padding_material)
-			to_chat(user, "\The [src] is already padded.")
-			return
-		var/obj/item/stack/C = W
-		if(C.get_amount() < 1) // How??
-			qdel(C)
-			return
-		var/padding_type //This is awful but it needs to be like this until tiles are given a material var.
-		if(istype(W,/obj/item/stack/tile/carpet))
+
+/obj/structure/bed/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Material Stack - Add padding
+	if (isstack(tool))
+		if (HAS_FLAGS(bed_flags, BED_FLAG_CANNOT_BE_PADDED))
+			USE_FEEDBACK_FAILURE("\The [src] cannot be padded.")
+			return TRUE
+		if (padding_material)
+			USE_FEEDBACK_FAILURE("\The [src] is already padded with [padding_material.display_name].")
+			return TRUE
+		var/obj/item/stack/stack = tool
+		if (!stack.can_use(1))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(stack, 1, "to pad \the [src].")
+			return TRUE
+		var/padding_type
+		if (istype(tool, /obj/item/stack/tile/carpet))
 			padding_type = MATERIAL_CARPET
-		else if(istype(W,/obj/item/stack/material))
-			var/obj/item/stack/material/M = W
-			if(M.material && (M.material.flags & MATERIAL_PADDING))
-				padding_type = "[M.material.name]"
-		if(!padding_type)
-			to_chat(user, "You cannot pad \the [src] with that.")
-			return
-		C.use(1)
-		if(!istype(src.loc, /turf))
-			src.forceMove(get_turf(src))
-		to_chat(user, "You add padding to \the [src].")
+		else if (istype(tool, /obj/item/stack/material))
+			var/obj/item/stack/material/material_stack = tool
+			if (!material_stack.material || !HAS_FLAGS(material_stack.material.flags, MATERIAL_PADDING))
+				USE_FEEDBACK_FAILURE("\The [tool] can't be used to pad \the [src].")
+				return TRUE
+			padding_type = material_stack.get_material_name()
+		else
+			USE_FEEDBACK_FAILURE("\The [tool] can't be used to pad \the [src].")
+			return TRUE
+		stack.use(1)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] pads \the [src] with \a [tool]."),
+			SPAN_NOTICE("You pad \the [src] with \the [tool].")
+		)
 		add_padding(padding_type)
-		return
+		return TRUE
 
-	else if(isWirecutter(W))
-		if(!padding_material)
-			to_chat(user, "\The [src] has no padding to remove.")
-			return
-		to_chat(user, "You remove the padding from \the [src].")
-		playsound(src, 'sound/items/Wirecutter.ogg', 100, 1)
+	// Wirecutters - Remove padding
+	if (isWirecutter(tool))
+		if (!padding_material)
+			USE_FEEDBACK_FAILURE("\The [src] has no padding to remove.")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] removes \the [src]'s padding with \a [tool]."),
+			SPAN_NOTICE("You remove \the [src]'s padding with \the [tool].")
+		)
+		playsound(src, 'sound/items/Wirecutter.ogg', 50, TRUE)
 		remove_padding()
+		return TRUE
 
-	else if(istype(W, /obj/item/grab))
-		var/obj/item/grab/G = W
-		var/mob/living/affecting = G.affecting
-		user.visible_message(SPAN_NOTICE("[user] attempts to buckle [affecting] into \the [src]!"))
-		if(do_after(user, 2 SECONDS, src, DO_PUBLIC_UNIQUE))
-			if(user_buckle_mob(affecting, user))
-				qdel(W)
-	else
-		..()
+	// Wrench - Dismantle
+	if (isWrench(tool))
+		if (HAS_FLAGS(bed_flags, BED_FLAG_CANNOT_BE_DISMANTLED))
+			USE_FEEDBACK_FAILURE("\The [src] cannot be dismantled.")
+			return TRUE
+		playsound(src, 'sound/items/Ratchet.ogg', 50, TRUE)
+		dismantle()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] dismantles \the [src] with \a [tool]."),
+			SPAN_NOTICE("You dismantle \the [src] with \the [tool].")
+		)
+		qdel_self()
+		return TRUE
+
+	return ..()
+
+
+/obj/structure/bed/use_grab(obj/item/grab/grab, list/click_params)
+	// Force-buckle
+	grab.assailant.visible_message(
+		SPAN_WARNING("\The [grab.assailant] starts to buckle \the [grab.affecting] to \the [src]."),
+		SPAN_DANGER("You start to buckle \the [grab.affecting] to \the [src]!"),
+		SPAN_ITALIC("You hear the sound of struggling."),
+		exclude_mobs = list(grab.affecting)
+	)
+	grab.affecting.show_message(
+		SPAN_DANGER("\The [grab.assailant] starts to buckle you to \the [src]!"),
+		VISIBLE_MESSAGE,
+		SPAN_DANGER("You feel someone trying to force you into a bed or chair!")
+	)
+	if (!do_after(grab.assailant, 2 SECONDS, src, DO_PUBLIC_UNIQUE) || QDELETED(grab) || !grab.assailant.use_sanity_check(src, grab.affecting))
+		return TRUE
+	grab.assailant.visible_message(
+		SPAN_WARNING("\The [grab.assailant] buckles \the [grab.affecting] to \the [src]."),
+		SPAN_DANGER("You buckle \the [grab.affecting] to \the [src]!"),
+		SPAN_ITALIC("You hear the sound of buckling."),
+		exclude_mobs = list(grab.affecting)
+	)
+	grab.affecting.show_message(
+		SPAN_DANGER("\The [grab.assailant] buckles you to \the [src]!"),
+		VISIBLE_MESSAGE,
+		SPAN_DANGER("You feel someone buckle you into a bed or chair!")
+	)
+	qdel(grab)
+	return TRUE
+
 
 /obj/structure/bed/proc/remove_padding()
 	if(padding_material)

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -15,22 +15,36 @@
 		rotate(user)
 	return TRUE
 
-/obj/structure/bed/chair/attackby(obj/item/W as obj, mob/user as mob)
-	..()
-	if(!padding_material && istype(W, /obj/item/assembly/shock_kit))
-		var/obj/item/assembly/shock_kit/SK = W
-		if(!SK.status)
-			to_chat(user, SPAN_NOTICE("\The [SK] is not ready to be attached!"))
-			return
-		if(!user.unEquip(SK))
-			return
-		var/obj/structure/bed/chair/e_chair/E = new (src.loc, material.name)
-		playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
-		E.set_dir(dir)
-		E.part = SK
-		SK.forceMove(E)
-		SK.master = E
-		qdel(src)
+
+/obj/structure/bed/chair/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Shock Kit - Attach shock kit
+	if (istype(tool, /obj/item/assembly/shock_kit))
+		if (padding_material)
+			USE_FEEDBACK_FAILURE("\The [src]'s [padding_material.display_name] must be removed before you can attach \the [tool].")
+			return TRUE
+		if (!user.unEquip(tool))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		var/obj/item/assembly/shock_kit/shock_kit = tool
+		if (!shock_kit.status)
+			USE_FEEDBACK_FAILURE("\The [tool] is not ready to be attached to \the [src].")
+			return TRUE
+		var/obj/structure/bed/chair/e_chair/electric_chair = new (loc, material.name)
+		playsound(src, 'sound/items/Deconstruct.ogg', 50, TRUE)
+		electric_chair.set_dir(dir)
+		electric_chair.part = shock_kit
+		shock_kit.forceMove(electric_chair)
+		shock_kit.master = electric_chair
+		transfer_fingerprints_to(electric_chair)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] attaches \a [tool] to \the [src], creating \a [electric_chair]."),
+			SPAN_NOTICE("You attach \the [tool] to \the [src], creating \a [electric_chair].")
+		)
+		qdel_self()
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/bed/chair/post_buckle_mob()
 	update_icon()
@@ -336,11 +350,7 @@
 	color = WOOD_COLOR_GENERIC
 	var/chair_material = MATERIAL_WOOD
 	buckle_movable = FALSE
-
-/obj/structure/bed/chair/wood/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W,/obj/item/stack) || istype(W, /obj/item/wirecutters))
-		return
-	..()
+	bed_flags = BED_FLAG_CANNOT_BE_PADDED
 
 /obj/structure/bed/chair/wood/New(newloc)
 	..(newloc, chair_material)

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -4,6 +4,7 @@
 	icon_state = "wheelchair"
 	anchored = FALSE
 	movement_handlers = list(/datum/movement_handler/deny_multiz, /datum/movement_handler/delay = list(2), /datum/movement_handler/move_relay_self)
+	bed_flags = BED_FLAG_CANNOT_BE_DISMANTLED | BED_FLAG_CANNOT_BE_PADDED
 	var/driving = 0
 	var/mob/living/pulling = null
 	var/bloodiness
@@ -19,11 +20,6 @@
 	overlays += O
 	if(buckled_mob)
 		buckled_mob.set_dir(dir)
-
-/obj/structure/bed/chair/wheelchair/attackby(obj/item/W as obj, mob/user as mob)
-	if(isWrench(W) || istype(W,/obj/item/stack) || isWirecutter(W))
-		return
-	..()
 
 /obj/structure/bed/chair/wheelchair/relaymove(mob/user, direction)
 	// Redundant check?

--- a/code/game/objects/structures/tank_dispenser.dm
+++ b/code/game/objects/structures/tank_dispenser.dm
@@ -6,6 +6,7 @@
 	density = TRUE
 	anchored = TRUE
 	w_class = ITEM_SIZE_NO_CONTAINER
+	obj_flags = OBJ_FLAG_ANCHORABLE
 	var/oxygentanks = 10
 	var/phorontanks = 10
 	var/list/oxytanks = list()	//sorry for the similar var names
@@ -46,41 +47,47 @@
 	return
 
 
-/obj/structure/dispenser/attackby(obj/item/I as obj, mob/user as mob)
-	if(istype(I, /obj/item/tank/oxygen) || istype(I, /obj/item/tank/air) || istype(I, /obj/item/tank/anesthetic))
-		if(oxygentanks < 10)
-			if(!user.unEquip(I, src))
-				return
-			oxytanks.Add(I)
+/obj/structure/dispenser/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Tank - Insert tank
+	if (istype(tool, /obj/item/tank))
+		// Oxygen Tanks
+		if (is_type_in_list(tool, list(/obj/item/tank/oxygen, /obj/item/tank/air, /obj/item/tank/anesthetic)))
+			if (oxygentanks >= 10)
+				USE_FEEDBACK_FAILURE("\The [src]'s oxygen tank rack is full.")
+				return TRUE
+			if (!user.unEquip(tool, src))
+				FEEDBACK_UNEQUIP_FAILURE(user, tool)
+				return TRUE
+			oxytanks += tool
 			oxygentanks++
-			to_chat(user, SPAN_NOTICE("You put [I] in [src]."))
-			if(oxygentanks < 5)
-				update_icon()
-		else
-			to_chat(user, SPAN_NOTICE("[src] is full."))
-		updateUsrDialog()
-		return
-	if(istype(I, /obj/item/tank/phoron))
-		if(phorontanks < 10)
-			if(!user.unEquip(I, src))
-				return
-			platanks.Add(I)
+			update_icon()
+			user.visible_message(
+				SPAN_NOTICE("\The [user] adds \a [tool] to \the [src]'s oxygen rack."),
+				SPAN_NOTICE("You add \the [tool] to \the [src]'s oxygen rack.")
+			)
+			return TRUE
+		// Phoron Tanks
+		if (istype(tool, /obj/item/tank/phoron))
+			if (phorontanks >= 10)
+				USE_FEEDBACK_FAILURE("\The [src]'s phoron tank rack is full.")
+				return TRUE
+			if (!user.unEquip(tool, src))
+				FEEDBACK_UNEQUIP_FAILURE(user, tool)
+				return TRUE
+			platanks += tool
 			phorontanks++
-			to_chat(user, SPAN_NOTICE("You put [I] in [src]."))
-			if(oxygentanks < 6)
-				update_icon()
-		else
-			to_chat(user, SPAN_NOTICE("[src] is full."))
-		updateUsrDialog()
-		return
-	if(isWrench(I))
-		if(anchored)
-			to_chat(user, SPAN_NOTICE("You lean down and unwrench [src]."))
-			anchored = FALSE
-		else
-			to_chat(user, SPAN_NOTICE("You wrench [src] into place."))
-			anchored = TRUE
-		return
+			update_icon()
+			user.visible_message(
+				SPAN_NOTICE("\The [user] adds \a [tool] to \the [src]'s phoron rack."),
+				SPAN_NOTICE("You add \the [tool] to \the [src]'s phoron rack.")
+			)
+			return TRUE
+		// Other tanks
+		USE_FEEDBACK_FAILURE("\The [tool] doesn't fit in any of \the [src]'s racks.")
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/dispenser/Topic(href, href_list)
 	if(usr.stat || usr.restrained())

--- a/code/game/objects/structures/under_wardrobe.dm
+++ b/code/game/objects/structures/under_wardrobe.dm
@@ -8,31 +8,36 @@
 	density = TRUE
 	var/static/list/amount_of_underwear_by_id_card
 
-/obj/structure/undies_wardrobe/attackby(obj/item/underwear/underwear, mob/user)
-	if(istype(underwear))
-		if(!user.unEquip(underwear))
-			return
-		qdel(underwear)
-		user.visible_message(SPAN_NOTICE("\The [user] inserts \their [underwear.name] into \the [src]."), SPAN_NOTICE("You insert your [underwear.name] into \the [src]."))
 
-		var/id = user.GetIdCard()
+/obj/structure/undies_wardrobe/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Underwear - Return to wardrobe
+	if (istype(tool, /obj/item/underwear))
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] inserts \a [tool] into \the [src]."),
+			SPAN_NOTICE("You insert \the [tool] into \the [src].")
+		)
+		qdel(tool)
+		var/obj/item/card/id/id = user.GetIdCard()
 		var/message
-		if(id)
+		if (id)
 			message = "ID card detected. Your underwear quota for this shift has been increased, if applicable."
 		else
 			message = "No ID card detected. Thank you for your contribution."
-
 		audible_message(message, WARDROBE_BLIND_MESSAGE(user))
 
 		var/number_of_underwear = LAZYACCESS(amount_of_underwear_by_id_card, id) - 1
-		if(number_of_underwear)
+		if (number_of_underwear)
 			LAZYSET(amount_of_underwear_by_id_card, id, number_of_underwear)
 			GLOB.destroyed_event.register(id, src, /obj/structure/undies_wardrobe/proc/remove_id_card)
 		else
 			remove_id_card(id)
+		return TRUE
 
-	else
-		..()
+	return ..()
+
 
 /obj/structure/undies_wardrobe/proc/remove_id_card(id_card)
 	LAZYREMOVE(amount_of_underwear_by_id_card, id_card)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -25,10 +25,14 @@
 /obj/structure/hygiene/proc/unclog()
 	clogged = 0
 
-/obj/structure/hygiene/attackby(obj/item/thing, mob/user)
-	if(clogged > 0 && isplunger(thing))
-		user.visible_message(SPAN_NOTICE("\The [user] strives valiantly to unclog \the [src] with \the [thing]!"))
-		spawn
+
+/obj/structure/hygiene/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Plunger - Unclog
+	if (isplunger(tool))
+		if (!clogged)
+			USE_FEEDBACK_FAILURE("\The [src] isn't clogged.")
+			return TRUE
+		spawn // TODO: Replace this with a single combined sound effect.
 			playsound(loc, 'sound/effects/plunger.ogg', 75, 1)
 			sleep(5)
 			playsound(loc, 'sound/effects/plunger.ogg', 75, 1)
@@ -38,14 +42,24 @@
 			playsound(loc, 'sound/effects/plunger.ogg', 75, 1)
 			sleep(5)
 			playsound(loc, 'sound/effects/plunger.ogg', 75, 1)
-		if(do_after(user, 4.5 SECONDS, src, DO_PUBLIC_UNIQUE) && clogged > 0)
-			visible_message(SPAN_NOTICE("With a loud gurgle, \the [src] begins flowing more freely."))
-			playsound(loc, pick(SSfluids.gurgles), 100, 1)
-			clogged--
-			if(clogged <= 0)
-				unclog()
-		return
-	. = ..()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] strives valiantly to unclog \the [src] with \a [tool]!"),
+			SPAN_NOTICE("You attempt to unclog \the [src] with \the [tool].")
+		)
+		if (!do_after(user, 4.5 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (!clogged)
+			USE_FEEDBACK_FAILURE("\The [src] isn't clogged.")
+			return TRUE
+		visible_message(SPAN_NOTICE("With a loud gurgle, \the [src] begins flowing more freely."))
+		playsound(src, pick(SSfluids.gurgles), 100, TRUE)
+		clogged--
+		if (clogged <= 0)
+			unclog()
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/hygiene/examine(mob/user)
 	. = ..()
@@ -132,53 +146,101 @@
 /obj/structure/hygiene/toilet/on_update_icon()
 	icon_state = "toilet[open][cistern]"
 
-/obj/structure/hygiene/toilet/attackby(obj/item/I as obj, mob/living/user)
-	if(isCrowbar(I))
-		to_chat(user, SPAN_NOTICE("You start to [cistern ? "replace the lid on the cistern" : "lift the lid off the cistern"]."))
-		playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 50, 1)
-		if(do_after(user, 3 SECONDS, src, DO_REPAIR_CONSTRUCT))
-			user.visible_message(
-				SPAN_NOTICE("[user] [cistern ? "replaces the lid on the cistern" : "lifts the lid off the cistern"]!"),
-				SPAN_NOTICE("You [cistern ? "replace the lid on the cistern" : "lift the lid off the cistern"]!"),
-				"You hear grinding porcelain."
-			)
-			cistern = !cistern
-			update_icon()
-			return
 
-	if(istype(I, /obj/item/grab))
-		var/obj/item/grab/G = I
+/obj/structure/hygiene/toilet/use_grab(obj/item/grab/grab, list/click_params)
+	// Harm intent - Slam into toilet
+	if (grab.assailant.a_intent == I_HURT)
+		if (!Adjacent(grab.affecting))
+			USE_FEEDBACK_GRAB_FAILURE("\The [grab.affecting] must be next \the [src] to bash them with it.")
+			return TRUE
+		grab.assailant.setClickCooldown(grab.assailant.get_attack_speed(grab))
+		grab.affecting.adjustBruteLoss(8)
+		playsound(src, 'sound/weapons/tablehit1.ogg', 50, TRUE)
+		grab.assailant.visible_message(
+			SPAN_WARNING("\The [grab.assailant] slams \the [grab.affecting] into \the [src]!"),
+			SPAN_DANGER("You slam \the [grab.affecting] into \the [src]!"),
+			exclude_mobs = list(grab.affecting)
+		)
+		grab.affecting.show_message(
+			SPAN_DANGER("\The [grab.assailant] slams you into \the [src]!"),
+			VISIBLE_MESSAGE,
+			SPAN_DANGER("You feel yourself being slammed against something hard!")
+		)
+		return TRUE
 
-		if(isliving(G.affecting))
-			var/mob/living/GM = G.affecting
-			if(!GM.loc == get_turf(src))
-				to_chat(user, SPAN_WARNING("\The [GM] needs to be on the toilet."))
-				return
-			if(open && !swirlie)
-				user.visible_message(SPAN_DANGER("\The [user] starts jamming \the [GM]'s face into \the [src]!"))
-				swirlie = GM
-				if(do_after(user, 3 SECONDS, src, DO_PUBLIC_UNIQUE))
-					user.visible_message(SPAN_DANGER("\The [user] gives [GM.name] a swirlie!"))
-					GM.adjustOxyLoss(5)
-				swirlie = null
-			else
-				user.visible_message(SPAN_DANGER("\The [user] slams [GM.name] into the [src]!"), SPAN_NOTICE("You slam [GM.name] into the [src]!"))
-				GM.adjustBruteLoss(8)
+	// Other intent - Give swirlie
+	if (!open)
+		USE_FEEDBACK_GRAB_FAILURE("\The [src] needs to be open before you can give \the [grab.affecting] a swirlie.")
+		return TRUE
+	if (!Adjacent(grab.affecting))
+		USE_FEEDBACK_GRAB_FAILURE("\The [grab.affecting] must be next \the [src] to give them a swirlie.")
+		return TRUE
+	grab.assailant.visible_message(
+		SPAN_WARNING("\The [grab.assailant] starts jamming \the [grab.affecting]'s face into \the [src]!"),
+		SPAN_DANGER("You start jamming \the [grab.affecting]'s face into \the [src]!"),
+		exclude_mobs = list(grab.affecting)
+	)
+	grab.affecting.show_message(
+		SPAN_DANGER("\The [grab.assailant] starts jamming your face into \the [src]!"),
+		VISIBLE_MESSAGE,
+		SPAN_DANGER("You feel your head being dunked in cold water!")
+	)
+	if (!do_after(grab.assailant, 3 SECONDS, src, DO_PUBLIC_UNIQUE) || !grab?.assailant.use_sanity_check(src, grab.affecting))
+		return TRUE
+	grab.assailant.visible_message(
+		SPAN_WARNING("\The [grab.assailant] gives \the [grab.affecting] a swirlie in \the [src]!"),
+		SPAN_DANGER("You give \the [grab.affecting] a swirlie in \the [src]!"),
+		exclude_mobs = list(grab.affecting)
+	)
+	grab.affecting.show_message(
+		SPAN_DANGER("\The [grab.assailant] gives you a swirlie in \the [src]!"),
+		VISIBLE_MESSAGE,
+		SPAN_DANGER("You hear the sound of flushing and feel water and air being sucked out around you!")
+	)
+	grab.affecting.adjustOxyLoss(5)
+	return TRUE
 
-	if(cistern && !istype(user,/mob/living/silicon/robot)) //STOP PUTTING YOUR MODULES IN THE TOILET.
-		if(I.w_class > ITEM_SIZE_NORMAL)
-			to_chat(user, SPAN_WARNING("\The [I] does not fit."))
-			return
-		if(w_items + I.w_class > 5)
-			to_chat(user, SPAN_WARNING("The cistern is full."))
-			return
-		if(!user.unEquip(I, src))
-			return
-		w_items += I.w_class
-		to_chat(user, SPAN_NOTICE("You carefully place \the [I] into the cistern."))
-		return
 
-	. = ..()
+/obj/structure/hygiene/toilet/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Crowbar - Toggle lid
+	if (isCrowbar(tool))
+		playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts to [cistern ? "lift" : "replace"] \the [src]'s cistern with \a [tool]."),
+			SPAN_NOTICE("You start to [cistern ? "lift" : "replace"] \the [src]'s cistern with \the [tool].")
+		)
+		if (!do_after(user, 3 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		playsound(loc, 'sound/effects/stonedoor_openclose.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [cistern ? "lifts" : "replaces"] \the [src]'s cistern with \a [tool]."),
+			SPAN_NOTICE("You [cistern ? "lift" : "replace"] \the [src]'s cistern with \the [tool].")
+		)
+		cistern = !cistern
+		update_icon()
+		return TRUE
+
+	// Anything else - Put item in cistern
+	if (cistern)
+		if (tool.w_class > ITEM_SIZE_NORMAL)
+			USE_FEEDBACK_FAILURE("\The [tool] is too large for \the [src]'s cistern.")
+			return TRUE
+		if (w_items + tool.w_class > 5)
+			USE_FEEDBACK_FAILURE("\The [src]'s cistern is too full to hold \the [tool].")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		w_items += tool.w_class
+		user.visible_message(
+			SPAN_NOTICE("\The [user] slips \a [tool] into \the [src]'s cistern."),
+			SPAN_NOTICE("You carefully place \the [tool] into \the [src]'s cistern."),
+			range = 2
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/hygiene/urinal
 	name = "urinal"
@@ -188,17 +250,26 @@
 	density = FALSE
 	anchored = TRUE
 
-/obj/structure/hygiene/urinal/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/grab))
-		var/obj/item/grab/G = I
-		if(isliving(G.affecting))
-			var/mob/living/GM = G.affecting
-			if(!GM.loc == get_turf(src))
-				to_chat(user, SPAN_WARNING("[GM.name] needs to be on the urinal."))
-				return
-			user.visible_message(SPAN_DANGER("[user] slams [GM.name] into the [src]!"))
-			GM.adjustBruteLoss(8)
-	. = ..()
+
+/obj/structure/hygiene/urinal/use_grab(obj/item/grab/grab, list/click_params)
+	// Harm intent - Slam into urinal
+	if (grab.assailant.a_intent == I_HURT)
+		if (!Adjacent(grab.affecting))
+			USE_FEEDBACK_GRAB_FAILURE("\The [grab.affecting] must be next \the [src] to bash them with it.")
+			return TRUE
+		grab.assailant.setClickCooldown(grab.assailant.get_attack_speed(grab))
+		grab.affecting.adjustBruteLoss(8)
+		playsound(src, 'sound/weapons/tablehit1.ogg', 50, TRUE)
+		grab.assailant.visible_message(
+			SPAN_WARNING("\The [grab.assailant] slams \the [grab.affecting] into \the [src]!"),
+			SPAN_DANGER("You slam \the [grab.affecting] into \the [src]!"),
+			exclude_mobs = list(grab.affecting)
+		)
+		to_chat(grab.affecting, SPAN_DANGER("\The [grab.assailant] slams you into \the [src]!"))
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/hygiene/shower
 	name = "shower"
@@ -242,21 +313,38 @@
 		for (var/atom/movable/G in src.loc)
 			G.clean_blood()
 
-/obj/structure/hygiene/shower/attackby(obj/item/I as obj, mob/user)
-	if(istype(I, /obj/item/device/scanner/gas))
-		to_chat(user, SPAN_NOTICE("The water temperature seems to be [watertemp]."))
-		return
 
-	if(isWrench(I))
-		var/newtemp = input(user, "What setting would you like to set the temperature valve to?", "Water Temperature Valve") in temperature_settings
-		to_chat(user,SPAN_NOTICE("You begin to adjust the temperature valve with \the [I]."))
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		if(do_after(user, 5 SECONDS, src, DO_REPAIR_CONSTRUCT))
-			watertemp = newtemp
-			user.visible_message(SPAN_NOTICE("\The [user] adjusts \the [src] with \the [I]."), SPAN_NOTICE("You adjust the shower with \the [I]."))
-			add_fingerprint(user)
-			return
-	. = ..()
+/obj/structure/hygiene/shower/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Gas Scanner - Fetch temperature
+	if (istype(tool, /obj/item/device/scanner/gas))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] scans \the [src] with \a [tool]."),
+			SPAN_NOTICE("You scan \the [src] with \the [tool]. The water temperature seems to be [watertemp].")
+		)
+		return TRUE
+
+	// Wrench - Set temperature
+	if (isWrench(tool))
+		var/input = input(user, "What setting would you like to set the temperature valve to?", "[name] Water Temperature Valve") as null|anything in temperature_settings
+		if (!input || !user.use_sanity_check(src, tool))
+			return TRUE
+		playsound(src, 'sound/items/Ratchet.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts adjusting \the [src]'s temperature with \a [tool]."),
+			SPAN_NOTICE("You start adjusting \the [src]'s temperature with \the [tool].")
+		)
+		if (!do_after(user, 5 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		watertemp = input
+		playsound(src, 'sound/items/Ratchet.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] adjusts \the [src]'s temperature with \a [tool]."),
+			SPAN_NOTICE("You set \the [src]'s temperature to [watertemp] with \the [tool].")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/hygiene/shower/on_update_icon()	//this is terribly unreadable, but basically it makes the shower mist up
 	overlays.Cut()					//once it's been on for a while, in addition to handling the water overlay.
@@ -398,66 +486,56 @@
 		SPAN_NOTICE("You wash your hands using \the [src]."))
 
 
-/obj/structure/hygiene/sink/attackby(obj/item/O as obj, mob/living/user)
+/obj/structure/hygiene/sink/use_tool(obj/item/tool, mob/user, list/click_params)
+	SHOULD_CALL_PARENT(FALSE)
 
-	if(isplunger(O) && clogged > 0)
+	// Plunger - Passthrough to parent if clogged
+	if (isplunger(tool) && clogged)
 		return ..()
 
-	if(busy)
-		to_chat(user, SPAN_WARNING("Someone's already washing here."))
-		return
-
-	var/obj/item/reagent_containers/RG = O
-	if (istype(RG) && RG.is_open_container() && RG.reagents)
-		RG.reagents.add_reagent(/datum/reagent/water, min(RG.volume - RG.reagents.total_volume, RG.amount_per_transfer_from_this))
-		user.visible_message(SPAN_NOTICE("[user] fills \the [RG] using \the [src]."),SPAN_NOTICE("You fill \the [RG] using \the [src]."))
-		playsound(loc, 'sound/effects/sink.ogg', 75, 1)
-		return 1
-
-	else if (istype(O, /obj/item/melee/baton))
-		var/obj/item/melee/baton/B = O
-		if(B.bcell)
-			if(B.bcell.charge > 0 && B.status == 1)
-				flick("baton_active", src)
-				user.Stun(10)
-				user.stuttering = 10
-				user.Weaken(10)
-				if(isrobot(user))
-					var/mob/living/silicon/robot/R = user
-					R.cell.charge -= 20
-				else
-					B.deductcharge(B.hitcost)
-				user.visible_message( \
-					SPAN_DANGER("[user] was stunned by \his wet [O]!"), \
-					SPAN_CLASS("userdanger", "[user] was stunned by \his wet [O]!"))
-				return 1
-	else if(istype(O, /obj/item/mop))
-		O.reagents.add_reagent(/datum/reagent/water, 5)
-		to_chat(user, SPAN_NOTICE("You wet \the [O] in \the [src]."))
-		playsound(loc, 'sound/effects/slosh.ogg', 25, 1)
-		return
-
-	var/turf/location = user.loc
-	if(!isturf(location)) return
-
-	var/obj/item/I = O
-	if(!I || !istype(I,/obj/item)) return
-
-	to_chat(usr, SPAN_NOTICE("You start washing \the [I]."))
-	playsound(loc, 'sound/effects/sink_long.ogg', 75, 1)
-
-	busy = 1
-	if(!do_after(user, 4 SECONDS, src, DO_PUBLIC_UNIQUE))
-		busy = 0
+	// Reagent Container - Fill container
+	if (istype(tool, /obj/item/reagent_containers))
+		if (!tool.reagents)
+			return ..()
+		var/obj/item/reagent_containers/container = tool
+		if (!container.is_open_container())
+			USE_FEEDBACK_FAILURE("\The [tool] needs to be open before you can fill it with \the [src].")
+			return TRUE
+		playsound(src, 'sound/effects/sink.ogg', 50, TRUE)
+		container.reagents.add_reagent(/datum/reagent/water, container.amount_per_transfer_from_this)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] fills \a [tool] with some water from \the [src]."),
+			SPAN_NOTICE("You fill \the [tool] with some water from \the [src]."),
+			SPAN_ITALIC("You hear running water.")
+		)
 		return TRUE
-	busy = 0
 
-	if(istype(O, /obj/item/extinguisher)) return TRUE // We're washing, not filling.
+	// Mop - Wet mop
+	if (istype(tool, /obj/item/mop))
+		tool.reagents.add_reagent(/datum/reagent/water, 5)
+		playsound(src, 'sound/effects/slosh.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] wets \a [tool] with \the [src]."),
+			SPAN_NOTICE("You wet \the [tool] with \the [src]."),
+			SPAN_ITALIC("You hear running water.")
+		)
+		return TRUE
 
-	O.clean_blood()
-	user.visible_message( \
-		SPAN_NOTICE("[user] washes \a [I] using \the [src]."), \
-		SPAN_NOTICE("You wash \a [I] using \the [src]."))
+	// Everything else - Wash
+	playsound(src, 'sound/effects/sink_long.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts washing \a [tool] in \the [src]."),
+		SPAN_NOTICE("You start washing \the [tool] in \the [src]."),
+		SPAN_ITALIC("You hear running water.")
+	)
+	if (!do_after(user, 4 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+		return TRUE
+	tool.clean_blood()
+	user.visible_message(
+		SPAN_NOTICE("\The [user] washes \a [tool] in \the [src]."),
+		SPAN_NOTICE("You wash \the [tool] in \the [src].")
+	)
+	return TRUE
 
 
 /obj/structure/hygiene/sink/kitchen
@@ -474,30 +552,50 @@
 	..()
 	icon_state = "puddle"
 
-/obj/structure/hygiene/sink/puddle/attackby(obj/item/O as obj, mob/user)
-	icon_state = "puddle-splash"
+
+/obj/structure/hygiene/sink/puddle/post_use_item(obj/item/tool, mob/user, interaction_handled, use_call, click_params)
 	..()
-	icon_state = "puddle"
+	if (interaction_handled)
+		flick("puddle-splash", src)
 
-//toilet paper interaction for clogging toilets and other facilities
 
-/obj/structure/hygiene/attackby(obj/item/I, mob/user)
-	if (!istype(I, /obj/item/taperoll/bog))
-		..()
-		return
-	if (clogged == -1)
-		to_chat(user, SPAN_WARNING("Try as you might, you can not clog \the [src] with \the [I]."))
-		return
-	if (clogged)
-		to_chat(user, SPAN_WARNING("\The [src] is already clogged."))
-		return
-	if (!do_after(user, 3 SECONDS, src, DO_PUBLIC_UNIQUE))
-		return
-	if (clogged || QDELETED(I) || !user.unEquip(I))
-		return
-	to_chat(user, SPAN_NOTICE("You unceremoniously jam \the [src] with \the [I]. What a rebel."))
-	clog(1)
-	qdel(I)
+/obj/structure/hygiene/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Toilet Paper - Clog drain
+	if (istype(tool, /obj/item/taperoll/bog))
+		if (clogged == -1)
+			USE_FEEDBACK_FAILURE("Try as you might, you can not clog \the [src] with \the [tool].")
+			return TRUE
+		if (clogged)
+			USE_FEEDBACK_FAILURE("\The [src] is already clogged.")
+			return TRUE
+		if (!user.canUnEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		user.visible_message(
+			SPAN_WARNING("\The [user] starts stuffing \the [src] with \a [tool]!"),
+			SPAN_WARNING("You start stuffing \the [src] with \the [tool]!")
+		)
+		if (!do_after(user, 3 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (clogged == -1)
+			USE_FEEDBACK_FAILURE("Try as you might, you can not clog \the [src] with \the [tool].")
+			return TRUE
+		if (clogged)
+			USE_FEEDBACK_FAILURE("\The [src] is already clogged.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		user.visible_message(
+			SPAN_WARNING("\The [user] unceremoniously jams \the [src] with \a [tool]. What a rebel."),
+			SPAN_WARNING("You unceremoniously jam \the [src] with \the [tool]. What a rebel.")
+		)
+		clog(1)
+		qdel(tool)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/taperoll/bog
 	name = "toilet paper roll"
@@ -564,17 +662,22 @@
 	var/fill_level = 500
 	var/open = FALSE
 
-/obj/structure/hygiene/faucet/attackby(obj/item/thing, mob/user)
-	if (isWrench(thing))
-		new /obj/item/faucet (loc)
-		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
+
+/obj/structure/hygiene/faucet/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Wrench - Disconnect faucet
+	if (isWrench(tool))
+		playsound(src, 'sound/items/Ratchet.ogg', 50, TRUE)
+		var/obj/item/faucet/faucet = new(loc)
+		transfer_fingerprints_to(faucet)
 		user.visible_message(
-			SPAN_WARNING("\The [user] unwrenches \the [src]."),
-			SPAN_WARNING("You unwrench \the [src].")
+			SPAN_NOTICE("\The [user] detaches \the [src] from the floor with \a [tool]."),
+			SPAN_NOTICE("You detach \the [src] from the floor with \the [tool].")
 		)
-		qdel(src)
+		qdel_self()
 		return TRUE
+
 	return ..()
+
 
 /obj/structure/hygiene/faucet/attack_hand(mob/user)
 	. = ..()

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -17,18 +17,23 @@
 	density = FALSE
 	dir = NORTH
 	w_class = ITEM_SIZE_NORMAL
+	obj_flags = OBJ_FLAG_ANCHORABLE
 
 	var/obj/item/airlock_electronics/electronics = null
 
 	//Vars to help with the icon's name
 	var/facing = "l"	//Does the windoor open to the left or right?
 	var/secure = ""		//Whether or not this creates a secure windoor
-	var/state = "01"	//How far the door assembly has progressed in terms of sprites
+
+	var/const/WINDOOR_STATE_FRAME = "01"
+	var/const/WINDOOR_STATE_WIRED = "02"
+	/// String (One of `WINDOOR_STATE_*`). How far the door assembly has progressed in terms of sprites
+	var/state = WINDOOR_STATE_FRAME
 
 /obj/structure/windoor_assembly/New(Loc, start_dir=NORTH, constructed=0)
 	..()
 	if(constructed)
-		state = "01"
+		state = WINDOOR_STATE_FRAME
 		anchored = FALSE
 	switch(start_dir)
 		if(NORTH, SOUTH, EAST, WEST)
@@ -64,174 +69,255 @@
 		return 1
 
 
-/obj/structure/windoor_assembly/attackby(obj/item/W as obj, mob/user as mob)
-	//I really should have spread this out across more states but thin little windoors are hard to sprite.
-	switch(state)
-		if("01")
-			if(isWelder(W) && !anchored )
-				var/obj/item/weldingtool/WT = W
-				if (WT.remove_fuel(0,user))
-					user.visible_message("[user] dissassembles the windoor assembly.", "You start to dissassemble the windoor assembly.")
-					playsound(src.loc, 'sound/items/Welder2.ogg', 50, 1)
+/obj/structure/windoor_assembly/can_anchor(obj/item/tool, mob/user, silent)
+	. = ..()
+	if (!.)
+		return
+	if (state != WINDOOR_STATE_FRAME)
+		if (!silent)
+			USE_FEEDBACK_FAILURE("\The [src]'s wiring must be removed before you can unanchor it.")
+		return FALSE
 
-					if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-						if(!src || !WT.isOn()) return
-						to_chat(user, SPAN_NOTICE("You dissasembled the windoor assembly!"))
-						new /obj/item/stack/material/glass/reinforced(get_turf(src), 5)
-						if(secure)
-							new /obj/item/stack/material/rods(get_turf(src), 4)
-						qdel(src)
-				else
-					to_chat(user, SPAN_NOTICE("You need more welding fuel to dissassemble the windoor assembly."))
-					return
 
-			//Wrenching an unsecure assembly anchors it in place. Step 4 complete
-			if(isWrench(W) && !anchored)
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-				user.visible_message("[user] secures the windoor assembly to the floor.", "You start to secure the windoor assembly to the floor.")
+/obj/structure/windoor_assembly/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Airlock electronics - Install electronics
+	if (istype(tool, /obj/item/airlock_electronics))
+		if (state != WINDOOR_STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be wired before you can install \the [tool].")
+			return TRUE
+		if (electronics)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [electronics] installed.")
+			return TRUE
+		if (!user.canUnEquip(tool))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts installing \a [tool] into \the [src]."),
+			SPAN_NOTICE("You start installing \the [tool] into \the [src].")
+		)
+		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (state != WINDOOR_STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be wired before you can install \the [tool].")
+			return TRUE
+		if (electronics)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [electronics] installed.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		electronics = tool
+		update_icon()
+		playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs \a [tool] into \the [src]."),
+			SPAN_NOTICE("You install \the [tool] into \the [src].")
+		)
+		return TRUE
 
-				if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-					if(!src) return
-					to_chat(user, SPAN_NOTICE("You've secured the windoor assembly!"))
-					src.anchored = TRUE
-					if(src.secure)
-						src.SetName("Secure Anchored Windoor Assembly")
-					else
-						src.SetName("Anchored Windoor Assembly")
+	// Cable Coil - Wire assembly
+	if (istype(tool, /obj/item/stack/cable_coil))
+		if (state != WINDOOR_STATE_FRAME)
+			USE_FEEDBACK_FAILURE("\The [src] is already wired.")
+			return TRUE
+		if (!anchored)
+			USE_FEEDBACK_FAILURE("\The [src] must be anchored before you can wire it.")
+			return TRUE
+		var/obj/item/stack/cable_coil/cable = tool
+		if (!cable.can_use(1))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(cable, 1, "to wire \the [src].")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts wiring \the [src] with \a [tool]."),
+			SPAN_NOTICE("You start wiring \the [src] with \the [tool].")
+		)
+		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (state != WINDOOR_STATE_FRAME)
+			USE_FEEDBACK_FAILURE("\The [src] is already wired.")
+			return TRUE
+		if (!anchored)
+			USE_FEEDBACK_FAILURE("\The [src] must be anchored before you can wire it.")
+			return TRUE
+		if (!cable.use(1))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(cable, 1, "to wire \the [src].")
+			return TRUE
+		state = WINDOOR_STATE_WIRED
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] wires \the [src] with \a [tool]."),
+			SPAN_NOTICE("You wires \the [src] with \the [tool].")
+		)
+		return TRUE
 
-			//Unwrenching an unsecure assembly un-anchors it. Step 4 undone
-			else if(isWrench(W) && anchored)
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-				user.visible_message("[user] unsecures the windoor assembly to the floor.", "You start to unsecure the windoor assembly to the floor.")
+	// Rods - Make assembly secure
+	if (istype(tool, /obj/item/stack/material/rods))
+		if (state != WINDOOR_STATE_FRAME)
+			USE_FEEDBACK_FAILURE("\The [src]'s wiring must be removed before you can reinforce it.")
+			return TRUE
+		if (secure)
+			USE_FEEDBACK_FAILURE("\The [src] already has reinforcements installed.")
+			return TRUE
+		var/obj/item/stack/material/rods/rods = tool
+		if (!rods.can_use(4))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(rods, 4, "to reinforce \the [src].")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts reinforcing \the [src] with some [tool.name]."),
+			SPAN_NOTICE("You start reinforcing \the [src] with some [tool.name].")
+		)
+		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (state != WINDOOR_STATE_FRAME)
+			USE_FEEDBACK_FAILURE("\The [src]'s wiring must be removed before you can reinforce it.")
+			return TRUE
+		if (secure)
+			USE_FEEDBACK_FAILURE("\The [src] already has reinforcements installed.")
+			return TRUE
+		if (!rods.use(4))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(rods, 4, "to reinforce \the [src].")
+			return TRUE
+		secure = "secure_"
+		SetName("secure [initial(name)]")
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] reinforces \the [src] with some [tool.name]."),
+			SPAN_NOTICE("You reinforce \the [src] with some [tool.name].")
+		)
+		return TRUE
 
-				if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-					if(!src) return
-					to_chat(user, SPAN_NOTICE("You've unsecured the windoor assembly!"))
-					src.anchored = FALSE
-					if(src.secure)
-						src.SetName("Secure Windoor Assembly")
-					else
-						src.SetName("Windoor Assembly")
+	// Screwdriver - Remove electronics
+	if (isScrewdriver(tool))
+		if (!electronics)
+			USE_FEEDBACK_FAILURE("\The [src] has no circuit to remove.")
+			return TRUE
+		playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts removing \the [src]'s circuits with \a [tool]."),
+			SPAN_NOTICE("You start removing \the [src]'s circuits with \the [tool].")
+		)
+		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (!electronics)
+			USE_FEEDBACK_FAILURE("\The [src] has no circuit to remove.")
+			return TRUE
+		electronics.dropInto(loc)
+		electronics.add_fingerprint(user, tool = tool)
+		electronics = null
+		update_icon()
+		playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts removing \the [src]'s circuits with \a [tool]."),
+			SPAN_NOTICE("You start removing \the [src]'s circuits with \the [tool].")
+		)
+		return TRUE
 
-			//Adding plasteel makes the assembly a secure windoor assembly. Step 2 (optional) complete.
-			else if(istype(W, /obj/item/stack/material/rods) && !secure)
-				var/obj/item/stack/material/rods/R = W
-				if(R.get_amount() < 4)
-					to_chat(user, SPAN_WARNING("You need more rods to do this."))
-					return
-				to_chat(user, SPAN_NOTICE("You start to reinforce the windoor with rods."))
+	// Wirecutter - Remove wiring
+	if (isWirecutter(tool))
+		if (state != WINDOOR_STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src] has no wiring to remove.")
+			return TRUE
+		if (electronics)
+			USE_FEEDBACK_FAILURE("\The [src]'s electronics need to be removed before you can cut the wiring.")
+			return TRUE
+		playsound(src, 'sound/items/Wirecutter.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts cutting \the [src]'s wiring with \a [tool]."),
+			SPAN_NOTICE("You start cutting \the [src]'s wiring with \the [tool].")
+		)
+		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (state != WINDOOR_STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src] has no wiring to remove.")
+			return TRUE
+		if (electronics)
+			USE_FEEDBACK_FAILURE("\The [src]'s electronics need to be removed before you can cut the wiring.")
+			return TRUE
+		var/obj/item/stack/cable_coil/cable = new (loc, 1)
+		cable.add_fingerprint(user, tool = tool)
+		state = WINDOOR_STATE_FRAME
+		update_icon()
+		playsound(src, 'sound/items/Wirecutter.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] cuts \the [src]'s wiring with \a [tool]."),
+			SPAN_NOTICE("You cut \the [src]'s wiring with \the [tool].")
+		)
+		return TRUE
 
-				if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) && !secure)
-					if (R.use(4))
-						to_chat(user, SPAN_NOTICE("You reinforce the windoor."))
-						src.secure = "secure_"
-						if(src.anchored)
-							src.SetName("Secure Anchored Windoor Assembly")
-						else
-							src.SetName("Secure Windoor Assembly")
+	// Welder - Dismantle
+	if (isWelder(tool))
+		if (state != WINDOOR_STATE_FRAME)
+			USE_FEEDBACK_FAILURE("\The [src]'s wiring must be removed before you can dismantle it.")
+			return TRUE
+		if (anchored)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be unanchored before you can dismantle it.")
+			return TRUE
+		var/obj/item/weldingtool/welder = tool
+		if (!welder.can_use(1, user, "to dismantle \the [src]."))
+			return TRUE
+		playsound(src, 'sound/items/Welder2.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts dismantling \the [src] with \a [tool]."),
+			SPAN_NOTICE("You start dismantling \the [src] with \the [tool].")
+		)
+		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (state != WINDOOR_STATE_FRAME)
+			USE_FEEDBACK_FAILURE("\The [src]'s wiring must be removed before you can dismantle it.")
+			return TRUE
+		if (anchored)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be unanchored before you can dismantle it.")
+			return TRUE
+		if (!welder.remove_fuel(1, user))
+			return TRUE
+		var/obj/item/stack/material/glass/reinforced/glass = new(loc, 5)
+		transfer_fingerprints_to(glass)
+		if (secure)
+			var/obj/item/stack/material/rods/rods = new(loc, 4)
+			transfer_fingerprints_to(rods)
+		playsound(src, 'sound/items/Welder2.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] dismantles \the [src] with \a [tool]."),
+			SPAN_NOTICE("You dismantle \the [src] with \the [tool].")
+		)
+		qdel_self()
+		return TRUE
 
-			//Adding cable to the assembly. Step 5 complete.
-			else if(istype(W, /obj/item/stack/cable_coil) && anchored)
-				user.visible_message("[user] wires the windoor assembly.", "You start to wire the windoor assembly.")
+	// Crowbar - Complete assembly
+	if (isCrowbar(tool))
+		if (!electronics)
+			USE_FEEDBACK_FAILURE("\The [src] needs a circuit board before you can complete it.")
+			return TRUE
+		playsound(src, 'sound/items/Crowbar.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts prying \the [src] into its frame with \a [tool]."),
+			SPAN_NOTICE("You start prying \the [src] into its frame with \the [tool].")
+		)
+		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (!electronics)
+			USE_FEEDBACK_FAILURE("\The [src] needs a circuit board before you can complete it.")
+			return TRUE
+		var/obj/machinery/door/window/windoor
+		if (secure)
+			windoor = new /obj/machinery/door/window/brigdoor(loc, src)
+		else
+			windoor = new (loc, src)
+		if (facing == "l")
+			windoor.base_state = "left"
+		else
+			windoor.base_state = "right"
+		transfer_fingerprints_to(windoor)
+		playsound(src, 'sound/items/Crowbar.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] finishes \the [windoor] with \a [tool]."),
+			SPAN_NOTICE("You finish \the [windoor] with \the [tool].")
+		)
+		qdel_self()
+		return TRUE
 
-				var/obj/item/stack/cable_coil/CC = W
-				if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-					if (CC.use(1))
-						to_chat(user, SPAN_NOTICE("You wire the windoor!"))
-						src.state = "02"
-						if(src.secure)
-							src.SetName("Secure Wired Windoor Assembly")
-						else
-							src.SetName("Wired Windoor Assembly")
-			else
-				..()
-
-		if("02")
-
-			//Removing wire from the assembly. Step 5 undone.
-			if(isWirecutter(W) && !src.electronics)
-				playsound(src.loc, 'sound/items/Wirecutter.ogg', 100, 1)
-				user.visible_message("[user] cuts the wires from the airlock assembly.", "You start to cut the wires from airlock assembly.")
-
-				if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-					if(!src) return
-
-					to_chat(user, SPAN_NOTICE("You cut the windoor wires.!"))
-					new/obj/item/stack/cable_coil(get_turf(user), 1)
-					src.state = "01"
-					if(src.secure)
-						src.SetName("Secure Anchored Windoor Assembly")
-					else
-						src.SetName("Anchored Windoor Assembly")
-
-			//Adding airlock electronics for access. Step 6 complete.
-			else if(istype(W, /obj/item/airlock_electronics) && W:icon_state != "door_electronics_smoked")
-				playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
-				user.visible_message("[user] installs the electronics into the airlock assembly.", "You start to install electronics into the airlock assembly.")
-
-				if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-					if(!src) return
-					if(!user.unEquip(W, src))
-						return
-					to_chat(user, SPAN_NOTICE("You've installed the airlock electronics!"))
-					src.SetName("Near finished Windoor Assembly")
-					src.electronics = W
-				else
-					W.dropInto(loc)
-
-			//Screwdriver to remove airlock electronics. Step 6 undone.
-			else if(isScrewdriver(W) && src.electronics)
-				playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
-				user.visible_message("[user] removes the electronics from the airlock assembly.", "You start to uninstall electronics from the airlock assembly.")
-
-				if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-					if(!src || !src.electronics) return
-					to_chat(user, SPAN_NOTICE("You've removed the airlock electronics!"))
-					if(src.secure)
-						src.SetName("Secure Wired Windoor Assembly")
-					else
-						src.SetName("Wired Windoor Assembly")
-					var/obj/item/airlock_electronics/ae = electronics
-					electronics = null
-					ae.dropInto(loc)
-
-			//Crowbar to complete the assembly, Step 7 complete.
-			else if(isCrowbar(W))
-				if(!src.electronics)
-					to_chat(usr, SPAN_WARNING("The assembly is missing electronics."))
-					return
-				close_browser(usr, "window=windoor_access")
-				playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-				user.visible_message("[user] pries the windoor into the frame.", "You start prying the windoor into the frame.")
-
-				if(do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-					set_density(1) //Shouldn't matter but just incase
-					to_chat(user, SPAN_NOTICE("You finish the windoor!"))
-
-					var/obj/machinery/door/window/windoor
-					if(secure)
-						windoor = new /obj/machinery/door/window/brigdoor(loc, src)
-						if(facing == "l")
-							windoor.icon_state = "leftsecureopen"
-							windoor.base_state = "leftsecure"
-						else
-							windoor.icon_state = "rightsecureopen"
-							windoor.base_state = "rightsecure"
-					else
-						windoor = new (loc, src)
-						if(src.facing == "l")
-							windoor.icon_state = "leftopen"
-							windoor.base_state = "left"
-						else
-							windoor.icon_state = "rightopen"
-							windoor.base_state = "right"
-					qdel(src)
-
-			else
-				..()
-
-	//Update to reflect changes(if applicable)
-	update_icon()
+	return ..()
 
 
 //Rotates the windoor assembly clockwise
@@ -243,12 +329,12 @@
 	if (src.anchored)
 		to_chat(usr, "It is fastened to the floor; therefore, you can't rotate it!")
 		return 0
-	if(src.state != "01")
+	if(src.state != WINDOOR_STATE_FRAME)
 		update_nearby_tiles(need_rebuild=1) //Compel updates before
 
 	src.set_dir(turn(src.dir, 270))
 
-	if(src.state != "01")
+	if(src.state != WINDOOR_STATE_FRAME)
 		update_nearby_tiles(need_rebuild=1)
 
 	update_icon()

--- a/code/modules/butchery/butchery.dm
+++ b/code/modules/butchery/butchery.dm
@@ -195,13 +195,15 @@
 		return TRUE
 	return FALSE
 
-/obj/structure/kitchenspike/attackby(obj/item/thing, mob/user)
-	if(!thing.sharp)
-		return ..()
-	if(!occupant)
-		to_chat(user, SPAN_WARNING("There is nothing on \the [src] to butcher."))
-		return
-	if(!busy)
+
+/obj/structure/kitchenspike/use_tool(obj/item/tool, mob/user, list/click_params)
+	if (is_sharp(tool))
+		if (!occupant)
+			USE_FEEDBACK_FAILURE("\The [src] doesn't have anything to butcher.")
+			return TRUE
+		if (busy)
+			USE_FEEDBACK_FAILURE("\The [src] is currently being used by someone else.")
+			return TRUE
 		busy = TRUE
 		switch(occupant_state)
 			if(CARCASS_FRESH)
@@ -211,6 +213,10 @@
 			if(CARCASS_JOINTED)
 				do_butchery_step(user, CARCASS_EMPTY,   "butchering")
 		busy = FALSE
+		return TRUE
+
+	return ..()
+
 
 #undef CARCASS_EMPTY
 #undef CARCASS_FRESH

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -142,6 +142,9 @@
 	icon_state = "boxing"
 	item_state = "boxing"
 
+/obj/structure/window/holowindow
+	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_NO_TOOLS
+
 /obj/structure/window/holowindow/full
 	dir = 5
 	icon_state = "window_full"
@@ -151,20 +154,6 @@
 
 /obj/structure/window/reinforced/holowindow/Destroy()
 	..()
-
-/obj/structure/window/reinforced/holowindow/attackby(obj/item/W as obj, mob/user as mob)
-
-	if(!istype(W) || W.item_flags & ITEM_FLAG_NO_BLUDGEON) return
-
-	if(isScrewdriver(W) || isCrowbar(W) || isWrench(W))
-		to_chat(user, (SPAN_NOTICE("It's a holowindow, you can't dismantle it!")))
-	else
-		if (W.damtype == DAMAGE_BRUTE || W.damtype == DAMAGE_BURN)
-			hit(W.force, user, W)
-		else
-			playsound(loc, 'sound/effects/Glasshit.ogg', 75, 1)
-		..()
-	return
 
 /obj/structure/window/reinforced/holowindow/shatter(display_message = 1)
 	playsound(src, "shatter", 70, 1)
@@ -209,13 +198,11 @@
 		visible_message("[src] fades away as it shatters!")
 	qdel(src)
 
+/obj/structure/bed/chair/holochair
+	bed_flags = BED_FLAG_CANNOT_BE_DISMANTLED | BED_FLAG_CANNOT_BE_ELECTRIFIED | BED_FLAG_CANNOT_BE_PADDED
+
 /obj/structure/bed/chair/holochair/Destroy()
 	..()
-
-/obj/structure/bed/chair/holochair/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/wrench))
-		to_chat(user, (SPAN_NOTICE("It's a holochair, you can't dismantle it!")))
-	return
 
 /obj/item/holo
 	damtype = DAMAGE_PAIN

--- a/code/modules/mechs/mech_wreckage.dm
+++ b/code/modules/mechs/mech_wreckage.dm
@@ -6,6 +6,8 @@
 	anchored = TRUE
 	icon_state = "wreck"
 	icon = 'icons/mecha/mech_part_items.dmi'
+	health_max = 100
+	health_min_damage = 20
 	var/prepared
 
 /obj/structure/mech_wreckage/New(newloc, mob/living/exosuit/exosuit, gibbed)
@@ -41,6 +43,14 @@
 			to_chat(user, "You retrieve \the [thing] from \the [src].")
 			return
 	return ..()
+
+
+/obj/structure/mech_wreckage/on_death()
+	. = ..()
+	visible_message(SPAN_WARNING("\The [src] breaks apart!"))
+	new /obj/item/stack/material/steel(loc, rand(1, 3))
+	qdel_self()
+
 
 /obj/structure/mech_wreckage/attackby(obj/item/W, mob/user)
 

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -178,25 +178,35 @@
 		if(guesschar != code[i])
 			. = 0
 
-/obj/structure/closet/crate/secure/loot/attackby(obj/item/W as obj, mob/user as mob)
-	if(locked)
-		if (istype(W, /obj/item/device/multitool)) // Greetings Urist McProfessor, how about a nice game of cows and bulls?
-			to_chat(user, SPAN_NOTICE("DECA-CODE LOCK ANALYSIS:"))
-			if (attempts == 1)
-				to_chat(user, SPAN_WARNING("* Anti-Tamper system will activate on the next failed access attempt."))
-			else
-				to_chat(user, SPAN_NOTICE("* Anti-Tamper system will activate after [src.attempts] failed access attempts."))
-			if(length(lastattempt))
-				var/bulls = 0
-				var/cows = 0
 
-				var/list/code_contents = code.Copy()
-				for(var/i in 1 to codelen)
-					if(lastattempt[i] == code[i])
-						++bulls
-					else if(lastattempt[i] in code_contents)
-						++cows
-					code_contents -= lastattempt[i]
-				to_chat(user, SPAN_NOTICE("Last code attempt had [bulls] correct digits at correct positions and [cows] correct digits at incorrect positions."))
-			return
-	..()
+/obj/structure/closet/crate/secure/loot/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Multitool - Check last code attempt
+	if (isMultitool(tool))
+		if (!locked)
+			USE_FEEDBACK_FAILURE("\The [src] is not locked.")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] scans \the [src] with \a [tool]."),
+			SPAN_NOTICE("You scan \the [src] with \the [tool].")
+		)
+		var/data = "<h2>DECA-CODE LOCK ANALYSIS:</h2>"
+		if (attempts == 1)
+			data += "<p style='color: red; font-weight: bold;'>* Anti-Tamper system will activate on the next failed access attempt.</p>"
+		else
+			data += "<p>* Anti-Tamper system will activate after <b>[src.attempts]</b> failed access attempts.</p>"
+		if(length(lastattempt))
+			var/bulls = 0
+			var/cows = 0
+
+			var/list/code_contents = code.Copy()
+			for(var/i in 1 to codelen)
+				if(lastattempt[i] == code[i])
+					++bulls
+				else if(lastattempt[i] in code_contents)
+					++cows
+				code_contents -= lastattempt[i]
+			data += "<p>Last code attempt had [bulls] correct digits at correct positions and [cows] correct digits at incorrect positions.</p>"
+		show_browser(user, data, "window=[name]")
+		return
+
+	return ..()

--- a/code/modules/mining/satchel_ore_boxdm.dm
+++ b/code/modules/mining/satchel_ore_boxdm.dm
@@ -10,18 +10,36 @@
 	var/last_update = 0
 	var/list/stored_ore = list()
 
-/obj/structure/ore_box/attackby(obj/item/W as obj, mob/user as mob)
-	if (istype(W, /obj/item/ore))
-		user.unEquip(W, src)
-	else if (istype(W, /obj/item/storage))
-		var/obj/item/storage/S = W
-		S.hide_from(usr)
-		for(var/obj/item/ore/O in S.contents)
-			S.remove_from_storage(O, src, 1) //This will move the item to this item's contents
-		S.finish_bulk_removal()
-		to_chat(user, SPAN_NOTICE("You empty the satchel into the box."))
 
-	update_ore_count()
+/obj/structure/ore_box/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Ore - Insert ore
+	if (istype(tool, /obj/item/ore))
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		update_ore_count()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] puts \a [tool] in \the [src]."),
+			SPAN_NOTICE("You put \the [tool] in \the [src].")
+		)
+		return TRUE
+
+	// Storage - Bulk insert ore
+	if (istype(tool, /obj/item/storage))
+		var/obj/item/storage/storage = tool
+		storage.hide_from(user)
+		for (var/obj/item/ore/ore in storage.contents)
+			storage.remove_from_storage(ore, src, TRUE)
+		storage.finish_bulk_removal()
+		update_ore_count()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] empties \a [tool] into \the [src]."),
+			SPAN_NOTICE("You empty \the [tool] into \the [src].")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/ore_box/proc/update_ore_count()
 

--- a/code/modules/mob/living/carbon/alien/diona/gestalt/gestalt_attacks.dm
+++ b/code/modules/mob/living/carbon/alien/diona/gestalt/gestalt_attacks.dm
@@ -9,9 +9,12 @@
 	visible_message(SPAN_DANGER("\The [user] has [attack_message] \the [src]!"))
 	shed_atom(forcefully = TRUE)
 
-/obj/structure/diona_gestalt/attackby(obj/item/thing, mob/user)
-	. = ..()
-	if(thing.force) shed_atom(forcefully = TRUE)
+
+/obj/structure/diona_gestalt/post_use_item(obj/item/tool, mob/user, interaction_handled, use_call, click_params)
+	..()
+	if (interaction_handled && use_call == "weapon" && tool.force)
+		shed_atom(forcefully = TRUE)
+
 
 /obj/structure/diona_gestalt/hitby()
 	. = ..()

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -45,8 +45,11 @@
 		target_up = null
 	return ..()
 
-/obj/structure/ladder/attackby(obj/item/I, mob/user)
-	climb(user, I)
+
+/obj/structure/ladder/use_tool(obj/item/tool, mob/user, list/click_params)
+	SHOULD_CALL_PARENT(FALSE)
+	climb(user, tool)
+
 
 /turf/hitby(atom/movable/AM)
 	if(isobj(AM))

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -46,16 +46,23 @@
 			I.forceMove(src)
 	. = ..()
 
-/obj/structure/filingcabinet/attackby(obj/item/P as obj, mob/user as mob)
-	if(is_type_in_list(P, can_hold))
-		if(!user.unEquip(P, src))
+
+/obj/structure/filingcabinet/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Any item - Attempt to put in cabinet
+	if (is_type_in_list(tool, can_hold))
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(tool, user)
 			return
-		add_fingerprint(user)
-		to_chat(user, SPAN_NOTICE("You put [P] in [src]."))
-		flick("[initial(icon_state)]-open",src)
+		flick("[initial(icon_state)]-open", src)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] puts \a [tool] in \the [src]."),
+			SPAN_NOTICE("You put \the [tool] in \the [src].")
+		)
 		updateUsrDialog()
-	else
-		..()
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/filingcabinet/attack_hand(mob/user as mob)
 	if(length(contents) <= 0)

--- a/code/modules/power/cable_structure.dm
+++ b/code/modules/power/cable_structure.dm
@@ -136,103 +136,79 @@ By design, d1 is the smallest direction and d2 is the highest
 /obj/structure/cable/proc/get_powernet()			//TODO: remove this as it is obsolete
 	return powernet
 
-// Items usable on a cable :
-//   - Wirecutters : cut it duh !
-//   - Cable coil : merge cables
-//   - Multitool : get the power currently passing through the cable
-//
 
-/obj/structure/cable/attackby(obj/item/W, mob/user)
-	var/turf/T = get_turf(src)
-	//sanity checking
-	if(!isturf(T))
-		return
+/obj/structure/cable/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Cable Coil - Join cable
+	if (isCoil(tool))
+		var/obj/item/stack/cable_coil/cable = tool
+		if (!cable.can_use(1))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(cable, 1, "to add cable to \the [src].")
+			return TRUE
+		cable.JoinCable(src, user)
+		return TRUE
 
-	if(istype(T, /turf/simulated/floor) && !T.is_plating())
-		return
-
-	if(get_dist(T, user) > 1) // make sure it's close enough
-		to_chat(user, SPAN_WARNING("You can't lay cable at a place that far away."))
-		return
-
-	// handle catwalks and plated catwalks
-	var/obj/structure/catwalk/cwalk = locate(/obj/structure/catwalk, T)
-	if(cwalk)
-		if(cwalk.plated_tile && !cwalk.hatch_open)
-			to_chat(user, SPAN_WARNING("Open the catwalk hatch first."))
-			return
-		else if(!cwalk.plated_tile)
-			to_chat(user, SPAN_WARNING("The catwalk is blocking the cable."))
-			return
-
-	if(isWirecutter(W))
-		cut_wire(W, user)
-
-	else if(isCoil(W))
-		var/obj/item/stack/cable_coil/coil = W
-		if (coil.get_amount() < 1)
-			to_chat(user, "Not enough cable")
-			return
-		coil.JoinCable(src, user)
-
-	else if(isMultitool(W))
-
-		if(powernet && (powernet.avail > 0))		// is it powered?
-			to_chat(user, SPAN_WARNING("[get_wattage()] in power network."))
-
-		else
-			to_chat(user, SPAN_WARNING("The cable is not powered."))
-
+	// Multitool - Measure power
+	if (isMultitool(tool))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] scans \the [src] with \a [tool]."),
+			SPAN_NOTICE("You scan \the [src] with \the [tool].")
+		)
 		shock(user, 5, 0.2)
-
-
-	else if(W.edge)
-
-		var/delay_holder
-
-		if(W.force < 5)
-			visible_message(SPAN_WARNING("[user] starts sawing away roughly at the cable with \the [W]."))
-			delay_holder = 8 SECONDS
+		if (!powernet?.avail)
+			to_chat(user, SPAN_WARNING("\The [src] is not powered."))
 		else
-			visible_message(SPAN_WARNING("[user] begins to cut through the cable with \the [W]."))
-			delay_holder = 3 SECONDS
+			to_chat(user, SPAN_INFO("\The [src] has [get_wattage()] flowing through it."))
+		return TRUE
 
-		if(user.do_skilled(delay_holder, SKILL_ELECTRICAL, src, do_flags = DO_REPAIR_CONSTRUCT))
-			cut_wire(W, user)
-			if(W.obj_flags & OBJ_FLAG_CONDUCTIBLE)
-				shock(user, 66, 0.7)
-		else
-			visible_message(SPAN_WARNING("[user] stops cutting before any damage is done."))
+	// Wirecutter - Cut wire
+	if (isWirecutter(tool))
+		cut_wire(tool, user)
+		return TRUE
 
-	src.add_fingerprint(user)
+	// Sharp Objects - Cut cable
+	if (tool.edge)
+		var/delay_time = 3 SECONDS
+		var/delay_message = "cutting through"
+		if (tool.force < 5)
+			delay_time = 8 SECONDS
+			delay_message = "sawing away roughly at"
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts [delay_message] \the [src] with \a [tool]."),
+			SPAN_NOTICE("You start [delay_message] \the [src] with \the [tool].")
+		)
+		if (!user.do_skilled(delay_time, SKILL_ELECTRICAL, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] cuts through \the [src] with \a [tool]."),
+			SPAN_NOTICE("You cut through \the [src] with \a [tool].")
+		)
+		return TRUE
 
-/obj/structure/cable/proc/cut_wire(obj/item/W, mob/user)
-	var/turf/T = get_turf(src)
+	return ..()
 
-	if(d1 == UP || d2 == UP)
-		to_chat(user, SPAN_WARNING("You must cut this cable from above."))
+
+/obj/structure/cable/proc/cut_wire(obj/item/tool, mob/user)
+	if (d1 == UP || d2 == UP)
+		USE_FEEDBACK_FAILURE("You must cut \the [src] from above.")
 		return
-
-	if(breaker_box)
-		to_chat(user, SPAN_WARNING("This cable is connected to a nearby breaker box. Use the breaker box to interact with it."))
+	if (breaker_box)
+		USE_FEEDBACK_FAILURE("\The [src] is connected to \the [breaker_box]. You must use that to interact with this cable.")
 		return
-
-	if (shock(user, 50))
+	if (HAS_FLAGS(tool.obj_flags, OBJ_FLAG_CONDUCTIBLE) && shock(user, 50))
 		return
-
-	new/obj/item/stack/cable_coil(T, (src.d1 ? 2 : 1), color)
-
-	visible_message(SPAN_WARNING("[user] cuts the cable."))
-
-	if(HasBelow(z))
-		for(var/turf/turf in GetBelow(src))
-			for(var/obj/structure/cable/c in turf)
-				if(c.d1 == UP || c.d2 == UP)
+	var/obj/item/stack/cable_coil/cable = new (loc, (d1 ? 2 : 1), color)
+	transfer_fingerprints_to(cable)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] cuts \the [src] with \a [tool]."),
+		SPAN_NOTICE("You cut \the [src] with \the [tool].")
+	)
+	if (HasBelow(z))
+		for (var/turf/turf in GetBelow(src))
+			for (var/obj/structure/cable/c in turf)
+				if (c.d1 == UP || c.d2 == UP)
 					qdel(c)
+	qdel_self()
 
-	investigate_log("was cut by [key_name(usr, usr.client)] in [user.loc.loc]","wires")
-
-	qdel(src)
 
 // shock the user with probability prb
 /obj/structure/cable/proc/shock(mob/user, prb, siemens_coeff = 1.0)

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -65,7 +65,11 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 	obj_flags = OBJ_FLAG_ROTATABLE
 
 	var/obj/machinery/particle_accelerator/control_box/master = null
-	var/construction_state = 0
+	var/const/CONSTRUCT_STATE_UNANCHORED = 0
+	var/const/CONSTRUCT_STATE_ANCHORED = 1
+	var/const/CONSTRUCT_STATE_WIRED = 2
+	var/const/CONSTRUCT_STATE_COMPLETE = 3
+	var/construction_state = CONSTRUCT_STATE_UNANCHORED
 	var/reference = null
 	var/powered = 0
 	var/strength = null
@@ -103,11 +107,78 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 				to_chat(user, "\The [src] is assembled")
 
 
-/obj/structure/particle_accelerator/attackby(obj/item/I, mob/user)
-	if (I?.istool())
-		if (process_tool_hit(I, user))
-			return
+/obj/structure/particle_accelerator/can_anchor(obj/item/tool, mob/user, silent)
+	. = ..()
+	if (!.)
+		return
+	if (construction_state > CONSTRUCT_STATE_ANCHORED)
+		if (!silent)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be further dismantled before you can move it.")
+		return FALSE
+
+
+/obj/structure/particle_accelerator/post_anchor_change()
+	construction_state = anchored ? CONSTRUCT_STATE_ANCHORED : CONSTRUCT_STATE_UNANCHORED
+	update_state()
+	update_icon()
 	..()
+
+
+/obj/structure/particle_accelerator/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Cable Coil - Add wiring
+	if (isCoil(tool))
+		if (construction_state < CONSTRUCT_STATE_ANCHORED)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be anchored before you can wire it.")
+			return TRUE
+		if (construction_state > CONSTRUCT_STATE_ANCHORED)
+			USE_FEEDBACK_FAILURE("\The [src] is already wired.")
+			return TRUE
+		var/obj/item/stack/cable_coil/cable = tool
+		if (!cable.use(1))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(cable, 1, "to wire \the [src].")
+			return TRUE
+		construction_state = CONSTRUCT_STATE_WIRED
+		update_state()
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] wires \the [src] with \a [tool]."),
+			SPAN_NOTICE("You wire \the [src] with \the [tool].")
+		)
+		return TRUE
+
+	// Screwdriver - Toggle panel
+	if (isScrewdriver(tool))
+		if (construction_state < CONSTRUCT_STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src] needs to be wired before you can close the panel.")
+			return TRUE
+		if (construction_state == CONSTRUCT_STATE_WIRED)
+			construction_state = CONSTRUCT_STATE_COMPLETE
+		else
+			construction_state = CONSTRUCT_STATE_WIRED
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [construction_state == CONSTRUCT_STATE_COMPLETE ? "closes" : "opens"] \the [src]'s maintenance panel with \a [tool]."),
+			SPAN_NOTICE("You [construction_state == CONSTRUCT_STATE_COMPLETE ? "close" : "open"] \the [src]'s maintenance panel with \the [tool].")
+		)
+		return TRUE
+
+	// Wirecutters - Remove wiring
+	if (isWirecutter(tool))
+		if (construction_state < CONSTRUCT_STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src] has no wiring to remove.")
+			return TRUE
+		if (construction_state > CONSTRUCT_STATE_WIRED)
+			USE_FEEDBACK_FAILURE("\The [src]'s panel must be open before you can access the wiring.")
+			return TRUE
+		construction_state = CONSTRUCT_STATE_ANCHORED
+		update_state()
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] cuts \the [src]'s wiring with \a [tool]."),
+			SPAN_NOTICE("You cut \the [src]'s wiring with \the [tool].")
+		)
+
+	return ..()
 
 
 /obj/structure/particle_accelerator/Move()
@@ -170,58 +241,6 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 			master = O
 			return 1
 	return 0
-
-
-/obj/structure/particle_accelerator/proc/process_tool_hit(obj/O, mob/user)
-	if(!(O) || !(user))
-		return 0
-	if(!ismob(user) || !isobj(O))
-		return 0
-	var/temp_state = src.construction_state
-
-	switch(src.construction_state)//TODO:Might be more interesting to have it need several parts rather than a single list of steps
-		if(0)
-			if(isWrench(O))
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-				src.anchored = TRUE
-				user.visible_message("[user.name] secures the [src.name] to the floor.", \
-					"You secure the external bolts.")
-				temp_state++
-		if(1)
-			if(isWrench(O))
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-				src.anchored = FALSE
-				user.visible_message("[user.name] detaches the [src.name] from the floor.", \
-					"You remove the external bolts.")
-				temp_state--
-			else if(isCoil(O))
-				if(O:use(1,user))
-					user.visible_message("[user.name] adds wires to the [src.name].", \
-						"You add some wires.")
-					temp_state++
-		if(2)
-			if(isWirecutter(O))//TODO:Shock user if its on?
-				user.visible_message("[user.name] removes some wires from the [src.name].", \
-					"You remove some wires.")
-				temp_state--
-			else if(isScrewdriver(O))
-				user.visible_message("[user.name] closes the [src.name]'s access panel.", \
-					"You close the access panel.")
-				temp_state++
-		if(3)
-			if(isScrewdriver(O))
-				user.visible_message("[user.name] opens the [src.name]'s access panel.", \
-					"You open the access panel.")
-				temp_state--
-	if(temp_state == src.construction_state)//Nothing changed
-		return 0
-	else
-		src.construction_state = temp_state
-		if(src.construction_state < 3)//Was taken apart, update state
-			update_state()
-		update_icon()
-		return 1
-
 
 
 /obj/machinery/particle_accelerator

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -629,39 +629,49 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 	sleep(20)	//wait until correct animation frame
 	playsound(src, 'sound/machines/hiss.ogg', 50, 0, 0)
 
-/obj/structure/disposaloutlet/attackby(obj/item/I, mob/user)
-	if(!I || !user)
-		return
-	src.add_fingerprint(user, 0, I)
-	if(isScrewdriver(I))
-		if(mode==0)
-			mode=1
-			playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-			to_chat(user, "You remove the screws around the power connection.")
-			return
-		else if(mode==1)
-			mode=0
-			playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-			to_chat(user, "You attach the screws around the power connection.")
-			return
-	else if(istype(I,/obj/item/weldingtool) && mode==1)
-		var/obj/item/weldingtool/W = I
-		if(W.remove_fuel(0,user))
-			playsound(src.loc, 'sound/items/Welder2.ogg', 100, 1)
-			to_chat(user, "You start slicing the floorweld off the disposal outlet.")
-			if(do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT))
-				if(!src || !W.isOn()) return
-				to_chat(user, "You sliced the floorweld off the disposal outlet.")
-				var/obj/structure/disposalconstruct/machine/outlet/C = new (loc, src)
-				src.transfer_fingerprints_to(C)
-				C.anchored = TRUE
-				C.set_density(1)
-				C.update()
-				qdel(src)
-				return
-		else
-			to_chat(user, "You need more welding fuel to complete this task.")
-			return
+
+/obj/structure/disposaloutlet/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Screwdriver - Toggle mode/power
+	if (isScrewdriver(tool))
+		mode = !mode
+		playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [mode ? "removes" : "attaches"] the screws around \the [src]'s power connection with \a [tool]."),
+			SPAN_NOTICE("You [mode ? "remove" : "attach"] the screws around \the [src]'s power connection with \the [tool].")
+		)
+		return TRUE
+
+	// Welding Tool - Detach from floor
+	if (isWelder(tool))
+		if (!mode)
+			USE_FEEDBACK_FAILURE("\The [src]'s power connection needs to be disconnected before you can remove \the [src] from the floor.")
+			return TRUE
+		var/obj/item/weldingtool/welder = tool
+		if (!welder.can_use(1, user, "to slice \the [src]'s floorweld."))
+			return TRUE
+		playsound(src, 'sound/items/Welder2.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts slicing \the [src]'s floorweld with \a [tool]."),
+			SPAN_NOTICE("You start slicing \the [src]'s floorweld with \the [tool]."),
+			SPAN_ITALIC("You hear the sound of welding.")
+		)
+		if (!do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool) || !welder.remove_fuel(1, user))
+			return TRUE
+		playsound(src, 'sound/items/Welder2.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] slices \the [src]'s floorweld with \a [tool]."),
+			SPAN_NOTICE("You start slices \the [src]'s floorweld with \the [tool].")
+		)
+		var/obj/structure/disposalconstruct/machine/outlet/outlet = new(loc, src)
+		transfer_fingerprints_to(outlet)
+		outlet.anchored = TRUE
+		outlet.set_density(TRUE)
+		outlet.update()
+		qdel_self()
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/disposaloutlet/forceMove()//updates this when shuttle moves. So you can YEET things out the airlock
 	. = ..()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -53,53 +53,59 @@
 		// Destroy will drop our wrapped object on the turf, so let it.
 		qdel(src)
 
-/obj/structure/bigDelivery/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/device/destTagger))
-		var/obj/item/device/destTagger/O = W
-		if(O.currTag)
-			if(src.sortTag != O.currTag)
-				to_chat(user, SPAN_NOTICE("You have labeled the destination as [O.currTag]."))
-				if(!src.sortTag)
-					src.sortTag = O.currTag
-					update_icon()
-				else
-					src.sortTag = O.currTag
-				playsound(src.loc, 'sound/machines/twobeep.ogg', 50, 1)
-			else
-				to_chat(user, SPAN_WARNING("The package is already labeled for [O.currTag]."))
-		else
-			to_chat(user, SPAN_WARNING("You need to set a destination first!"))
 
-	else if(istype(W, /obj/item/pen))
-		switch(alert("What would you like to alter?",,"Title","Description", "Cancel"))
-			if("Title")
-				var/str = sanitizeSafe(input(usr,"Label text?","Set label",""), MAX_NAME_LEN)
-				if(!str || !length(str))
-					to_chat(usr, SPAN_WARNING(" Invalid text."))
-					return
-				user.visible_message("\The [user] titles \the [src] with \a [W], marking down: \"[str]\"",\
-				SPAN_NOTICE("You title \the [src]: \"[str]\""),\
-				"You hear someone scribbling a note.")
-				SetName("[name] ([str])")
-				if(!examtext && !nameset)
-					nameset = 1
-					update_icon()
-				else
-					nameset = 1
-			if("Description")
-				var/str = sanitize(input(usr,"Label text?","Set label",""))
-				if(!str || !length(str))
-					to_chat(usr, SPAN_WARNING("Invalid text."))
-					return
-				if(!examtext && !nameset)
-					examtext = str
-					update_icon()
-				else
-					examtext = str
-				user.visible_message("\The [user] labels \the [src] with \a [W], scribbling down: \"[examtext]\"",\
-				SPAN_NOTICE("You label \the [src]: \"[examtext]\""),\
-				"You hear someone scribbling a note.")
-	return
+/obj/structure/bigDelivery/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Destination Tagger - Tag
+	if (istype(tool, /obj/item/device/destTagger))
+		var/obj/item/device/destTagger/tagger = tool
+		if (!tagger.currTag)
+			USE_FEEDBACK_FAILURE("\The [tool] does not have a tag set.")
+			return TRUE
+		if (tagger.currTag == sortTag)
+			USE_FEEDBACK_FAILURE("\The [src] is already tagged for [sortTag].")
+			return TRUE
+		sortTag = tagger.currTag
+		update_icon()
+		playsound(src.loc, 'sound/machines/twobeep.ogg', 50, 1)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] tags \the [src] with \a [tool]."),
+			SPAN_NOTICE("You tag \the [src] as [sortTag] with \the [tool].")
+		)
+		return TRUE
+
+	// Pen - Label
+	if (istype(tool, /obj/item/pen))
+		var/input = alert(user, "What would you like to alter?", "[name] - Label", "Title", "Description", "Cancel")
+		if (input == "Cancel" || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (input == "Title")
+			var/new_title = input(user, "What would you like to set the label to?", "[name] - Label Title") as null|text
+			new_title = sanitizeSafe(new_title, MAX_NAME_LEN)
+			if (!new_title || !user.use_sanity_check(src, tool))
+				return TRUE
+			user.visible_message(
+				SPAN_NOTICE("\The [user] updates \the [src]'s label with \a [tool]."),
+				SPAN_NOTICE("You set \the [src]'s label title to '[new_title]' with \the [tool].")
+			)
+			SetName("[initial(name)] ([new_title])")
+			update_icon()
+			nameset = TRUE
+		else if (input == "Description")
+			var/new_desc = input(user, "What would you like to set the label to?", "[name] - Label Title") as null|text
+			new_desc = sanitizeSafe(new_desc, MAX_NAME_LEN)
+			if (!new_desc || !user.use_sanity_check(src, tool))
+				return TRUE
+			user.visible_message(
+				SPAN_NOTICE("\The [user] updates \the [src]'s label with \a [tool]."),
+				SPAN_NOTICE("You set \the [src]'s label description to '[new_desc]' with \the [tool].")
+			)
+			examtext = new_desc
+			update_icon()
+			nameset = TRUE
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/bigDelivery/on_update_icon()
 	overlays.Cut()

--- a/code/modules/synthesized_instruments/real_instruments/Synthesizer/synthesizer.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Synthesizer/synthesizer.dm
@@ -12,31 +12,6 @@
 	path = /datum/instrument
 	sound_player = /datum/sound_player/synthesizer
 
-/obj/structure/synthesized_instrument/synthesizer/attackby(obj/item/O, mob/user, params)
-	if (istype(O, /obj/item/wrench))
-		if (!anchored && !isinspace())
-			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-			to_chat(usr, SPAN_NOTICE(" You begin to tighten \the [src] to the floor..."))
-			if (do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT))
-				if(!anchored && !isinspace())
-					user.visible_message( \
-						"[user] tightens \the [src]'s casters.", \
-						SPAN_NOTICE(" You tighten \the [src]'s casters. Now it can be played again."), \
-						SPAN_CLASS("italics", "You hear ratchet."))
-					src.anchored = TRUE
-		else if(anchored)
-			playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-			to_chat(usr, SPAN_NOTICE(" You begin to loosen \the [src]'s casters..."))
-			if (do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
-				if(anchored)
-					user.visible_message( \
-						"[user] loosens \the [src]'s casters.", \
-						SPAN_NOTICE(" You loosen \the [src]. Now it can be pulled somewhere else."), \
-						SPAN_CLASS("italics", "You hear ratchet."))
-					src.anchored = FALSE
-	else
-		..()
-
 /obj/structure/synthesized_instrument/synthesizer/shouldStopPlaying(mob/user)
 	return !((src && in_range(src, user) && src.anchored) || src.real_instrument.player.song.autorepeat)
 

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -90,106 +90,141 @@
 		T.update_icon()
 	. = ..()
 
-/obj/structure/table/attackby(obj/item/W, mob/user, click_params)
-	if(!reinforced && !carpeted && material && isWrench(W) && (user.a_intent != I_HELP || issilicon(user))) //robots dont have disarm so it's harm
-		remove_material(W, user)
-		if(!material)
-			update_connections(1)
-			update_icon()
-			for(var/obj/structure/table/T in oview(src, 1))
-				T.update_icon()
-			update_desc()
-			update_material()
-		return 1
 
-	if(!carpeted && !reinforced && !material && isWrench(W) && (user.a_intent != I_HELP || issilicon(user)))
-		dismantle(W, user)
-		return 1
-
-	if (user.a_intent == I_HURT)
-		..()
-		return
-
-	if(reinforced && isScrewdriver(W))
-		remove_reinforced(W, user)
-		if(!reinforced)
-			update_desc()
-			update_icon()
-			update_material()
-		return 1
-
-	if(carpeted && isCrowbar(W))
-		user.visible_message(SPAN_NOTICE("\The [user] removes the carpet from \the [src]."),
-		                              SPAN_NOTICE("You remove the carpet from \the [src]."))
-		new /obj/item/stack/tile/carpet(loc)
-		carpeted = 0
+/obj/structure/table/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	// Carpet - Add carpeting
+	if (istype(weapon, /obj/item/stack/tile/carpet))
+		if (carpeted)
+			USE_FEEDBACK_FAILURE("\The [src] is already carpeted.")
+			return TRUE
+		if (!material)
+			USE_FEEDBACK_FAILURE("\The [src] needs plating before you can carpet it.")
+			return TRUE
+		var/obj/item/stack/tile/carpet/carpet = weapon
+		if (!carpet.use(1))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(carpet, 1, "to pad \the [src].")
+			return TRUE
+		carpeted = TRUE
 		update_icon()
-		return 1
+		user.visible_message(
+			SPAN_NOTICE("\The [user] pads \the [src] with \a [weapon]."),
+			SPAN_NOTICE("You pad \the [src] with \the [weapon].")
+		)
+		return TRUE
 
-	if(!carpeted && material && istype(W, /obj/item/stack/tile/carpet))
-		var/obj/item/stack/tile/carpet/C = W
-		if(C.use(1))
-			user.visible_message(SPAN_NOTICE("\The [user] adds \the [C] to \the [src]."),
-			                              SPAN_NOTICE("You add \the [C] to \the [src]."))
-			carpeted = 1
-			update_icon()
-			return 1
-		else
-			to_chat(user, SPAN_WARNING("You don't have enough carpet!"))
-		return
+	// Crowbar - Remove carpeting
+	if (isCrowbar(weapon))
+		if (!carpeted)
+			USE_FEEDBACK_FAILURE("\The [src] has no carpeting to remove.")
+			return TRUE
+		new /obj/item/stack/tile/carpet(loc)
+		carpeted = FALSE
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] removes the carpting from \the [src] with \a [weapon]."),
+			SPAN_NOTICE("You remove the carpting from \the [src] with \the [weapon].")
+		)
+		return TRUE
 
-	if(health_damaged() && isWelder(W))
-		var/obj/item/weldingtool/F = W
-		if(F.welding)
-			to_chat(user, SPAN_NOTICE("You begin reparing damage to \the [src]."))
-			playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
-			if(!do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) || !F.remove_fuel(1, user))
-				return
-			user.visible_message(SPAN_NOTICE("\The [user] repairs some damage to \the [src]."),
-			                              SPAN_NOTICE("You repair some damage to \the [src]."))
-			restore_health(get_max_health() / 5) // 20% repair per application
-			return 1
-		return
+	// Energy Blade, Psiblade
+	if (istype(weapon, /obj/item/melee/energy/blade) || istype(weapon, /obj/item/psychic_power/psiblade/master/grand/paramount))
+		var/datum/effect/effect/system/spark_spread/spark_system = new(src)
+		spark_system.set_up(5, EMPTY_BITFIELD, loc)
+		spark_system.start()
+		playsound(loc, 'sound/weapons/blade1.ogg', 50, TRUE)
+		playsound(loc, "sparks", 50, TRUE)
+		user.visible_message(
+			SPAN_WARNING("\The [user] slices \the [src] apart with \a [weapon]."),
+			SPAN_WARNING("You slice \the [src] apart with \the [weapon].")
+		)
+		break_to_parts()
+		return TRUE
 
-	if(!material && can_plate && istype(W, /obj/item/stack/material))
-		material = common_material_add(W, user, "plat")
-		if(material)
-			update_connections(1)
+	// Material - Plate table
+	if (istype(weapon, /obj/item/stack/material))
+		if (material)
+			USE_FEEDBACK_FAILURE("\The [src] is already plated.")
+			return TRUE
+		material = common_material_add(weapon, user, "plat")
+		if (material)
+			update_connections(TRUE)
 			update_icon()
 			update_desc()
 			update_material()
-		return 1
+		return TRUE
 
-	// Handle dismantling or placing things on the table from here on.
-	if(isrobot(user))
-		return
+	// Welding Tool - Repair damage
+	if (isWelder(weapon))
+		if (!health_damaged())
+			USE_FEEDBACK_FAILURE("\The [src] isn't damaged.")
+			return TRUE
+		var/obj/item/weldingtool/welder = weapon
+		if (!welder.can_use(1, user, "to repair \the [src]"))
+			return TRUE
+		playsound(src, 'sound/items/Welder.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts repairing \the [src] with \a [weapon]."),
+			SPAN_NOTICE("You start repairing \the [src] with \the [weapon].")
+		)
+		if (!do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, weapon) || !welder.remove_fuel(1))
+			return TRUE
+		playsound(src, 'sound/items/Welder.ogg', 50, TRUE)
+		restore_health(get_max_health() / 5) // 20% repair per application
+		user.visible_message(
+			SPAN_NOTICE("\The [user] repairs some of \the [src]'s damage with \a [weapon]."),
+			SPAN_NOTICE("You repair some of \the [src]'s damage with \the [weapon].")
+		)
+		return TRUE
 
-	if(W.loc != user) // This should stop mounted modules ending up outside the module.
-		return
+	// Wrench - Remove material
+	if (isWrench(weapon))
+		if (!material)
+			USE_FEEDBACK_FAILURE("\The [src] has no plating to remove.")
+			return TRUE
+		if (reinforced)
+			USE_FEEDBACK_FAILURE("\The [src]'s reinforcements need to be removed before you can remove the plating.")
+			return TRUE
+		if (carpeted)
+			USE_FEEDBACK_FAILURE("\The [src]'s carpeting needs to be removed before you can remove the plating.")
+			return TRUE
+		remove_material(weapon, user)
+		if (!material)
+			update_connections(TRUE)
+			update_icon()
+			for (var/obj/structure/table/table in oview(src, 1))
+				table.update_icon()
+			update_desc()
+			update_material()
+		return TRUE
 
-	if(istype(W, /obj/item/melee/energy/blade) || istype(W,/obj/item/psychic_power/psiblade/master/grand/paramount))
-		var/datum/effect/effect/system/spark_spread/spark_system = new /datum/effect/effect/system/spark_spread()
-		spark_system.set_up(5, 0, src.loc)
-		spark_system.start()
-		playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
-		playsound(src.loc, "sparks", 50, 1)
-		user.visible_message(SPAN_DANGER("\The [src] was sliced apart by [user]!"))
-		break_to_parts()
-		return
-
-	if (istype(W, /obj/item/natural_weapon))
-		return ..()
-
-	if(can_plate && !material)
-		to_chat(user, SPAN_WARNING("There's nothing to put \the [W] on! Try adding plating to \the [src] first."))
-		return
-
-	// Placing stuff on tables
-	if(user.unEquip(W, src.loc))
-		auto_align(W, click_params)
-		return 1
+	// Screwdriver - Remove reinforcement
+	if (isScrewdriver(weapon))
+		if (!reinforced)
+			USE_FEEDBACK_FAILURE("\The [src] has no reinforcements to remove.")
+			return TRUE
+		remove_reinforced(weapon, user)
+		if (!reinforced)
+			update_desc()
+			update_icon()
+			update_material()
+		return TRUE
 
 	return ..()
+
+
+/obj/structure/table/use_tool(obj/item/tool, mob/user, list/click_params)
+	SHOULD_CALL_PARENT(FALSE)
+
+	// Put things on table
+	if (can_plate && !material)
+		USE_FEEDBACK_FAILURE("\The [src] needs to be plated before you can put \the [tool] on it.")
+		return TRUE
+	if (!user.unEquip(tool, loc))
+		FEEDBACK_UNEQUIP_FAILURE(user, tool)
+		return TRUE
+	auto_align(tool, click_params)
+	return TRUE
+
 
 /obj/structure/table/MouseDrop_T(obj/item/stack/material/what)
 	if(can_reinforce && isliving(usr) && (!usr.stat) && istype(what) && usr.get_active_hand() == what && Adjacent(usr))

--- a/maps/away/blueriver/blueriver.dm
+++ b/maps/away/blueriver/blueriver.dm
@@ -185,16 +185,6 @@
 	density = TRUE
 	anchored = TRUE
 
-/obj/structure/deity/attackby(obj/item/W as obj, mob/user as mob)
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	user.do_attack_animation(src)
-	playsound(get_turf(src), 'sound/effects/Glasshit.ogg', 50, 1)
-	user.visible_message(
-		SPAN_DANGER("[user] hits \the [src] with \the [W]!"),
-		SPAN_DANGER("You hit \the [src] with \the [W]!"),
-		SPAN_DANGER("You hear something breaking!")
-		)
-	damage_health(W.force, W.damtype)
 
 /obj/structure/deity/on_death()
 	visible_message(SPAN_DANGER("\The [src] crumbles!"))

--- a/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
@@ -51,18 +51,32 @@
 	desc = "Impact resistant server rack. You might be able to pry a disk out."
 	var/obj/item/stock_parts/computer/hard_drive/cluster/drive = new /obj/item/stock_parts/computer/hard_drive/cluster
 
-/obj/structure/backup_server/attackby(obj/item/W, mob/user, click_params)
-	if(isCrowbar(W))
-		if (!drive)
-			to_chat(user, SPAN_WARNING("There is nothing else to take from \the [src]."))
-			return
 
-		to_chat(user, SPAN_NOTICE("You pry out the data drive from \the [src]."))
-		playsound(loc, 'sound/items/Crowbar.ogg', 50, 1)
-		drive.origin_tech = list(TECH_DATA = rand(4,5), TECH_ENGINEERING = rand(4,5), TECH_PHORON = rand(4,5), TECH_COMBAT = rand(2,5), TECH_ESOTERIC = rand(0,6))
-		var/obj/item/stock_parts/computer/hard_drive/cluster/extracted_drive = drive
-		user.put_in_hands(extracted_drive)
+/obj/structure/backup_server/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Crowbar - Remove drive
+	if (isCrowbar(tool))
+		if (!drive)
+			USE_FEEDBACK_FAILURE("\The [src] has no drive to remove.")
+			return TRUE
+		playsound(src, 'sound/items/Crowbar.ogg', 50, TRUE)
+		drive.origin_tech = list(
+			TECH_DATA = rand(4, 5),
+			TECH_ENGINEERING = rand(4, 5),
+			TECH_PHORON = rand(4, 5),
+			TECH_COMBAT = rand(2, 5),
+			TECH_ESOTERIC = rand(0, 6)
+		)
+		drive.add_fingerprint(user, tool = tool)
+		user.put_in_hands(drive)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] pries a drive from \the [src] with \a [tool]."),
+			SPAN_NOTICE("You pry \a [drive] from \the [src] with \a [tool].")
+		)
 		drive = null
+		return TRUE
+
+	return ..()
+
 
 /obj/effect/landmark/map_load_mark/ejected_datapod
 	name = "random datapod contents"

--- a/maps/torch/structures/memorabilia.dm
+++ b/maps/torch/structures/memorabilia.dm
@@ -29,22 +29,41 @@
 		pixel_z = 8
 	else pixel_z = 0
 
-/obj/structure/decorative/ed209/attackby(obj/item/O, mob/user)
-	. = ..()
-	if(isScrewdriver(O) && user.skill_check(SKILL_DEVICES, SKILL_BASIC))
-		if(!salvaged)
-			var/delay = 2 SECONDS * user.skill_delay_mult(SKILL_DEVICES)
-			user.visible_message(SPAN_NOTICE("\The [user] starts rummaging through \the [src]."), SPAN_NOTICE("You start looking for useful components in \the [src]."))
-			if(do_after(user, delay, src, DO_PUBLIC_UNIQUE) && !salvaged)
-				playsound(user.loc, 'sound/items/Crowbar.ogg', 40, 1)
-				user.visible_message(SPAN_NOTICE("\The [user] detaches some components from \the [src]."), SPAN_NOTICE("You detach some useful components from \the [src]."))
-				var/obj/item/part = pickweight(loot)
-				part = new part(loc)
-				part.forceMove(get_turf(user))
-				user.put_in_hands(part)
-				salvaged = prob(25) //Sometimes more, sometimes less
-		else
-			to_chat(user, SPAN_NOTICE("It doesn't seem like there's anything of use left on this thing."))
+
+/obj/structure/decorative/ed209/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Screwdriver - Salvage parts
+	if (isScrewdriver(tool))
+		if (!user.skill_check(SKILL_DEVICES, SKILL_BASIC))
+			USE_FEEDBACK_FAILURE("You're not skill enough to salvage \the [src].")
+			return TRUE
+		if (salvaged)
+			USE_FEEDBACK_FAILURE("It doesn't seem like there's anything of use left on \the [src].")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts rummaging through \the [src] with \a [tool]."),
+			SPAN_NOTICE("You start looking for useful components \the [src] with \the [tool].")
+		)
+		if (!user.do_skilled(2 SECONDS, SKILL_DEVICES, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (!user.skill_check(SKILL_DEVICES, SKILL_BASIC))
+			USE_FEEDBACK_FAILURE("You're not skill enough to salvage \the [src].")
+			return TRUE
+		if (salvaged)
+			USE_FEEDBACK_FAILURE("It doesn't seem like there's anything of use left on \the [src].")
+			return TRUE
+		playsound(src, 'sound/items/Crowbar.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] detaches some components from \the [src] with \a [tool]."),
+			SPAN_NOTICE("You detach some useful components from \the [src] with \the [tool].")
+		)
+		var/obj/item/part = pickweight(loot)
+		part = new part(get_turf(user))
+		user.put_in_hands(part)
+		salvaged = prob(25) //Sometimes more, sometimes less
+		return TRUE
+
+	return ..()
+
 
 /obj/structure/decorative/md_slug
 	name = "charred mass driver slug"

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -44,7 +44,7 @@ exactly 25 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 5 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 353 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 354 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 0 "anchored = 0/1" 'anchored\s*=\s*\d' -P
 exactly 2 "density = 0/1" 'density\s*=\s*\d' -P
@@ -53,7 +53,7 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 5 "uses of .len" '\.len\b' -P
-exactly 549 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 445 "attackby() override" '\/attackby\((.*)\)'  -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 num=`find ./html/changelogs -not -name "*.yml" | wc -l`


### PR DESCRIPTION
# Add `use_*` calls to `/obj/structure`
## Changelog
:cl: SierraKomodo
balance: Harmful grab actions on structures, such as bashing people against the EC plaque, now set a click cooldown.
bugfix: Removing wiring from a rigged crate now gives back the used cable.
refactor: Updated click interactions with `/obj/structure` and its subtypes when you have an item in your hand. Interactions are now more intent-aware (help, grab, harm) and have been standardized with proper feedback and visible messages where applicable. See https://github.com/Baystation12/Baystation12/pull/33242 for details.
rscadd: Mech wreckage now uses standardized health and damage.
rscdel: AI can no longer remotely unlock a fireaxe cabinet.
tweak: Using a multitool on an abandoned crate now displays the results in a popup window instead of chat.
tweak: Welding various structures now uses 1 unit of fuel.
tweak: Slicing open lockers with energy blades now requires harm intent.
tweak: Dismantling open lockers with any tool now requires harm intent. This allows safely placing items into lockers that would otherwise destroy them.
tweak: Dumping laundry baskest into open lockers now requires harm intent. This allows placing the basket into the closet without dumping it, if desired.
tweak: Clicking closed lockers with an item in hand no longer toggles the locker's lock or opens it. Hand labelers rejoice.
tweak: Fingerprints are now properly transferred and added when dismantling structures, or performing other interactions with structures that replace them with a new instance.
tweak: Harmful grab actions on structures, such as bashing people against the EC plaque, now require harm intent.
tweak: Catwalks now block access to all under-floor objects (Wiring, pipes, etc) and turfs.
tweak: Grilles can now be anchored/unanchored with a wrench instead of a screwdriver.
tweak: Any interaction of items with a grille now performs a shock chance.
/:cl:

## Other Changes
- Replaced `/obj/structure/.*/attackby()` with `/obj/structure/.*/use_*()`.
- Updated `/obj/structure/use_weapon()` to pass the weapon's damage type and damage flags through to `attack_generic()`.
- Moved `/obj/structure/broken_cryo`'s `icon_state` updates to `update_icon()` override.
- Removed redundant `/obj/structure/broken_cryo/busy` var.
- Moved `/obj/structure/closet/crate/secure/loot/use_tool()`'s results response from chat to a popup window.
- Refactored body bag label handling.
- Moved hardcoded barsign access requirement to `req_access` var.
- Added `/obj/structure/bed/var/bed_flags` bitflag for restricting certain interactions.
- Moved `/obj/structure/sign/memorial` hardcoded branch checks to a new `accepted_branches` var.
