### PR TITLE
`/mob` `New()` -> `Initialize()`

### DIFF
--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -432,9 +432,11 @@
 /mob/living/simple_animal/hostile/carp/holodeck/on_update_icon()
 	return
 
-/mob/living/simple_animal/hostile/carp/holodeck/New()
-	..()
+
+/mob/living/simple_animal/hostile/carp/holodeck/Initialize(mapload, ...)
+	. = ..()
 	set_light(0.5, 0.1, 2) //hologram lighting
+
 
 /mob/living/simple_animal/hostile/carp/holodeck/proc/set_safety(safe)
 	var/obj/item/NW = get_natural_weapon()

--- a/code/modules/mechs/premade/powerloader.dm
+++ b/code/modules/mechs/premade/powerloader.dm
@@ -55,7 +55,8 @@
 	name = "firefighting exosuit"
 	desc = "A mix and match of industrial parts designed to withstand fires."
 
-/mob/living/exosuit/premade/firefighter/New()
+
+/mob/living/exosuit/premade/firefighter/Initialize(mapload)
 	if(!arms)
 		arms = new /obj/item/mech_component/manipulators/powerloader(src)
 		arms.color = "#385b3c"
@@ -69,9 +70,10 @@
 		body = new /obj/item/mech_component/chassis/heavy(src)
 		body.color = "#385b3c"
 
-	..()
+	. = ..()
 
 	material = SSmaterials.get_material_by_name(MATERIAL_OSMIUM_CARBIDE_PLASTEEL)
+
 
 /mob/living/exosuit/premade/firefighter/spawn_mech_equipment()
 	..()

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -62,7 +62,7 @@
 
 
 /// Place I into the first slot it fits in the order of slots_by_priority, returning the slot or falsy.
-/mob/proc/equip_to_appropriate_slot(obj/item/I, skip_storage)
+/mob/proc/equip_to_appropriate_slot(obj/item/I, skip_storage, skip_timer)
 	var/static/list/slots_by_priority = list(
 		slot_back, slot_wear_id, slot_w_uniform, slot_wear_suit,
 		slot_wear_mask, slot_head, slot_shoes, slot_gloves, slot_l_ear,
@@ -71,10 +71,13 @@
 	)
 	if (!istype(I))
 		return
+	var/equip_flags = TRYEQUIP_REDRAW | TRYEQUIP_SILENT
+	if (skip_timer)
+		equip_flags |= TRYEQUIP_INSTANT
 	for (var/slot in slots_by_priority)
 		if (skip_storage && (slot == slot_s_store || slot == slot_l_store || slot == slot_r_store))
 			continue
-		if (equip_to_slot_if_possible(I, slot, TRYEQUIP_REDRAW | TRYEQUIP_SILENT))
+		if (equip_to_slot_if_possible(I, slot, equip_flags))
 			return slot //slot is truthy; we can return it for info
 
 

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -46,8 +46,9 @@
 
 	layer = HIDING_MOB_LAYER
 
-/mob/living/bot/New()
-	..()
+
+/mob/living/bot/Initialize(mapload)
+	. = ..()
 	update_icons()
 
 	botcard = new /obj/item/card/id(src)
@@ -55,6 +56,7 @@
 
 	access_scanner = new /obj(src)
 	access_scanner.req_access = req_access.Copy()
+
 
 /mob/living/bot/Initialize()
 	. = ..()

--- a/code/modules/mob/living/bot/cleanbot.dm
+++ b/code/modules/mob/living/bot/cleanbot.dm
@@ -15,9 +15,11 @@
 	var/blood = 1
 	var/list/target_types = list()
 
-/mob/living/bot/cleanbot/New()
-	..()
+
+/mob/living/bot/cleanbot/Initialize(mapload)
+	. = ..()
 	get_targets()
+
 
 /mob/living/bot/cleanbot/handleIdle()
 	if(!screwloose && !oddbutton && prob(5))

--- a/code/modules/mob/living/bot/farmbot.dm
+++ b/code/modules/mob/living/bot/farmbot.dm
@@ -22,12 +22,14 @@
 
 	var/obj/structure/reagent_dispensers/watertank/tank
 
-/mob/living/bot/farmbot/New(newloc, newTank)
-	..(newloc)
+
+/mob/living/bot/farmbot/Initialize(mapload, newTank)
+	. = ..()
 	if(!newTank)
 		newTank = new /obj/structure/reagent_dispensers/watertank(src)
 	tank = newTank
 	tank.forceMove(src)
+
 
 /mob/living/bot/farmbot/premade
 	name = "Old Ben"

--- a/code/modules/mob/living/bot/mulebot.dm
+++ b/code/modules/mob/living/bot/mulebot.dm
@@ -38,8 +38,9 @@
 
 	var/static/amount = 0
 
-/mob/living/bot/mulebot/New()
-	..()
+
+/mob/living/bot/mulebot/Initialize()
+	. = ..()
 
 	var/turf/T = get_turf(loc)
 	var/obj/machinery/navbeacon/N = locate() in T
@@ -50,7 +51,7 @@
 		homeName = "Unset"
 
 	suffix = num2text(++amount)
-	name = "Mulebot #[suffix]"
+	SetName("Mulebot #[suffix]")
 
 
 /mob/living/bot/mulebot/get_antag_interactions_info()

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -10,13 +10,13 @@
 	var/death_msg = "lets out a waning guttural screech, green blood bubbling from its maw."
 	var/instance_num
 
-/mob/living/carbon/alien/New()
 
+/mob/living/carbon/alien/Initialize()
 	verbs += /mob/living/proc/ventcrawl
 	verbs += /mob/living/proc/hide
 
 	instance_num = rand(1, 1000)
-	name = "[initial(name)] ([instance_num])"
+	SetName("[initial(name)] ([instance_num])")
 	real_name = name
 	regenerate_icons()
 
@@ -25,7 +25,8 @@
 
 	gender = NEUTER
 
-	..()
+	. = ..()
+
 
 /mob/living/carbon/alien/u_equip(obj/item/W as obj)
 	return

--- a/code/modules/mob/living/carbon/brain/brain.dm
+++ b/code/modules/mob/living/carbon/brain/brain.dm
@@ -9,9 +9,11 @@
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "brain1"
 
-/mob/living/carbon/brain/New()
+
+/mob/living/carbon/brain/Initialize()
 	create_reagents(1000)
-	..()
+	. = ..()
+
 
 /mob/living/carbon/brain/Destroy()
 	if(key)				//If there is a mob connected to this thing. Have to check key twice to avoid false death reporting.

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/New()
+/mob/living/carbon/Initialize(mapload)
 	//setup reagent holders
 	bloodstr = new/datum/reagents/metabolism(120, src, CHEM_BLOOD)
 	touching = new/datum/reagents/metabolism(1000, src, CHEM_TOUCH)
@@ -6,7 +6,8 @@
 
 	if (!default_language && species_language)
 		default_language = all_languages[species_language]
-	..()
+	. = ..()
+
 
 /mob/living/carbon/Destroy()
 	QDEL_NULL(touching)
@@ -358,7 +359,7 @@
 		if(buckled && buckled.buckle_require_restraints)
 			buckled.unbuckle_mob()
 	else
-	 ..()
+		..()
 
 	return
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -13,8 +13,8 @@
 	var/step_count
 	var/dream_timer
 
-/mob/living/carbon/human/New(new_loc, new_species = null)
 
+/mob/living/carbon/human/Initialize(mapload, new_species = null)
 	grasp_limbs = list()
 	stance_limbs = list()
 
@@ -24,7 +24,7 @@
 
 	if(!species)
 		if(new_species)
-			set_species(new_species,1)
+			set_species(new_species, TRUE)
 		else
 			set_species()
 
@@ -47,7 +47,7 @@
 	hud_list[STATUS_HUD_OOC]  = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudhealthy")
 
 	GLOB.human_mobs |= src
-	..()
+	. = ..()
 
 	if(dna)
 		dna.ready_dna(src)
@@ -55,6 +55,7 @@
 		dna.base_skin = base_skin
 		sync_organ_dna()
 	make_blood()
+
 
 /mob/living/carbon/human/Destroy()
 	if (dream_timer)

--- a/code/modules/mob/living/carbon/human/human_species.dm
+++ b/code/modules/mob/living/carbon/human/human_species.dm
@@ -21,40 +21,40 @@
 /mob/living/carbon/human/dummy/mannequin/InitializeHud()
 	return	// Mannequins don't get HUDs
 
-/mob/living/carbon/human/skrell/New(new_loc)
+/mob/living/carbon/human/skrell/Initialize(mapload)
 	head_hair_style = "Skrell Male Tentacles"
-	..(new_loc, SPECIES_SKRELL)
+	. = ..(mapload, SPECIES_SKRELL)
 
-/mob/living/carbon/human/unathi/New(new_loc)
+/mob/living/carbon/human/unathi/Initialize(mapload)
 	head_hair_style = "Unathi Horns"
-	..(new_loc, SPECIES_UNATHI)
+	. = ..(mapload, SPECIES_UNATHI)
 
-/mob/living/carbon/human/vox/New(new_loc)
+/mob/living/carbon/human/vox/Initialize(mapload)
 	head_hair_style = "Long Vox Quills"
-	..(new_loc, SPECIES_VOX)
+	. = ..(mapload, SPECIES_VOX)
 
-/mob/living/carbon/human/diona/New(new_loc)
-	..(new_loc, SPECIES_DIONA)
+/mob/living/carbon/human/diona/Initialize(mapload)
+	. = ..(mapload, SPECIES_DIONA)
 
-/mob/living/carbon/human/machine/New(new_loc)
-	..(new_loc, SPECIES_IPC)
+/mob/living/carbon/human/machine/Initialize(mapload)
+	. = ..(mapload, SPECIES_IPC)
 
-/mob/living/carbon/human/nabber/New(new_loc)
-	pulling_punches = 1
-	..(new_loc, SPECIES_NABBER)
+/mob/living/carbon/human/nabber/Initialize(mapload)
+	pulling_punches = TRUE
+	. = ..(mapload, SPECIES_NABBER)
 
-/mob/living/carbon/human/monkey/New(new_loc)
+/mob/living/carbon/human/monkey/Initialize(mapload)
 	gender = pick(MALE, FEMALE)
-	..(new_loc, SPECIES_MONKEY)
+	. = ..(mapload, SPECIES_MONKEY)
 
-/mob/living/carbon/human/farwa/New(new_loc)
-	..(new_loc, "Farwa")
+/mob/living/carbon/human/farwa/Initialize(mapload)
+	. = ..(mapload, "Farwa")
 
-/mob/living/carbon/human/neaera/New(new_loc)
-	..(new_loc, "Neaera")
+/mob/living/carbon/human/neaera/Initialize(mapload)
+	. = ..(mapload, "Neaera")
 
-/mob/living/carbon/human/stok/New(new_loc)
-	..(new_loc, "Stok")
+/mob/living/carbon/human/stok/Initialize(mapload)
+	. = ..(mapload, "Stok")
 
-/mob/living/carbon/human/adherent/New(new_loc)
-	..(new_loc, SPECIES_ADHERENT)
+/mob/living/carbon/human/adherent/Initialize(mapload)
+	. = ..(mapload, SPECIES_ADHERENT)

--- a/code/modules/mob/living/carbon/human/npcs.dm
+++ b/code/modules/mob/living/carbon/human/npcs.dm
@@ -1,7 +1,15 @@
-/mob/living/carbon/human/monkey/punpun/New()
-	..()
+/mob/living/carbon/human/monkey/punpun
 	name = "Pun Pun"
+
+
+/mob/living/carbon/human/monkey/punpun/Initialize(mapload)
+	. = ..()
 	real_name = name
+	return INITIALIZE_HINT_LATELOAD
+
+
+/mob/living/carbon/human/monkey/punpun/LateInitialize(mapload)
+	..()
 	var/obj/item/clothing/C
 	if(prob(50))
 		C = new /obj/item/clothing/under/punpun(src)
@@ -13,6 +21,7 @@
 		if(prob(10))
 			C = new/obj/item/clothing/head/collectable/petehat(src)
 			equip_to_appropriate_slot(C)
+
 
 /singleton/hierarchy/outfit/blank_subject
 	name = "Test Subject"
@@ -29,8 +38,10 @@
 		C.has_sensor  = SUIT_LOCKED_SENSORS
 		C.sensor_mode = SUIT_SENSOR_OFF
 
-/mob/living/carbon/human/blank/New(new_loc)
-	..(new_loc, "Vat-Grown Human")
+
+/mob/living/carbon/human/blank/Initialize(mapload)
+	. = ..(mapload, SPECIES_VATGROWN)
+
 
 /mob/living/carbon/human/blank/Initialize()
 	..()

--- a/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
+++ b/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
@@ -79,17 +79,19 @@
 /mob/living/carbon/slime/setToxLoss(amount)
 	adjustToxLoss(amount-getToxLoss())
 
-/mob/living/carbon/slime/New(location, colour="grey")
+
+/mob/living/carbon/slime/Initialize(mapload, _colour = "grey")
 	ingested = new(240, src, CHEM_INGEST)
 	verbs += /mob/living/proc/ventcrawl
 
-	src.colour = colour
+	colour = _colour
 	number = random_id(/mob/living/carbon/slime, 1, 1000)
-	name = "[colour] [is_adult ? "adult" : "baby"] slime ([number])"
+	SetName("[colour] [is_adult ? "adult" : "baby"] slime ([number])")
 	real_name = name
 	mutation_chance = rand(25, 35)
 	regenerate_icons()
-	..(location)
+	. = ..()
+
 
 /mob/living/carbon/slime/movement_delay()
 	if (bodytemperature >= 330.23) // 135 F

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1,5 +1,5 @@
-/mob/living/New()
-	..()
+/mob/living/Initialize(mapload)
+	. = ..()
 	if(stat == DEAD)
 		add_to_dead_mob_list()
 	else

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -113,11 +113,12 @@ var/global/list/ai_verbs_default = list(
 	src.verbs -= ai_verbs_default
 	src.verbs += /mob/living/verb/ghost
 
-/mob/living/silicon/ai/New(loc, datum/ai_laws/L, obj/item/device/mmi/B, safety = 0)
+
+/mob/living/silicon/ai/Initialize(mapload, datum/ai_laws/L, obj/item/device/mmi/B, safety = FALSE)
 	announcement = new()
 	announcement.title = "A.I. Announcement"
 	announcement.announcement_type = "A.I. Announcement"
-	announcement.newscast = 1
+	announcement.newscast = TRUE
 
 	var/list/possibleNames = GLOB.ai_names
 
@@ -131,7 +132,7 @@ var/global/list/ai_verbs_default = list(
 
 	fully_replace_character_name(pickedName)
 	anchored = TRUE
-	set_density(1)
+	set_density(TRUE)
 
 	holo_icon = getHologramIcon(icon('icons/mob/hologram.dmi',"Face"))
 	holo_icon_longrange = getHologramIcon(icon('icons/mob/hologram.dmi',"Face"), hologram_color = HOLOPAD_LONG_RANGE)
@@ -147,19 +148,19 @@ var/global/list/ai_verbs_default = list(
 		add_ai_verbs(src)
 
 	//Languages
-	add_language(LANGUAGE_ROBOT_GLOBAL, 1)
-	add_language(LANGUAGE_EAL, 1)
-	add_language(LANGUAGE_HUMAN_EURO, 1)
-	add_language(LANGUAGE_HUMAN_ARABIC, 1)
-	add_language(LANGUAGE_HUMAN_CHINESE, 1)
-	add_language(LANGUAGE_HUMAN_IBERIAN, 1)
-	add_language(LANGUAGE_HUMAN_INDIAN, 1)
-	add_language(LANGUAGE_HUMAN_RUSSIAN, 1)
-	add_language(LANGUAGE_HUMAN_SELENIAN, 1)
-	add_language(LANGUAGE_UNATHI_SINTA, 1)
-	add_language(LANGUAGE_SKRELLIAN, 1)
-	add_language(LANGUAGE_SPACER, 1)
-	add_language(LANGUAGE_SIGN, 0)
+	add_language(LANGUAGE_ROBOT_GLOBAL, TRUE)
+	add_language(LANGUAGE_EAL, TRUE)
+	add_language(LANGUAGE_HUMAN_EURO, TRUE)
+	add_language(LANGUAGE_HUMAN_ARABIC, TRUE)
+	add_language(LANGUAGE_HUMAN_CHINESE, TRUE)
+	add_language(LANGUAGE_HUMAN_IBERIAN, TRUE)
+	add_language(LANGUAGE_HUMAN_INDIAN, TRUE)
+	add_language(LANGUAGE_HUMAN_RUSSIAN, TRUE)
+	add_language(LANGUAGE_HUMAN_SELENIAN, TRUE)
+	add_language(LANGUAGE_UNATHI_SINTA, TRUE)
+	add_language(LANGUAGE_SKRELLIAN, TRUE)
+	add_language(LANGUAGE_SPACER, TRUE)
+	add_language(LANGUAGE_SIGN, FALSE)
 
 	if(!safety)//Only used by AIize() to successfully spawn an AI.
 		if (!B)//If there is no player/brain inside.
@@ -183,7 +184,7 @@ var/global/list/ai_verbs_default = list(
 	hud_list[SPECIALROLE_HUD] = new /image/hud_overlay('icons/mob/hud.dmi', src, "hudblank")
 
 	ai_list += src
-	..()
+	. = ..()
 	ai_radio = silicon_radio
 	ai_radio.myAi = src
 

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -2,13 +2,15 @@
 	var/datum/ai_laws/laws
 	var/list/additional_law_channels = list("State" = "")
 
-/mob/living/silicon/New()
-	..()
+
+/mob/living/silicon/Initialize(mapload)
+	. = ..()
 	if(!laws)
 		laws = GLOB.using_map.default_law_type
 	if(ispath(laws))
 		laws = new laws()
 	laws_sanity_check()
+
 
 /mob/living/silicon/proc/laws_sanity_check()
 	if (!src.laws)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -88,20 +88,22 @@ GLOBAL_LIST_INIT(possible_say_verbs, list(
 
 	hud_type = /datum/hud/pai
 
-/mob/living/silicon/pai/New(obj/item/device/paicard)
+
+/mob/living/silicon/pai/Initialize(mapload, obj/item/device/paicard)
 	status_flags |= NO_ANTAG
 	card = paicard
 
 	//As a human made device, we'll understand sol common without the need of the translator
-	add_language(LANGUAGE_HUMAN_EURO, 1)
+	add_language(LANGUAGE_HUMAN_EURO, TRUE)
 	verbs -= /mob/living/verb/ghost
 
-	..()
+	. = ..()
 
 	if(card)
 		if(!card.radio)
 			card.radio = new /obj/item/device/radio(card)
 		silicon_radio = card.radio
+
 
 /mob/living/silicon/pai/Destroy()
 	card = null

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -33,9 +33,11 @@ var/global/list/default_pai_software = list()
 			default_pai_software[P.id] = P
 	return r
 
-/mob/living/silicon/pai/New()
-	..()
+
+/mob/living/silicon/pai/Initialize(mapload)
+	. = ..()
 	software = default_pai_software.Copy()
+
 
 /mob/living/silicon/pai/proc/paiInterface()
 	ui_interact(src)

--- a/code/modules/mob/living/silicon/posi_brainmob.dm
+++ b/code/modules/mob/living/silicon/posi_brainmob.dm
@@ -20,12 +20,14 @@
 	var/list/owner_channels = list()
 	var/list/law_channels = list()
 
-/mob/living/silicon/sil_brainmob/New()
+
+/mob/living/silicon/sil_brainmob/Initialize(mapload)
 	reagents = new/datum/reagents(1000, src)
 	if(istype(loc, /obj/item/organ/internal/posibrain))
 		container = loc
 	add_language(LANGUAGE_ROBOT_GLOBAL)
-	..()
+	. = ..()
+
 
 /mob/living/silicon/sil_brainmob/Destroy()
 	if(key)				//If there is a mob connected to this thing. Have to check key twice to avoid false death reporting.

--- a/code/modules/mob/living/silicon/subsystems.dm
+++ b/code/modules/mob/living/silicon/subsystems.dm
@@ -7,13 +7,15 @@
 		/datum/nano_module/crew_manifest
 	)
 
-/mob/living/silicon/ai/New()
+
+/mob/living/silicon/ai/Initialize(mapload)
 	silicon_subsystems.Cut()
 	for(var/subtype in subtypesof(/datum/nano_module))
 		var/datum/nano_module/NM = subtype
 		if(initial(NM.available_to_ai))
 			silicon_subsystems += NM
-	..()
+	. = ..()
+
 
 /mob/living/silicon/robot/syndicate
 	silicon_subsystems = list(

--- a/code/modules/mob/living/simple_animal/aquatic/_aquatic.dm
+++ b/code/modules/mob/living/simple_animal/aquatic/_aquatic.dm
@@ -18,12 +18,14 @@
 
 	say_list_type = /datum/say_list/aquatic
 
-/mob/living/simple_animal/aquatic/New()
-	..()
+
+/mob/living/simple_animal/aquatic/Initialize(mapload)
+	. = ..()
 	default_pixel_x = rand(-12,12)
 	default_pixel_y = rand(-12,12)
 	pixel_x = default_pixel_x
 	pixel_y = default_pixel_y
+
 
 /mob/living/simple_animal/aquatic/Life()
 	if(!submerged())

--- a/code/modules/mob/living/simple_animal/aquatic/aquatic_carp.dm
+++ b/code/modules/mob/living/simple_animal/aquatic/aquatic_carp.dm
@@ -15,9 +15,10 @@
 	bone_material = MATERIAL_BONE_FISH
 	skin_material = MATERIAL_SKIN_FISH
 
-/mob/living/simple_animal/hostile/retaliate/aquatic/carp/New()
-	..()
-	default_pixel_x = rand(-8,8)
-	default_pixel_y = rand(-8,8)
+
+/mob/living/simple_animal/hostile/retaliate/aquatic/carp/Initialize(mapload)
+	. = ..()
+	default_pixel_x = rand(-8, 8)
+	default_pixel_y = rand(-8, 8)
 	pixel_x = default_pixel_x
 	pixel_y = default_pixel_y

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -40,15 +40,17 @@
 /mob/living/simple_animal/construct/cultify()
 	return
 
-/mob/living/simple_animal/construct/New()
-	..()
-	name = text("[initial(name)] ([random_id(/mob/living/simple_animal/construct, 1000, 9999)])")
+
+/mob/living/simple_animal/construct/Initialize()
+	. = ..()
+	SetName("[initial(name)] ([random_id(/mob/living/simple_animal/construct, 1000, 9999)])")
 	real_name = name
 	add_language(LANGUAGE_CULT)
 	add_language(LANGUAGE_CULT_GLOBAL)
 	for(var/spell in construct_spells)
 		add_spell(new spell, "const_spell_ready")
 	update_icon()
+
 
 /mob/living/simple_animal/construct/death(gibbed, deathmessage, show_dead_message)
 	new /obj/item/ectoplasm (src.loc)

--- a/code/modules/mob/living/simple_animal/crow/crow.dm
+++ b/code/modules/mob/living/simple_animal/crow/crow.dm
@@ -40,10 +40,12 @@
 	sharp = TRUE
 	force = 7
 
-/mob/living/simple_animal/crow/New()
-	..()
+
+/mob/living/simple_animal/crow/Initialize()
+	. = ..()
 	messenger_bag = new(src)
 	update_icon()
+
 
 /mob/living/simple_animal/crow/GetIdCard()
 	return access_card

--- a/code/modules/mob/living/simple_animal/familiars/familiars.dm
+++ b/code/modules/mob/living/simple_animal/familiars/familiars.dm
@@ -16,11 +16,13 @@
 
 	var/list/wizardy_spells = list()
 
-/mob/living/simple_animal/familiar/New()
-	..()
+
+/mob/living/simple_animal/familiar/Initialize(maplaod)
+	. = ..()
 	add_language(LANGUAGE_HUMAN_EURO)
 	for(var/spell in wizardy_spells)
 		src.add_spell(new spell, "const_spell_ready")
+
 
 /mob/living/simple_animal/familiar/carcinus
 	name = "carcinus"
@@ -156,11 +158,12 @@
 
 	wizardy_spells = list(/spell/aoe_turf/smoke)
 
-/mob/living/simple_animal/familiar/pet/mouse/New()
-	..()
 
+/mob/living/simple_animal/familiar/pet/mouse/Initialize(mapload)
+	. = ..()
 	verbs += /mob/living/proc/ventcrawl
 	verbs += /mob/living/proc/hide
+
 
 /mob/living/simple_animal/familiar/pet/cat
 	name = "black cat"

--- a/code/modules/mob/living/simple_animal/friendly/cat.dm
+++ b/code/modules/mob/living/simple_animal/friendly/cat.dm
@@ -214,9 +214,11 @@
 	holder_type = /obj/item/holder/cat/fluff/bones
 	var/friend_name = "Erstatz Vryroxes"
 
-/mob/living/simple_animal/passive/cat/kitten/New()
+
+/mob/living/simple_animal/passive/cat/kitten/Initialize(mapload)
+	. = ..()
 	gender = pick(MALE, FEMALE)
-	..()
+
 
 /datum/ai_holder/simple_animal/passive/cat
 	can_flee = TRUE

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -31,9 +31,11 @@
 	if(holder.stat == CONSCIOUS && prob(50))
 		holder.visible_message(SPAN_WARNING("\The [holder] gets an evil-looking gleam in their eye."))
 
-/mob/living/simple_animal/hostile/retaliate/goat/New()
+
+/mob/living/simple_animal/hostile/retaliate/goat/Initialize(mapload)
+	. = ..()
 	udder = new(50, src)
-	..()
+
 
 /mob/living/simple_animal/hostile/retaliate/goat/Destroy()
 	QDEL_NULL(udder)
@@ -136,9 +138,10 @@
 	ai_holder = /datum/ai_holder/simple_animal/passive/cow
 	say_list_type = /datum/say_list/cow
 
-/mob/living/simple_animal/passive/cow/New()
+
+/mob/living/simple_animal/passive/cow/Initialize(mapload)
 	udder = new(50, src)
-	..()
+	. = ..()
 
 
 /mob/living/simple_animal/passive/cow/get_interactions_info()
@@ -226,10 +229,12 @@
 	ai_holder = /datum/ai_holder/simple_animal/passive/chick
 	say_list_type = /datum/say_list/chick
 
-/mob/living/simple_animal/passive/chick/New()
-	..()
+
+/mob/living/simple_animal/passive/chick/Initialize(mapload)
+	. = ..()
 	pixel_x = rand(-6, 6)
 	pixel_y = rand(0, 10)
+
 
 /mob/living/simple_animal/passive/chick/Life()
 	. = ..()
@@ -270,8 +275,9 @@ var/global/chicken_count = 0
 	ai_holder = /datum/ai_holder/simple_animal/passive/chicken
 	say_list_type = /datum/say_list/chicken
 
-/mob/living/simple_animal/passive/chicken/New()
-	..()
+
+/mob/living/simple_animal/passive/chicken/Initialize(mapload)
+	. = ..()
 	if(!body_color)
 		body_color = pick( list("brown","black","white") )
 	icon_state = "chicken_[body_color]"
@@ -280,6 +286,7 @@ var/global/chicken_count = 0
 	pixel_x = rand(-6, 6)
 	pixel_y = rand(0, 10)
 	chicken_count += 1
+
 
 /mob/living/simple_animal/passive/chicken/death(gibbed, deathmessage, show_dead_message)
 	..(gibbed, deathmessage, show_dead_message)
@@ -411,9 +418,10 @@ var/global/chicken_count = 0
 	ai_holder = /datum/ai_holder/simple_animal/passive
 	say_list_type = /datum/say_list/thoom
 
-/mob/living/simple_animal/passive/thoom/New()
+
+/mob/living/simple_animal/passive/thoom/Initialize(mapload)
 	udder = new(50, src)
-	..()
+	. = ..()
 
 
 /mob/living/simple_animal/passive/thoom/get_interactions_info()

--- a/code/modules/mob/living/simple_animal/friendly/juvenile_space_whale.dm
+++ b/code/modules/mob/living/simple_animal/friendly/juvenile_space_whale.dm
@@ -36,13 +36,15 @@
 	ai_holder = /datum/ai_holder/simple_animal/passive
 	say_list_type = /datum/say_list/juvenile_space_whale
 
-/mob/living/simple_animal/passive/juvenile_space_whale/New()
-	..()
+
+/mob/living/simple_animal/passive/juvenile_space_whale/Initialize(mapload)
+	. = ..()
 	var/mob/living/simple_animal/hostile/retaliate/space_whale/W = locate() in viewers(src, 7)
 	if(W && !parent && !W.baby)
 		W.baby = src
 		parent = W
 		color = parent.color
+
 
 /mob/living/simple_animal/passive/juvenile_space_whale/Life()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/mushroom.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mushroom.dm
@@ -28,10 +28,12 @@
 
 	ai_holder = /datum/ai_holder/simple_animal/passive/mushroom
 
-/mob/living/simple_animal/passive/mushroom/New()
-	..()
+
+/mob/living/simple_animal/passive/mushroom/Initialize(mapload)
+	. = ..()
 	harvest_time = world.time
 	total_mushrooms++
+
 
 /mob/living/simple_animal/passive/mushroom/verb/spawn_spores()
 

--- a/code/modules/mob/living/simple_animal/friendly/slime.dm
+++ b/code/modules/mob/living/simple_animal/friendly/slime.dm
@@ -35,8 +35,9 @@
 	response_harm   = "stomps on"
 	var/colour = "grey"
 
-/mob/living/simple_animal/adultslime/New()
-	..()
+
+/mob/living/simple_animal/adultslime/Initialize(mapload)
+	. = ..()
 	overlays += "aslime-:33"
 
 

--- a/code/modules/mob/living/simple_animal/hostile/hivebot/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot/hivebot.dm
@@ -83,15 +83,17 @@ Teleporter beacon, and its subtypes
 
 	ai_holder = /datum/ai_holder/simple_animal/hivebot/tele
 
-/mob/living/simple_animal/hostile/hivebot/tele/New()
-	..()
-	var/datum/effect/effect/system/smoke_spread/smoke = new /datum/effect/effect/system/smoke_spread()
-	smoke.set_up(5, 0, src.loc)
+
+/mob/living/simple_animal/hostile/hivebot/tele/Initialize(mapload)
+	. = ..()
+	var/datum/effect/effect/system/smoke_spread/smoke = new
+	smoke.set_up(5, 0, loc)
 	smoke.start()
 	visible_message(SPAN_DANGER("\The [src] warps in!"))
-	playsound(src.loc, 'sound/effects/EMPulse.ogg', 25, 1)
+	playsound(src, 'sound/effects/EMPulse.ogg', 25, TRUE)
 	set_AI_busy(TRUE)
 	spawn_time = world.time + spawn_delay
+
 
 /mob/living/simple_animal/hostile/hivebot/tele/proc/warpbots()
 	while(bot_amt > 0 && bot_type)

--- a/code/modules/mob/living/simple_animal/hostile/mimic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mimic.dm
@@ -62,12 +62,13 @@ GLOBAL_LIST_INIT(mimic_protected, list(
 		return . - M.creator.resolve()
 
 
-/mob/living/simple_animal/hostile/mimic/New(newloc, obj/o, mob/living/creator)
-	..()
+/mob/living/simple_animal/hostile/mimic/Initialize(mapload, obj/o, mob/living/creator)
+	. = ..()
 	if(o)
 		if(ispath(o))
-			o = new o(newloc)
+			o = new o(loc)
 		CopyObject(o,creator)
+
 
 /mob/living/simple_animal/hostile/mimic/proc/CopyObject(obj/O, mob/living/creator)
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -95,25 +95,29 @@
 	var/impatience = 5 //we lose this much from relax_chance each time we calm down
 	var/icon_set = "parrot"
 
+	var/list/spawn_headset_options = list(
+		/obj/item/device/radio/headset/headset_sec,
+		/obj/item/device/radio/headset/headset_eng,
+		/obj/item/device/radio/headset/headset_med,
+		/obj/item/device/radio/headset/headset_sci,
+		/obj/item/device/radio/headset/headset_cargo
+	)
+
 	ai_holder = /datum/ai_holder/simple_animal/retaliate/parrot
 
 
-/mob/living/simple_animal/hostile/retaliate/parrot/New()
-	..()
-	if(!ears)
-		var/headset = pick(/obj/item/device/radio/headset/headset_sec, \
-						/obj/item/device/radio/headset/headset_eng, \
-						/obj/item/device/radio/headset/headset_med, \
-						/obj/item/device/radio/headset/headset_sci, \
-						/obj/item/device/radio/headset/headset_cargo)
+/mob/living/simple_animal/hostile/retaliate/parrot/Initialize(mapload)
+	. = ..()
+	if (!ears && length(spawn_headset_options))
+		var/headset = pick(spawn_headset_options)
 		ears = new headset(src)
 
 	parrot_sleep_dur = parrot_sleep_max //In case someone decides to change the max without changing the duration var
 
-	verbs.Add(/mob/living/simple_animal/hostile/retaliate/parrot/proc/steal_from_ground, \
-			  /mob/living/simple_animal/hostile/retaliate/parrot/proc/steal_from_mob, \
-			  /mob/living/simple_animal/hostile/retaliate/parrot/verb/drop_held_item_player, \
-			  /mob/living/simple_animal/hostile/retaliate/parrot/proc/perch_player)
+	verbs += /mob/living/simple_animal/hostile/retaliate/parrot/proc/steal_from_ground
+	verbs += /mob/living/simple_animal/hostile/retaliate/parrot/proc/steal_from_mob
+	verbs += /mob/living/simple_animal/hostile/retaliate/parrot/verb/drop_held_item_player
+	verbs += /mob/living/simple_animal/hostile/retaliate/parrot/proc/perch_player
 
 	update_icon()
 
@@ -700,11 +704,8 @@
 /mob/living/simple_animal/hostile/retaliate/parrot/Poly
 	name = "Poly"
 	desc = "Poly the Parrot. An expert on quantum cracker theory."
+	spawn_headset_options = list(/obj/item/device/radio/headset/headset_eng)
 
-/mob/living/simple_animal/hostile/retaliate/parrot/Poly/New()
-	ears = new /obj/item/device/radio/headset/headset_eng(src)
-	available_channels = list(":e")
-	..()
 
 /mob/living/simple_animal/hostile/retaliate/parrot/say(message)
 

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -21,8 +21,8 @@
 	virtual_mob = null // Hear no evil, speak no evil
 
 
-/mob/new_player/New()
-	..()
+/mob/new_player/Initialize(mapload)
+	. = ..()
 	verbs += /mob/proc/toggle_antag_pool
 
 

--- a/code/modules/mob/observer/freelook/ai/eye.dm
+++ b/code/modules/mob/observer/freelook/ai/eye.dm
@@ -7,18 +7,22 @@
 	name = "Inactive Camera Eye"
 	name_sufix = "Camera Eye"
 
-/mob/observer/eye/cameranet/New()
-	..()
+
+/mob/observer/eye/cameranet/Initialize(mapload)
+	. = ..()
 	visualnet = cameranet
+
 
 /mob/observer/eye/aiEye
 	name = "Inactive AI Eye"
 	name_sufix = "AI Eye"
 	icon_state = "AI-eye"
 
-/mob/observer/eye/aiEye/New()
-	..()
+
+/mob/observer/eye/aiEye/Initialize(mapload)
+	. = ..()
 	visualnet = cameranet
+
 
 /mob/observer/eye/aiEye/setLoc(T, cancel_tracking = 1)
 	. = ..()
@@ -65,9 +69,10 @@
 	eyeobj.possess(src)
 
 // Intiliaze the eye by assigning it's "ai" variable to us. Then set it's loc to us.
-/mob/living/silicon/ai/New()
-	..()
+/mob/living/silicon/ai/Initialize(mapload)
+	. = ..()
 	create_eyeobj()
+
 
 /mob/living/silicon/ai/Destroy()
 	destroy_eyeobj()

--- a/code/modules/mob/observer/freelook/ai/update_triggers.dm
+++ b/code/modules/mob/observer/freelook/ai/update_triggers.dm
@@ -37,9 +37,10 @@
 	invalidateCameraCache()
 
 // Mobs
-/mob/living/silicon/ai/New()
-	..()
+/mob/living/silicon/ai/Initialize(mapload)
+	. = ..()
 	cameranet.add_source(src)
+
 
 /mob/living/silicon/ai/Destroy()
 	cameranet.remove_source(src)

--- a/code/modules/mob/observer/freelook/cult/mask.dm
+++ b/code/modules/mob/observer/freelook/cult/mask.dm
@@ -2,9 +2,11 @@
 	name = "Mask of God"
 	desc = "A terrible fracture of reality coinciding into a mirror to another world."
 
-/mob/observer/eye/cult/New(loc, net)
-	..()
+
+/mob/observer/eye/cult/Initialize(mapload, net)
+	. = ..()
 	visualnet = net
+
 
 /mob/observer/eye/cult/Destroy()
 	visualnet = null

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -32,12 +32,13 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 	var/obj/item/device/multitool/ghost_multitool
 	var/list/hud_images // A list of hud images
 
-/mob/observer/ghost/New(mob/body)
+/mob/observer/ghost/Initialize(mapload)
 	see_in_dark = 100
 	verbs += /mob/proc/toggle_antag_pool
 
 	var/turf/T
-	if(ismob(body))
+	if(ismob(loc))
+		var/mob/body = loc
 		T = get_turf(body)               //Where is the body located?
 		attack_logs_ = body.attack_logs_ //preserve our attack logs by copying them to our ghost
 
@@ -72,7 +73,7 @@ var/global/list/image/ghost_sightless_images = list() //this is a list of images
 
 	GLOB.ghost_mobs += src
 
-	..()
+	. = ..()
 
 /mob/observer/ghost/Destroy()
 	GLOB.ghost_mobs -= src

--- a/code/modules/mob/observer/observer.dm
+++ b/code/modules/mob/observer/observer.dm
@@ -16,8 +16,8 @@ var/global/const/GHOST_IMAGE_ALL = ~GHOST_IMAGE_NONE
 	var/ghost_image_flag = GHOST_IMAGE_DARKNESS
 	var/image/ghost_image = null //this mobs ghost image, for deleting and stuff
 
-/mob/observer/New()
-	..()
+/mob/observer/Initialize(mapload)
+	. = ..()
 	ghost_image = image(src.icon,src)
 	ghost_image.plane = plane
 	ghost_image.layer = layer

--- a/code/modules/mob/observer/virtual/base.dm
+++ b/code/modules/mob/observer/virtual/base.dm
@@ -17,8 +17,9 @@ var/global/list/all_virtual_listeners = list()
 
 	var/static/list/overlay_icons
 
-/mob/observer/virtual/New(location, atom/movable/host)
-	..()
+/mob/observer/virtual/Initialize(mapload, atom/movable/host)
+	. = ..()
+
 	if(!istype(host, host_type))
 		CRASH("Received an unexpected host type. Expected [host_type], was [log_info_line(host)].")
 	src.host = host
@@ -28,8 +29,6 @@ var/global/list/all_virtual_listeners = list()
 
 	update_icon()
 
-/mob/observer/virtual/Initialize()
-	. = ..()
 	STOP_PROCESSING_MOB(src)
 
 /mob/observer/virtual/Destroy()

--- a/code/modules/mob/observer/virtual/mob.dm
+++ b/code/modules/mob/observer/virtual/mob.dm
@@ -1,14 +1,16 @@
 /mob/observer/virtual/mob
 	host_type = /mob
 
-/mob/observer/virtual/mob/New(location, mob/host)
-	..()
+
+/mob/observer/virtual/mob/Initialize(mapload, mob/host)
+	. = ..()
 
 	GLOB.sight_set_event.register(host, src, /mob/observer/virtual/mob/proc/sync_sight)
 	GLOB.see_invisible_set_event.register(host, src, /mob/observer/virtual/mob/proc/sync_sight)
 	GLOB.see_in_dark_set_event.register(host, src, /mob/observer/virtual/mob/proc/sync_sight)
 
 	sync_sight(host)
+
 
 /mob/observer/virtual/mob/Destroy()
 	GLOB.sight_set_event.unregister(host, src, /mob/observer/virtual/mob/proc/sync_sight)

--- a/code/modules/species/outsider/zombie.dm
+++ b/code/modules/species/outsider/zombie.dm
@@ -510,21 +510,29 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 	update_icon()
 
 
-/mob/living/carbon/human/zombie/New(new_loc)
-	..(new_loc, SPECIES_ZOMBIE)
+/mob/living/carbon/human/zombie
+	/// List (`/singleton/hierarchy/outfit`) - List of possible outfits the zombie can spawn as. Randomly chosen during init.
+	var/list/spawn_outfit_options = list(
+		/singleton/hierarchy/outfit/job/science/scientist,
+		/singleton/hierarchy/outfit/job/engineering/engineer,
+		/singleton/hierarchy/outfit/job/cargo/mining,
+		/singleton/hierarchy/outfit/job/medical/chemist
+	)
+
+
+/mob/living/carbon/human/zombie/Initialize(mapload)
+	. = ..(mapload, SPECIES_ZOMBIE)
 
 	var/singleton/cultural_info/culture = get_cultural_value(TAG_CULTURE)
 	SetName(culture.get_random_name(gender))
 	real_name = name
 
-	var/singleton/hierarchy/outfit/outfit = pick(
-		/singleton/hierarchy/outfit/job/science/scientist,\
-		/singleton/hierarchy/outfit/job/engineering/engineer,\
-		/singleton/hierarchy/outfit/job/cargo/mining,\
-		/singleton/hierarchy/outfit/job/medical/chemist\
-	)
-	outfit = outfit_by_type(outfit)
-	outfit.equip(src, OUTFIT_ADJUSTMENT_SKIP_SURVIVAL_GEAR)
-
 	ChangeToHusk()
 	zombify()
+
+
+/mob/living/carbon/human/zombie/LateInitialize(mapload)
+	..()
+	var/singleton/hierarchy/outfit/outfit = pick(spawn_outfit_options)
+	outfit = outfit_by_type(outfit)
+	outfit.equip(src, OUTFIT_ADJUSTMENT_SKIP_SURVIVAL_GEAR)

--- a/code/modules/spells/racial_wizard.dm
+++ b/code/modules/spells/racial_wizard.dm
@@ -239,9 +239,11 @@
 /mob/observer/eye/wizard_eye
 	name_sufix = "Wizard Eye"
 
-/mob/observer/eye/wizard_eye/New() //we dont use the Ai one because it has AI specific procs imbedded in it.
-	..()
+
+/mob/observer/eye/wizard_eye/Initialize(mapload) //we dont use the Ai one because it has AI specific procs imbedded in it.
+	. = ..()
 	visualnet = cameranet
+
 
 /mob/living/proc/release_eye()
 	set name = "Release Vision"

--- a/maps/torch/torch_npcs.dm
+++ b/maps/torch/torch_npcs.dm
@@ -3,19 +3,25 @@
 	id = "Punitelli"
 	item_path = /mob/living/carbon/human/monkey/punitelli
 
-/mob/living/carbon/human/monkey/punitelli/New()
-	..()
+/mob/living/carbon/human/monkey/punitelli
 	name = "Warrant Officer Punitelli"
-	real_name = name
 	gender = MALE
 	faction = MOB_FACTION_CREW
-	var/obj/item/clothing/C
-	C = new /obj/item/clothing/under/solgov/utility/expeditionary/monkey(src)
-	equip_to_appropriate_slot(C)
+
+
+/mob/living/carbon/human/monkey/punitelli/Initialize(mapload)
+	. = ..()
+	real_name = name
+	return INITIALIZE_HINT_LATELOAD
+
+
+/mob/living/carbon/human/monkey/punitelli/LateInitialize(mapload)
+	..()
+	equip_to_appropriate_slot(new /obj/item/clothing/under/solgov/utility/expeditionary/monkey, skip_timer = TRUE)
 	put_in_hands(new /obj/item/reagent_containers/food/drinks/glass2/coffeecup/punitelli)
-	equip_to_appropriate_slot(new /obj/item/clothing/mask/smokable/cigarette/jerichos)
+	equip_to_appropriate_slot(new /obj/item/clothing/mask/smokable/cigarette/jerichos, skip_timer = TRUE)
 	if(prob(50))
-		equip_to_appropriate_slot(new /obj/item/clothing/shoes/sandal)
+		equip_to_appropriate_slot(new /obj/item/clothing/shoes/sandal, skip_timer = TRUE)
 
 /obj/random_multi/single_item/runtime
 	name = "Multi Point - Runtime"


### PR DESCRIPTION
Passes through all cases of `/mob` subtypes overriding `New()` and replaces them with `Initialize()`, `LateInitialize()`, or type definitions as applicable.

## Changelog
:cl: SierraKomodo
refactor: Updated intialization for mobs.
/:cl:

## Other Changes
- Added `skip_timer` flag to `/mob/proc/equip_to_appropriate_slot()`, which causes the proc chain to skip the do_after timer call by passing directly through to `equip_to_slot_if_possible()` as `TRYEQUIP_INSTANT`.