### PR TITLE
Fix ahelp replies not going to discord

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -849,7 +849,7 @@ GLOBAL_VAR_INIT(skip_allow_lists, FALSE)
 	if (config.hub_visible && !world.reachable)
 		message_admins("WARNING: The server will not show up on the hub because byond is detecting that a firewall is blocking incoming connections.")
 
-	send_to_admin_discord(EXCOM_MSG_AHELP, "[key_name(src)]" + long_message)
+	send_to_admin_discord(EXCOM_MSG_AHELP, "[key_name(src, highlight_special_characters = FALSE)]" + long_message)
 	log_and_message_admins(long_message)
 
 /datum/admins/proc/toggletraitorscaling()

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -135,5 +135,5 @@ var/global/list/adminhelp_ignored_words = list("unknown","the","a","an","of","mo
 		adminmsg2adminirc(src, null, "[html_decode(original_msg)]")
 
 
-	send_to_admin_discord(EXCOM_MSG_AHELP, "HELP: [key_name(src)]: [original_msg]")
+	send_to_admin_discord(EXCOM_MSG_AHELP, "HELP: [key_name(src, highlight_special_characters = FALSE)]: [original_msg]")
 	return

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -131,7 +131,7 @@
 		sound_to(C, 'sound/ui/pm-notify.ogg')
 
 	log_admin("PM: [key_name(src)]->[key_name(C)]: [msg]")
-	adminmsg2adminirc(src, C, html_decode(msg))
+	send_to_admin_discord(EXCOM_MSG_AHELP, "PM: [key_name(src, highlight_special_characters = FALSE)]->[key_name(C, highlight_special_characters = FALSE)]:[html_decode(msg)]")
 
 	ticket.msgs += new /datum/ticket_msg(src.ckey, C.ckey, msg)
 	update_ticket_panels()
@@ -160,7 +160,7 @@
 //		to_chat(src, SPAN_NOTICE("[msg]"))
 //		return
 
-	adminmsg2adminirc(src, sender, html_decode(msg))
+	send_to_admin_discord(EXCOM_MSG_AHELP, "PM: [key_name(src, highlight_special_characters = FALSE)]->DISC-[sender]:[html_decode(msg)]")
 	msg = sanitize(msg)
 	log_admin("PM: [key_name(src)]->IRC-[sender]: [msg]")
 	admin_pm_repository.store_pm(src, "IRC-[sender]", msg)

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -21,7 +21,7 @@
 		var/datum/admins/holder = admin_datums[ckey]
 		message_staff("[holder.rank] logout: [key_name(src)]")
 		if(!length(GLOB.admins)) //Apparently the admin logging out is no longer an admin at this point, so we have to check this towards 0 and not towards 1. Awell.
-			send_to_admin_discord(EXCOM_MSG_AHELP, "[key_name(src)] logged out - no more admins online.")
+			send_to_admin_discord(EXCOM_MSG_AHELP, "[key_name(src, highlight_special_characters = FALSE)] logged out - no more admins online.")
 			if(config.delist_when_no_admins && config.hub_visible)
 				world.update_hub_visibility(FALSE)
 				send_to_admin_discord(EXCOM_MSG_AHELP, "Updated hub visibility. The server is now invisible.")


### PR DESCRIPTION
:cl: Mucker
admin: Replies to admin-helps should not relay to discord. 
/:cl: