### PR TITLE
Upgrade bridge solar SMES roundstart

### DIFF
--- a/code/modules/power/smes_presets.dm
+++ b/code/modules/power/smes_presets.dm
@@ -32,4 +32,13 @@
 	_input_on = TRUE
 	_output_on = TRUE
 	_fully_charged = TRUE
-	
+
+/obj/machinery/power/smes/buildable/preset/bridgesolars
+	uncreated_component_parts = list(
+		/obj/item/stock_parts/smes_coil/advanced = 1
+	)
+	_input_maxed = TRUE
+	_output_maxed = TRUE
+	_input_on = TRUE
+	_output_on = TRUE
+	_fully_charged = TRUE

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -13469,17 +13469,16 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Solar - Bridge";
-	capacity = 1e+007;
-	dir = 4
-	},
 /obj/item/device/radio/intercom{
 	pixel_y = 23
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Solar Control - Bridge";
 	dir = 4
+	},
+/obj/machinery/power/smes/buildable/preset/bridgesolars{
+	dir = 4;
+	RCon_tag = "Solar - Bridge"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarbridge)


### PR DESCRIPTION
:cl:
maptweak: Bridge Solar SMES starts on, full, and with 1 magnetic coil in it.
/:cl:

This is to give more time for low pop rounds with no engineering.