### PR TITLE
Bearcat adjustments

### DIFF
--- a/maps/away/bearcat/bearcat-1.dmm
+++ b/maps/away/bearcat/bearcat-1.dmm
@@ -16,6 +16,7 @@
 	name = "External Blast Doors";
 	opacity = 0
 	},
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "ad" = (
@@ -23,6 +24,13 @@
 	id_tag = "cargo_out"
 	},
 /obj/machinery/shield_diffuser,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
 /turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "ae" = (
@@ -35,6 +43,13 @@
 	pixel_y = 17
 	},
 /obj/machinery/shield_diffuser,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
 /turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "ag" = (
@@ -44,6 +59,7 @@
 /turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "ah" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/escape_port)
 "ai" = (
@@ -76,15 +92,20 @@
 	tag_exterior_door = "cargo_out";
 	tag_interior_door = "cargo_in"
 	},
+/obj/machinery/airlock_sensor{
+	id_tag = "cargo_sensor";
+	pixel_x = 25
+	},
 /turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "al" = (
-/turf/simulated/wall/r_wall,
+/obj/effect/wallframe_spawn/reinforced,
+/obj/effect/paint/brown,
+/turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "am" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
-	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
@@ -92,6 +113,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "an" = (
@@ -109,6 +131,7 @@
 /turf/simulated/floor/tiled,
 /area/ship/scrap/escape_star)
 "ao" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/cargo/lower)
 "ap" = (
@@ -133,14 +156,6 @@
 /area/ship/scrap/escape_port)
 "at" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
-	},
 /obj/item/device/radio/intercom/map_preset/bearcat{
 	default_hailing = 1;
 	dir = 4;
@@ -149,27 +164,11 @@
 /turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "au" = (
-/obj/machinery/airlock_sensor{
-	id_tag = "cargo_sensor";
-	pixel_x = 25
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
-	},
 /turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "av" = (
 /obj/structure/ladder/up,
-/obj/machinery/light/small{
-	dir = 8;
-	icon_state = "bulb1"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/simulated/floor/tiled,
 /area/ship/scrap/cargo/lower)
@@ -195,7 +194,8 @@
 /turf/simulated/floor/airless,
 /area/ship/scrap/escape_star)
 "ay" = (
-/turf/simulated/wall/r_wall,
+/obj/effect/paint/brown,
+/turf/simulated/wall,
 /area/ship/scrap/escape_star)
 "az" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -234,17 +234,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ship/scrap/escape_port)
-"aC" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/portables_connector,
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/turf/simulated/floor/tiled,
-/area/ship/scrap/cargo/lower)
 "aD" = (
 /obj/machinery/door/airlock/external/bolted/cycling{
 	id_tag = "cargo_in"
@@ -320,10 +309,16 @@
 /turf/simulated/floor/tiled,
 /area/ship/scrap/escape_star)
 "aK" = (
-/turf/simulated/wall,
-/area/ship/scrap/gambling)
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 8;
+	icon_state = "bulb1"
+	},
+/turf/simulated/floor/tiled,
+/area/ship/scrap/cargo/lower)
 "aL" = (
-/turf/simulated/wall/r_wall,
+/obj/effect/paint/brown,
+/turf/simulated/wall,
 /area/ship/scrap/gambling)
 "aM" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -336,15 +331,9 @@
 /area/ship/scrap/escape_port)
 "aN" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/atmospherics/pipe/simple/hidden{
-	dir = 5
-	},
-/obj/machinery/power/apc/derelict{
-	dir = 8
-	},
-/obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+/obj/machinery/portable_atmospherics/canister/air,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/ship/scrap/cargo/lower)
@@ -393,7 +382,8 @@
 /turf/simulated/wall,
 /area/ship/scrap/crew/dorms1)
 "aU" = (
-/turf/simulated/wall/r_wall,
+/obj/effect/paint/brown,
+/turf/simulated/wall,
 /area/ship/scrap/crew/dorms1)
 "aV" = (
 /obj/item/device/flashlight/lamp,
@@ -444,9 +434,11 @@
 	icon_state = "bulb1"
 	},
 /obj/structure/cable/green{
-	d1 = 1;
 	d2 = 2;
-	icon_state = "1-2"
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/derelict{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/ship/scrap/cargo/lower)
@@ -540,6 +532,7 @@
 "bi" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
@@ -547,6 +540,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/gambling)
 "bj" = (
@@ -752,6 +746,7 @@
 "bA" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
@@ -759,6 +754,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/crew/dorms1)
 "bB" = (
@@ -948,9 +944,6 @@
 /obj/structure/cable/green,
 /turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
-"bV" = (
-/turf/simulated/wall/r_wall,
-/area/ship/scrap/broken2)
 "bW" = (
 /obj/machinery/floodlight,
 /turf/simulated/floor,
@@ -976,6 +969,7 @@
 /turf/simulated/floor,
 /area/ship/scrap/broken2)
 "bZ" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/broken2)
 "ca" = (
@@ -1057,9 +1051,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
-"ch" = (
-/turf/simulated/wall,
-/area/ship/scrap/crew/dorms2)
 "ci" = (
 /obj/structure/cable/green{
 	d2 = 2;
@@ -1102,11 +1093,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/ship/scrap/crew/dorms2)
 "cl" = (
-/turf/simulated/wall/r_wall,
+/obj/effect/paint/brown,
+/turf/simulated/wall,
 /area/ship/scrap/crew/dorms2)
 "cm" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
@@ -1114,10 +1107,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/broken2)
 "cn" = (
-/obj/structure/foamedmetal,
+/obj/structure/inflatable/wall,
 /turf/simulated/floor,
 /area/ship/scrap/broken2)
 "co" = (
@@ -1269,6 +1263,7 @@
 "cC" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
@@ -1276,6 +1271,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/crew/dorms2)
 "cD" = (
@@ -1286,7 +1282,7 @@
 	dir = 1;
 	level = 2
 	},
-/obj/structure/foamedmetal,
+/obj/structure/inflatable/wall,
 /turf/simulated/floor,
 /area/ship/scrap/broken2)
 "cF" = (
@@ -1345,6 +1341,7 @@
 /turf/simulated/floor,
 /area/ship/scrap/broken1)
 "cN" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/broken1)
 "cO" = (
@@ -1440,9 +1437,6 @@
 	pixel_y = 22
 	},
 /turf/simulated/floor,
-/area/ship/scrap/broken1)
-"cY" = (
-/turf/simulated/wall/r_wall,
 /area/ship/scrap/broken1)
 "cZ" = (
 /obj/machinery/light/small{
@@ -1578,6 +1572,7 @@
 "dk" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
@@ -1585,6 +1580,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/broken1)
 "dl" = (
@@ -1708,6 +1704,7 @@
 "dw" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
@@ -1715,6 +1712,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/crew/dorms3)
 "dx" = (
@@ -1755,6 +1753,7 @@
 /area/ship/scrap/broken1)
 "dA" = (
 /obj/machinery/door/airlock/autoname/bearcat,
+/obj/effect/paint/brown,
 /turf/simulated/floor/tiled,
 /area/ship/scrap/cargo/lower)
 "dB" = (
@@ -1779,7 +1778,8 @@
 /turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "dD" = (
-/turf/simulated/wall/r_wall,
+/obj/effect/paint/brown,
+/turf/simulated/wall,
 /area/ship/scrap/crew/dorms3)
 "dE" = (
 /obj/machinery/alarm{
@@ -2002,13 +2002,12 @@
 /turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "dU" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/maintenance/techstorage)
-"dV" = (
-/turf/simulated/wall,
-/area/ship/scrap/maintenance/storage)
 "dW" = (
-/turf/simulated/wall/r_wall,
+/obj/effect/paint/brown,
+/turf/simulated/wall,
 /area/ship/scrap/maintenance/storage)
 "dX" = (
 /obj/structure/cable/green{
@@ -2021,15 +2020,10 @@
 /obj/machinery/door/airlock/autoname/bearcat,
 /turf/simulated/floor,
 /area/ship/scrap/maintenance/storage)
-"dY" = (
-/turf/simulated/wall/r_wall,
-/area/ship/scrap/maintenance/eva)
 "dZ" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/maintenance/eva)
-"ea" = (
-/turf/simulated/wall/r_wall,
-/area/ship/scrap/maintenance/techstorage)
 "eb" = (
 /obj/item/stock_parts/circuitboard/pacman,
 /obj/item/stock_parts/circuitboard/recharge_station,
@@ -2172,6 +2166,14 @@
 /area/ship/scrap/maintenance/eva)
 "em" = (
 /obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/maintenance/eva)
 "en" = (
@@ -2429,6 +2431,14 @@
 	pixel_y = -18
 	},
 /obj/machinery/shield_diffuser,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
 /turf/simulated/floor,
 /area/ship/scrap/maintenance/eva)
 "eE" = (
@@ -2615,7 +2625,6 @@
 "eY" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
-	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
@@ -2623,6 +2632,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/maintenance/storage)
 "fb" = (
@@ -8713,12 +8723,12 @@ vY
 vY
 ah
 ah
-aK
-aK
+aL
+aL
 bi
 aL
 aL
-bV
+kz
 cm
 cD
 cK
@@ -8835,11 +8845,11 @@ kH
 ai
 ar
 az
-aK
+aL
 aV
 bj
 bB
-aK
+aL
 bW
 cn
 cn
@@ -8849,9 +8859,9 @@ cV
 dx
 dH
 cN
-ea
-ea
-ea
+dU
+dU
+dU
 yN
 yN
 aa
@@ -8961,7 +8971,7 @@ aL
 aW
 bk
 bC
-aK
+aL
 bX
 co
 cE
@@ -8974,7 +8984,7 @@ cN
 eb
 en
 eE
-ea
+dU
 yN
 aa
 aa
@@ -9079,11 +9089,11 @@ kH
 ai
 ar
 aF
-aK
+aL
 aX
 bl
 bD
-aK
+aL
 bY
 cp
 cF
@@ -9096,7 +9106,7 @@ cN
 ec
 eo
 eF
-ea
+dU
 yN
 aa
 aa
@@ -9202,15 +9212,15 @@ ai
 ar
 tW
 aL
-aK
+aL
 bm
-aK
-aK
+aL
+aL
 bZ
 cq
 bZ
 cN
-cY
+cN
 dn
 cN
 cN
@@ -9218,7 +9228,7 @@ cN
 ed
 ep
 eG
-ea
+dU
 yN
 yN
 aa
@@ -9339,9 +9349,9 @@ dK
 dU
 dU
 eq
-ea
-ea
-ea
+dU
+dU
+dU
 yN
 aa
 aa
@@ -9443,8 +9453,8 @@ aa
 aa
 GU
 GU
-al
-al
+ao
+ao
 ao
 ao
 bo
@@ -9458,7 +9468,7 @@ ao
 bo
 ao
 dL
-dV
+dW
 ee
 er
 eH
@@ -9562,11 +9572,11 @@ aa
 aa
 aa
 aa
-ac
-ac
 GU
-al
-aC
+GU
+GU
+GU
+GU
 aN
 aZ
 bp
@@ -9580,7 +9590,7 @@ da
 do
 dA
 dM
-dV
+dW
 ef
 es
 eI
@@ -9928,11 +9938,11 @@ aa
 aa
 aa
 aa
-ac
+GU
 ac
 GU
 al
-al
+GU
 lQ
 bb
 bs
@@ -10054,7 +10064,7 @@ aa
 aa
 am
 av
-dp
+aK
 aQ
 bc
 bt
@@ -10068,7 +10078,7 @@ dd
 dp
 ao
 dQ
-dY
+dZ
 dZ
 ew
 dZ
@@ -10190,7 +10200,7 @@ de
 dr
 dB
 dR
-dY
+dZ
 ej
 ex
 eM
@@ -10312,12 +10322,12 @@ ao
 bo
 ao
 dS
-dY
+dZ
 ek
 ey
 eN
 eW
-dY
+dZ
 Bu
 aa
 aa
@@ -10439,7 +10449,7 @@ el
 ez
 eO
 eX
-dY
+dZ
 Bu
 aa
 aa
@@ -10543,16 +10553,16 @@ kH
 ap
 ax
 an
-aT
-aT
+aU
+aU
 bw
-aT
-aT
-ch
+aU
+aU
+cl
 cy
-ch
-ch
-dg
+cl
+cl
+dD
 ds
 dD
 dD
@@ -10665,15 +10675,15 @@ kH
 ap
 ax
 Ro
-aT
+aU
 bf
 bx
 bL
-aT
+aU
 ci
 cz
 cH
-ch
+cl
 dh
 dt
 dE
@@ -10791,11 +10801,11 @@ aT
 bg
 by
 bM
-aT
+aU
 cj
 cA
 cI
-ch
+cl
 di
 du
 dF
@@ -10913,19 +10923,19 @@ aU
 bh
 bz
 vU
-aT
+aU
 ck
 cB
 fb
-ch
+cl
 dj
 dv
 dG
 xc
 aa
-em
+Bu
 eD
-em
+Bu
 aa
 aa
 aa
@@ -11034,15 +11044,15 @@ ay
 aU
 aU
 bA
-aT
+aU
 aU
 cl
 cC
-ch
-ch
-dg
-dw
+cl
+cl
 dD
+dw
+dg
 xc
 aa
 aa

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -6,18 +6,6 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor,
-/area/ship/scrap/command/bridge)
-"ac" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
 	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
@@ -25,6 +13,20 @@
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/paint/brown,
+/turf/simulated/floor,
+/area/ship/scrap/command/bridge)
+"ac" = (
+/obj/effect/wallframe_spawn/reinforced,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
+/obj/machinery/door/firedoor,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/command/bridge)
 "ad" = (
@@ -32,12 +34,12 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular{
 	density = 0;
-	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
 	opacity = 0
 	},
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/command/bridge)
 "ag" = (
@@ -113,7 +115,8 @@
 /turf/space,
 /area/space)
 "ar" = (
-/turf/simulated/wall/r_wall,
+/obj/effect/paint/brown,
+/turf/simulated/wall,
 /area/ship/scrap/comms)
 "as" = (
 /obj/machinery/door/blast/regular{
@@ -207,21 +210,9 @@
 /turf/simulated/floor,
 /area/ship/scrap/command/captain)
 "aC" = (
-/turf/simulated/wall/r_wall,
+/obj/effect/paint/brown,
+/turf/simulated/wall,
 /area/ship/scrap/command/captain)
-"aD" = (
-/obj/effect/wallframe_spawn/reinforced,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	dir = 4;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
-	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor,
-/area/ship/scrap/comms)
 "aE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -326,12 +317,14 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/comms)
 "aO" = (
@@ -444,12 +437,14 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/command/captain)
 "aX" = (
@@ -527,17 +522,18 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
-	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/command/captain)
 "be" = (
-/turf/simulated/wall/r_wall,
+/obj/effect/paint/brown,
+/turf/simulated/wall,
 /area/ship/scrap/dock)
 "bf" = (
 /obj/structure/cable/green{
@@ -558,13 +554,13 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
-	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/dock)
 "bj" = (
@@ -613,6 +609,7 @@
 	name = "External Blast Doors";
 	opacity = 0
 	},
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/dock)
 "bn" = (
@@ -695,6 +692,14 @@
 	id_tag = "dock_port_out"
 	},
 /obj/machinery/shield_diffuser,
+/obj/machinery/door/blast/regular{
+	density = 0;
+	dir = 4;
+	icon_state = "pdoor0";
+	id_tag = "scraplock";
+	name = "External Blast Doors";
+	opacity = 0
+	},
 /turf/simulated/floor/tiled,
 /area/ship/scrap/dock)
 "bv" = (
@@ -879,19 +884,15 @@
 	id_tag = "dock_star_out"
 	},
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/tiled,
-/area/ship/scrap/dock)
-"bK" = (
-/obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
 	opacity = 0
 	},
-/obj/machinery/door/firedoor,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/dock)
 "bL" = (
 /obj/structure/window/reinforced{
@@ -991,6 +992,7 @@
 	name = "External Blast Doors";
 	opacity = 0
 	},
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/dock)
 "bT" = (
@@ -1004,16 +1006,7 @@
 /turf/simulated/floor/tiled,
 /area/ship/scrap/dock)
 "bV" = (
-/obj/structure/lattice,
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
-	},
-/obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/dock)
 "bW" = (
 /obj/structure/cable/green{
@@ -1032,12 +1025,14 @@
 "bZ" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
 	opacity = 0
 	},
 /obj/effect/wallframe_spawn/reinforced,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/crew/hallway/port)
 "ca" = (
@@ -1046,23 +1041,27 @@
 "cc" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
 	opacity = 0
 	},
 /obj/effect/wallframe_spawn/reinforced,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/dock)
 "ce" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
 	opacity = 0
 	},
 /obj/effect/wallframe_spawn/reinforced,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/crew/hallway/starboard)
 "cf" = (
@@ -1092,6 +1091,7 @@
 /turf/simulated/floor/tiled,
 /area/ship/scrap/crew/hallway/starboard)
 "ck" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/crew/saloon)
 "cl" = (
@@ -1143,22 +1143,20 @@
 /turf/simulated/floor/tiled,
 /area/ship/scrap/crew/saloon)
 "cq" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall,
-/area/ship/scrap/crew/toilets)
-"cr" = (
-/turf/simulated/wall/r_wall,
 /area/ship/scrap/crew/toilets)
 "cs" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
-	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/crew/toilets)
 "ct" = (
@@ -1218,27 +1216,26 @@
 /obj/item/crowbar,
 /turf/simulated/floor/tiled,
 /area/ship/scrap/crew/hallway/starboard)
-"cA" = (
-/turf/simulated/wall/r_wall,
-/area/ship/scrap/crew/cryo)
 "cB" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/crew/cryo)
 "cC" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
-	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/paint/brown,
 /turf/simulated/floor/tiled,
 /area/ship/scrap/crew/cryo)
 "cD" = (
 /obj/machinery/computer/cryopod,
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/crew/cryo)
 "cF" = (
@@ -1354,12 +1351,14 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/crew/toilets)
 "cR" = (
@@ -1577,12 +1576,14 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/crew/cryo)
 "di" = (
@@ -1644,6 +1645,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/crew/saloon)
 "dn" = (
@@ -1732,10 +1734,8 @@
 /obj/effect/submap_landmark/spawnpoint/crewman,
 /turf/simulated/floor/tiled/white,
 /area/ship/scrap/crew/cryo)
-"dv" = (
-/turf/simulated/wall/r_wall,
-/area/ship/scrap/crew/kitchen)
 "dw" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/crew/kitchen)
 "dx" = (
@@ -1748,6 +1748,7 @@
 /turf/simulated/floor/tiled,
 /area/ship/scrap/crew/hallway/port)
 "dy" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/cargo)
 "dz" = (
@@ -1774,14 +1775,12 @@
 /turf/simulated/floor/tiled,
 /area/ship/scrap/crew/hallway/starboard)
 "dB" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/crew/medbay)
 "dC" = (
 /obj/machinery/door/airlock/autoname/bearcat,
 /turf/simulated/floor/tiled/white,
-/area/ship/scrap/crew/medbay)
-"dD" = (
-/turf/simulated/wall/r_wall,
 /area/ship/scrap/crew/medbay)
 "dE" = (
 /obj/machinery/reagentgrinder,
@@ -1929,12 +1928,14 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/crew/kitchen)
 "dT" = (
@@ -2093,6 +2094,7 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
@@ -2104,6 +2106,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/crew/kitchen)
 "ej" = (
@@ -2391,6 +2394,7 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
@@ -2402,6 +2406,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/crew/medbay)
 "eA" = (
@@ -2673,6 +2678,7 @@
 /turf/space,
 /area/ship/scrap/maintenance/engine/port)
 "eY" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/crew/wash)
 "eZ" = (
@@ -2964,6 +2970,7 @@
 /turf/simulated/floor,
 /area/ship/scrap/crew/hallway/starboard)
 "fw" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/tcomms)
 "fx" = (
@@ -3023,6 +3030,7 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
@@ -3032,6 +3040,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/crew/wash)
 "fI" = (
@@ -3186,6 +3195,7 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
@@ -3195,6 +3205,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
 	},
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/tcomms)
 "fU" = (
@@ -3302,10 +3313,8 @@
 /obj/machinery/telecomms/server/map_preset/bearcat,
 /turf/simulated/floor,
 /area/ship/scrap/tcomms)
-"ge" = (
-/turf/simulated/wall/r_wall,
-/area/ship/scrap/fire)
 "gf" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/fire)
 "gg" = (
@@ -3353,9 +3362,7 @@
 /turf/simulated/floor,
 /area/ship/scrap/crew/hallway/starboard)
 "gk" = (
-/turf/simulated/wall/r_wall,
-/area/ship/scrap/hidden)
-"gl" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/hidden)
 "gm" = (
@@ -3503,6 +3510,7 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
@@ -3512,6 +3520,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/fire)
 "gz" = (
@@ -3635,9 +3644,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/r_wall{
-	can_open = 1
-	},
+/obj/effect/paint/brown,
+/turf/simulated/wall,
 /area/ship/scrap/hidden)
 "gG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3908,21 +3916,21 @@
 /turf/simulated/floor,
 /area/ship/scrap/hidden)
 "gY" = (
-/turf/simulated/wall/r_wall,
+/obj/effect/paint/brown,
+/turf/simulated/wall,
 /area/ship/scrap/maintenance/atmos)
 "gZ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/autoname/engineering/bearcat,
 /turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
-"ha" = (
-/turf/simulated/wall,
-/area/ship/scrap/maintenance/atmos)
 "hb" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/maintenance/engineering)
 "hc" = (
 /obj/structure/disposalpipe/segment,
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/maintenance/engineering)
 "hd" = (
@@ -3939,6 +3947,7 @@
 /turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/engineering)
 "he" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/maintenance/power)
 "hf" = (
@@ -4542,12 +4551,14 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
+	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
 	opacity = 0
 	},
 /obj/machinery/door/firedoor,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/maintenance/power)
 "id" = (
@@ -4600,6 +4611,7 @@
 /turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/engine/aft)
 "ij" = (
+/obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/maintenance/engine/aft)
 "ik" = (
@@ -4613,6 +4625,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/wallframe_spawn/reinforced,
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "il" = (
@@ -5186,13 +5199,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
 	},
-/turf/simulated/wall,
+/obj/effect/paint/brown,
+/turf/simulated/wall/r_wall,
 /area/ship/scrap/maintenance/power)
 "jA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 10
 	},
-/turf/simulated/wall,
+/turf/simulated/wall/r_wall,
 /area/ship/scrap/maintenance/power)
 "jB" = (
 /obj/item/stack/material/rods,
@@ -5257,7 +5271,8 @@
 /area/ship/scrap/maintenance/engine/aft)
 "jL" = (
 /obj/machinery/door/blast/regular{
-	id_tag = "scram"
+	id_tag = "scram";
+	dir = 4
 	},
 /turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
@@ -5340,25 +5355,8 @@
 /turf/space,
 /area/ship/scrap/maintenance/engine/aft)
 "jY" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
-	},
 /obj/structure/sign/warning/hot_exhaust{
 	pixel_y = 32
-	},
-/turf/simulated/floor/airless,
-/area/ship/scrap/maintenance/engine/aft)
-"jZ" = (
-/obj/machinery/door/blast/regular{
-	density = 0;
-	icon_state = "pdoor0";
-	id_tag = "scraplock";
-	name = "External Blast Doors";
-	opacity = 0
 	},
 /turf/simulated/floor/airless,
 /area/ship/scrap/maintenance/engine/aft)
@@ -5712,7 +5710,6 @@
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
 	density = 0;
-	dir = 4;
 	icon_state = "pdoor0";
 	id_tag = "scraplock";
 	name = "External Blast Doors";
@@ -5722,6 +5719,7 @@
 /obj/machinery/light_switch{
 	pixel_x = -25
 	},
+/obj/effect/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/comms)
 "Wu" = (
@@ -5730,12 +5728,9 @@
 /area/ship/scrap/maintenance/engine/aft)
 "XU" = (
 /obj/structure/sign/redcross,
+/obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/crew/medbay)
-"Yl" = (
-/obj/structure/lattice,
-/turf/simulated/wall/r_wall,
-/area/ship/scrap/maintenance/atmos)
 "Yv" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
@@ -11565,7 +11560,7 @@ id
 io
 id
 iO
-Yl
+vs
 aa
 aa
 aa
@@ -11689,7 +11684,7 @@ hw
 iP
 Eq
 id
-Yl
+vs
 Hd
 aa
 aa
@@ -11785,10 +11780,10 @@ aa
 aa
 km
 km
-cr
+cq
 cQ
-cr
-dv
+cq
+dw
 GG
 dS
 ei
@@ -11798,9 +11793,9 @@ Ur
 fH
 Ur
 LW
-ge
+gf
 gy
-ge
+gf
 gY
 hh
 hx
@@ -11899,14 +11894,14 @@ aa
 aa
 aa
 aa
-bm
+Ly
 bu
-bm
+Ly
 aa
 aa
 aa
 km
-cr
+cq
 di
 cR
 di
@@ -12143,14 +12138,14 @@ Yv
 Yv
 aa
 Ly
-be
+Ly
 bw
-bK
+Ly
 bT
 bY
 bY
 km
-cr
+cq
 kb
 cT
 dk
@@ -12163,11 +12158,11 @@ eY
 fq
 fK
 fX
-ge
+gf
 go
 gB
 gL
-ha
+gY
 hk
 hz
 hQ
@@ -12178,7 +12173,7 @@ iS
 je
 jr
 jD
-gY
+wp
 aa
 aa
 aa
@@ -12263,16 +12258,16 @@ ar
 aN
 ar
 Yv
-aa
+bY
 Ly
-be
+Ly
 bx
 bL
 Ly
 bZ
 bZ
 ou
-cr
+cq
 cq
 cU
 cq
@@ -12285,11 +12280,11 @@ eY
 fr
 eY
 eY
-ge
-ge
+gf
+gf
 gC
 gf
-ha
+gY
 hl
 hA
 hR
@@ -12300,7 +12295,7 @@ iT
 Od
 Od
 jE
-gY
+wp
 aa
 aa
 aa
@@ -12385,7 +12380,7 @@ PZ
 aO
 aX
 Yv
-aa
+bY
 bh
 bn
 by
@@ -12411,16 +12406,16 @@ gg
 gp
 gD
 gM
-ha
-ha
+gY
+gY
 hB
 gY
-gY
-gY
-gY
-gY
-gY
-gY
+wp
+wp
+wp
+wp
+wp
+wp
 hx
 jN
 jT
@@ -12502,7 +12497,7 @@ aa
 Lp
 as
 ax
-aD
+aN
 aH
 aH
 aH
@@ -12547,7 +12542,7 @@ Wu
 jO
 vN
 jY
-jZ
+jF
 aa
 aa
 aa
@@ -12618,7 +12613,7 @@ aa
 aa
 aa
 aa
-ab
+at
 ab
 ab
 ab
@@ -12633,7 +12628,7 @@ Ly
 Ly
 bp
 be
-Ly
+be
 Ly
 aa
 ch
@@ -12755,8 +12750,8 @@ be
 bj
 bq
 bA
-Ly
 bV
+Ly
 cc
 ch
 cm
@@ -12877,8 +12872,8 @@ bf
 bk
 br
 bB
-bO
 bW
+bO
 bW
 ci
 cn
@@ -12999,8 +12994,8 @@ be
 bl
 bq
 bC
-Ly
 bV
+Ly
 cc
 ch
 co
@@ -13106,7 +13101,7 @@ aa
 aa
 aa
 aa
-ab
+at
 ab
 ab
 ab
@@ -13121,7 +13116,7 @@ Ly
 Ly
 IL
 be
-Ly
+be
 Ly
 aa
 ch
@@ -13279,7 +13274,7 @@ jK
 jS
 vN
 jY
-jZ
+jF
 aa
 aa
 aa
@@ -13361,7 +13356,7 @@ aM
 aV
 bc
 nS
-aa
+bY
 bh
 bt
 bE
@@ -13391,11 +13386,11 @@ he
 he
 hI
 he
-hg
-he
-hg
-hg
-hg
+xU
+xU
+xU
+xU
+xU
 jz
 jL
 jL
@@ -13483,16 +13478,16 @@ aC
 aW
 aC
 nS
-aa
+bY
 Ly
-be
+Ly
 bF
 bR
 Ly
 ce
 ce
 cg
-cA
+cB
 cB
 dd
 cB
@@ -13607,9 +13602,9 @@ nS
 nS
 aa
 Ly
-be
+Ly
 bG
-bK
+Ly
 bT
 bY
 bY
@@ -13627,7 +13622,7 @@ dB
 fx
 fQ
 gb
-gl
+gk
 Mp
 gG
 PP
@@ -13732,7 +13727,7 @@ Ly
 Ly
 bH
 bS
-bY
+aa
 aa
 aa
 Kj
@@ -13745,15 +13740,15 @@ dP
 ef
 ex
 eP
-dD
+dB
 fy
 fR
 gc
-gl
+gk
 gv
 gH
 gW
-hg
+he
 hv
 hL
 ib
@@ -13851,11 +13846,11 @@ aa
 aa
 aa
 aa
-bm
+Ly
 bI
-bm
-bY
-bY
+Ly
+aa
+aa
 aa
 Ul
 cD
@@ -13871,16 +13866,16 @@ dB
 fz
 fS
 gd
-gl
+gk
 gw
 gI
 gX
-hg
-hg
-hg
+he
+he
+he
 ic
-hg
-hg
+he
+he
 iN
 jc
 jo
@@ -13981,9 +13976,9 @@ aa
 aa
 Ul
 Ul
-cA
+cB
 dh
-cA
+cB
 so
 so
 so


### PR DESCRIPTION
🆑 Jux
maptweak: The bearcat has had a number of non-major mapping changes. Almost none of these effect the actual layout.
/🆑 
Frankly, the bearcat deserves a remap or at least a more significant facelift, but this eliminates some general inconsistencies in the map. Started as me noticing multiple walls on the bearcat were partially reinforced and partially standard, with seemingly no pattern to why it was done.


If you want a more detailed changelog, I'll swap it for this:

maptweak: Most interior walls on the bearcat are now unreinforced; if it wouldn't be opposite space, the engine room or the place a reactor should go, it's unreinforced.
maptweak: The bearcat no longer has windows facing bulkheads or windows directly adjacent to airlocks. This means many of the Bearcat's external airlocks now have significantly less windows.
maptweak: The bearcat's external airlocks now all have blast doors, linked to the same button as all other bearcat external blast doors. Most of those have been rotated to match how other maps align them.
maptweak: The bearcat is fully painted in the same brown color as the external hull. This includes previously torch-black color low walls found under windows.
maptweak: Some metal foam next to inflatables on the bearcat's lower level has been swapped for inflatables.