### PR TITLE
Fix deathgrips (again)

### DIFF
--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -299,8 +299,6 @@
 	if(shock >= 50)
 		break_strength--
 
-	if (assailant.incapacitated(INCAPACITATION_ALL))
-		break_strength+=5
 	if(assailant.confused)
 		break_strength++
 	if(assailant.eye_blind)
@@ -319,6 +317,10 @@
 		return
 
 	var/break_chance = break_chance_table[clamp(break_strength, 1, length(break_chance_table))]
+
+	if (assailant.incapacitated(INCAPACITATION_ALL))
+		let_go(G)
+
 	if(prob(break_chance))
 		if(can_downgrade_on_resist && !prob((break_chance+100)/2))
 			affecting.visible_message(SPAN_WARNING("[affecting] has loosened [assailant]'s grip!"))

--- a/code/modules/mob/grab/normal/norm_aggressive.dm
+++ b/code/modules/mob/grab/normal/norm_aggressive.dm
@@ -24,6 +24,12 @@
 
 /datum/grab/normal/aggressive/process_effect(obj/item/grab/G)
 	var/mob/living/carbon/human/affecting = G.affecting
+	var/mob/living/carbon/human/assailant = G.assailant
+
+	if (assailant.incapacitated(INCAPACITATION_ALL))
+		affecting.visible_message(SPAN_WARNING("[assailant] lets go of \his grab!"))
+		qdel(G)
+		return
 
 	if(G.target_zone in list(BP_L_HAND, BP_R_HAND))
 		affecting.drop_l_hand()

--- a/code/modules/mob/grab/normal/norm_kill.dm
+++ b/code/modules/mob/grab/normal/norm_kill.dm
@@ -24,6 +24,12 @@
 
 /datum/grab/normal/kill/process_effect(obj/item/grab/G)
 	var/mob/living/carbon/human/affecting = G.affecting
+	var/mob/living/carbon/human/assailant = G.assailant
+
+	if (assailant.incapacitated(INCAPACITATION_ALL))
+		affecting.visible_message(SPAN_WARNING("[assailant] lets go of \his grab!"))
+		qdel(G)
+		return
 
 	affecting.drop_l_hand()
 	affecting.drop_r_hand()

--- a/code/modules/mob/grab/normal/norm_neck.dm
+++ b/code/modules/mob/grab/normal/norm_neck.dm
@@ -27,6 +27,12 @@
 
 /datum/grab/normal/neck/process_effect(obj/item/grab/G)
 	var/mob/living/carbon/human/affecting = G.affecting
+	var/mob/living/carbon/human/assailant = G.assailant
+
+	if (assailant.incapacitated(INCAPACITATION_ALL))
+		affecting.visible_message(SPAN_WARNING("[assailant] lets go of \his grab!"))
+		qdel(G)
+		return
 
 	affecting.drop_l_hand()
 	affecting.drop_r_hand()

--- a/code/modules/mob/grab/normal/norm_struggle.dm
+++ b/code/modules/mob/grab/normal/norm_struggle.dm
@@ -28,6 +28,11 @@
 	var/mob/living/carbon/human/affecting = G.affecting
 	var/mob/living/carbon/human/assailant = G.assailant
 
+	if (assailant.incapacitated(INCAPACITATION_ALL))
+		affecting.visible_message(SPAN_WARNING("[assailant] lets go of \his grab!"))
+		qdel(G)
+		return
+
 	if(affecting.incapacitated(INCAPACITATION_UNRESISTING) || affecting.a_intent == I_HELP)
 		affecting.visible_message(SPAN_WARNING("[affecting] isn't prepared to fight back as [assailant] tightens \his grip!"))
 		G.done_struggle = TRUE


### PR DESCRIPTION
:cl:
tweak: Dying while gripping someone drops the grip.
/:cl:

Previous fix was good for giving a fairer chance to the gripped person, and even fixed deathgrips to an extent; but not fully apparently when the one being gripped is injured, and needed to be awake and be able to resist.

This fixes that properly.