### PR TITLE
Aghost improvements

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -13,6 +13,7 @@
 #define INVISIBILITY_LEVEL_TWO   45
 #define INVISIBILITY_OBSERVER    60
 #define INVISIBILITY_EYE         61
+#define INVISIBILITY_AGHOST	     62
 #define INVISIBILITY_SYSTEM      99
 #define INVISIBILITY_ABSTRACT   101	// special: this can never be seen, regardless of see_invisible
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -394,6 +394,9 @@ var/global/list/admin_verbs_mod = list(
 		//ghostize
 		var/mob/body = mob
 		var/mob/observer/ghost/ghost = body.ghostize(1)
+		if (ghost.client.is_stealthed())
+			ghost.set_invisibility(INVISIBILITY_AGHOST)
+			ghost.set_see_invisible(INVISIBILITY_AGHOST)
 		sound_to(usr, sound(null))
 
 		if (!ghost)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -184,7 +184,7 @@
 	if(ssd_msg && (!should_have_organ(BP_BRAIN) || has_brain()) && stat != DEAD)
 		if(!key)
 			msg += SPAN_DEBUG("[P.He] [P.is] [ssd_msg]. [P.He] won't be recovering any time soon. (Ghosted)") + "\n"
-		else if(!client)
+		else if(!client && !client.is_stealthed())
 			msg += SPAN_DEBUG("[P.He] [P.is] [ssd_msg]. (Disconnected)") + "\n"
 
 	if (admin_paralyzed)


### PR DESCRIPTION
:cl: Mucker
admin: admin-ghosts are now invisible to other ghosts.
admin: The 'Disconnected' message will no longer show on admin-ghosted mobs. 
/:cl: