### PR TITLE
Bug Fixes 2023-04-12

### DIFF
--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -33,6 +33,7 @@
 
 	material = SSmaterials.get_material_by_name(materialtype)
 	set_max_health(material.integrity)
+	SetName("[material.use_name] [name]")
 
 	update_connections(1)
 	update_icon()

--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -155,7 +155,7 @@
 	dismantle()
 
 /obj/structure/wall_frame/proc/dismantle()
-	new /obj/item/stack/material/steel(get_turf(src), 3)
+	material.place_sheet(get_turf(src), 3)
 	qdel(src)
 
 /obj/structure/wall_frame/get_color()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -196,7 +196,9 @@
 		qdel_self()
 		return
 
+	user.drop_from_inventory(src)
 	user.put_in_hands(wrapped)
+	wrapped = null
 	// Take out any other items that might be in the package
 	for(var/obj/item/I in src)
 		user.put_in_hands(I)


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Small packages now properly drop their contents when unwrapped.
bugfix: Low walls now drop the appropriate material when dismantled.
rscadd: Low walls now include their constructed material in their name.
/:cl:

## Bug Fixes
- Fixes #33276 
- Fixes #33249