### PR TITLE
Stack Name Helpers

### DIFF
--- a/code/__defines/feedback.dm
+++ b/code/__defines/feedback.dm
@@ -11,7 +11,7 @@
 /// ID card lacks access
 #define USE_FEEDBACK_ID_CARD_DENIED(REFUSER, ID_CARD) USE_FEEDBACK_FAILURE("\The [REFUSER] refuses [ID_CARD].")
 /// Item stack did not have enough items. `STACK` is assumed to be of type `/obj/item/stack`.
-#define USE_FEEDBACK_STACK_NOT_ENOUGH(STACK, NEEDED_AMT, ACTION) USE_FEEDBACK_FAILURE("You need at least [NEEDED_AMT] [NEEDED_AMT == 1 ? STACK.singular_name : STACK.plural_name] of \the [STACK] [ACTION]")
+#define USE_FEEDBACK_STACK_NOT_ENOUGH(STACK, NEEDED_AMT, ACTION) USE_FEEDBACK_FAILURE("You need at least [STACK.get_exact_name(NEEDED_AMT)] [ACTION]")
 
 /// Feedback messages intended for use in `use_grab()` overrides. These assume the presence of the `grab` variable.
 #define USE_FEEDBACK_GRAB_FAILURE(MSG) FEEDBACK_FAILURE(grab.assailant, MSG)

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -304,7 +304,7 @@ Standard helpers for users interacting with machinery parts.
 	if(isstack(part))
 		var/obj/item/stack/stack = part
 		if (!stack.can_use(number))
-			to_chat(user, SPAN_WARNING("You need at least [number] [stack.plural_name] to install into \the [src]."))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(stack, number, "to install into \the [src].")
 			return FALSE
 		install_component(stack.split(number, TRUE))
 	else

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -213,7 +213,7 @@
 				transfer = repairing.amount
 
 		if (transfer)
-			to_chat(user, SPAN_NOTICE("You fit [transfer] [stack.singular_name]\s to damaged and broken parts on \the [src]."))
+			to_chat(user, SPAN_NOTICE("You fit [stack.get_exact_name(transfer)] to damaged and broken parts on \the [src]."))
 
 		return
 

--- a/code/game/machinery/doors/simple.dm
+++ b/code/game/machinery/doors/simple.dm
@@ -145,7 +145,7 @@
 		var/amount_needed = Ceil(get_damage_value() / DOOR_REPAIR_AMOUNT)
 		var/used = min(amount_needed,stack.amount)
 		if (used)
-			to_chat(user, SPAN_NOTICE("You fit [used] [stack.singular_name]\s to damaged and broken parts on \the [src]."))
+			to_chat(user, SPAN_NOTICE("You fit [stack.get_exact_name(used)] to damaged and broken parts on \the [src]."))
 			stack.use(used)
 			restore_health(used * DOOR_REPAIR_AMOUNT)
 		return

--- a/code/game/objects/items/stacks/sheets/leather.dm
+++ b/code/game/objects/items/stacks/sheets/leather.dm
@@ -75,7 +75,7 @@
 		//visible message on mobs is defined as visible_message(var/message, var/self_message, var/blind_message)
 		usr.visible_message(SPAN_NOTICE("\The [usr] starts cutting hair off \the [src]"), SPAN_NOTICE("You start cutting the hair off \the [src]"), "You hear the sound of a knife rubbing against flesh")
 		if(do_after(user, 5 SECONDS, src, DO_REPAIR_CONSTRUCT))
-			to_chat(usr, SPAN_NOTICE("You cut the hair from this [src.singular_name]"))
+			to_chat(usr, SPAN_NOTICE("You cut the hair from [get_exact_name(1)]"))
 			//Try locating an exisitng stack on the tile and add to there if possible
 			for(var/obj/item/stack/hairlesshide/HS in usr.loc)
 				if(HS.amount < 50)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -340,6 +340,49 @@
 	else
 		return ..()
 
+
+/**
+ * Returns a string forming a basic name of the stack. By default, this is `name`.
+ *
+ * Has no parameters.
+ */
+/obj/item/stack/proc/get_stack_name()
+	return name
+
+
+/**
+ * Generates a name usable in messages without a specific number attached, i.e. `a sheet of paper` or `some paper sheets`.
+ *
+ * **Parameters**:
+ * - `plural` (Boolean, default `(src.amount == 1)`) - Whether the message uses `plural_name` or `singular_name`, and the proper grammatical rules.
+ *
+ * Returns string.
+ */
+/obj/item/stack/proc/get_vague_name(plural)
+	if (isnull(plural))
+		plural = (src.amount == 1)
+	if (plural)
+		return "some [get_stack_name()] [plural_name]"
+	else
+		return "\a [singular_name] of [get_stack_name()]"
+
+
+/**
+ * Generates a name usable in messages with a specific number attached, i.e. `1 sheet of paper` or `5 paper sheets`.
+ *
+ * **Parameters**:
+ * - `amount` (Integer, default `src.amount`) - The number of items for the message. Also determines whether `plural_name` or `singular_name` are used.
+ *
+ * Returns string.
+ */
+/obj/item/stack/proc/get_exact_name(amount)
+	if (isnull(amount))
+		amount = src.amount
+	if (amount == 1)
+		return "[amount] [singular_name] of [get_stack_name()]"
+	return "[amount] [get_stack_name()] [plural_name]"
+
+
 /*
  * Recipe datum
  */

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -50,9 +50,9 @@
 	. = ..()
 	if(distance <= 1)
 		if(!uses_charge)
-			to_chat(user, "There [src.amount == 1 ? "is" : "are"] [src.amount] [src.singular_name]\s in the stack.")
+			to_chat(user, "There [amount == 1 ? "is 1 [singular_name]" : "are [amount] [plural_name]"] in the stack.")
 		else
-			to_chat(user, "There is enough charge for [get_amount()].")
+			to_chat(user, "There is enough charge for [get_amount() == 1 ? "1 [singular_name]" : "[amount] [plural_name]"].")
 
 /obj/item/stack/attack_self(mob/user as mob)
 	list_recipes(user)
@@ -302,7 +302,7 @@
 			continue
 		var/transfer = src.transfer_to(item)
 		if (transfer)
-			to_chat(user, SPAN_NOTICE("You add a new [item.singular_name] to the stack. It now contains [item.amount] [item.singular_name]\s."))
+			to_chat(user, SPAN_NOTICE("You add a new [item.singular_name] to the stack. It now contains [item.get_exact_name(item.amount)]."))
 		if(!amount)
 			break
 
@@ -313,7 +313,7 @@
 
 /obj/item/stack/attack_hand(mob/user as mob)
 	if (user.get_inactive_hand() == src)
-		var/N = input("How many stacks of [src] would you like to split off?", "Split stacks", 1) as num|null
+		var/N = input("How many [plural_name] of \the [src] would you like to split off?", "Split stacks", 1) as num|null
 		if(N)
 			var/obj/item/stack/F = src.split(N)
 			if (F)

--- a/code/modules/crafting/_crafting_stage.dm
+++ b/code/modules/crafting/_crafting_stage.dm
@@ -44,7 +44,7 @@
 
 /singleton/crafting_stage/proc/on_insufficient_material(mob/user, obj/item/stack/thing)
 	if(istype(thing))
-		to_chat(user, SPAN_NOTICE("You need at least [stack_consume_amount] [stack_consume_amount == 1 ? thing.singular_name : thing.plural_name] to complete this task."))
+		USE_FEEDBACK_STACK_NOT_ENOUGH(thing, stack_consume_amount, "to complete this task.")
 
 /singleton/crafting_stage/proc/on_progress(mob/user)
 	if(progress_message)

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -142,12 +142,12 @@
 // Placeholders for light tiles and rglass.
 /material/proc/reinforce(mob/user, obj/item/stack/material/used_stack, obj/item/stack/material/target_stack)
 	if(!used_stack.can_use(1))
-		to_chat(user, SPAN_WARNING("You need need at least one [used_stack.singular_name] to reinforce [target_stack]."))
+		USE_FEEDBACK_STACK_NOT_ENOUGH(used_stack, 1, "to reinforce \the [target_stack].")
 		return
 
 	var/needed_sheets = 2 * used_stack.matter_multiplier
 	if(!target_stack.can_use(needed_sheets))
-		to_chat(user, SPAN_WARNING("You need need at least [needed_sheets] [target_stack.plural_name] for reinforcement with [used_stack]."))
+		USE_FEEDBACK_STACK_NOT_ENOUGH(target_stack, needed_sheets, "for reinforcement with \the [used_stack].")
 		return
 
 	var/material/reinf_mat = used_stack.material

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -83,16 +83,17 @@
 	if(material_flags & USE_MATERIAL_PLURAL_NAME)
 		plural_name = material.sheet_plural_name
 
+	SetName(get_stack_name())
 	if(amount>1)
-		SetName("[material.use_name] [plural_name]")
+		SetName("[name] [plural_name]")
 		desc = "A stack of [get_vague_name()]."
 		gender = PLURAL
 	else
-		SetName("[material.use_name] [singular_name]")
+		SetName("[name] [singular_name]")
 		desc = "[get_vague_name()]."
 		gender = NEUTER
 	if(reinf_material)
-		SetName("reinforced [name]")
+		SetName("[reinf_material.use_name]-reinforced [name]")
 		desc += "\nIt is reinforced with the [reinf_material.use_name] lattice."
 
 /obj/item/stack/material/use(used)

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -85,15 +85,15 @@
 
 	if(amount>1)
 		SetName("[material.use_name] [plural_name]")
-		desc = "A stack of [material.use_name] [plural_name]."
+		desc = "A stack of [get_vague_name()]."
 		gender = PLURAL
 	else
 		SetName("[material.use_name] [singular_name]")
-		desc = "A [singular_name] of [material.use_name]."
+		desc = "[get_vague_name()]."
 		gender = NEUTER
 	if(reinf_material)
 		SetName("reinforced [name]")
-		desc = "[desc]\nIt is reinforced with the [reinf_material.use_name] lattice."
+		desc += "\nIt is reinforced with the [reinf_material.use_name] lattice."
 
 /obj/item/stack/material/use(used)
 	. = ..()
@@ -143,7 +143,7 @@
 		var/obj/item/weldingtool/WT = W
 		if(WT.isOn() && WT.get_fuel() > 2 && use(2))
 			WT.remove_fuel(2, user)
-			to_chat(user,SPAN_NOTICE("You recover some [reinf_material.use_name] from the [src]."))
+			to_chat(user,SPAN_NOTICE("You recover some [reinf_material.use_name] from \the [src]."))
 			reinf_material.place_sheet(get_turf(user), 1)
 			return
 	return ..()

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -17,6 +17,13 @@
 	var/material_flags = USE_MATERIAL_COLOR|USE_MATERIAL_SINGULAR_NAME|USE_MATERIAL_PLURAL_NAME
 	var/matter_multiplier = 1
 
+
+/obj/item/stack/material/get_stack_name()
+	. = material.use_name
+	if (reinf_material)
+		. = "[reinf_material.use_name]-reinforced [.]"
+
+
 /obj/item/stack/material/Initialize(mapload, amount, _material, _reinf_material)
 	. = ..()
 	if(_material)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -519,8 +519,8 @@
 			USE_FEEDBACK_STACK_NOT_ENOUGH(cable, 1, "to repair \the [src]'s electronics damage.")
 			return TRUE
 		user.visible_message(
-			SPAN_NOTICE("\The [user] starts repairing some of the electronics in \the [src] with some [cable.plural_name] of \a [cable]."),
-			SPAN_NOTICE("You start repairing some of the electronics in \the [src] with some [cable.plural_name] of \the [cable]."),
+			SPAN_NOTICE("\The [user] starts repairing some of the electronics in \the [src] with [cable.get_vague_name(FALSE)]."),
+			SPAN_NOTICE("You start repairing some of the electronics in \the [src] with [cable.get_exact_name(1)]."),
 		)
 		if (!do_after(user, 1 SECOND, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check())
 			return TRUE
@@ -537,8 +537,8 @@
 		adjustFireLoss(-30)
 		updatehealth()
 		user.visible_message(
-			SPAN_NOTICE("\The [user] repairs some of the electronics in \the [src] with some [cable.plural_name] of \a [cable]."),
-			SPAN_NOTICE("You repair some of the electronics in \the [src] with some [cable.plural_name] of \the [cable]."),
+			SPAN_NOTICE("\The [user] repairs some of the electronics in \the [src] with [cable.get_vague_name(FALSE)]."),
+			SPAN_NOTICE("You repair some of the electronics in \the [src] with some [cable.get_exact_name(1)]."),
 		)
 		return TRUE
 

--- a/code/modules/mob/living/simple_animal/defense.dm
+++ b/code/modules/mob/living/simple_animal/defense.dm
@@ -123,11 +123,11 @@
 			return TRUE
 		adjustBruteLoss(-medical.animal_heal)
 		user.visible_message(
-			SPAN_NOTICE("\The [user] applies a [medical.singular_name] from \a [medical.name] to \the [src]'s injuries."),
-			SPAN_NOTICE("You apply a [medical.singular_name] from \the [medical.name] to \the [src]'s injuries."),
+			SPAN_NOTICE("\The [user] applies [medical.get_vague_name(FALSE)] to \the [src]'s injuries."),
+			SPAN_NOTICE("You apply [medical.get_exact_name(1)] to \the [src]'s injuries."),
 			exclude_mobs = list(src)
 		)
-		to_chat(src, SPAN_NOTICE("\The [user] applies a [medical.singular_name] from \a [medical.name] to your injuries."),)
+		to_chat(src, SPAN_NOTICE("\The [user] applies [medical.get_vague_name(FALSE)] to your injuries."),)
 		return TRUE
 
 	return ..()


### PR DESCRIPTION
There will be a separate PR to synergize this with the feedback messages added in #33242.

Does not modify any messages in `/obj/structure/.*/attackby()` to avoid conflict with #33242.

## Changelog
:cl: SierraKomodo
refactor: Updated various message strings relating to stacks and material stacks.
rscadd: Material stacks now include their reinforcement material in the name. I.e., `reinforced glass` is now `steel-reinforced glass`.
rscadd: Feedback messages when using stacks should now tell you how many items from the stack were used.
/:cl:

## Other Changes
- Added `get_stack_name()`, `get_vague_name()`, and `get_exact_name()` procs to `/obj/item/stack` for generating name strings to be used in feedback and visible messages involving stacks. Includes some overrides for `/material` subtypes.
- Replaced applicable `to_chat()` calls with `USE_FEEDBACK_STACK_NOT_ENOUGH()`.

![dreamseeker_0MmmYxcmFo](https://user-images.githubusercontent.com/11140088/231247548-bb65abcf-fd43-4c51-b4b1-b623b7973e07.png)
![dreamseeker_T0u7Hwitkk](https://user-images.githubusercontent.com/11140088/231247597-d093fe49-3153-4dfd-a0f5-57ce55202d30.png)
![dreamseeker_piOpijq1wr](https://user-images.githubusercontent.com/11140088/231247610-7424cd60-625d-463a-a946-58e156b9400d.png)
