### PR TITLE
Reduce sword force multiplier

### DIFF
--- a/code/game/objects/items/weapons/material/swords.dm
+++ b/code/game/objects/items/weapons/material/swords.dm
@@ -6,7 +6,7 @@
 	item_state = "claymore"
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_LARGE
-	force_multiplier = 0.5 // 30 when wielded with hardness 60 (steel)
+	force_multiplier = 0.25 // 15 when wielded with hardness 60 (steel)
 	armor_penetration = 10
 	thrown_force_multiplier = 0.5 // 10 when thrown with weight 20 (steel)
 	sharp = TRUE


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
balance: Craftable sword damage has been reduced by half.
/:cl:

This reduces the titanium claymore's damage from 40 to 20, and steel claymore from 30 to 15.