### PR TITLE
Inflatable cases now use "case" for their inhand icon

### DIFF
--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -323,7 +323,7 @@
 	name = "inflatable barrier box"
 	desc = "Contains inflatable walls and doors."
 	icon_state = "inf_box"
-	item_state = "painted_secure"
+	item_state = "case"
 	w_class = ITEM_SIZE_LARGE
 	max_storage_space = DEFAULT_LARGEBOX_STORAGE
 	can_hold = list(/obj/item/inflatable)


### PR DESCRIPTION
"painted_secure" has a flag on the side of it, case doesn't. Why did it even have that flag? I don't know.

🆑 Jux
tweak: Inflatables boxes no longer have a flag on their side when held in hands.
/🆑 