### PR TITLE
Upgrades bridge deck solars roundstart

### DIFF
--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -13469,16 +13469,14 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/power/smes/buildable{
-	RCon_tag = "Solar - Bridge";
-	capacity = 1e+007;
-	dir = 4
-	},
 /obj/item/device/radio/intercom{
 	pixel_y = 23
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Solar Control - Bridge";
+	dir = 4
+	},
+/obj/machinery/power/smes/buildable/preset/torch/bridge_solar{
 	dir = 4
 	},
 /turf/simulated/floor/plating,

--- a/maps/torch/torch_presets.dm
+++ b/maps/torch/torch_presets.dm
@@ -183,6 +183,18 @@ var/global/const/NETWORK_PETROV  = "Petrov"
 	_output_on = TRUE
 	_fully_charged = TRUE
 
+// Bridge Solars SMES. For those low pop rounds.
+/obj/machinery/power/smes/buildable/preset/torch/bridge_solar
+	uncreated_component_parts = list(
+		/obj/item/stock_parts/smes_coil/advanced = 1
+	)
+	RCon_tag = "Solar - Bridge"
+	_input_maxed = TRUE
+	_output_maxed = TRUE
+	_input_on = TRUE
+	_output_on = TRUE
+	_fully_charged = TRUE
+
 var/global/const/NETWORK_COMMAND = "Command"
 var/global/const/NETWORK_ENGINE  = "Engine"
 var/global/const/NETWORK_ENGINEERING_OUTPOST = "Engineering Outpost"


### PR DESCRIPTION
:cl:
maptweak: Bridge Solar SMES starts on, full, and with 1 magnetic coil in it.
/:cl:

This is to give more time for low pop rounds with no engineering.