### PR TITLE
Fix get_stack_name using the wrong var

### DIFF
--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -19,9 +19,9 @@
 
 
 /obj/item/stack/material/get_stack_name()
-	. = material.use_name
+	. = material.display_name
 	if (reinf_material)
-		. = "[reinf_material.use_name]-reinforced [.]"
+		. = "[reinf_material.display_name]-reinforced [.]"
 
 
 /obj/item/stack/material/Initialize(mapload, amount, _material, _reinf_material)


### PR DESCRIPTION
Probably won't really be much of a different user side. Used the wrong variable like a silly.