### PR TITLE
Relabel bug report button

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1115,7 +1115,7 @@ window "rpane"
 		anchor1 = none
 		anchor2 = none
 		saved-params = "is-checked"
-		text = "Report Issue"
+		text = "Bug Report"
 		command = "link-issue"
 	elem "linkrules"
 		type = BUTTON


### PR DESCRIPTION
:cl: SierraKomodo
tweak: The 'Report Issue' button has been re-labeled to 'Bug Report.'
/:cl:

Fixes the text being longer than the button.