### PR TITLE
Increase wall health

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -70,23 +70,23 @@
 
 /turf/simulated/wall/proc/calculate_damage_data()
 	// Health
-	var/max_health = material.integrity
+	var/max_health = material.integrity * 1.5
 	if (reinf_material)
-		max_health += round(reinf_material.integrity / 2)
+		max_health += round(reinf_material.integrity * 0.75)
 	set_max_health(max_health)
 
 	// Minimum force required to damage the wall
-	health_min_damage = material.hardness * 1.5
+	health_min_damage = material.hardness * 2.6
 	if (reinf_material)
-		health_min_damage += round(reinf_material.hardness * 1.5)
+		health_min_damage += round(reinf_material.hardness * 1.9)
 	health_min_damage = round(health_min_damage / 10)
 
 	// Brute and burn armor
-	var/brute_armor = material.brute_armor * 0.2
-	var/burn_armor = material.burn_armor * 0.2
+	var/brute_armor = material.brute_armor * 0.4
+	var/burn_armor = material.burn_armor * 0.4
 	if (reinf_material)
-		brute_armor += reinf_material.brute_armor * 0.2
-		burn_armor += reinf_material.burn_armor * 0.2
+		brute_armor += reinf_material.brute_armor * 0.4
+		burn_armor += reinf_material.burn_armor * 0.4
 	// Materials enter armor as divisors, health system uses multipliers
 	if (brute_armor)
 		brute_armor = round(1 / brute_armor, 0.01)


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
balance: Wall health, minimum damage value, and basic resistance values have all been increased to make walls harder to break down without tools. See https://github.com/Baystation12/Baystation12/pull/33263 for specific numbers.
/:cl:

## Notes
The changes are balanced around the following:
- Stun batons (15 damage) can no longer damage steel walls (Default steel bulkhead).
- Energy swords (30 damage) can no longer damage plasteel-reinforced steel walls (Default reinforced steel bulkhead).
- Resistance to brute and burn damage and health increased to make breaking down walls from damage take longer.
- Explosion damage ratios are unaffected, and walls should still be as susceptible to a bomb as before.

## Some magic data
| +++++ | Steel Wall (Old) | Steel Wall (New) | Reinforced Wall (Old) | Reinforced Wall (New) |
| ----- | ---------------- | ---------------- | --------------------- | --------------------- |
| Health | 150 | 225 | 350 | 525 |
| Min Damage | 9 | 16 | 21 | 31 |
| Brute Armor | 0.71 | 0.36 | 0.33 | 0.17 |
| Burn Armor | 1 | 1 | 0.50 | 0.25 |