### PR TITLE
Bug Fixes 2023-04-09

### DIFF
--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -34,8 +34,8 @@
 	to_chat(usr, SPAN_NOTICE("Issuing reason: [reason]."))
 
 /obj/item/card/id/guest/proc/expire()
-	color = COLOR_BLACK
-	detail_color = COLOR_BLACK
+	color = COLOR_GRAY20
+	detail_color = COLOR_GRAY15
 	update_icon()
 
 	expired = TRUE

--- a/code/game/machinery/jukebox.dm
+++ b/code/game/machinery/jukebox.dm
@@ -10,6 +10,7 @@
 	active_power_usage = 100
 	clicksound = 'sound/machines/buttonbeep.ogg'
 	pixel_x = -8
+	obj_flags = OBJ_FLAG_ANCHORABLE
 
 	var/jukebox/jukebox
 

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -264,6 +264,16 @@ BLIND     // can't see anything
 	else
 		return icon_state
 
+/obj/item/clothing/glasses/on_update_icon()
+	if (toggleable)
+		if (active)
+			var/datum/extension/base_icon_state/BIS = get_extension(src, /datum/extension/base_icon_state)
+			icon_state = BIS.base_icon_state
+		else
+			icon_state = off_state
+	else
+		icon_state = initial(icon_state)
+
 /obj/item/clothing/glasses/update_clothing_icon()
 	if (ismob(src.loc))
 		var/mob/M = src.loc

--- a/code/modules/clothing/glasses/eyepatch.dm
+++ b/code/modules/clothing/glasses/eyepatch.dm
@@ -24,6 +24,12 @@
 	update_clothing_icon()
 
 
+/obj/item/clothing/glasses/eyepatch/on_update_icon()
+	..()
+	if (flipped)
+		icon_state += "_r"
+
+
 /obj/item/clothing/glasses/eyepatch/hud
 	name = "iPatch"
 	desc = "For the technologically inclined pirate. It connects directly to the optical nerve of the user, replacing the need for that useless eyeball."
@@ -46,6 +52,7 @@
 	update_icon()
 
 /obj/item/clothing/glasses/eyepatch/hud/on_update_icon()
+	..()
 	overlays.Cut()
 	if(active)
 		var/image/eye = overlay_image(icon, "[icon_state]_eye", flags=RESET_COLOR)

--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -36,9 +36,7 @@
 
 /obj/item/clothing/glasses/proc/activate(mob/user)
 	if(toggleable && !active)
-		var/datum/extension/base_icon_state/BIS = get_extension(src, /datum/extension/base_icon_state)
 		active = TRUE
-		icon_state = BIS.base_icon_state
 		flash_protection = initial(flash_protection)
 		tint = initial(tint)
 		if(user)
@@ -51,13 +49,13 @@
 			else
 				to_chat(user, "You activate the optical matrix on \the [src].")
 
+		update_icon()
 		update_clothing_icon()
 		update_vision()
 
 /obj/item/clothing/glasses/proc/deactivate(mob/user, manual = TRUE)
 	if(toggleable && active)
 		active = FALSE
-		icon_state = off_state
 		if(user)
 			if(manual)
 				if(toggle_off_message)
@@ -71,6 +69,7 @@
 
 		flash_protection = FLASH_PROTECTION_NONE
 		tint = TINT_NONE
+		update_icon()
 		update_clothing_icon()
 		update_vision()
 

--- a/code/modules/shuttles/shuttle_console_multi.dm
+++ b/code/modules/shuttles/shuttle_console_multi.dm
@@ -19,22 +19,3 @@
 		if(dest_key && CanInteract(usr, GLOB.default_state))
 			shuttle.set_destination(dest_key, usr)
 		return TOPIC_REFRESH
-
-
-/obj/machinery/computer/shuttle_control/multi/antag
-	ui_template = "shuttle_control_console_antag.tmpl"
-
-/obj/machinery/computer/shuttle_control/multi/antag/get_ui_data(datum/shuttle/autodock/multi/antag/shuttle)
-	. = ..()
-	if(istype(shuttle))
-		. += list(
-			"cloaked" = shuttle.cloaked,
-		)
-
-/obj/machinery/computer/shuttle_control/multi/antag/handle_topic_href(datum/shuttle/autodock/multi/antag/shuttle, list/href_list)
-	if((. = ..()) != null)
-		return
-
-	if(href_list["toggle_cloaked"])
-		shuttle.cloaked = !shuttle.cloaked
-		return TOPIC_REFRESH


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Jukeboxes can be anchored/unanchored with a wrench again.
bugfix: FLipped iPatches no longer erset their position when toggled on/off.
refactor: Reworked how icon states were handled for toggleable glasses.
tweak: Expired guest passes are now a dark gray that still shows sprite details instad of a black void rectangle.
/:cl:

## Bug Fixes
- Fixes #33173

## Other Changes
- Removed `/obj/machinery/computer/shuttle_control/multi/antag` - This is unused, and future implementation of stealth will require a refactor for overmap usability anyway.