### PR TITLE
Airless Turf Refactor

### DIFF
--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -79,6 +79,8 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/planetary_surface = FALSE
 	/// Boolean. Some base_turfs might cause issues with changing turfs, this flags it as a special case. See `/proc/get_base_turf_by_area()`.
 	var/base_turf_special_handling = FALSE
+	/// Boolean (Default `FALSE`) - If set, floor turfs in the area will be set to airless when they initialize. This is unset during `LateInitialize()` to avoid interfering with player-placed tiles.
+	var/turfs_airless = FALSE
 
 /*-----------------------------------------------------------------------------*/
 

--- a/code/game/area/Space Station 13 areas.dm
+++ b/code/game/area/Space Station 13 areas.dm
@@ -101,6 +101,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	area_flags = AREA_FLAG_EXTERNAL | AREA_FLAG_IS_NOT_PERSISTENT
 	ambience = list('sound/ambience/ambispace1.ogg','sound/ambience/ambispace2.ogg','sound/ambience/ambispace3.ogg','sound/ambience/ambispace4.ogg','sound/ambience/ambispace5.ogg')
 	secure = FALSE
+	turfs_airless = TRUE
 
 /area/space/atmosalert()
 	return

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -36,6 +36,12 @@
 		power_equip = 0
 		power_environ = 0
 	power_change()		// all machines set to current power level, also updates lighting icon
+	if (turfs_airless)
+		return INITIALIZE_HINT_LATELOAD
+
+/area/LateInitialize(mapload, ...)
+	..()
+	turfs_airless = FALSE
 
 /area/Destroy()
 	..()

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -14,9 +14,6 @@
 	light_max_bright = 1
 	light_color = COLOR_BLUE
 
-/turf/simulated/floor/bluegrid/airless
-	initial_gas = null
-
 /turf/simulated/floor/greengrid
 	name = "mainframe floor"
 	icon = 'icons/turf/flooring/circuit.dmi'
@@ -34,9 +31,6 @@
 	light_outer_range = 2
 	light_max_bright = 2
 	light_color = COLOR_RED
-
-/turf/simulated/floor/greengrid/airless
-	initial_gas = null
 
 /turf/simulated/floor/wood
 	name = "wooden floor"
@@ -127,9 +121,6 @@
 	icon_state = "reinforced"
 	initial_flooring = /singleton/flooring/reinforced
 
-/turf/simulated/floor/reinforced/airless
-	initial_gas = null
-
 /turf/simulated/floor/reinforced/airmix
 	initial_gas = list(GAS_OXYGEN = MOLES_O2ATMOS, GAS_NITROGEN = MOLES_N2ATMOS)
 
@@ -189,9 +180,6 @@
 	icon_state = "monotiledark"
 	initial_flooring = /singleton/flooring/tiling/mono/dark
 
-/turf/simulated/floor/tiled/dark/airless
-	initial_gas = null
-
 /turf/simulated/floor/tiled/white
 	name = "white floor"
 	icon_state = "white"
@@ -206,11 +194,6 @@
 	name = "floor"
 	icon_state = "steel_monofloor"
 	initial_flooring = /singleton/flooring/tiling/mono
-
-/turf/simulated/floor/tiled/white/airless
-	name = "airless floor"
-	initial_gas = null
-	temperature = TCMB
 
 /turf/simulated/floor/tiled/freezer
 	name = "tiles"
@@ -306,35 +289,13 @@
 	initial_flooring = /singleton/flooring/linoleum
 
 //ATMOS PREMADES
-/turf/simulated/floor/reinforced/airless
-	name = "vacuum floor"
-	initial_gas = null
-	temperature = TCMB
-
-/turf/simulated/floor/airless
-	name = "airless plating"
-	initial_gas = null
-	temperature = TCMB
-
-/turf/simulated/floor/tiled/airless
-	name = "airless floor"
-	initial_gas = null
-	temperature = TCMB
-
-/turf/simulated/floor/bluegrid/airless
-	name = "airless floor"
-	initial_gas = null
-	temperature = TCMB
-
-/turf/simulated/floor/greengrid/airless
-	name = "airless floor"
-	initial_gas = null
-	temperature = TCMB
-
 /turf/simulated/floor/greengrid/nitrogen
 	initial_gas = list(GAS_NITROGEN = MOLES_N2STANDARD)
 
 // Placeholders
+/turf/simulated/floor/airless
+	map_airless = TRUE
+
 /turf/simulated/floor/airless/lava
 	name = "lava"
 	icon = 'icons/turf/flooring/lava.dmi'
@@ -355,7 +316,7 @@
 	..()
 
 /turf/simulated/floor/light
-/turf/simulated/floor/airless/ceiling
+/turf/simulated/floor/ceiling
 
 /turf/simulated/floor/beach
 	name = "beach"

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -21,6 +21,10 @@
 	var/singleton/flooring/flooring
 	var/mineral = DEFAULT_WALL_MATERIAL
 
+	// Initialization modifiers for mapping
+	/// Boolean (Default `FALSE`) - If set, the tile will not have atmosphere on init.
+	var/map_airless = FALSE
+
 	thermal_conductivity = 0.040
 	heat_capacity = 10000
 	var/lava = 0
@@ -34,6 +38,10 @@
 	return (A.level == ATOM_LEVEL_UNDER_TILE && !is_plating()) || ..()
 
 /turf/simulated/floor/New(newloc, floortype)
+	var/area/area = get_area(src)
+	if (map_airless || area?.turfs_airless)
+		initial_gas = null
+		temperature = TCMB
 	..(newloc)
 	if(!floortype && initial_flooring)
 		floortype = initial_flooring

--- a/code/game/turfs/simulated/floor_static.dm
+++ b/code/game/turfs/simulated/floor_static.dm
@@ -43,10 +43,6 @@
 	var/style = A.hardness % 2 ? "curvy" : "jaggy"
 	icon_state = "[style][(x*y) % 7]"
 
-/turf/simulated/floor/fixed/alium/airless
-	initial_gas = null
-	temperature = TCMB
-
 /turf/simulated/floor/fixed/alium/ex_act(severity)
 	var/material/A = SSmaterials.get_material_by_name(MATERIAL_ALIENALLOY)
 	if(prob(A.explosion_resistance))

--- a/code/modules/overmap/exoplanets/planet_themes/ruined_city.dm
+++ b/code/modules/overmap/exoplanets/planet_themes/ruined_city.dm
@@ -141,7 +141,7 @@
 
 /datum/random_map/maze/lab
 	wall_type =  /turf/simulated/wall/containment
-	floor_type = /turf/simulated/floor/fixed/alium/airless
+	floor_type = /turf/simulated/floor/fixed/alium
 	preserve_map = 0
 	var/artifacts_to_spawn = 1
 

--- a/code/unit_tests/zas_tests.dm
+++ b/code/unit_tests/zas_tests.dm
@@ -53,14 +53,23 @@
 		test_result["result"] = FAILURE
 		return test_result
 
+	// Airless areas are skipped
+	if (initial(A.turfs_airless))
+		test_result["result"] = SUCCESS
+		test_result["msg"] = "Area flagged airless. Skipped."
+
 	var/list/GM_checked = list()
 
 	for(var/turf/simulated/T in A)
 
-		if(!istype(T) || isnull(T.zone) || istype(T, /turf/simulated/floor/airless))
+		if(!istype(T) || isnull(T.zone))
 			continue
 		if(T.zone.air in GM_checked)
 			continue
+		var/turf/simulated/floor/floor = T
+		if (istype(floor) && floor.map_airless)
+			continue
+
 
 		var/t_msg = "Turf: [T] |  Location: [T.x] // [T.y] // [T.z]"
 

--- a/maps/away/bearcat/bearcat-1.dmm
+++ b/maps/away/bearcat/bearcat-1.dmm
@@ -17,7 +17,9 @@
 	opacity = 0
 	},
 /obj/effect/paint/brown,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/cargo/lower)
 "ad" = (
 /obj/machinery/door/airlock/external/bolted/cycling{
@@ -31,7 +33,9 @@
 	name = "External Blast Doors";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/cargo/lower)
 "ae" = (
 /obj/machinery/door/airlock/external/bolted/cycling{
@@ -50,13 +54,17 @@
 	name = "External Blast Doors";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/cargo/lower)
 "ag" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/cargo/lower)
 "ah" = (
 /obj/effect/paint/brown,
@@ -69,7 +77,9 @@
 	id_tag = "engwindow";
 	opacity = 0
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/escape_port)
 "aj" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
@@ -78,7 +88,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/cargo/lower)
 "ak" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
@@ -96,12 +108,16 @@
 	id_tag = "cargo_sensor";
 	pixel_x = 25
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/cargo/lower)
 "al" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/brown,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/cargo/lower)
 "am" = (
 /obj/machinery/door/blast/regular{
@@ -114,7 +130,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/brown,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/cargo/lower)
 "an" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -141,7 +159,9 @@
 	id_tag = "engwindow";
 	opacity = 0
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/escape_star)
 "aq" = (
 /obj/effect/paint/brown,
@@ -152,7 +172,9 @@
 	dir = 4
 	},
 /obj/machinery/door/window/southright,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/escape_port)
 "at" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -161,11 +183,15 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/cargo/lower)
 "au" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/cargo/lower)
 "av" = (
 /obj/structure/ladder/up,
@@ -191,7 +217,9 @@
 	dir = 4
 	},
 /obj/machinery/door/window/southright,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/escape_star)
 "ay" = (
 /obj/effect/paint/brown,
@@ -239,7 +267,9 @@
 	id_tag = "cargo_in"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/cargo/lower)
 "aE" = (
 /obj/machinery/door/airlock/external/bolted/cycling{
@@ -251,7 +281,9 @@
 	pixel_y = -12
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/cargo/lower)
 "aF" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -327,7 +359,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/escape_port)
 "aN" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -376,7 +410,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/escape_star)
 "aT" = (
 /turf/simulated/wall,
@@ -387,7 +423,9 @@
 /area/ship/scrap/crew/dorms1)
 "aV" = (
 /obj/item/device/flashlight/lamp,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/gambling)
 "aW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -397,7 +435,9 @@
 	icon_state = "bulb1"
 	},
 /obj/item/hand/missing_card,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/gambling)
 "aX" = (
 /obj/structure/cable/green{
@@ -410,7 +450,9 @@
 /obj/machinery/power/apc/derelict{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/gambling)
 "aY" = (
 /obj/machinery/light/small{
@@ -422,7 +464,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "aZ" = (
 /obj/effect/floor_decal/corner/beige{
@@ -485,7 +529,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "bf" = (
 /obj/machinery/power/apc/derelict{
@@ -541,12 +587,16 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/brown,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/gambling)
 "bj" = (
 /obj/structure/holostool,
 /obj/item/hand/missing_card,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/gambling)
 "bk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -558,7 +608,9 @@
 /obj/structure/table/gamblingtable,
 /obj/item/deck/cards,
 /obj/item/dice,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/gambling)
 "bl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -574,7 +626,9 @@
 	},
 /obj/structure/holostool,
 /obj/item/hand/missing_card,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/gambling)
 "bm" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -589,7 +643,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/gambling)
 "bn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -608,11 +664,15 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "bo" = (
 /obj/machinery/door/airlock/autoname/bearcat,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/cargo/lower)
 "bp" = (
 /obj/effect/floor_decal/corner/beige{
@@ -699,7 +759,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "bw" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -755,10 +817,14 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/brown,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/crew/dorms1)
 "bB" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/gambling)
 "bC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -767,7 +833,9 @@
 	},
 /obj/structure/holostool,
 /obj/item/hand/missing_card,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/gambling)
 "bD" = (
 /obj/machinery/alarm{
@@ -777,7 +845,9 @@
 	},
 /obj/item/hand/missing_card,
 /obj/item/hand/missing_card,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/gambling)
 "bE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -787,7 +857,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "bF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -942,18 +1014,24 @@
 	icon_state = "16-0"
 	},
 /obj/structure/cable/green,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "bW" = (
 /obj/machinery/floodlight,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/broken2)
 "bX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light_construct/small{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/broken2)
 "bY" = (
 /obj/structure/cable/green{
@@ -966,7 +1044,9 @@
 /obj/machinery/power/apc/derelict{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/broken2)
 "bZ" = (
 /obj/effect/paint/brown,
@@ -985,7 +1065,9 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "cb" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1049,7 +1131,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "ci" = (
 /obj/structure/cable/green{
@@ -1108,11 +1192,15 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/brown,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/broken2)
 "cn" = (
 /obj/structure/inflatable/wall,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/broken2)
 "co" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1122,7 +1210,9 @@
 	dir = 5
 	},
 /obj/item/cell/high/empty,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/broken2)
 "cp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1136,7 +1226,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/broken2)
 "cq" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -1152,7 +1244,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/broken2)
 "cr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -1171,7 +1265,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "cs" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1215,7 +1311,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "cy" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -1272,10 +1370,14 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/brown,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/crew/dorms2)
 "cD" = (
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/broken2)
 "cE" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1283,7 +1385,9 @@
 	level = 2
 	},
 /obj/structure/inflatable/wall,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/broken2)
 "cF" = (
 /obj/machinery/alarm{
@@ -1292,7 +1396,9 @@
 	req_access = newlist()
 	},
 /obj/item/stack/cable_coil/green,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/broken2)
 "cG" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1338,7 +1444,9 @@
 /area/ship/scrap/broken1)
 "cM" = (
 /obj/structure/girder,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/broken1)
 "cN" = (
 /obj/effect/paint/brown,
@@ -1353,7 +1461,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/autoname/bearcat,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "cP" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1436,7 +1546,9 @@
 /obj/item/device/radio/intercom/map_preset/bearcat{
 	pixel_y = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/broken1)
 "cZ" = (
 /obj/machinery/light/small{
@@ -1449,7 +1561,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "da" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -1522,7 +1636,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "dg" = (
 /turf/simulated/wall,
@@ -1581,7 +1697,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/brown,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/broken1)
 "dl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1596,7 +1714,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/broken1)
 "dm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1610,7 +1730,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/broken1)
 "dn" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -1626,7 +1748,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/broken1)
 "do" = (
 /obj/effect/floor_decal/corner/beige{
@@ -1713,7 +1837,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/brown,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/crew/dorms3)
 "dx" = (
 /obj/structure/mopbucket,
@@ -1765,7 +1891,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/autoname/bearcat,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/cargo/lower)
 "dC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1775,7 +1903,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "dD" = (
 /obj/effect/paint/brown,
@@ -1814,7 +1944,9 @@
 /area/ship/scrap/crew/dorms3)
 "dH" = (
 /obj/machinery/floodlight,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/broken1)
 "dI" = (
 /obj/item/stool/padded,
@@ -1848,7 +1980,9 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "dL" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -1863,7 +1997,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "dM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1877,7 +2013,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "dN" = (
 /obj/structure/cable/green{
@@ -1896,7 +2034,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "dO" = (
 /obj/machinery/light/small{
@@ -1914,7 +2054,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "dP" = (
 /obj/structure/cable/green{
@@ -1938,7 +2080,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "dQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1952,7 +2096,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "dR" = (
 /obj/structure/cable/green{
@@ -1967,7 +2113,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "dS" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -1982,7 +2130,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "dT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1999,7 +2149,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "dU" = (
 /obj/effect/paint/brown,
@@ -2018,7 +2170,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/autoname/bearcat,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/storage)
 "dZ" = (
 /obj/effect/paint/brown,
@@ -2107,7 +2261,9 @@
 	dir = 1;
 	icon_state = "bulb1"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/storage)
 "eh" = (
 /obj/structure/ladder/up,
@@ -2115,7 +2271,9 @@
 /obj/structure/sign/deck/second{
 	pixel_y = 32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/storage)
 "ei" = (
 /obj/structure/cable/green{
@@ -2130,11 +2288,15 @@
 	pixel_x = 22
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/storage)
 "ej" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/eva)
 "ek" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2150,7 +2312,9 @@
 	},
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/eva)
 "el" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -2174,7 +2338,9 @@
 	opacity = 0
 	},
 /obj/effect/paint/brown,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/eva)
 "en" = (
 /obj/machinery/light/small{
@@ -2209,7 +2375,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/techstorage)
 "eq" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -2224,7 +2392,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/techstorage)
 "er" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -2345,7 +2515,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/eva)
 "ez" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -2380,7 +2552,9 @@
 	name = "External Blast Doors";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/eva)
 "eB" = (
 /obj/machinery/light/small{
@@ -2408,7 +2582,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/eva)
 "eC" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
@@ -2419,7 +2595,9 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/eva)
 "eD" = (
 /obj/machinery/door/airlock/external/bolted/cycling{
@@ -2439,7 +2617,9 @@
 	name = "External Blast Doors";
 	opacity = 0
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/eva)
 "eE" = (
 /obj/item/stock_parts/capacitor,
@@ -2473,7 +2653,9 @@
 	dir = 1;
 	level = 2
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/techstorage)
 "eG" = (
 /obj/structure/table/rack,
@@ -2483,7 +2665,9 @@
 /obj/item/stock_parts/circuitboard/unary_atmos/engine,
 /obj/item/stock_parts/circuitboard/unary_atmos/engine,
 /obj/item/stock_parts/circuitboard/unary_atmos/engine,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/techstorage)
 "eH" = (
 /obj/item/storage/toolbox/mechanical{
@@ -2517,7 +2701,9 @@
 /area/ship/scrap/maintenance/storage)
 "eL" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/storage)
 "eM" = (
 /obj/item/device/radio/intercom/map_preset/bearcat{
@@ -2528,7 +2714,9 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/eva)
 "eN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2598,11 +2786,15 @@
 /obj/item/device/radio/intercom/map_preset/bearcat{
 	pixel_y = -32
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/storage)
 "eU" = (
 /obj/machinery/vending/tool/bearcat,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/storage)
 "eV" = (
 /obj/machinery/suit_cycler/salvage/bearcat,
@@ -2633,7 +2825,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/brown,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/storage)
 "fb" = (
 /obj/structure/curtain/open/bed,
@@ -2665,10 +2859,14 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/space)
 "kV" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/ship/scrap/gambling)
 "lQ" = (
 /obj/machinery/light_switch{
@@ -2681,7 +2879,9 @@
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/broken1)
 "tc" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/ship/scrap/crew/dorms1)
 "tW" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2707,7 +2907,9 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "vU" = (
 /obj/effect/floor_decal/corner/beige{
@@ -2735,7 +2937,9 @@
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/maintenance/eva)
 "En" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/ship/scrap/crew/dorms3)
 "EP" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -2750,10 +2954,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/cargo/lower)
 "Gr" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/ship/scrap/crew/dorms2)
 "GU" = (
 /obj/effect/paint/brown,
@@ -2780,7 +2988,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/lower)
 "Ro" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2797,7 +3007,9 @@
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/maintenance/storage)
 "Ul" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/storage)
 "UZ" = (
 /obj/effect/paint/brown,

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -44,14 +44,18 @@
 /area/ship/scrap/command/bridge)
 "ag" = (
 /obj/machinery/computer/modular/preset/cardslot/command,
-/turf/simulated/floor/bluegrid/airless,
+/turf/simulated/floor/bluegrid{
+	map_airless = 1
+	},
 /area/ship/scrap/command/bridge)
 "ah" = (
 /obj/machinery/computer/ship/helm{
 	req_access = list(list("ACCESS_BEARCAT"))
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/bluegrid/airless,
+/turf/simulated/floor/bluegrid{
+	map_airless = 1
+	},
 /area/ship/scrap/command/bridge)
 "ai" = (
 /obj/structure/table/standard,
@@ -122,7 +126,7 @@
 /obj/machinery/door/blast/regular{
 	id_tag = "sensor"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/comms)
 "at" = (
 /obj/effect/paint/brown,
@@ -165,7 +169,7 @@
 /area/ship/scrap/command/bridge)
 "ax" = (
 /obj/machinery/shipsensors,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/comms)
 "ay" = (
 /obj/machinery/light,
@@ -2049,7 +2053,7 @@
 /area/ship/scrap/crew/hallway/starboard)
 "ed" = (
 /obj/effect/paint/brown,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/comms)
 "ee" = (
 /obj/item/stool/padded,
@@ -2418,7 +2422,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/port)
 "eB" = (
 /obj/machinery/light/small{
@@ -2434,7 +2438,7 @@
 	dir = 6
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/port)
 "eC" = (
 /obj/structure/cable/green{
@@ -2446,7 +2450,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/autoname/engineering/bearcat,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/port)
 "eD" = (
 /obj/item/screwdriver,
@@ -2458,7 +2462,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/port)
 "eE" = (
 /obj/structure/table/standard,
@@ -2616,7 +2620,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 6
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/starboard)
 "eS" = (
 /obj/structure/cable/green{
@@ -2646,7 +2650,7 @@
 	dir = 10
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/starboard)
 "eU" = (
 /obj/machinery/power/apc/derelict{
@@ -2656,21 +2660,21 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/starboard)
 "eV" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 6
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/port)
 "eW" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/port)
 "eX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -2796,14 +2800,14 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/starboard)
 "fj" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/starboard)
 "fk" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -2815,7 +2819,7 @@
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/port)
 "fm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -3004,7 +3008,7 @@
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/starboard)
 "fD" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -3013,7 +3017,9 @@
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/maintenance/engine/starboard)
 "fE" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/ship/scrap/command/captain)
 "fF" = (
 /obj/structure/lattice,
@@ -3504,8 +3510,10 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/space)
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
+/area/ship/scrap/fire)
 "gy" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -3950,9 +3958,6 @@
 /obj/effect/paint/brown,
 /turf/simulated/wall,
 /area/ship/scrap/maintenance/power)
-"hf" = (
-/turf/simulated/floor/reinforced/airless,
-/area/ship/scrap/comms)
 "hg" = (
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/maintenance/power)
@@ -3962,7 +3967,7 @@
 	},
 /obj/effect/floor_decal/corner/blue,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "hi" = (
 /obj/machinery/atmospherics/binary/pump/on{
@@ -3976,13 +3981,13 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "hj" = (
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "hk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
@@ -3999,7 +4004,7 @@
 	dir = 1
 	},
 /mob/living/simple_animal/hostile/carp,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "hl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
@@ -4013,7 +4018,7 @@
 /obj/machinery/light_switch{
 	pixel_y = 25
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "hm" = (
 /obj/machinery/power/apc/derelict{
@@ -4138,7 +4143,7 @@
 /turf/space,
 /area/ship/scrap/maintenance/atmos)
 "hx" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/atmos)
 "hy" = (
 /obj/structure/window/reinforced{
@@ -4151,7 +4156,7 @@
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/atmos)
 "hz" = (
 /obj/machinery/atmospherics/portables_connector,
@@ -4163,7 +4168,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "hA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
@@ -4181,7 +4186,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "hB" = (
 /obj/machinery/door/firedoor,
@@ -4381,7 +4386,7 @@
 /area/ship/scrap/maintenance/atmos)
 "hN" = (
 /obj/item/material/shard,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/atmos)
 "hO" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
@@ -4392,7 +4397,7 @@
 	use_power = 1
 	},
 /mob/living/simple_animal/hostile/carp,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/atmos)
 "hP" = (
 /obj/structure/window/reinforced{
@@ -4411,7 +4416,7 @@
 	pump_direction = 0;
 	use_power = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/atmos)
 "hQ" = (
 /obj/machinery/meter,
@@ -4421,7 +4426,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "hR" = (
 /obj/effect/floor_decal/corner/blue,
@@ -4433,7 +4438,7 @@
 	icon_state = "bulb1"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "hS" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -4568,7 +4573,7 @@
 /area/ship/scrap/maintenance/atmos)
 "ie" = (
 /obj/item/stack/material/steel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/atmos)
 "if" = (
 /obj/structure/window/reinforced{
@@ -4577,14 +4582,14 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/atmos)
 "ig" = (
 /obj/effect/floor_decal/corner/white{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "ih" = (
 /obj/structure/dispenser/oxygen,
@@ -4597,7 +4602,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "ii" = (
 /obj/machinery/door/firedoor,
@@ -4678,7 +4683,7 @@
 /obj/effect/floor_decal/corner/white/diagonal{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/atmos)
 "ir" = (
 /obj/machinery/atmospherics/omni/mixer{
@@ -4693,7 +4698,7 @@
 /obj/effect/floor_decal/corner/white{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "is" = (
 /obj/effect/floor_decal/corner/blue,
@@ -4704,7 +4709,7 @@
 /obj/machinery/atmospherics/binary/passive_gate{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "iu" = (
 /obj/structure/sign/warning/fire{
@@ -4718,14 +4723,14 @@
 	dir = 1;
 	icon_state = "bulb1"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "iv" = (
 /obj/machinery/light_switch{
 	pixel_y = 25
 	},
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "iw" = (
 /obj/machinery/atmospherics/portables_connector,
@@ -4735,7 +4740,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "ix" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -4744,7 +4749,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "iy" = (
 /obj/machinery/atmospherics/portables_connector,
@@ -4753,11 +4758,11 @@
 	dir = 1;
 	icon_state = "bulb1"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "iz" = (
 /obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "iA" = (
 /obj/structure/closet/radiation,
@@ -4793,7 +4798,7 @@
 	dir = 4;
 	name = "Air to Ports"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "iE" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
@@ -4804,7 +4809,7 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "iF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -4812,32 +4817,32 @@
 	dir = 8
 	},
 /obj/structure/cable/green,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "iG" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "iH" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "iI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
 	},
 /mob/living/simple_animal/hostile/carp,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "iJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	level = 2
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "iL" = (
 /obj/machinery/atmospherics/omni/mixer{
@@ -4847,7 +4852,7 @@
 	tag_west = 1;
 	tag_west_con = 0.64
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "iM" = (
 /obj/structure/cable/green{
@@ -4889,7 +4894,7 @@
 /area/ship/scrap/maintenance/atmos)
 "iQ" = (
 /obj/item/stack/material/plasteel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/atmos)
 "iR" = (
 /obj/structure/window/reinforced{
@@ -4911,7 +4916,7 @@
 	pump_direction = 0;
 	use_power = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/atmos)
 "iS" = (
 /obj/machinery/meter,
@@ -4921,7 +4926,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "iT" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -4940,7 +4945,7 @@
 	pixel_x = 24;
 	req_access = newlist()
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "iU" = (
 /obj/machinery/alarm{
@@ -4949,7 +4954,7 @@
 	req_access = newlist()
 	},
 /obj/machinery/atmospherics/valve/shutoff/fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "iV" = (
 /obj/structure/window/boron_reinforced{
@@ -4961,7 +4966,7 @@
 	icon_state = "phoronrwindow"
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/engine/aft)
 "iW" = (
 /obj/structure/window/boron_reinforced{
@@ -4972,7 +4977,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/engine/aft)
 "iX" = (
 /obj/structure/window/boron_reinforced{
@@ -4991,7 +4996,7 @@
 	icon_state = "map_injector";
 	use_power = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/engine/aft)
 "iY" = (
 /obj/structure/window/boron_reinforced,
@@ -5001,13 +5006,13 @@
 /obj/item/stack/material/glass/boron_reinforced{
 	amount = 20
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "iZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "ja" = (
 /obj/machinery/meter,
@@ -5015,7 +5020,7 @@
 	dir = 9
 	},
 /obj/structure/closet/crate/solar,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jb" = (
 /obj/structure/cable/green{
@@ -5046,7 +5051,7 @@
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
 /obj/structure/window/reinforced,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/atmos)
 "je" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -5055,7 +5060,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "jf" = (
 /obj/machinery/light/small{
@@ -5063,7 +5068,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/machinery/meter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jg" = (
 /obj/structure/window/boron_reinforced{
@@ -5071,31 +5076,31 @@
 	icon_state = "phoronrwindow"
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/engine/aft)
 "jh" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/machinery/igniter{
 	id_tag = "engine"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/engine/aft)
 "ji" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/engine/aft)
 "jj" = (
 /obj/machinery/door/blast/regular{
 	id_tag = "scram"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jk" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jl" = (
 /obj/item/device/radio/intercom/map_preset/bearcat{
@@ -5107,7 +5112,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jm" = (
 /obj/structure/cable/green,
@@ -5129,12 +5134,12 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "js" = (
 /obj/machinery/atmospherics/valve/open,
 /obj/item/material/shard/phoron,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jt" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -5175,14 +5180,14 @@
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jy" = (
 /obj/machinery/atmospherics/omni/filter{
@@ -5193,7 +5198,7 @@
 	use_power = 0
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black{
@@ -5227,7 +5232,7 @@
 	dir = 8
 	},
 /obj/machinery/space_heater,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "jE" = (
 /obj/machinery/pipedispenser,
@@ -5239,24 +5244,24 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "jF" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jG" = (
 /obj/item/material/shard/phoron,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jH" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jI" = (
 /obj/machinery/atmospherics/valve/open{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jK" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -5267,12 +5272,12 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jL" = (
 /obj/machinery/door/blast/regular{
-	id_tag = "scram";
-	dir = 4
+	dir = 4;
+	id_tag = "scram"
 	},
 /turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
@@ -5302,7 +5307,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning,
 /mob/living/simple_animal/hostile/carp,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jQ" = (
 /obj/structure/window/reinforced,
@@ -5310,7 +5315,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jR" = (
 /obj/structure/window/reinforced,
@@ -5318,7 +5323,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jS" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -5328,7 +5333,7 @@
 	icon_state = "warning"
 	},
 /obj/structure/closet/crate/solar_assembly,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jT" = (
 /obj/structure/lattice,
@@ -5348,7 +5353,7 @@
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "jX" = (
 /obj/item/stack/material/rods,
@@ -5358,7 +5363,7 @@
 /obj/structure/sign/warning/hot_exhaust{
 	pixel_y = 32
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "kb" = (
 /obj/machinery/light/small{
@@ -5389,7 +5394,9 @@
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/crew/toilets)
 "lC" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/ship/scrap/crew/toilets)
 "lX" = (
 /obj/item/stack/material/steel,
@@ -5418,7 +5425,7 @@
 /area/ship/scrap/crew/medbay)
 "sy" = (
 /obj/structure/lattice,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/atmos)
 "ts" = (
 /obj/structure/lattice,
@@ -5429,7 +5436,7 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/ash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "uM" = (
 /obj/item/stack/material/steel,
@@ -5458,7 +5465,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/blue/diagonal,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/atmos)
 "Cs" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -5503,7 +5510,7 @@
 /area/ship/scrap/maintenance/atmos)
 "FI" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "GG" = (
 /obj/effect/paint/brown,
@@ -5515,7 +5522,7 @@
 /area/space)
 "HQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/atmos)
 "IG" = (
 /obj/item/material/shard,
@@ -5526,7 +5533,7 @@
 	id = "n2_in";
 	use_power = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/atmos)
 "IL" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -5572,14 +5579,20 @@
 /turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/engineering)
 "JH" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/power)
 "Kj" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/ship/scrap/crew/cryo)
 "Lp" = (
-/turf/simulated/floor/reinforced/airless,
-/area/ship/scrap/command/bridge)
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
+/area/ship/scrap/comms)
 "Ly" = (
 /obj/effect/paint/brown,
 /turf/simulated/wall/r_wall,
@@ -5593,7 +5606,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red/diagonal,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/atmos)
 "Mp" = (
 /obj/structure/closet/crate,
@@ -5616,7 +5629,7 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 "Ok" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -5643,7 +5656,7 @@
 /area/ship/scrap/maintenance/engine/port)
 "PG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/port)
 "PP" = (
 /obj/machinery/power/port_gen/pacman/super,
@@ -5675,7 +5688,7 @@
 	},
 /obj/machinery/meter,
 /obj/effect/decal/cleanable/ash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "RZ" = (
 /obj/structure/lattice,
@@ -5692,7 +5705,7 @@
 /obj/item/device/radio/intercom/map_preset/bearcat{
 	pixel_x = -32
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "Ul" = (
 /obj/effect/paint/brown,
@@ -5724,7 +5737,7 @@
 /area/ship/scrap/comms)
 "Wu" = (
 /obj/effect/decal/cleanable/molten_item,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
 "XU" = (
 /obj/structure/sign/redcross,
@@ -5740,7 +5753,7 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/ash,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
 
 (1,1,1) = {"
@@ -12133,7 +12146,7 @@ aa
 Yv
 Yv
 Yv
-hf
+Lp
 Yv
 Yv
 aa
@@ -13226,7 +13239,7 @@ aa
 aa
 aa
 aa
-Lp
+fE
 fE
 aB
 aF

--- a/maps/away/bearcat/bearcat_areas.dm
+++ b/maps/away/bearcat/bearcat_areas.dm
@@ -83,10 +83,12 @@
 /area/ship/scrap/broken1
 	name = "Robotic Maintenance"
 	icon_state = "green"
+	turfs_airless = TRUE
 
 /area/ship/scrap/broken2
 	name = "Compartment 1-B"
 	icon_state = "yellow"
+	turfs_airless = TRUE
 
 /area/ship/scrap/gambling
 	name = "Compartment 1-C"
@@ -124,11 +126,13 @@
 	name = "Atmospherics Comparment"
 	icon_state = "atmos"
 	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambiatm1.ogg')
+	turfs_airless = TRUE
 
 /area/ship/scrap/maintenance/power
 	name = "Power Compartment"
 	icon_state = "engine_smes"
 	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/ambigen5.ogg','sound/ambience/ambigen6.ogg','sound/ambience/ambigen7.ogg','sound/ambience/ambigen8.ogg','sound/ambience/ambigen9.ogg','sound/ambience/ambigen10.ogg','sound/ambience/ambigen11.ogg','sound/ambience/ambieng1.ogg')
+	turfs_airless = TRUE
 
 /area/ship/scrap/maintenance/engine
 	icon_state = "engine"
@@ -136,12 +140,15 @@
 
 /area/ship/scrap/maintenance/engine/aft
 	name = "Main Engine Bay"
+	turfs_airless = TRUE
 
 /area/ship/scrap/maintenance/engine/port
 	name = "Port Thruster"
+	turfs_airless = TRUE
 
 /area/ship/scrap/maintenance/engine/starboard
 	name = "Starboard Thruster"
+	turfs_airless = TRUE
 
 /area/ship/scrap/command/hallway
 	name = "Command Deck"

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -1197,7 +1197,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "dt" = (
 /obj/structure/hygiene/toilet{
@@ -1269,7 +1269,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "dM" = (
 /obj/structure/bed/chair/comfy/red{
@@ -1344,10 +1344,10 @@
 	name = "Starboard Auxiliary Solar Array"
 	},
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ed" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ee" = (
 /obj/structure/hygiene/shower{
@@ -1425,7 +1425,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "er" = (
 /obj/structure/cable/yellow{
@@ -1443,7 +1443,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "es" = (
 /obj/structure/cable/yellow{
@@ -1451,7 +1451,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "et" = (
 /obj/structure/cable/yellow{
@@ -1469,7 +1469,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "eu" = (
 /obj/structure/cable/yellow{
@@ -1487,7 +1487,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ev" = (
 /obj/structure/cable/yellow{
@@ -1500,7 +1500,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ew" = (
 /obj/structure/reagent_dispensers/beerkeg,
@@ -1581,7 +1581,7 @@
 	name = "Starboard Auxiliary Solar Array"
 	},
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "eJ" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -2029,7 +2029,7 @@
 	},
 /obj/structure/cable/yellow,
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "fN" = (
 /obj/structure/mopbucket,
@@ -2293,7 +2293,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "gx" = (
 /obj/structure/cable/yellow{
@@ -2310,7 +2310,7 @@
 	pixel_y = 24;
 	req_access = newlist()
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "gy" = (
 /obj/machinery/door/airlock/external{
@@ -2412,7 +2412,7 @@
 	name = "Port Auxiliary Solar Array"
 	},
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "gL" = (
 /obj/machinery/door/airlock/external{
@@ -2461,7 +2461,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "hb" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2538,7 +2538,7 @@
 	name = "Port Auxiliary Solar Array"
 	},
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "hl" = (
 /obj/structure/cable/yellow,
@@ -2840,7 +2840,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ih" = (
 /obj/machinery/door/firedoor,
@@ -3371,7 +3371,9 @@
 	icon_state = "map_injector";
 	use_power = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/space)
 "jv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -4708,18 +4710,18 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 6
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/casino/casino_bow)
 "nh" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/black,
 /obj/machinery/meter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/casino/casino_bow)
 "ni" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/casino/casino_bow)
 "nj" = (
 /obj/structure/bed/chair,
@@ -4783,7 +4785,7 @@
 /turf/simulated/wall/r_titanium,
 /area/casino/casino_bow)
 "ns" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/casino/casino_bow)
 "ob" = (
 /obj/structure/table/gamblingtable,
@@ -5365,7 +5367,9 @@
 /area/casino/casino_mainfloor)
 "Mb" = (
 /obj/machinery/shipsensors,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/casino/casino_bridge)
 "Mc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -5579,7 +5583,7 @@
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/casino/casino_bow)
 "SP" = (
 /obj/structure/cable/green{
@@ -5601,7 +5605,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/casino/casino_bow)
 "Uc" = (
 /obj/structure/hygiene/sink{

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -122,7 +122,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/derelict/ship)
 "ar" = (
 /obj/structure/shuttle/engine/propulsion{
@@ -416,11 +416,11 @@
 "bh" = (
 /obj/structure/grille,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "bi" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "bj" = (
 /obj/structure/table/standard,
@@ -445,18 +445,18 @@
 /area/derelict/ship)
 "bn" = (
 /obj/random/hostile,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "bo" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "bp" = (
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "bq" = (
 /obj/random/cash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "br" = (
 /obj/structure/table/standard,
@@ -477,7 +477,7 @@
 /area/derelict/ship)
 "bu" = (
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "bv" = (
 /turf/simulated/wall,
@@ -486,54 +486,54 @@
 /obj/structure/grille,
 /obj/machinery/door/blast/regular/open,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/bridge)
 "bx" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/bridge)
 "by" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular/open,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/bridge)
 "bz" = (
 /obj/structure/grille,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/bridge)
 "bA" = (
 /obj/random/material,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "bB" = (
 /obj/structure/table/standard,
 /obj/item/modular_computer/laptop,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/bridge)
 "bC" = (
 /obj/structure/table/standard,
 /obj/random/drinkbottle,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/bridge)
 "bD" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/bridge)
 "bE" = (
 /obj/structure/table,
 /obj/random/loot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/bridge)
 "bF" = (
 /turf/space,
 /area/constructionsite/maintenance)
 "bG" = (
 /obj/random/loot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "bH" = (
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/maintenance)
@@ -558,23 +558,23 @@
 /turf/simulated/floor/tiled,
 /area/derelict/ship)
 "bK" = (
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/bridge)
 "bL" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/bridge)
 "bM" = (
 /obj/random/trash,
 /obj/structure/table,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/bridge)
 "bN" = (
 /obj/random/closet,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "bO" = (
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/bridge)
 "bP" = (
 /obj/structure/table/standard,
@@ -582,15 +582,15 @@
 	info = "\\\[center]\\\[b]ATTN: Regarding Meteor Storms\\\[/b]\[/center]\\\[br]\\\[br]We've recently heard mutterings from the Atmospheric Technicians that the meteor showers in this sector are becoming too much. However, this should be disregarded.\\\[br]\\\[br] High Command has assured us that our shields can easily keep pace with any meteor storm and then some. Any uneasiness the crew may feel should be disspelled swiftly. Thank you.";
 	name = "ATTN: Regarding Meteor Storms"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/bridge)
 "bQ" = (
 /obj/structure/table,
 /obj/random/material,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/bridge)
 "bR" = (
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/bridge)
@@ -598,7 +598,7 @@
 /obj/random/hostile{
 	spawn_nothing_percentage = 60
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/bridge)
 "bT" = (
 /obj/structure/bed/chair,
@@ -686,15 +686,15 @@
 /area/derelict/ship)
 "cd" = (
 /obj/structure/girder,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "ce" = (
 /obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "cf" = (
 /obj/random/handgun,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/bridge)
 "cg" = (
 /obj/item/stack/cable_coil,
@@ -708,29 +708,29 @@
 "ci" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/door/blast/regular/open,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/bridge)
 "cj" = (
 /obj/random/hostile{
 	spawn_nothing_percentage = 60
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/bridge)
 "ck" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/bridge)
 "cl" = (
 /obj/machinery/door/airlock/hatch,
 /obj/machinery/door/blast/regular,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/bridge)
 "cm" = (
 /obj/random/closet,
 /obj/random/maintenance,
 /obj/random/maintenance,
 /obj/random/material,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "cn" = (
 /turf/simulated/wall/voxshuttle,
@@ -767,78 +767,78 @@
 /area/derelict/ship)
 "cs" = (
 /obj/machinery/computer/modular,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/bridge)
 "ct" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/bridge)
 "cu" = (
 /obj/random/closet,
 /obj/random/energy,
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "cv" = (
 /obj/structure/bookcase/manuals/engineering,
 /obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "cw" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "cx" = (
 /obj/structure/bookcase,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/hallway/fore)
 "cy" = (
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/hallway/fore)
 "cz" = (
 /obj/structure/bookcase/manuals/xenoarchaeology,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "cA" = (
 /obj/structure/bookcase,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "cB" = (
 /obj/structure/girder,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/bridge)
 "cC" = (
 /obj/random/loot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/bridge)
 "cD" = (
 /obj/structure/table/marble,
 /obj/random/coin,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "cE" = (
 /obj/structure/table/marble,
 /obj/machinery/microwave,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "cF" = (
 /obj/structure/table/marble,
 /obj/random/loot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "cG" = (
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/constructionsite/hallway/fore)
 "cH" = (
 /obj/structure/table,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "cI" = (
 /obj/structure/table,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/constructionsite/hallway/fore)
 "cJ" = (
 /obj/structure/table/standard,
@@ -859,35 +859,35 @@
 "cM" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/excavation,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "cN" = (
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/hallway/fore)
 "cO" = (
 /obj/structure/bookcase/manuals/xenoarchaeology,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/hallway/fore)
 "cP" = (
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "cQ" = (
 /obj/structure/bookcase,
 /obj/item/book/manual/ripley_build_and_repair,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "cR" = (
 /obj/structure/noticeboard{
 	pixel_x = 32
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/bridge)
 "cS" = (
 /obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "cT" = (
 /obj/structure/window/reinforced,
@@ -936,18 +936,18 @@
 /area/derelict/ship)
 "cX" = (
 /obj/machinery/bookbinder,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/hallway/fore)
 "cY" = (
 /obj/structure/filingcabinet/filingcabinet,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "cZ" = (
 /obj/machinery/door/airlock/glass/command{
 	name = "Bridge"
 	},
 /obj/machinery/door/blast/regular,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/bridge)
 "da" = (
 /obj/structure/closet/secure_closet/freezer/fridge{
@@ -955,110 +955,110 @@
 	locked = 0
 	},
 /obj/random/contraband,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "db" = (
 /obj/structure/table/marble,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dc" = (
 /obj/structure/table/marble,
 /obj/item/material/kitchen/rollingpin,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dd" = (
 /obj/structure/table,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/hallway/fore)
 "de" = (
 /obj/random/closet,
 /obj/random/voidhelmet,
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "df" = (
 /obj/structure/table/rack,
 /obj/random/loot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dg" = (
 /obj/structure/bookcase/manuals/medical,
 /obj/item/book/manual/nuclear,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/hallway/fore)
 "dh" = (
 /obj/random/trash,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/hallway/fore)
 "di" = (
 /obj/structure/table/rack,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dj" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dk" = (
 /obj/structure/table/marble,
 /obj/random/drinkbottle,
 /obj/random/drinkbottle,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dl" = (
 /obj/structure/table/marble,
 /obj/random/gloves,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dm" = (
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dn" = (
 /obj/structure/table/marble,
 /obj/random/drinkbottle,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "do" = (
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dp" = (
 /obj/structure/table/rack,
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dq" = (
 /obj/structure/table/rack,
 /obj/random/hat,
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dr" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/constructionsite/hallway/fore)
 "ds" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/hallway/fore)
 "dt" = (
 /obj/structure/table/standard,
 /obj/random/toy,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/hallway/fore)
 "du" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dv" = (
 /obj/structure/grille,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dw" = (
 /turf/simulated/floor/holofloor/tiled/dark,
@@ -1066,40 +1066,40 @@
 "dx" = (
 /obj/random/junk,
 /obj/structure/table,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dy" = (
 /obj/random/snack,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dz" = (
 /turf/simulated/wall,
 /area/constructionsite/hallway/fore)
 "dA" = (
 /obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dB" = (
 /obj/machinery/door/airlock/glass{
 	name = "Library"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dC" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/hallway/fore)
 "dD" = (
 /obj/structure/grille/broken,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/hallway/fore)
 "dE" = (
 /obj/structure/grille,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/hallway/fore)
@@ -1111,7 +1111,7 @@
 /obj/machinery/door/airlock/glass/command{
 	name = "Bridge"
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/hallway/fore)
 "dH" = (
 /obj/machinery/door/airlock/glass/command{
@@ -1123,45 +1123,45 @@
 /obj/machinery/door/airlock/glass{
 	name = "Kitchen"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dJ" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/hallway/fore)
 "dK" = (
 /obj/structure/table/marble,
 /obj/machinery/door/blast/shutters/open,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dL" = (
 /obj/structure/table,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/hallway/fore)
 "dM" = (
 /obj/structure/table,
 /obj/machinery/door/blast/shutters/open,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dN" = (
 /obj/structure/girder/displaced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dO" = (
 /turf/simulated/wall,
 /area/space)
 "dP" = (
 /obj/structure/grille/broken,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dQ" = (
 /obj/random/smokes,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/hallway/fore)
 "dR" = (
 /obj/structure/lattice,
@@ -1169,16 +1169,16 @@
 /area/constructionsite/hallway/fore)
 "dS" = (
 /obj/random/snack,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/hallway/fore)
 "dT" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/hallway/fore)
 "dU" = (
 /obj/structure/grille/broken,
 /obj/structure/wall_frame,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/hallway/fore)
 "dV" = (
 /obj/structure/lattice,
@@ -1188,7 +1188,7 @@
 "dW" = (
 /obj/structure/table/rack,
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "dX" = (
 /obj/effect/shuttle_landmark/derelict/nav2,
@@ -1199,51 +1199,51 @@
 /area/constructionsite/storage)
 "dZ" = (
 /obj/structure/girder/displaced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "ea" = (
 /obj/structure/extinguisher_cabinet{
 	icon_state = "extinguisher_empty";
 	pixel_x = 30
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "eb" = (
 /turf/simulated/wall,
 /area/constructionsite/teleporter)
 "ec" = (
 /obj/machinery/mech_recharger,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "ed" = (
 /obj/machinery/robotics_fabricator,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "ee" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "ef" = (
 /obj/structure/table/standard,
 /obj/random/material,
 /obj/random/material,
 /obj/random/coin,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "eg" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/storage)
 "eh" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "ei" = (
 /obj/structure/table,
 /obj/random/medical,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "ej" = (
 /obj/machinery/shieldgen,
@@ -1335,10 +1335,10 @@
 /obj/structure/table/rack,
 /obj/random/maintenance,
 /obj/random/toolbox,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "es" = (
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/storage)
@@ -1346,18 +1346,18 @@
 /obj/structure/bed/chair/office/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/storage)
 "eu" = (
 /obj/machinery/optable{
 	name = "Robotics Operating Table"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "ev" = (
 /obj/random/closet,
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "ew" = (
 /obj/machinery/shieldgen,
@@ -1420,20 +1420,20 @@
 /area/constructionsite/teleporter)
 "eD" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "eE" = (
 /obj/machinery/door/airlock/glass/science{
 	name = "Robotics"
 	},
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/storage)
 "eF" = (
 /obj/structure/grille/broken,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "eG" = (
 /obj/structure/sign/warning/science,
@@ -1446,7 +1446,7 @@
 	pixel_y = -10;
 	req_access = newlist()
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/hallway/fore)
 "eI" = (
 /obj/machinery/access_button/airlock_interior{
@@ -1471,18 +1471,18 @@
 /area/constructionsite/teleporter)
 "eL" = (
 /obj/structure/skele_stand,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "eM" = (
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "eN" = (
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "eO" = (
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/storage)
 "eP" = (
 /obj/machinery/door/airlock/glass/science{
@@ -1491,14 +1491,14 @@
 /obj/machinery/door/blast/shutters{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "eQ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "eR" = (
 /obj/machinery/door/airlock/external{
@@ -1514,7 +1514,7 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/hallway/fore)
 "eU" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -1536,11 +1536,11 @@
 /area/constructionsite/teleporter)
 "eX" = (
 /obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "eY" = (
 /obj/random/hostile,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "eZ" = (
 /obj/machinery/door/airlock/glass/science{
@@ -1549,7 +1549,7 @@
 /obj/machinery/door/blast/shutters/open{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "fa" = (
 /obj/machinery/light/small,
@@ -1633,12 +1633,12 @@
 "fj" = (
 /obj/structure/grille,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "fk" = (
 /obj/structure/grille/broken,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/storage)
@@ -1646,13 +1646,13 @@
 /obj/machinery/door/airlock/glass/science{
 	name = "Research"
 	},
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/storage)
 "fm" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/storage)
 "fn" = (
 /obj/structure/window/basic{
@@ -1718,7 +1718,7 @@
 /area/constructionsite/teleporter)
 "ft" = (
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "fu" = (
 /obj/structure/window/basic,
@@ -1748,26 +1748,26 @@
 /area/constructionsite/teleporter)
 "fx" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen/prechilled,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "fy" = (
 /obj/machinery/r_n_d/circuit_imprinter,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/storage)
 "fz" = (
 /obj/machinery/r_n_d/destructive_analyzer,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "fA" = (
 /obj/machinery/r_n_d/protolathe{
 	icon_state = "protolathe_t";
 	reason_broken = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "fB" = (
 /obj/machinery/r_n_d/server/centcom,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/storage)
 "fC" = (
 /obj/machinery/pipedispenser,
@@ -1820,7 +1820,7 @@
 /area/constructionsite/teleporter)
 "fK" = (
 /obj/structure/girder/displaced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "fL" = (
 /turf/simulated/wall,
@@ -1829,65 +1829,65 @@
 /obj/random/closet,
 /obj/random/material,
 /obj/random/contraband,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "fN" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/solar)
 "fO" = (
 /obj/structure/lattice,
 /turf/space,
 /area/constructionsite/solar)
 "fP" = (
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/solar)
 "fQ" = (
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/maintenance)
 "fR" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "fS" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/hallway/fore)
 "fT" = (
 /obj/effect/overmap/visitable/sector/derelict,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/solar)
 "fU" = (
 /turf/space,
 /area/constructionsite/solar)
 "fV" = (
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/solar)
 "fW" = (
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/solar)
 "fX" = (
 /obj/structure/grille,
 /obj/structure/wall_frame,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/hallway/fore)
 "fY" = (
 /obj/structure/grille,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/solar)
 "fZ" = (
 /obj/structure/grille/broken,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/solar)
 "ga" = (
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "gb" = (
 /obj/effect/shuttle_landmark/derelict/nav3,
@@ -1895,7 +1895,7 @@
 /area/space)
 "gc" = (
 /obj/random/firstaid,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "gd" = (
 /obj/structure/lattice,
@@ -1906,35 +1906,35 @@
 /obj/structure/table/rack,
 /obj/random/plushie,
 /obj/random/loot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "gf" = (
 /obj/machinery/door/airlock/highsecurity{
 	icon_state = "door_closed";
 	name = "AI Upload Access"
 	},
-/turf/simulated/floor/bluegrid/airless,
+/turf/simulated/floor/bluegrid,
 /area/constructionsite/hallway/fore)
 "gg" = (
 /turf/simulated/wall,
 /area/constructionsite/ai)
 "gh" = (
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/ai)
 "gi" = (
-/turf/simulated/floor/bluegrid/airless,
+/turf/simulated/floor/bluegrid,
 /area/constructionsite/ai)
 "gj" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "gk" = (
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/space)
 "gl" = (
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "gm" = (
 /obj/structure/sign/warning/lethal_turrets,
@@ -1945,45 +1945,45 @@
 	icon_state = "door_closed";
 	name = "AI Upload"
 	},
-/turf/simulated/floor/bluegrid/airless,
+/turf/simulated/floor/bluegrid,
 /area/constructionsite/ai)
 "go" = (
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "gp" = (
 /obj/machinery/porta_turret_construct,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/ai)
 "gq" = (
 /obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/ai)
 "gr" = (
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/space)
 "gs" = (
 /obj/structure/table/rack,
 /obj/random/maintenance,
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "gt" = (
 /obj/structure/table/rack,
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "gu" = (
 /obj/random/loot,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/ai)
 "gv" = (
 /obj/random/trash,
-/turf/simulated/floor/bluegrid/airless,
+/turf/simulated/floor/bluegrid,
 /area/constructionsite/ai)
 "gw" = (
 /obj/machinery/drone_fabricator/derelict,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/ai)
 "gx" = (
 /obj/structure/cable/blue{
@@ -1995,15 +1995,15 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/ai)
 "gy" = (
 /obj/machinery/computer/drone_control,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/ai)
 "gz" = (
 /obj/random/hostile,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "gA" = (
 /obj/structure/lattice,
@@ -2013,13 +2013,13 @@
 /obj/machinery/door/airlock/highsecurity{
 	name = "Messaging Server"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "gC" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Messaging Server"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/ai)
 "gD" = (
 /obj/structure/showcase{
@@ -2028,13 +2028,13 @@
 	icon_state = "4";
 	name = "Deactivated AI Core"
 	},
-/turf/simulated/floor/bluegrid/airless,
+/turf/simulated/floor/bluegrid,
 /area/constructionsite/ai)
 "gE" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Cyborg Station"
 	},
-/turf/simulated/floor/bluegrid/airless,
+/turf/simulated/floor/bluegrid,
 /area/constructionsite/ai)
 "gF" = (
 /obj/structure/cable/blue{
@@ -2042,29 +2042,29 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/bluegrid/airless,
+/turf/simulated/floor/bluegrid,
 /area/constructionsite/ai)
 "gG" = (
 /obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/bluegrid/airless,
+/turf/simulated/floor/bluegrid,
 /area/constructionsite/ai)
 "gH" = (
 /obj/machinery/door/airlock/highsecurity{
 	name = "Cyborg Station"
 	},
-/turf/simulated/floor/bluegrid/airless,
+/turf/simulated/floor/bluegrid,
 /area/constructionsite/hallway/fore)
 "gI" = (
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "gJ" = (
 /obj/random/material,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "gK" = (
 /obj/machinery/recharge_station,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/ai)
 "gL" = (
 /obj/structure/lattice,
@@ -2076,29 +2076,29 @@
 /area/constructionsite/hallway/fore)
 "gM" = (
 /obj/machinery/porta_turret/stationary,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/ai)
 "gN" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/ai)
 "gO" = (
 /turf/simulated/wall,
 /area/constructionsite/hallway/aft)
 "gP" = (
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/hallway/aft)
 "gQ" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "gR" = (
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/hallway/aft)
 "gS" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "gT" = (
 /obj/structure/lattice,
@@ -2106,43 +2106,43 @@
 /area/constructionsite/hallway/aft)
 "gU" = (
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "gV" = (
 /obj/structure/grille,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "gW" = (
 /obj/structure/grille/broken,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "gX" = (
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "gY" = (
 /obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "gZ" = (
 /obj/machinery/door/airlock/highsecurity{
 	icon_state = "door_closed";
 	name = "AI Upload Access"
 	},
-/turf/simulated/floor/bluegrid/airless,
+/turf/simulated/floor/bluegrid,
 /area/constructionsite/hallway/aft)
 "ha" = (
 /obj/structure/table/rack,
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "hb" = (
 /obj/effect/floor_decal/plaque{
 	desc = "To commemorate the beginning of the Eternity Project, a station that will ferry us through the stars forever without fail.";
 	name = "Eternity Project Dedication Plaque"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "hc" = (
 /obj/structure/lattice,
@@ -2155,11 +2155,11 @@
 	opened = 1
 	},
 /obj/random/plushie/large,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/maintenance)
 "he" = (
 /obj/random/trash,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/hallway/aft)
@@ -2167,18 +2167,18 @@
 /obj/machinery/door/airlock/multi_tile/glass{
 	name = "Emergency Entrance"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "hg" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/hallway/aft)
 "hh" = (
 /obj/structure/grille/broken,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/hallway/aft)
@@ -2188,14 +2188,14 @@
 /area/space)
 "hj" = (
 /obj/structure/door_assembly,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "hk" = (
 /obj/machinery/mech_recharger,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/constructionsite/medical)
 "hl" = (
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/constructionsite/medical)
 "hm" = (
 /obj/structure/table/standard,
@@ -2204,31 +2204,31 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/constructionsite/medical)
 "hn" = (
 /turf/simulated/wall,
 /area/constructionsite/medical)
 "ho" = (
 /obj/machinery/sleeper,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/constructionsite/medical)
 "hp" = (
 /obj/structure/iv_stand,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/constructionsite/medical)
 "hq" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/constructionsite/medical)
 "hr" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "hs" = (
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/atmospherics)
 "ht" = (
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/atmospherics)
@@ -2236,25 +2236,25 @@
 /obj/machinery/light_construct{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "hv" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "hw" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/constructionsite/medical)
 "hx" = (
 /obj/random/junk,
 /obj/effect/floor_decal/corner/green{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/constructionsite/medical)
 "hy" = (
 /obj/effect/floor_decal/corner/green,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/constructionsite/medical)
 "hz" = (
 /obj/item/reagent_containers/ivbag,
@@ -2267,44 +2267,44 @@
 /area/constructionsite/hallway/aft)
 "hA" = (
 /obj/structure/girder,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "hB" = (
 /obj/structure/table,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "hC" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "hD" = (
 /obj/machinery/door/airlock/glass/medical{
 	name = "Medbay"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "hE" = (
 /obj/structure/door_assembly{
 	name = "Medbay"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "hF" = (
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "hG" = (
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "hH" = (
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "hI" = (
 /obj/structure/table/standard,
 /obj/random/firstaid,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "hJ" = (
 /obj/structure/sign/directions/examroom,
@@ -2314,26 +2314,26 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/constructionsite/medical)
 "hL" = (
 /obj/machinery/disposal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "hM" = (
 /obj/structure/table,
 /obj/random/medical,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/constructionsite/medical)
 "hN" = (
 /obj/structure/table,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/constructionsite/medical)
 "hO" = (
 /obj/structure/fireaxecabinet{
 	pixel_x = 32
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "hP" = (
 /turf/simulated/wall,
@@ -2345,25 +2345,25 @@
 "hR" = (
 /obj/item/roller_bed,
 /obj/item/roller_bed,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "hS" = (
 /obj/structure/closet/medical_wall/filled{
 	pixel_x = 32
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "hT" = (
 /obj/structure/girder/displaced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "hU" = (
 /obj/structure/closet/firecloset,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "hV" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/atmospherics)
 "hW" = (
 /obj/structure/lattice,
@@ -2371,26 +2371,26 @@
 /area/constructionsite/medical)
 "hX" = (
 /obj/random/medical/lite,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "hY" = (
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "hZ" = (
 /obj/item/roller_bed,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "ia" = (
 /obj/random/closet,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "ib" = (
 /turf/space,
 /area/constructionsite/medical)
 "ic" = (
 /obj/structure/mech_wreckage/powerloader,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "id" = (
 /obj/structure/closet/secure_closet/atmos_personal{
@@ -2399,19 +2399,19 @@
 	},
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "ie" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "if" = (
 /obj/structure/iv_stand,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "ig" = (
 /obj/random/snack,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "ih" = (
 /obj/structure/lattice,
@@ -2428,40 +2428,40 @@
 /obj/machinery/door/airlock/glass/atmos{
 	name = "Atmospherics"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "ik" = (
 /obj/random/firstaid,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "il" = (
 /obj/item/storage/box/freezer,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "im" = (
 /obj/random/closet,
 /obj/random/masks,
 /obj/random/loot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "in" = (
 /obj/random/tool,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/atmospherics)
 "io" = (
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "ip" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "iq" = (
 /obj/random/ammo,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "ir" = (
 /obj/structure/lattice,
@@ -2476,7 +2476,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "iv" = (
 /turf/space,
@@ -2494,7 +2494,7 @@
 /obj/random/junk,
 /obj/random/masks,
 /obj/random/loot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "iy" = (
 /obj/machinery/computer/air_control{
@@ -2508,7 +2508,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "iz" = (
 /obj/structure/grille,
@@ -2595,30 +2595,30 @@
 	dir = 4;
 	name = "Medbay"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "iK" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/atmospherics)
 "iL" = (
 /obj/structure/girder,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "iM" = (
 /obj/effect/floor_decal/plaque{
 	desc = "In memory of Earl Whitenmeinster. We'll never forget you.";
 	name = "Whitenmeister Memorial Hall Plaque"
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/hallway/aft)
 "iN" = (
 /obj/effect/floor_decal/industrial/warning/dust{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "iO" = (
 /obj/machinery/computer/air_control{
@@ -2631,7 +2631,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "iP" = (
 /obj/machinery/atmospherics/unary/vent_pump/tank{
@@ -2660,17 +2660,17 @@
 /turf/simulated/floor/reinforced/oxygen,
 /area/constructionsite/atmospherics)
 "iR" = (
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/medical)
 "iS" = (
 /obj/random/material,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "iT" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/constructionsite/medical)
 "iU" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
@@ -2696,7 +2696,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/atmospherics)
 "iY" = (
 /turf/simulated/wall,
@@ -2704,12 +2704,12 @@
 "iZ" = (
 /obj/structure/grille/broken,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "ja" = (
 /obj/structure/grille,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jb" = (
 /obj/structure/cable/blue{
@@ -2717,7 +2717,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "jc" = (
 /obj/machinery/computer/air_control{
@@ -2730,7 +2730,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "jd" = (
 /obj/machinery/atmospherics/unary/vent_pump/tank{
@@ -2760,7 +2760,7 @@
 /area/constructionsite/atmospherics)
 "jf" = (
 /obj/random/smokes,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite)
 "jg" = (
 /obj/structure/lattice,
@@ -2769,41 +2769,41 @@
 "jh" = (
 /obj/structure/table/standard,
 /obj/structure/bedsheetbin,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "ji" = (
 /obj/structure/table,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jj" = (
 /obj/structure/table/standard,
 /obj/random/hat,
 /obj/random/gloves,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jk" = (
 /obj/structure/table/standard,
 /obj/random/gloves,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite)
 "jl" = (
 /obj/structure/table/standard,
 /obj/random/maintenance,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite)
 "jm" = (
 /obj/structure/girder/displaced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jn" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "jo" = (
 /obj/structure/table/standard,
 /obj/structure/closet/body_bag/cryobag,
 /obj/structure/closet/body_bag/cryobag,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/medical)
 "jp" = (
 /obj/structure/cable/blue,
@@ -2811,13 +2811,13 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "jq" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/atmospherics)
 "jr" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
@@ -2836,30 +2836,30 @@
 "jt" = (
 /obj/structure/grille/broken,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite)
 "ju" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jv" = (
 /obj/structure/door_assembly,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jw" = (
 /turf/space,
 /area/constructionsite)
 "jx" = (
 /obj/structure/lattice,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite)
 "jy" = (
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite)
 "jz" = (
 /obj/structure/girder,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jA" = (
 /obj/structure/lattice,
@@ -2867,28 +2867,28 @@
 /area/constructionsite)
 "jB" = (
 /obj/random/clothing,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite)
 "jC" = (
 /obj/structure/coatrack,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite)
 "jD" = (
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite)
 "jE" = (
 /obj/structure/closet/cabinet,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jF" = (
 /obj/structure/bed,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite)
 "jG" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jH" = (
 /obj/structure/lattice,
@@ -2899,133 +2899,133 @@
 /obj/machinery/door/airlock{
 	name = "Cabin"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jJ" = (
 /obj/random/hat,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jK" = (
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jL" = (
 /obj/random/snack,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jM" = (
 /obj/machinery/door/airlock{
 	name = "Bunk Room"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jN" = (
 /obj/structure/girder/displaced,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite)
 "jO" = (
 /obj/item/bedsheet,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite)
 "jP" = (
 /obj/random/loot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jQ" = (
 /obj/structure/extinguisher_cabinet{
 	icon_state = "extinguisher_empty";
 	pixel_x = 30
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/hallway/aft)
 "jR" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite)
 "jS" = (
 /obj/random/maintenance/clean,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jT" = (
 /obj/machinery/washing_machine,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jU" = (
 /obj/structure/table,
 /obj/random/clothing,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jV" = (
 /obj/structure/grille,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite)
 "jW" = (
 /obj/random/clothing,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jX" = (
 /obj/structure/grille,
 /obj/structure/wall_frame,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite)
 "jY" = (
 /obj/item/clothing/head/radiation,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "jZ" = (
 /obj/machinery/constructable_frame,
 /obj/random/material,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "ka" = (
 /obj/machinery/door/airlock/glass/engineering,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "kb" = (
 /obj/random/obstruction,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "kc" = (
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "kd" = (
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "ke" = (
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "kf" = (
 /obj/random/action_figure,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "kg" = (
 /obj/random/voidhelmet,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "kh" = (
 /obj/structure/table/standard,
 /obj/random/hardsuit,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite)
 "ki" = (
 /obj/random/hostile,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite)
 "kj" = (
 /obj/random/hostile,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "kk" = (
 /obj/structure/table,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite)
@@ -3033,71 +3033,71 @@
 /obj/structure/table/standard,
 /obj/machinery/cell_charger,
 /obj/random/powercell,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "km" = (
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "kn" = (
 /obj/machinery/power/smes/buildable,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "ko" = (
 /obj/structure/table/rack,
 /obj/random/tool,
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "kp" = (
 /obj/structure/table/rack,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "kq" = (
 /obj/random/glasses,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "kr" = (
 /obj/machinery/power/shield_generator{
 	desc = "A heavy-duty shield generator and capacitor, capable of generating energy shields at large distances. This one seems to be in a state of disrepair.";
 	name = "disused shield generator"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "ks" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite)
 "kt" = (
 /obj/machinery/power/breakerbox,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "ku" = (
 /obj/structure/table/rack,
 /obj/random/toolbox,
 /obj/random/loot,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite)
 "kv" = (
 /obj/structure/girder/displaced,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite)
 "kw" = (
 /obj/random/closet,
 /obj/random/loot,
 /obj/random/junk,
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "kx" = (
 /obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite)
 "ky" = (
 /obj/structure/closet/radiation,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/hallway/aft)
 "kz" = (
 /turf/simulated/wall,
@@ -3106,10 +3106,10 @@
 /obj/machinery/door/airlock/glass/engineering{
 	name = "Engine Access"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "kB" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "kC" = (
 /obj/effect/shuttle_landmark/derelict/nav6,
@@ -3117,7 +3117,7 @@
 /area/space)
 "kD" = (
 /obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "kE" = (
 /obj/structure/lattice,
@@ -3125,11 +3125,11 @@
 /area/constructionsite/engineering)
 "kF" = (
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "kG" = (
 /obj/machinery/door/airlock/glass/engineering,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "kH" = (
 /obj/structure/sign/warning/compressed_gas,
@@ -3137,17 +3137,17 @@
 /area/constructionsite/engineering)
 "kI" = (
 /obj/machinery/portable_atmospherics/canister/empty/phoron,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "kJ" = (
 /turf/space,
 /area/constructionsite/engineering)
 "kK" = (
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/engineering)
 "kL" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/engineering)
 "kM" = (
 /obj/structure/sign/warning/radioactive,
@@ -3158,35 +3158,35 @@
 /obj/random/tool,
 /obj/random/maintenance,
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "kO" = (
 /obj/structure/table,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "kP" = (
 /obj/structure/grille,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "kQ" = (
 /obj/random/maintenance,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/engineering)
 "kR" = (
 /obj/structure/grille/broken,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "kS" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "kT" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "kU" = (
 /obj/structure/table/standard,
@@ -3194,10 +3194,10 @@
 /obj/random/material,
 /obj/random/material,
 /obj/random/material,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "kV" = (
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg2"
 	},
 /area/constructionsite/engineering)
@@ -3205,12 +3205,12 @@
 /obj/structure/table/standard,
 /obj/random/toolbox,
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "kX" = (
 /obj/structure/table/standard,
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "kY" = (
 /obj/structure/grille/broken,
@@ -3220,7 +3220,7 @@
 "kZ" = (
 /obj/structure/table/rack,
 /obj/random/loot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "la" = (
 /obj/structure/grille,
@@ -3229,56 +3229,56 @@
 /area/constructionsite/engineering)
 "lb" = (
 /obj/random/hostile,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "lc" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "ld" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen/engine_setup,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "le" = (
 /obj/machinery/power/rad_collector,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "lf" = (
 /obj/structure/table/standard,
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "lg" = (
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "lh" = (
 /obj/random/maintenance,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/engineering)
 "li" = (
 /obj/structure/table/standard,
 /obj/random/tool,
 /obj/random/voidsuit,
 /obj/random/coin,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "lj" = (
 /obj/structure/table/standard,
 /obj/random/toolbox,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "lk" = (
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "ll" = (
 /obj/structure/closet/radiation,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/engineering)
 "lm" = (
 /obj/machinery/portable_atmospherics/canister/phoron/engine_setup,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "ln" = (
 /obj/random/maintenance,
@@ -3288,23 +3288,23 @@
 /obj/machinery/door/airlock/glass/engineering{
 	name = "SMES"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "lp" = (
 /obj/structure/cable/blue{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "lq" = (
 /obj/structure/girder,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "lr" = (
 /obj/structure/table/rack,
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "ls" = (
 /obj/structure/cable/blue{
@@ -3312,20 +3312,20 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/engineering)
 "lt" = (
 /obj/structure/table/rack,
 /obj/random/toolbox,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "lu" = (
 /turf/simulated/wall/r_wall,
-/area/AIsattele)
+/area/constructionsite/AIsattele)
 "lv" = (
 /obj/machinery/power/smes/buildable,
 /obj/structure/cable/blue,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "lw" = (
 /obj/machinery/power/terminal{
@@ -3335,7 +3335,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/engineering)
 "lx" = (
 /obj/structure/cable/blue{
@@ -3343,7 +3343,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "ly" = (
 /obj/structure/cable/blue{
@@ -3361,7 +3361,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "lz" = (
 /obj/structure/cable/blue{
@@ -3369,7 +3369,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/engineering)
 "lA" = (
 /obj/machinery/power/terminal{
@@ -3379,12 +3379,12 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "lB" = (
 /obj/structure/table/rack,
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "lC" = (
 /obj/machinery/constructable_frame/computerframe,
@@ -3392,27 +3392,27 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
-/area/AIsattele)
+/turf/simulated/floor,
+/area/constructionsite/AIsattele)
 "lD" = (
 /obj/machinery/tele_projector,
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
-/area/AIsattele)
+/turf/simulated/floor,
+/area/constructionsite/AIsattele)
 "lE" = (
 /obj/machinery/tele_pad,
-/turf/simulated/floor/airless,
-/area/AIsattele)
+/turf/simulated/floor,
+/area/constructionsite/AIsattele)
 "lF" = (
 /obj/machinery/power/smes/buildable,
 /obj/structure/cable/blue{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "lG" = (
 /obj/machinery/power/terminal{
@@ -3422,7 +3422,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "lH" = (
 /obj/structure/cable/blue{
@@ -3435,97 +3435,97 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "lI" = (
 /obj/item/material/shard{
 	icon_state = "medium"
 	},
-/turf/simulated/floor/airless,
-/area/AIsattele)
+/turf/simulated/floor,
+/area/constructionsite/AIsattele)
 "lJ" = (
-/turf/simulated/floor/airless,
-/area/AIsattele)
+/turf/simulated/floor,
+/area/constructionsite/AIsattele)
 "lK" = (
 /obj/structure/cable,
-/turf/simulated/floor/airless,
-/area/AIsattele)
+/turf/simulated/floor,
+/area/constructionsite/AIsattele)
 "lL" = (
 /obj/structure/table/rack,
 /obj/item/clothing/gloves/insulated,
-/turf/simulated/floor/airless,
-/area/AIsattele)
+/turf/simulated/floor,
+/area/constructionsite/AIsattele)
 "lM" = (
 /obj/structure/table/rack,
 /obj/random/maintenance,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/engineering)
 "lN" = (
 /obj/structure/cable/blue,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "lO" = (
 /obj/structure/girder,
-/turf/simulated/floor/airless,
-/area/AIsattele)
+/turf/simulated/floor,
+/area/constructionsite/AIsattele)
 "lP" = (
 /obj/item/cell/standard,
-/turf/simulated/floor/airless,
-/area/AIsattele)
+/turf/simulated/floor,
+/area/constructionsite/AIsattele)
 "lQ" = (
 /obj/structure/grille/broken,
-/turf/simulated/floor/airless,
-/area/AIsattele)
+/turf/simulated/floor,
+/area/constructionsite/AIsattele)
 "lR" = (
 /turf/space,
-/area/AIsattele)
+/area/constructionsite/AIsattele)
 "lS" = (
 /obj/structure/table,
 /obj/random/loot,
-/turf/simulated/floor/airless,
-/area/AIsattele)
+/turf/simulated/floor,
+/area/constructionsite/AIsattele)
 "lT" = (
 /obj/random/hostile,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/constructionsite/engineering)
 "lU" = (
 /obj/structure/lattice,
 /turf/space,
-/area/AIsattele)
+/area/constructionsite/AIsattele)
 "lV" = (
 /obj/structure/closet,
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
-/area/AIsattele)
+/turf/simulated/floor,
+/area/constructionsite/AIsattele)
 "lW" = (
 /obj/structure/cable{
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/airless,
-/area/AIsattele)
+/turf/simulated/floor,
+/area/constructionsite/AIsattele)
 "lX" = (
 /obj/structure/grille/broken,
 /turf/space,
-/area/AIsattele)
+/area/constructionsite/AIsattele)
 "lY" = (
 /obj/item/storage/toolbox/electrical{
 	pixel_x = 1;
 	pixel_y = -1
 	},
-/turf/simulated/floor/airless,
-/area/AIsattele)
+/turf/simulated/floor,
+/area/constructionsite/AIsattele)
 "lZ" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
 	dir = 4;
 	state = 2
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "ma" = (
 /obj/machinery/field_generator,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "mb" = (
 /obj/machinery/power/emitter{
@@ -3533,11 +3533,11 @@
 	dir = 8;
 	state = 2
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "mc" = (
 /obj/machinery/the_singularitygen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/engineering)
 "md" = (
 /obj/effect/shuttle_landmark/derelict/nav7,
@@ -3584,17 +3584,17 @@
 /obj/structure/grille,
 /obj/structure/wall_frame,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "BO" = (
 /obj/structure/grille,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 "DP" = (
 /obj/structure/grille,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "HP" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -3620,12 +3620,12 @@
 	dir = 4;
 	name = "Atmospherics"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/aft)
 "Lk" = (
 /obj/structure/grille/broken,
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/constructionsite/hallway/fore)
 
 (1,1,1) = {"

--- a/maps/away/derelict/derelict.dm
+++ b/maps/away/derelict/derelict.dm
@@ -23,10 +23,10 @@
 	suffixes = list("derelict/derelict-station.dmm")
 	spawn_cost = 1
 	accessibility_weight = 10
-	area_usage_test_exempted_areas = list(/area/AIsattele)
+	area_usage_test_exempted_areas = list(/area/constructionsite/AIsattele)
 	area_usage_test_exempted_root_areas = list(/area/constructionsite, /area/derelict)
 	apc_test_exempt_areas = list(
-		/area/AIsattele = NO_SCRUBBER|NO_VENT|NO_APC,
+		/area/constructionsite/AIsattele = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/constructionsite = NO_SCRUBBER|NO_VENT|NO_APC,
 		/area/constructionsite/ai = NO_SCRUBBER|NO_VENT,
 		/area/constructionsite/atmospherics = NO_SCRUBBER|NO_VENT,

--- a/maps/away/derelict/derelict_areas.dm
+++ b/maps/away/derelict/derelict_areas.dm
@@ -1,8 +1,9 @@
 /area/derelict/ship
 	name = "\improper Abandoned Ship"
 	icon_state = "yellow"
+	turfs_airless = TRUE
 
-/area/AIsattele
+/area/constructionsite/AIsattele
 	name = "\improper AI Satellite Teleporter Room"
 	icon_state = "teleporter"
 	ambience = list('sound/ambience/ambimalf.ogg')
@@ -11,6 +12,7 @@
 	name = "\improper Construction Site"
 	icon_state = "storage"
 	ambience = list('sound/ambience/spookyspace1.ogg', 'sound/ambience/spookyspace2.ogg')
+	turfs_airless = TRUE
 
 /area/constructionsite/storage
 	name = "\improper Construction Site Storage Area"

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -503,7 +503,7 @@
 /obj/machinery/power/solar{
 	id = "XynergySolarStarboard"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "bv" = (
 /obj/structure/cable/yellow{
@@ -516,7 +516,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "bw" = (
 /obj/effect/floor_decal/solarpanel,
@@ -527,7 +527,7 @@
 /obj/machinery/power/solar{
 	id = "XynergySolarStarboard"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "bx" = (
 /obj/machinery/light/small{
@@ -663,7 +663,7 @@
 /obj/machinery/power/solar{
 	id = "XynergySolarPort"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "bR" = (
 /obj/effect/floor_decal/solarpanel,
@@ -674,7 +674,7 @@
 /obj/machinery/power/solar{
 	id = "XynergySolarPort"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "bS" = (
 /obj/structure/cable/yellow{
@@ -692,7 +692,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "bT" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
@@ -1383,7 +1383,7 @@
 	id = "n2_in";
 	use_power = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "dB" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -1611,7 +1611,7 @@
 /obj/machinery/power/tracker{
 	id = "XynergySolarStarboard"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ed" = (
 /obj/structure/cable/yellow{
@@ -1619,7 +1619,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ee" = (
 /obj/structure/cable/yellow{
@@ -1637,7 +1637,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ef" = (
 /obj/structure/cable/yellow{
@@ -1655,7 +1655,9 @@
 	master_tag = "xyn_solar_starboard_airlock";
 	pixel_y = 20
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/errant_pisces/solar_starboard)
 "eg" = (
 /obj/machinery/door/airlock/external{
@@ -1894,7 +1896,7 @@
 	master_tag = "xyn_solar_port_airlock";
 	pixel_y = 20
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/errant_pisces/solar_port)
 "eE" = (
 /obj/structure/cable/yellow{
@@ -1912,7 +1914,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "eF" = (
 /obj/machinery/power/tracker{
@@ -1922,7 +1924,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "eG" = (
 /obj/structure/cable/yellow{
@@ -1940,7 +1942,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "eH" = (
 /obj/machinery/door/airlock/external{
@@ -2945,7 +2947,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "gL" = (
 /obj/structure/bed/chair/comfy/green,
@@ -3185,7 +3187,7 @@
 /obj/machinery/power/solar{
 	id = "XynergySolarPort"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "hq" = (
 /turf/simulated/wall/r_wall,
@@ -6221,7 +6223,7 @@
 	icon_state = "pdoor0";
 	id_tag = "xynergy_perimeter_blast"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/errant_pisces/bridge)
 "pq" = (
 /obj/structure/lattice,
@@ -6598,7 +6600,7 @@
 /area/errant_pisces/fishing_wing)
 "qx" = (
 /obj/machinery/shipsensors,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/errant_pisces/bridge)
 "qy" = (
 /obj/structure/closet/firecloset,
@@ -6689,8 +6691,13 @@
 /turf/simulated/floor/plating,
 /area/errant_pisces/fishing_wing)
 "qM" = (
-/turf/simulated/wall/r_wall,
-/area/space)
+/obj/machinery/door/blast/regular/open{
+	dir = 2;
+	icon_state = "pdoor0";
+	id_tag = "xynergy_perimeter_blast"
+	},
+/turf/simulated/floor/reinforced,
+/area/errant_pisces/bridge)
 "qN" = (
 /obj/structure/bed/chair,
 /turf/simulated/floor/plating,
@@ -6763,7 +6770,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/plating,
-/area/space)
+/area/errant_pisces/fishing_wing)
 "qT" = (
 /obj/structure/net,
 /obj/machinery/access_button/airlock_exterior{
@@ -24374,9 +24381,9 @@ aa
 aa
 bc
 aa
-qM
+og
 qS
-qM
+og
 aa
 aa
 pw
@@ -29422,7 +29429,7 @@ pK
 qa
 po
 qx
-pp
+qM
 qH
 bc
 aa
@@ -29825,7 +29832,7 @@ py
 oS
 qc
 po
-pp
+qM
 pq
 aa
 aa
@@ -30027,7 +30034,7 @@ oS
 oS
 qd
 po
-pp
+qM
 pq
 aa
 aa
@@ -30431,7 +30438,7 @@ oS
 oS
 qf
 po
-pp
+qM
 pq
 aa
 aa
@@ -31037,7 +31044,7 @@ oS
 oS
 qh
 po
-pp
+qM
 pq
 aa
 aa
@@ -31239,7 +31246,7 @@ oS
 oS
 qc
 po
-pp
+qM
 pq
 aa
 aa
@@ -31441,7 +31448,7 @@ oS
 oS
 pA
 po
-pp
+qM
 pq
 aa
 aa
@@ -31643,7 +31650,7 @@ oS
 oS
 pj
 po
-pp
+qM
 pq
 aa
 aa
@@ -31845,7 +31852,7 @@ oS
 pL
 pj
 po
-pp
+qM
 pq
 aa
 aa
@@ -32047,7 +32054,7 @@ pA
 pM
 qc
 po
-pp
+qM
 pq
 aa
 aa
@@ -33254,8 +33261,8 @@ Ph
 oi
 oi
 oi
-pp
-pp
+qM
+qM
 oi
 aa
 aa

--- a/maps/away/lost_supply_base/lost_supply_base.dmm
+++ b/maps/away/lost_supply_base/lost_supply_base.dmm
@@ -17,7 +17,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ae" = (
 /obj/effect/shuttle_landmark/nav_lost_supply_base/nav3,
@@ -29,7 +29,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ag" = (
 /obj/structure/cable/yellow{
@@ -41,7 +41,7 @@
 	name = "Starboard Auxiliary Solar Array"
 	},
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ah" = (
 /obj/structure/cable/yellow{
@@ -50,7 +50,7 @@
 	icon_state = "1-2"
 	},
 /obj/item/stack/material/steel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ai" = (
 /obj/structure/cable/yellow{
@@ -63,7 +63,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "aj" = (
 /obj/structure/cable/yellow{
@@ -81,7 +81,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ak" = (
 /obj/structure/cable/yellow{
@@ -89,7 +89,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "al" = (
 /obj/structure/cable/yellow{
@@ -107,7 +107,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "am" = (
 /obj/structure/cable/yellow{
@@ -125,7 +125,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "an" = (
 /obj/structure/cable/yellow{
@@ -138,7 +138,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ao" = (
 /obj/structure/cable/yellow,
@@ -147,10 +147,10 @@
 	name = "Starboard Auxiliary Solar Array"
 	},
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ap" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "aq" = (
 /obj/item/stack/material/rods,
@@ -166,7 +166,7 @@
 	amount = 50
 	},
 /obj/item/stack/material/steel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "as" = (
 /obj/machinery/power/solar{
@@ -174,7 +174,7 @@
 	name = "Starboard Auxiliary Solar Array"
 	},
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "at" = (
 /obj/effect/shuttle_landmark/nav_lost_supply_base/nav1,
@@ -187,7 +187,7 @@
 	},
 /obj/structure/cable/yellow,
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "av" = (
 /obj/structure/girder/displaced,
@@ -197,7 +197,7 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /obj/structure/grille,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ax" = (
 /turf/simulated/wall/r_wall,
@@ -279,16 +279,16 @@
 "aF" = (
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "aG" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "aH" = (
 /obj/machinery/light_construct{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "aI" = (
 /obj/structure/cable{
@@ -300,7 +300,7 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "aJ" = (
 /obj/structure/table/rack,
@@ -308,7 +308,7 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/random/toolbox,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "aK" = (
 /turf/simulated/wall,
@@ -375,7 +375,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "aP" = (
 /obj/structure/cable{
@@ -386,7 +386,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "aQ" = (
 /obj/structure/cable{
@@ -409,7 +409,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/office)
 "aS" = (
 /obj/structure/cable{
@@ -421,27 +421,27 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/office)
 "aT" = (
 /obj/structure/bed/chair/comfy/captain,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/office)
 "aU" = (
 /obj/machinery/computer/modular{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/office)
 "aV" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/office)
 "aW" = (
 /obj/item/paper,
 /obj/structure/safe,
 /obj/random/drinkbottle,
 /obj/random/handgun,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/office)
 "aX" = (
 /obj/machinery/atmospherics/unary/vent_pump/tank{
@@ -458,14 +458,14 @@
 	pump_direction = 0;
 	use_power = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "aY" = (
 /obj/machinery/atmospherics/binary/pump/on{
 	dir = 8;
 	target_pressure = 200
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "aZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
@@ -480,23 +480,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "bb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "bc" = (
 /obj/random/projectile,
 /obj/effect/landmark/corpse/syndicate,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "bd" = (
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "be" = (
 /obj/structure/cable{
@@ -504,7 +504,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "bf" = (
 /obj/structure/closet/crate/solar,
@@ -540,19 +540,19 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "bj" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "bk" = (
 /obj/structure/table/steel_reinforced,
 /obj/random/handgun,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/office)
 "bl" = (
 /obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/office)
 "bm" = (
 /obj/item/stack/tile/floor_dark{
@@ -560,12 +560,12 @@
 	pixel_y = -3
 	},
 /obj/item/stack/material/steel,
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_burned0"
 	},
 /area/lost_supply_base/office)
 "bn" = (
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_burned0"
 	},
 /area/lost_supply_base/office)
@@ -582,7 +582,7 @@
 /area/space)
 "bq" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "br" = (
 /obj/machinery/door/airlock/external{
@@ -593,7 +593,7 @@
 	locked = 1;
 	name = "Transport Airlock"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "bs" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -606,22 +606,22 @@
 	pixel_y = 24;
 	req_access = newlist()
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "bt" = (
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_broken4"
 	},
 /area/lost_supply_base)
 "bu" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "bv" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "bw" = (
 /obj/structure/cable{
@@ -629,7 +629,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "bx" = (
 /obj/structure/cable{
@@ -637,7 +637,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "by" = (
 /obj/structure/cable{
@@ -649,7 +649,7 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/random/tech_supply,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "bz" = (
 /obj/structure/cable{
@@ -712,29 +712,29 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "bE" = (
 /obj/item/pen/red,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/office)
 "bF" = (
 /obj/effect/landmark/corpse/engineer,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/office)
 "bG" = (
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_broken4"
 	},
 /area/lost_supply_base/office)
 "bH" = (
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_broken1"
 	},
 /area/lost_supply_base/office)
 "bI" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base/office)
 "bJ" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -751,18 +751,18 @@
 	pixel_x = 24;
 	pixel_y = 12
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "bK" = (
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "bL" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "bM" = (
 /obj/structure/table/rack,
@@ -771,7 +771,7 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/item/device/radio,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "bN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -780,34 +780,34 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base/solar)
 "bO" = (
 /obj/random/ammo,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/office)
 "bP" = (
 /obj/structure/girder/displaced,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/office)
 "bQ" = (
 /turf/space,
 /area/lost_supply_base/office)
 "bR" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "bS" = (
 /obj/random/trash,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "bT" = (
 /obj/item/stack/tile/floor_dark{
 	pixel_x = 5;
 	pixel_y = -3
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "bU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
@@ -816,13 +816,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "bV" = (
 /turf/simulated/wall,
 /area/lost_supply_base)
 "bW" = (
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_broken1"
 	},
 /area/lost_supply_base)
@@ -830,22 +830,22 @@
 /obj/machinery/door/airlock{
 	name = "Control room"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/office)
 "bY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/office)
 "bZ" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/office)
 "ca" = (
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/office)
 "cb" = (
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_broken0"
 	},
 /area/lost_supply_base/office)
@@ -857,18 +857,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "ce" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cf" = (
 /obj/item/stack/material/rods,
 /obj/item/stack/material/steel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cg" = (
 /obj/structure/cable{
@@ -880,7 +880,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_broken4"
 	},
 /area/lost_supply_base)
@@ -888,7 +888,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "ci" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -910,11 +910,11 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cm" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_broken1"
 	},
 /area/lost_supply_base)
@@ -924,17 +924,17 @@
 	icon_state = "warning"
 	},
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "co" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cp" = (
 /obj/structure/door_assembly,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cq" = (
 /obj/machinery/atmospherics/omni/mixer{
@@ -945,7 +945,7 @@
 	tag_west = 2;
 	use_power = 0
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cr" = (
 /obj/structure/cable,
@@ -957,7 +957,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cs" = (
 /obj/item/stack/tile/floor_dark{
@@ -968,26 +968,26 @@
 	pixel_x = 5;
 	pixel_y = -3
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "ct" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "cu" = (
 /obj/item/stack/tile/floor_dark{
 	pixel_x = 5;
 	pixel_y = -3
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "cv" = (
 /turf/simulated/wall,
 /area/lost_supply_base/common)
 "cw" = (
 /obj/machinery/fabricator/replicator,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "cx" = (
 /obj/structure/table/standard,
@@ -1003,59 +1003,59 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "cy" = (
 /obj/machinery/gibber,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "cz" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/cooker/oven,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "cA" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_burned1"
 	},
 /area/lost_supply_base/common)
 "cB" = (
 /obj/structure/closet/secure_closet/freezer/meat,
 /obj/structure/closet/secure_closet/freezer/meat,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "cC" = (
 /obj/structure/closet/crate/freezer,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cD" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cE" = (
 /obj/item/stack/material/cardboard,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cF" = (
 /obj/item/device/scanner/price,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cH" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cI" = (
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_broken0"
 	},
 /area/lost_supply_base)
@@ -1067,15 +1067,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_burned1"
 	},
 /area/lost_supply_base)
 "cK" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "cL" = (
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_burned1"
 	},
 /area/lost_supply_base/common)
@@ -1083,17 +1083,17 @@
 /obj/machinery/light_construct{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cO" = (
 /obj/structure/closet/crate/freezer/rations,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1108,14 +1108,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cS" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cT" = (
 /obj/structure/girder/displaced,
@@ -1129,29 +1129,29 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_burned0"
 	},
 /area/lost_supply_base)
 "cV" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "cW" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base/common)
 "cX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "cZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1174,11 +1174,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "db" = (
 /obj/machinery/door/window/southleft,
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_burned1"
 	},
 /area/lost_supply_base/common)
@@ -1188,28 +1188,28 @@
 	pixel_x = 10
 	},
 /obj/item/trash/tray,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "dd" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "de" = (
 /obj/structure/table/standard,
 /obj/item/material/kitchen/utensil/fork,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "df" = (
 /obj/structure/table/standard,
 /obj/machinery/microwave,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "dg" = (
 /obj/structure/closet/crate/secure/phoron{
 	name = "mineral crate";
 	req_access = newlist()
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "dh" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1219,33 +1219,33 @@
 	name = "mineral crate";
 	req_access = newlist()
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "di" = (
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "dj" = (
 /obj/random/ammo,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "dk" = (
 /obj/structure/mech_wreckage/powerloader,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "dl" = (
 /obj/machinery/light_construct,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "dm" = (
 /obj/item/stack/material/steel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "dn" = (
 /obj/structure/closet/firecloset,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "do" = (
 /obj/machinery/light{
@@ -1261,13 +1261,13 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "dp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_burned1"
 	},
 /area/lost_supply_base)
@@ -1278,23 +1278,23 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "dr" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "ds" = (
 /obj/structure/closet/crate/secure/gear,
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "dt" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/closet/crate/hydroponics,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "du" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1302,12 +1302,12 @@
 	icon_state = "warning"
 	},
 /obj/item/storage/backpack/dufflebag,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "dv" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/writing,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "dw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1315,33 +1315,33 @@
 /area/lost_supply_base)
 "dx" = (
 /obj/item/material/kitchen/utensil/spoon,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "dy" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "dz" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
 /obj/item/trash/plate,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "dA" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "dB" = (
 /obj/item/material/kitchen/utensil/fork,
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "dC" = (
 /obj/random/trash,
@@ -1349,20 +1349,20 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "dJ" = (
 /obj/random/junk,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "dL" = (
 /obj/machinery/atmospherics/unary/tank/oxygen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "dM" = (
 /obj/machinery/atmospherics/unary/tank/air,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "dN" = (
 /obj/structure/cable{
@@ -1372,15 +1372,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "dO" = (
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_burned0"
 	},
 /area/lost_supply_base)
 "dP" = (
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_burned0"
 	},
 /area/lost_supply_base/common)
@@ -1388,57 +1388,57 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "dY" = (
 /obj/item/stack/tile/floor_dark,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "dZ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "eb" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "ec" = (
 /obj/random/tank,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "ed" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "ee" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "ef" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "el" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "em" = (
 /obj/effect/decal/cleanable/blood/splatter,
 /obj/effect/landmark/corpse/engineer,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "en" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1446,56 +1446,56 @@
 	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "eo" = (
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "ep" = (
 /obj/random/tank,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "eq" = (
 /obj/structure/closet/medical_wall{
 	pixel_x = -30
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "er" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
 /obj/item/flame/lighter/random,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "es" = (
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
 /obj/item/reagent_containers/food/drinks/cans/waterbottle,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "et" = (
 /obj/machinery/light{
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_burned0"
 	},
 /area/lost_supply_base/common)
 "ey" = (
 /obj/item/stack/material/cardboard,
 /obj/item/grenade/fake,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "ez" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "eA" = (
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_broken4"
 	},
 /area/lost_supply_base/common)
@@ -1503,7 +1503,7 @@
 /obj/machinery/atmospherics/unary/tank/phoron{
 	volume = 3200
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "eE" = (
 /obj/item/bedsheet,
@@ -1514,40 +1514,40 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "eF" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "eG" = (
 /obj/machinery/light,
 /obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "eH" = (
 /obj/machinery/computer/arcade,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "eI" = (
 /obj/machinery/light,
 /obj/machinery/computer/arcade,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "eJ" = (
 /obj/machinery/jukebox,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "eQ" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "eS" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "eT" = (
 /obj/structure/cable{
@@ -1559,7 +1559,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "eU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1574,16 +1574,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/common)
 "eY" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "eZ" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "fa" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1591,11 +1591,11 @@
 	icon_state = "warning"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "fb" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_broken0"
 	},
 /area/lost_supply_base)
@@ -1609,7 +1609,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "fd" = (
 /obj/structure/cable{
@@ -1621,7 +1621,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "fe" = (
 /obj/machinery/door/airlock{
@@ -1635,7 +1635,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "ff" = (
 /obj/structure/cable{
@@ -1646,7 +1646,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "fg" = (
 /obj/structure/closet/emcloset,
@@ -1659,34 +1659,34 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "fh" = (
 /obj/structure/bed,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "fi" = (
 /obj/structure/closet,
 /obj/random/clothing,
 /obj/item/trash/liquidfood,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "fj" = (
 /obj/structure/bed,
 /obj/random/plushie,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "fk" = (
 /obj/structure/closet,
 /obj/random/clothing,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "fl" = (
 /turf/simulated/wall/r_wall,
 /area/lost_supply_base/supply)
 "fm" = (
 /obj/machinery/portable_atmospherics/canister,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "fn" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1694,7 +1694,7 @@
 	icon_state = "warning"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "fo" = (
 /obj/random/junk,
@@ -1705,28 +1705,28 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "fp" = (
 /turf/simulated/wall,
 /area/lost_supply_base/supply)
 "fq" = (
 /obj/item/bedsheet,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "fr" = (
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_burned0"
 	},
 /area/lost_supply_base/supply)
 "fs" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "ft" = (
 /obj/structure/table/standard,
 /obj/random/smokes,
 /obj/item/device/radio,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "fu" = (
 /obj/effect/shuttle_landmark/nav_lost_supply_base/nav2,
@@ -1735,27 +1735,27 @@
 "fv" = (
 /obj/structure/window/reinforced,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "fw" = (
 /obj/structure/window/reinforced,
 /obj/machinery/portable_atmospherics/canister,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "fx" = (
 /obj/machinery/atmospherics/unary/vent_scrubber{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "fz" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "fA" = (
 /obj/structure/table/standard,
 /obj/item/storage/briefcase,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "fB" = (
 /obj/structure/sign/warning{
@@ -1763,30 +1763,30 @@
 	},
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "fC" = (
 /obj/random/energy,
 /obj/effect/landmark/corpse/syndicate,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "fD" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/effect/landmark/corpse/engineer,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "fE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "fF" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "fG" = (
 /obj/machinery/light,
 /obj/structure/bed,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "fH" = (
 /obj/structure/largecrate,
@@ -1794,17 +1794,17 @@
 	dir = 8;
 	target_pressure = 200
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "fI" = (
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "fJ" = (
 /obj/item/material/twohanded/fireaxe,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "fK" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -1813,14 +1813,14 @@
 	pixel_x = 5;
 	pixel_y = -3
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "fL" = (
 /obj/effect/decal/cleanable/blood/writing{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "fM" = (
 /obj/structure/cable{
@@ -1832,7 +1832,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_burned1"
 	},
 /area/lost_supply_base)
@@ -1841,7 +1841,7 @@
 	dir = 4
 	},
 /obj/item/stack/material/steel,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "fO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1860,14 +1860,14 @@
 /area/lost_supply_base/supply)
 "fQ" = (
 /obj/structure/door_assembly,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "fR" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "fS" = (
 /obj/structure/cable{
@@ -1882,7 +1882,7 @@
 	pixel_x = 5;
 	pixel_y = -3
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "fT" = (
 /obj/structure/cable{
@@ -1904,24 +1904,24 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_broken0"
 	},
 /area/lost_supply_base/supply)
 "fV" = (
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_burned1"
 	},
 /area/lost_supply_base/supply)
 "fW" = (
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_broken0"
 	},
 /area/lost_supply_base/supply)
 "fX" = (
 /obj/item/gun/projectile/shotgun/pump,
 /obj/effect/landmark/corpse/syndicate,
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_broken4"
 	},
 /area/lost_supply_base/supply)
@@ -1929,13 +1929,13 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "fZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "ga" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -1961,7 +1961,7 @@
 	pixel_x = 24;
 	pixel_y = 12
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "gc" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -1969,7 +1969,7 @@
 	dir = 8;
 	target_pressure = 200
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "gd" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1979,25 +1979,25 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "ge" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning/full,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "gf" = (
 /obj/structure/closet/emcloset,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "gg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "gh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2007,25 +2007,25 @@
 	pixel_x = 5;
 	pixel_y = -3
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "gi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "gj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "gk" = (
 /obj/machinery/door/airlock{
 	name = "Head"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "gl" = (
 /obj/structure/lattice,
@@ -2034,7 +2034,7 @@
 /area/lost_supply_base)
 "gm" = (
 /obj/machinery/light,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/lost_supply_base)
 "gn" = (
 /obj/structure/closet/crate/trashcart,
@@ -2053,18 +2053,18 @@
 	pump_direction = 0;
 	use_power = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "go" = (
 /obj/item/stack/material/steel,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base)
 "gq" = (
 /obj/structure/hygiene/toilet{
 	dir = 1
 	},
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "gr" = (
 /obj/structure/hygiene/shower{
@@ -2072,7 +2072,7 @@
 	},
 /obj/random/soap,
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/lost_supply_base/supply)
 "gs" = (
 /obj/effect/shuttle_landmark/nav_lost_supply_base/navantag,
@@ -2094,7 +2094,7 @@
 	pixel_x = -32
 	},
 /obj/machinery/light/small,
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_broken0"
 	},
 /area/lost_supply_base/supply)
@@ -2105,11 +2105,11 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "mI" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "pr" = (
 /obj/structure/window/reinforced{
@@ -2117,11 +2117,11 @@
 	},
 /obj/item/stock_parts/circuitboard/broken,
 /obj/machinery/constructable_frame/machine_frame,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "sO" = (
 /obj/item/bikehorn/rubberducky,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "zC" = (
 /obj/effect/paint/red,
@@ -2132,13 +2132,13 @@
 /obj/item/organ/internal/kidneys,
 /obj/item/organ/internal/kidneys,
 /obj/item/organ/internal/kidneys,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "DF" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "EM" = (
 /obj/effect/paint/silver,
@@ -2146,7 +2146,7 @@
 /area/space)
 "Rn" = (
 /obj/machinery/artifact,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "Wm" = (
 /obj/effect/paint/red,

--- a/maps/away/lost_supply_base/lost_supply_base_areas.dm
+++ b/maps/away/lost_supply_base/lost_supply_base_areas.dm
@@ -2,6 +2,7 @@
 	name = "\improper Abandoned supply station"
 	icon_state = "lost_supply_base"
 	icon = 'maps/away/lost_supply_base/lost_supply_base_sprites.dmi'
+	turfs_airless = TRUE
 
 /area/lost_supply_base/solar
 	name = "\improper Abandoned supply station solars control room"

--- a/maps/away/magshield/magshield.dmm
+++ b/maps/away/magshield/magshield.dmm
@@ -20,7 +20,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "af" = (
 /obj/structure/cable/yellow{
@@ -32,7 +32,7 @@
 	name = "Starboard Auxiliary Solar Array"
 	},
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ag" = (
 /obj/structure/cable/yellow{
@@ -40,7 +40,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ah" = (
 /obj/structure/cable/yellow{
@@ -53,7 +53,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ai" = (
 /obj/structure/cable/yellow{
@@ -71,7 +71,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "aj" = (
 /obj/structure/cable/yellow{
@@ -79,7 +79,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ak" = (
 /obj/structure/cable/yellow{
@@ -97,7 +97,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "al" = (
 /obj/structure/cable/yellow{
@@ -115,7 +115,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "am" = (
 /obj/structure/cable/yellow{
@@ -128,7 +128,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "an" = (
 /obj/structure/cable/yellow,
@@ -137,14 +137,14 @@
 	name = "Starboard Auxiliary Solar Array"
 	},
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ao" = (
 /obj/item/stack/material/rods,
 /turf/space,
 /area/space)
 "ap" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "aq" = (
 /obj/machinery/power/solar{
@@ -153,7 +153,7 @@
 	},
 /obj/structure/cable/yellow,
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ar" = (
 /turf/simulated/wall/r_wall,
@@ -168,7 +168,7 @@
 	pixel_x = -25;
 	pixel_y = -25
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "at" = (
 /obj/machinery/light/small,
@@ -184,7 +184,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "aw" = (
 /turf/simulated/wall/r_wall,
@@ -203,30 +203,30 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = -25
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "ay" = (
 /obj/structure/table/steel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "az" = (
 /obj/structure/table/steel,
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "aA" = (
 /obj/structure/table/steel,
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "aB" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "aC" = (
 /obj/structure/table/rack,
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "aD" = (
 /obj/machinery/door/airlock/external/bolted_open,
@@ -236,10 +236,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "aE" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "aF" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -247,11 +247,11 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "aG" = (
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "aH" = (
 /obj/effect/wingrille_spawn/reinforced_phoron/full,
@@ -260,7 +260,7 @@
 	icon_state = "pdoor0";
 	id_tag = "prototype_chamber_blast"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "aI" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -290,7 +290,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "aN" = (
 /obj/structure/cable/yellow{
@@ -312,7 +312,7 @@
 	pump_direction = 0;
 	use_power = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "aO" = (
 /obj/structure/cable/yellow{
@@ -320,7 +320,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "aP" = (
 /obj/structure/cable/yellow{
@@ -334,7 +334,7 @@
 	icon_state = "2-4"
 	},
 /obj/item/ore,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "aQ" = (
 /obj/structure/cable/yellow{
@@ -347,7 +347,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "aR" = (
 /obj/structure/cable/yellow{
@@ -355,17 +355,17 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "aS" = (
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "aT" = (
 /obj/structure/sign/warning/airlock{
 	pixel_y = 30
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "aU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -374,27 +374,27 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "aV" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "aW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 5
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "aX" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/black,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "aY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 9
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "aZ" = (
 /obj/machinery/door/airlock/hatch,
@@ -403,21 +403,21 @@
 	icon_state = "pdoor0";
 	id_tag = "prototype_chamber_blast"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "ba" = (
 /obj/machinery/mass_driver{
 	dir = 4;
 	id_tag = "enginecore"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bb" = (
 /obj/machinery/door/blast/regular/open{
 	icon_state = "pdoor0";
 	id_tag = "prototype_chamber_blast"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bc" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
@@ -427,12 +427,12 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "be" = (
 /obj/machinery/power/terminal,
 /obj/structure/cable/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "bf" = (
 /obj/structure/cable/yellow{
@@ -440,7 +440,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "bg" = (
 /turf/space,
@@ -453,7 +453,7 @@
 	icon_state = "4-8"
 	},
 /obj/random/loot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "bi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -467,28 +467,28 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "bj" = (
 /obj/machinery/light/small{
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "bk" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bl" = (
 /obj/machinery/atmospherics/unary/vent_pump,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bm" = (
 /obj/machinery/atmospherics/unary/outlet_injector,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bn" = (
 /obj/machinery/power/smes/buildable/outpost_substation,
@@ -496,11 +496,11 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "bo" = (
 /obj/item/ore,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "bp" = (
 /obj/structure/lattice,
@@ -509,26 +509,26 @@
 "bq" = (
 /obj/structure/closet,
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "br" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bs" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bt" = (
 /obj/machinery/light/small{
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bu" = (
 /obj/effect/wingrille_spawn/reinforced_phoron/full,
@@ -537,7 +537,7 @@
 	id_tag = "prototype_chamber_blast"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bv" = (
 /obj/effect/wingrille_spawn/reinforced_phoron/full,
@@ -545,7 +545,7 @@
 	icon_state = "pdoor0";
 	id_tag = "prototype_chamber_blast"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bw" = (
 /obj/effect/shuttle_landmark/nav_magshield/nav2,
@@ -557,7 +557,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "by" = (
 /obj/structure/cable{
@@ -570,7 +570,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "bz" = (
 /obj/structure/cable{
@@ -578,29 +578,29 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "bA" = (
 /obj/structure/closet,
 /obj/item/toy/therapy_purple,
 /obj/random/hat,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "bB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 6
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bE" = (
 /obj/item/ore,
@@ -613,31 +613,31 @@
 "bG" = (
 /obj/structure/closet,
 /obj/item/device/flashlight/flare/glowstick/random,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "bH" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bI" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bJ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 6
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -664,7 +664,7 @@
 /area/space)
 "bP" = (
 /obj/structure/girder/displaced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "bQ" = (
 /obj/structure/table/steel,
@@ -673,29 +673,29 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "bR" = (
 /obj/structure/table/steel,
 /obj/random/drinkbottle,
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "bS" = (
 /obj/structure/closet/crate/trashcart,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "bT" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
@@ -703,7 +703,7 @@
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "bW" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -720,7 +720,7 @@
 /obj/machinery/computer/modular{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "bY" = (
 /obj/structure/bed/chair{
@@ -730,7 +730,7 @@
 	dir = 4;
 	icon_state = "bulb1"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "bZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -740,19 +740,19 @@
 	icon_state = "1-2"
 	},
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "ca" = (
 /obj/structure/table/steel,
 /obj/item/device/geiger,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cb" = (
 /obj/machinery/computer/modular{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cc" = (
 /obj/machinery/door/blast/regular{
@@ -778,13 +778,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cg" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -807,7 +807,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cj" = (
 /obj/structure/cable/yellow{
@@ -818,7 +818,7 @@
 /obj/machinery/computer/modular{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "ck" = (
 /obj/machinery/door/blast/regular{
@@ -843,7 +843,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
@@ -852,7 +852,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cn" = (
 /obj/machinery/atmospherics/binary/pump,
@@ -861,7 +861,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "co" = (
 /obj/structure/cable/yellow{
@@ -879,7 +879,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cq" = (
 /obj/structure/cable/yellow{
@@ -893,7 +893,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cr" = (
 /obj/structure/cable/yellow{
@@ -907,7 +907,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cs" = (
 /obj/machinery/door/airlock,
@@ -917,7 +917,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "ct" = (
 /obj/structure/cable/yellow{
@@ -931,7 +931,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -941,20 +941,20 @@
 /obj/machinery/computer/modular{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 5
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cx" = (
 /obj/machinery/atmospherics/binary/circulator{
@@ -974,7 +974,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cz" = (
 /obj/structure/cable{
@@ -982,24 +982,24 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cA" = (
 /obj/item/device/flashlight/flare/glowstick/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cC" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cD" = (
 /obj/machinery/atmospherics/portables_connector,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cE" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -1021,7 +1021,7 @@
 	icon_state = "1-2"
 	},
 /obj/item/ore,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cG" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
@@ -1032,7 +1032,7 @@
 	pixel_y = 1;
 	use_power = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cH" = (
 /obj/machinery/power/apc{
@@ -1044,12 +1044,12 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cI" = (
 /obj/structure/closet,
 /obj/random/gloves,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cJ" = (
 /obj/machinery/light/small{
@@ -1057,7 +1057,7 @@
 	icon_state = "bulb1"
 	},
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cK" = (
 /obj/structure/table/steel,
@@ -1066,21 +1066,21 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cL" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/radiation,
 /obj/item/device/flashlight,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cM" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cN" = (
 /obj/machinery/atmospherics/binary/pump,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cO" = (
 /obj/structure/girder/displaced,
@@ -1096,7 +1096,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cQ" = (
 /obj/structure/table/steel,
@@ -1112,7 +1112,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cR" = (
 /obj/structure/cable{
@@ -1131,7 +1131,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cS" = (
 /obj/machinery/door/airlock,
@@ -1146,7 +1146,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cT" = (
 /obj/structure/cable{
@@ -1160,7 +1160,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cU" = (
 /obj/structure/cable{
@@ -1173,7 +1173,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1187,7 +1187,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/smes_storage)
 "cW" = (
 /obj/machinery/door/airlock/hatch,
@@ -1202,7 +1202,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1216,7 +1216,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1231,7 +1231,7 @@
 	icon_state = "4-8"
 	},
 /mob/living/simple_animal/hostile/carp,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "cZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1245,7 +1245,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "da" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1260,23 +1260,23 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "db" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 5
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "dc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "dd" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/engine)
 "de" = (
 /turf/simulated/wall/r_wall,
@@ -1289,7 +1289,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dg" = (
 /turf/space,
@@ -1302,55 +1302,55 @@
 	icon_state = "1-2"
 	},
 /obj/random/obstruction,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "di" = (
 /obj/item/ore,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dj" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dk" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dl" = (
 /obj/machinery/portable_atmospherics/canister,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dm" = (
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dn" = (
 /obj/item/storage/wallet/random,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "do" = (
 /obj/structure/largecrate,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dp" = (
 /obj/random/shoes,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dq" = (
 /obj/machinery/portable_atmospherics/hydroponics,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dr" = (
 /obj/structure/iv_stand,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "ds" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dt" = (
 /turf/simulated/wall,
@@ -1362,40 +1362,40 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dv" = (
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dw" = (
 /obj/random/tank,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dx" = (
 /obj/structure/table/steel,
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dy" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dz" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dA" = (
 /obj/structure/closet,
 /obj/random/toolbox,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dB" = (
 /obj/structure/closet,
 /obj/random/suit,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dC" = (
 /obj/structure/closet,
@@ -1403,25 +1403,25 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dD" = (
 /obj/structure/closet,
 /obj/structure/plushie/ian,
 /obj/random/drinkbottle,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dE" = (
 /obj/random/material,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dF" = (
 /obj/item/stack/material/rods,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dG" = (
 /obj/structure/girder/displaced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dH" = (
 /obj/structure/lattice,
@@ -1429,26 +1429,26 @@
 /area/magshield/north)
 "dI" = (
 /obj/item/clothing/under/color/lightpurple,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dJ" = (
 /obj/random/firstaid,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dK" = (
 /obj/random/toolbox,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dL" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /obj/structure/largecrate,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dM" = (
 /obj/random/obstruction,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dN" = (
 /obj/machinery/power/apc{
@@ -1461,52 +1461,52 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dO" = (
 /obj/machinery/computer/modular{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dP" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dQ" = (
 /obj/machinery/field_generator,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dR" = (
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dS" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/random/loot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dT" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/largecrate,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dU" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dV" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/item/flame/lighter/random,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dW" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/random/tank,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dX" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1514,7 +1514,7 @@
 	icon_state = "warning"
 	},
 /obj/random/toolbox,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dY" = (
 /obj/structure/cable{
@@ -1522,35 +1522,35 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "dZ" = (
 /obj/structure/table/steel,
 /obj/random/powercell,
 /obj/machinery/cell_charger,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "ea" = (
 /obj/machinery/power/port_gen/pacman/mrs,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eb" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "ec" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "ed" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "ee" = (
 /obj/structure/table/rack,
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "ef" = (
 /obj/structure/grille,
@@ -1562,7 +1562,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eh" = (
 /obj/structure/cable{
@@ -1570,7 +1570,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "ei" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1581,7 +1581,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "ej" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1592,7 +1592,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "ek" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1606,7 +1606,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "el" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -1618,7 +1618,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "em" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1633,7 +1633,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "en" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -1648,7 +1648,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1662,7 +1662,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "ep" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1674,7 +1674,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1693,7 +1693,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "er" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1705,13 +1705,13 @@
 /obj/structure/cable{
 	icon_state = "6-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "es" = (
 /obj/structure/sign/warning/airlock{
 	pixel_x = 30
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "et" = (
 /obj/machinery/light/small{
@@ -1721,7 +1721,7 @@
 /area/space)
 "eu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "ev" = (
 /obj/structure/sign/warning/airlock{
@@ -1733,7 +1733,7 @@
 /obj/structure/sign/warning/docking_area{
 	pixel_y = -30
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "ex" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1745,7 +1745,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "ey" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1757,7 +1757,7 @@
 /obj/structure/cable{
 	icon_state = "4-9"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "ez" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1770,7 +1770,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -1783,7 +1783,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1798,7 +1798,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -1818,7 +1818,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eD" = (
 /obj/machinery/door/airlock/external/bolted,
@@ -1830,7 +1830,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eE" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -1847,7 +1847,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eF" = (
 /obj/machinery/door/airlock/external/bolted,
@@ -1856,7 +1856,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eG" = (
 /obj/machinery/access_button{
@@ -1868,7 +1868,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eI" = (
 /obj/structure/magshield/maggen,
@@ -1876,7 +1876,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "eJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -1888,7 +1888,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1904,48 +1904,48 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/item/newspaper,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eO" = (
 /obj/machinery/light_construct/small,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eP" = (
 /obj/structure/table,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eQ" = (
 /obj/structure/table/steel,
 /obj/item/storage/toolbox/mechanical,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eR" = (
 /obj/structure/table/steel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eS" = (
 /obj/structure/table/steel,
 /obj/item/storage/box/lights,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eT" = (
 /obj/machinery/door/airlock/external/bolted_open,
@@ -1954,39 +1954,39 @@
 	pixel_x = -25;
 	pixel_y = 25
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eU" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eV" = (
 /obj/structure/closet,
 /obj/random/material,
 /obj/random/material,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eW" = (
 /obj/structure/closet,
 /obj/random/material,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eX" = (
 /obj/structure/closet,
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eY" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "eZ" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "fa" = (
 /obj/structure/janitorialcart,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "fb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1997,7 +1997,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "fc" = (
 /obj/machinery/light/small{
@@ -2017,7 +2017,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_x = -25
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "fe" = (
 /turf/simulated/wall,
@@ -2027,22 +2027,22 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fh" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fi" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2052,7 +2052,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fk" = (
 /turf/simulated/wall/r_wall,
@@ -2063,27 +2063,27 @@
 /area/magshield/north)
 "fm" = (
 /obj/item/mop,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "fn" = (
 /obj/machinery/door/airlock/external/bolted_open,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "fo" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/black,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fp" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fr" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -2093,14 +2093,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fs" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8;
 	level = 2
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "ft" = (
 /obj/effect/shuttle_landmark/nav_magshield/nav5,
@@ -2124,7 +2124,7 @@
 	pixel_x = -25;
 	pixel_y = 25
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "fx" = (
 /obj/machinery/atmospherics/unary/tank,
@@ -2134,19 +2134,19 @@
 /obj/machinery/light_construct{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fy" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fz" = (
 /obj/machinery/light_construct{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fA" = (
 /turf/simulated/floor/tiled,
@@ -2187,13 +2187,13 @@
 /area/magshield/west)
 "fH" = (
 /obj/effect/overmap/visitable/sector/magshield,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/north)
 "fI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fJ" = (
 /obj/structure/grille,
@@ -2247,7 +2247,7 @@
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fR" = (
 /obj/machinery/atmospherics/omni/mixer{
@@ -2257,7 +2257,7 @@
 	tag_south = 1;
 	tag_south_con = 0.79
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2270,7 +2270,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fT" = (
 /obj/machinery/atmospherics/omni/filter{
@@ -2278,19 +2278,19 @@
 	tag_south = 1;
 	tag_west = 3
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fV" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -2306,7 +2306,7 @@
 	id = "d_n2_in";
 	use_power = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "fY" = (
 /obj/structure/cable{
@@ -2341,11 +2341,11 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "ge" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gf" = (
 /obj/structure/cable{
@@ -2365,30 +2365,30 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gi" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gj" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gk" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 5
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gl" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gm" = (
 /obj/structure/cable{
@@ -2414,19 +2414,19 @@
 /obj/structure/magshield/nav_light/red{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "gq" = (
 /obj/structure/magshield/nav_light{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "gr" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gs" = (
 /obj/structure/closet,
@@ -2460,18 +2460,18 @@
 /obj/machinery/light_construct{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gy" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2480,7 +2480,7 @@
 "gB" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/portable_atmospherics/canister,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gC" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -2488,7 +2488,7 @@
 	icon_state = "warning"
 	},
 /obj/machinery/portable_atmospherics/canister,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2500,17 +2500,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gE" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gF" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2558,7 +2558,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2572,7 +2572,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2584,7 +2584,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gO" = (
 /obj/machinery/door/firedoor,
@@ -2625,7 +2625,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "gU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2690,14 +2690,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "hg" = (
 /obj/machinery/door/airlock/external/bolted_open,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "hh" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -2706,7 +2706,7 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = -25
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "hi" = (
 /obj/structure/lattice,
@@ -2726,7 +2726,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "hl" = (
 /obj/structure/magshield/rad_sensor,
@@ -2734,7 +2734,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "hm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2778,14 +2778,14 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "hu" = (
 /turf/space,
 /area/magshield/east)
 "hv" = (
 /obj/item/ore/slag,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "hw" = (
 /obj/structure/table/woodentable,
@@ -2808,13 +2808,13 @@
 /obj/structure/cable{
 	icon_state = "1-10"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "hA" = (
 /obj/structure/table/rack,
 /obj/random/voidsuit,
 /obj/random/voidhelmet,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "hB" = (
 /obj/structure/safe,
@@ -2858,7 +2858,7 @@
 	dir = 4;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "hH" = (
 /obj/structure/cable{
@@ -2867,12 +2867,12 @@
 /obj/structure/cable{
 	icon_state = "2-5"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "hI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "hJ" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -2898,7 +2898,7 @@
 /area/magshield/east)
 "hO" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "hP" = (
 /obj/structure/cable{
@@ -2906,14 +2906,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "hQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light_construct{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "hR" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -3034,13 +3034,13 @@
 "if" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/reagent_containers/glass/bucket,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "ig" = (
 /obj/structure/cable{
 	icon_state = "1-10"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "ih" = (
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -3073,7 +3073,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "il" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -3085,7 +3085,7 @@
 /obj/structure/cable{
 	icon_state = "2-5"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "im" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3094,7 +3094,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "in" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3103,7 +3103,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 "io" = (
 /obj/machinery/light_construct{
@@ -3189,7 +3189,7 @@
 /turf/space,
 /area/space)
 "iC" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/west)
 "iD" = (
 /obj/structure/table/steel,
@@ -3512,11 +3512,11 @@
 /area/magshield/south)
 "jE" = (
 /obj/structure/magshield/maggen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "jF" = (
 /obj/machinery/door/airlock/external/bolted,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/south)
 "jG" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -3529,14 +3529,14 @@
 /obj/machinery/airlock_sensor{
 	pixel_y = -25
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/south)
 "jH" = (
 /obj/machinery/door/airlock/external/bolted,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/south)
 "jI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3691,7 +3691,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/south)
 "kb" = (
 /obj/structure/cable{
@@ -3699,14 +3699,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/south)
 "kc" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/south)
 "kd" = (
 /obj/structure/roller_bed,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ke" = (
 /obj/structure/cable{
@@ -3714,7 +3714,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "kf" = (
 /obj/structure/sign/warning/airlock{
@@ -4152,7 +4152,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "lv" = (
 /obj/structure/cable/yellow{
@@ -4160,7 +4160,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "lw" = (
 /obj/structure/cable/yellow{
@@ -4172,7 +4172,7 @@
 	name = "Port Auxiliary Solar Array"
 	},
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "lx" = (
 /obj/structure/cable/yellow{
@@ -4190,7 +4190,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ly" = (
 /obj/structure/cable/yellow,
@@ -4199,7 +4199,7 @@
 	name = "Port Auxiliary Solar Array"
 	},
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "lz" = (
 /obj/structure/cable/yellow{
@@ -4217,7 +4217,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "lA" = (
 /obj/effect/shuttle_landmark/nav_magshield/nav3,
@@ -4233,7 +4233,7 @@
 	tag_south = 1;
 	tag_west = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/magshield/east)
 
 (1,1,1) = {"

--- a/maps/away/magshield/magshield_areas.dm
+++ b/maps/away/magshield/magshield_areas.dm
@@ -1,3 +1,6 @@
+/area/magshield
+	turfs_airless = TRUE
+
 /area/magshield/south
 	name = "Orbital Station South Wing"
 	icon_state = "south"

--- a/maps/away/meatstation/meatstation.dmm
+++ b/maps/away/meatstation/meatstation.dmm
@@ -16,17 +16,19 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "ae" = (
 /obj/effect/paint/meatstation,
 /turf/simulated/wall/r_wall,
 /area/meatstation/engineering)
 "af" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "ag" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ah" = (
 /obj/effect/paint/meatstation,
@@ -43,7 +45,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "aj" = (
 /obj/effect/floor_decal/solarpanel,
@@ -54,7 +56,7 @@
 /obj/machinery/power/solar{
 	id = "meatstation_mainsolars"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ak" = (
 /obj/structure/cable/yellow{
@@ -72,7 +74,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "al" = (
 /obj/structure/cable/yellow{
@@ -81,7 +83,7 @@
 	},
 /obj/machinery/power/tracker,
 /obj/effect/floor_decal/industrial/warning/full,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "am" = (
 /obj/structure/cable/yellow{
@@ -99,7 +101,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "an" = (
 /obj/structure/cable/yellow{
@@ -112,7 +114,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ao" = (
 /obj/structure/cable/yellow{
@@ -120,11 +122,11 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ap" = (
 /obj/structure/girder,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "aq" = (
 /obj/structure/cable/yellow{
@@ -142,7 +144,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ar" = (
 /obj/structure/cable/yellow{
@@ -155,17 +157,17 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "as" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "at" = (
 /obj/structure/lattice,
 /turf/space,
 /area/meatstation/dorm)
 "au" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/dorm)
 "av" = (
 /obj/effect/paint/meatstation,
@@ -177,14 +179,14 @@
 /area/space)
 "ax" = (
 /obj/structure/girder,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/dorm)
 "ay" = (
 /obj/structure/lattice,
 /turf/space,
 /area/meatstation/engineering)
 "az" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "aA" = (
 /obj/effect/paint/meatstation,
@@ -211,7 +213,7 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 9
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "aG" = (
 /obj/machinery/power/terminal{
@@ -221,7 +223,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "aH" = (
 /obj/machinery/power/terminal{
@@ -236,7 +238,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "aI" = (
 /obj/structure/cable/cyan{
@@ -250,7 +252,7 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "aJ" = (
 /obj/structure/cable/yellow{
@@ -262,7 +264,7 @@
 	id_tag = "meatstation_nairlockext";
 	locked = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "aK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -277,12 +279,12 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "aM" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/meatstation,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "aN" = (
 /obj/machinery/button/alternate/door/bolts{
@@ -303,7 +305,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "aP" = (
 /obj/effect/paint/meatstation,
@@ -319,7 +321,7 @@
 /area/space)
 "aS" = (
 /obj/structure/bookcase/manuals/engineering,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "aT" = (
 /obj/structure/bed/chair/office/comfy/red{
@@ -329,7 +331,7 @@
 /area/space)
 "aU" = (
 /obj/structure/bookcase/manuals/medical,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "aV" = (
 /obj/effect/paint/meatstation,
@@ -342,7 +344,7 @@
 /area/meatstation/centerhallway)
 "aX" = (
 /obj/item/book/manual/engineering_guide,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "aY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -355,7 +357,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "aZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -369,13 +373,15 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "ba" = (
 /obj/machinery/light/small/red{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "bb" = (
 /obj/effect/floor_decal/solarpanel,
@@ -386,7 +392,7 @@
 /obj/machinery/power/solar{
 	id = "meatstation_mainsolars"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "bc" = (
 /obj/structure/cable/yellow{
@@ -404,11 +410,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "bd" = (
 /obj/structure/girder,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "be" = (
 /obj/structure/lattice,
@@ -419,7 +425,7 @@
 /area/meatstation/medical)
 "bg" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "bh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -433,7 +439,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "bi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -447,7 +455,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "bj" = (
 /obj/structure/cable/cyan{
@@ -463,16 +473,16 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "bk" = (
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/dorm)
 "bl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "bm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -487,7 +497,7 @@
 	icon_state = "1-4"
 	},
 /obj/item/inflatable/door,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "bn" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -499,7 +509,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "bo" = (
 /obj/item/book/manual/psionics,
@@ -511,7 +523,7 @@
 	pixel_x = -23;
 	pixel_y = -3
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "bq" = (
 /obj/structure/cable/cyan{
@@ -519,7 +531,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "br" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -527,7 +539,9 @@
 	level = 2
 	},
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "bs" = (
 /obj/effect/paint/meatstation,
@@ -539,7 +553,7 @@
 /area/space)
 "bu" = (
 /obj/item/paper_bin,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "bv" = (
 /obj/structure/barricade/spike{
@@ -547,13 +561,15 @@
 	},
 /obj/machinery/light/small/red,
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "bw" = (
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "bx" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -580,7 +596,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "bA" = (
 /obj/effect/paint/meatstation,
@@ -604,7 +620,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "bG" = (
 /obj/machinery/door/airlock{
@@ -621,7 +639,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/mess)
 "bH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -650,7 +670,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "bL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -664,7 +686,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "bM" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -678,7 +700,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "bN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -688,7 +712,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "bO" = (
 /obj/machinery/door/airlock{
@@ -705,17 +729,19 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "bP" = (
 /obj/random/maintenance/clean,
 /obj/random/single/meatstation/meatball,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "bQ" = (
 /obj/structure/inflatable/wall,
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "bR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -729,20 +755,24 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "bS" = (
 /obj/structure/inflatable/wall,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "bT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/dorm)
 "bU" = (
 /obj/effect/decal/cleanable/filth,
@@ -750,7 +780,7 @@
 /area/meatstation/dorm)
 "bV" = (
 /obj/item/device/flashlight/lamp,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "bW" = (
 /obj/effect/floor_decal/corner/brown/border{
@@ -768,12 +798,12 @@
 	pixel_x = -24;
 	pixel_y = -6
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "bX" = (
 /obj/item/device/flashlight/lamp,
 /obj/random/junk,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "bY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -787,12 +817,12 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "bZ" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/meatstation,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/dorm)
 "ca" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -803,7 +833,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "cc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -817,10 +847,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "cd" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "ce" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -829,7 +861,7 @@
 /area/meatstation/dorm)
 "cf" = (
 /obj/machinery/jukebox/old,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "cg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -843,7 +875,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "ch" = (
 /obj/effect/floor_decal/corner/black/border{
@@ -854,7 +888,9 @@
 	name = "exterior lab bolt control";
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "ci" = (
 /obj/machinery/door/airlock{
@@ -871,7 +907,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "cj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -890,7 +928,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "ck" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -900,7 +938,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "cl" = (
 /obj/structure/inflatable/wall,
@@ -929,7 +969,9 @@
 	dir = 1;
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "co" = (
 /obj/machinery/door/airlock{
@@ -982,7 +1024,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/cargo)
 "ct" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -1003,14 +1047,14 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /obj/structure/inflatable/door,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "cu" = (
 /obj/structure/stasis_cage,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "cv" = (
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "cw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1020,7 +1064,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "cx" = (
 /obj/machinery/door/airlock{
@@ -1033,7 +1077,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/engineering)
 "cy" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -1055,7 +1101,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "cA" = (
 /obj/machinery/door/airlock{
@@ -1146,18 +1192,22 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "cJ" = (
 /obj/structure/inflatable/wall,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "cK" = (
 /turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "cL" = (
 /obj/random/maintenance/clean,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "cM" = (
 /obj/machinery/light{
@@ -1213,7 +1263,9 @@
 /obj/random/junk,
 /obj/machinery/light/small/red,
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "cS" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -1224,7 +1276,9 @@
 /obj/machinery/door/airlock{
 	stripe_color = "#aab1c1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/dorm)
 "cU" = (
 /obj/structure/closet/wardrobe/pjs,
@@ -1271,7 +1325,7 @@
 	dir = 1
 	},
 /obj/random/junk,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "da" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -1307,7 +1361,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/single/meatstation/meatball,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "de" = (
 /obj/machinery/door/airlock/vault/bolted{
@@ -1338,7 +1392,7 @@
 /area/meatstation/bathroom)
 "dh" = (
 /obj/item/paper,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "di" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1439,7 +1493,7 @@
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/effect/floor_decal/corner/purple/diagonal,
 /obj/random/single/meatstation/meatball,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "ds" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -1472,13 +1526,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "dw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "dx" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -1531,7 +1585,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "dE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -1578,7 +1634,7 @@
 /area/meatstation/bathroom)
 "dJ" = (
 /obj/item/pen,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "dK" = (
 /obj/machinery/door/airlock{
@@ -1604,7 +1660,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "dN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1622,14 +1680,18 @@
 /turf/simulated/floor/tiled/monotile,
 /area/meatstation/hydroponics)
 "dO" = (
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/meatstation/bathroom)
 "dP" = (
 /obj/random/single/meatstation/low/wormscientist,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "dQ" = (
 /obj/item/stack/material/rods,
@@ -1659,7 +1721,7 @@
 /turf/space,
 /area/meatstation/kitchen)
 "dU" = (
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "dV" = (
 /obj/item/storage/box,
@@ -1674,7 +1736,7 @@
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "dY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1689,10 +1751,10 @@
 	icon_state = "1-8"
 	},
 /obj/structure/inflatable/door,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "dZ" = (
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/meatstation/kitchen)
 "ea" = (
 /obj/machinery/door/airlock{
@@ -1789,7 +1851,9 @@
 /obj/structure/barricade/spike{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "en" = (
 /obj/machinery/door/airlock{
@@ -1876,7 +1940,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "et" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -1888,7 +1954,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "eu" = (
 /obj/item/paper,
@@ -1922,7 +1990,7 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /obj/random/single/meatstation/meatball,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "ey" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -1939,7 +2007,9 @@
 "ez" = (
 /obj/effect/floor_decal/corner/black/border,
 /obj/item/tape_roll,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "eA" = (
 /obj/structure/table/rack/dark,
@@ -1963,11 +2033,11 @@
 /area/meatstation/armory)
 "eC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "eD" = (
 /obj/random/single/meatstation/meatworm,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "eE" = (
 /obj/structure/cable/cyan{
@@ -2028,7 +2098,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "eL" = (
 /obj/random/junk,
@@ -2038,7 +2110,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "eM" = (
 /obj/machinery/door/airlock{
@@ -2064,14 +2138,16 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "eO" = (
 /obj/structure/inflatable/wall,
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "eP" = (
 /obj/machinery/power/smes/buildable,
@@ -2079,7 +2155,7 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "eQ" = (
 /obj/machinery/power/terminal{
@@ -2097,7 +2173,7 @@
 /obj/effect/floor_decal/corner/purple/bordercorner{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "eR" = (
 /obj/structure/cable/yellow{
@@ -2113,7 +2189,7 @@
 	name = "interior airlock bolt control";
 	pixel_x = -24
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "eS" = (
 /obj/random/single/meatstation/low/wormguard,
@@ -2134,7 +2210,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "eV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2224,7 +2302,9 @@
 "fb" = (
 /obj/effect/floor_decal/corner/black/border,
 /obj/random/single/meatstation/meatworm,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "fc" = (
 /obj/effect/paint/meatstation,
@@ -2271,13 +2351,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small/red,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/storage)
 "fi" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/corner/purple/border,
 /obj/machinery/light,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "fj" = (
 /obj/structure/cable/cyan{
@@ -2290,7 +2370,7 @@
 /obj/machinery/power/apc/meatstation{
 	pixel_y = -28
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "fk" = (
 /obj/effect/floor_decal/corner/lightgrey/border{
@@ -2306,7 +2386,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "fm" = (
 /obj/effect/paint/meatstation,
@@ -2328,7 +2408,7 @@
 "fo" = (
 /obj/machinery/portable_atmospherics/canister/empty/air,
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "fp" = (
 /obj/structure/window/basic,
@@ -2376,11 +2456,13 @@
 	pixel_x = -6;
 	pixel_y = 30
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "fs" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "ft" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2399,12 +2481,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "fu" = (
 /obj/item/paper,
 /obj/structure/bed/chair/office/comfy/beige,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "fv" = (
 /obj/effect/floor_decal/corner/red/bordercorner{
@@ -2459,7 +2543,9 @@
 	locked = 1;
 	stripe_color = "#aab1c1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/hydroponics)
 "fA" = (
 /obj/structure/table/rack/dark,
@@ -2488,7 +2574,9 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "fC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2503,7 +2591,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "fD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2521,7 +2609,7 @@
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "fE" = (
 /obj/structure/cable/cyan{
@@ -2554,7 +2642,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "fG" = (
 /obj/item/storage/box/canned_beans,
@@ -2605,14 +2693,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "fM" = (
 /obj/effect/floor_decal/solarpanel,
 /obj/machinery/power/solar{
 	id = "meatstation_mainsolars"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "fN" = (
 /obj/structure/cable/yellow{
@@ -2630,7 +2718,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "fO" = (
 /obj/structure/cable/yellow{
@@ -2643,7 +2731,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "fP" = (
 /turf/simulated/floor/exoplanet/grass,
@@ -2688,7 +2776,7 @@
 /obj/structure/table/marble,
 /obj/machinery/microwave,
 /obj/effect/floor_decal/corner/lime/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "fW" = (
 /obj/item/paper,
@@ -2744,7 +2832,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "ge" = (
 /obj/structure/table/glass,
@@ -2764,7 +2854,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "gg" = (
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -2815,7 +2905,7 @@
 /obj/item/clothing/ring/material/bronze,
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/effect/floor_decal/corner/purple/diagonal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "go" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2840,12 +2930,12 @@
 /area/meatstation/hydroponics)
 "gq" = (
 /obj/random/single/meatstation/meatball,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "gr" = (
 /obj/machinery/cooker/fryer,
 /obj/effect/floor_decal/corner/lime/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "gs" = (
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -2910,7 +3000,7 @@
 /area/meatstation/hydroponics)
 "gA" = (
 /obj/item/storage/candle_box/scented,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "gB" = (
 /obj/item/paper,
@@ -2939,7 +3029,7 @@
 /obj/structure/table/marble,
 /obj/machinery/cooker/cereal,
 /obj/effect/floor_decal/corner/lime/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "gE" = (
 /obj/random/hostile,
@@ -2973,7 +3063,7 @@
 "gI" = (
 /obj/random/single/meatstation/wormguard,
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "gJ" = (
 /obj/machinery/vending/medical,
@@ -3039,7 +3129,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "gQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3060,7 +3150,7 @@
 	dir = 1
 	},
 /obj/structure/inflatable/wall,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "gR" = (
 /obj/machinery/sleeper,
@@ -3138,7 +3228,7 @@
 	},
 /obj/machinery/door/window/northleft,
 /obj/effect/floor_decal/corner/purple/diagonal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "gZ" = (
 /obj/machinery/power/rad_collector,
@@ -3147,7 +3237,7 @@
 	},
 /obj/machinery/door/window/northright,
 /obj/effect/floor_decal/corner/purple/diagonal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "ha" = (
 /obj/structure/cable/cyan{
@@ -3170,7 +3260,7 @@
 /area/meatstation/storage)
 "hc" = (
 /obj/machinery/portable_atmospherics/canister,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "hd" = (
 /obj/machinery/portable_atmospherics/powered/pump,
@@ -3182,12 +3272,12 @@
 /area/space)
 "hf" = (
 /obj/machinery/power/port_gen/pacman,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "hg" = (
 /obj/item/stack/material/titanium/ten,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "hh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -3222,7 +3312,7 @@
 	},
 /obj/machinery/door/window/southleft,
 /obj/effect/floor_decal/corner/purple/diagonal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "hl" = (
 /obj/machinery/reagentgrinder,
@@ -3294,7 +3384,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "hx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3321,7 +3413,7 @@
 /area/space)
 "hA" = (
 /obj/structure/table/marble,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "hB" = (
 /obj/item/reagent_containers/glass/beaker/vial/random/toxin,
@@ -3335,7 +3427,7 @@
 /obj/item/stack/cable_coil/cyan{
 	amount = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "hD" = (
 /obj/effect/floor_decal/corner/b_green/border{
@@ -3345,13 +3437,13 @@
 /area/meatstation/storage)
 "hE" = (
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "hF" = (
 /obj/item/paper,
 /obj/structure/bed/chair/office/comfy/yellow,
 /obj/random/junk,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "hG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3378,12 +3470,12 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 9
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "hI" = (
 /obj/machinery/portable_atmospherics/canister/empty/oxygen,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "hJ" = (
 /obj/effect/floor_decal/corner/lightgrey/border{
@@ -3441,7 +3533,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "hP" = (
 /obj/machinery/light{
@@ -3450,7 +3542,7 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "hQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3506,7 +3598,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/dorm)
 "hV" = (
 /obj/item/stack/material/rods,
@@ -3522,7 +3614,7 @@
 /area/meatstation/storage)
 "hX" = (
 /obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "hY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3563,7 +3655,7 @@
 /area/meatstation/dorm)
 "id" = (
 /obj/structure/bed/chair/office/comfy/green,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "ie" = (
 /obj/structure/hygiene/toilet{
@@ -3582,7 +3674,7 @@
 /area/meatstation/bathroom)
 "ig" = (
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "ih" = (
 /obj/structure/hygiene/shower,
@@ -3640,11 +3732,11 @@
 	dir = 1
 	},
 /obj/structure/inflatable/wall,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "io" = (
 /obj/machinery/icecream_vat,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/meatstation/kitchen)
 "ip" = (
 /obj/machinery/door/airlock{
@@ -3658,7 +3750,7 @@
 /area/meatstation/bathroom)
 "ir" = (
 /obj/item/reagent_containers/food/snacks/meat/meatstationmeat,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "is" = (
 /obj/item/ammo_magazine/shotholder/empty,
@@ -3681,13 +3773,13 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "iu" = (
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "iv" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -3701,21 +3793,23 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "iw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "ix" = (
 /obj/structure/girder,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/meatstation/bathroom)
 "iy" = (
 /obj/structure/girder,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/meatstation/kitchen)
 "iz" = (
 /obj/item/material/knife/kitchen,
@@ -3748,7 +3842,7 @@
 /area/meatstation/storage)
 "iC" = (
 /obj/item/reagent_containers/food/snacks/slice/meatbread,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/meatstation/kitchen)
 "iD" = (
 /obj/item/reagent_containers/food/snacks/slice/meatpizza,
@@ -3756,7 +3850,7 @@
 /area/space)
 "iE" = (
 /obj/item/storage/box/handcuffs,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/cargo)
 "iF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3767,16 +3861,16 @@
 	icon_state = "1-2"
 	},
 /obj/structure/table/marble,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "iG" = (
 /obj/structure/table/marble,
 /obj/item/material/knife/kitchen,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "iH" = (
 /obj/item/material/knife/kitchen/cleaver,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/meatstation/kitchen)
 "iI" = (
 /obj/item/reagent_containers/food/snacks/sliceable/pizza/meatpizza,
@@ -3785,13 +3879,13 @@
 "iJ" = (
 /obj/machinery/cooker/grill,
 /obj/effect/floor_decal/corner/lime/diagonal,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/meatstation/kitchen)
 "iK" = (
 /obj/structure/table/marble,
 /obj/machinery/cooker/candy,
 /obj/effect/floor_decal/corner/lime/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "iL" = (
 /obj/machinery/conveyor{
@@ -3824,13 +3918,13 @@
 /area/meatstation/storage)
 "iO" = (
 /obj/effect/floor_decal/corner/lime/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "iP" = (
 /obj/machinery/cooker/oven,
 /obj/random/single/meatstation/meatworm,
 /obj/effect/floor_decal/corner/lime/diagonal,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/meatstation/kitchen)
 "iQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -3870,7 +3964,7 @@
 /area/meatstation/storage)
 "iW" = (
 /obj/item/material/knife/kitchen,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "iX" = (
 /obj/machinery/light{
@@ -3879,7 +3973,7 @@
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "iY" = (
 /obj/item/material/kitchen/utensil/fork,
@@ -3910,7 +4004,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/material/kitchen/utensil/fork,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "jb" = (
 /obj/structure/lattice,
@@ -3918,7 +4012,7 @@
 /area/meatstation/storage)
 "jc" = (
 /obj/item/material/kitchen/utensil/spork/plastic,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "jd" = (
 /obj/item/storage/mirror{
@@ -3934,7 +4028,9 @@
 /area/meatstation/bathroom)
 "jf" = (
 /obj/structure/girder,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/meatstation/mess)
 "jg" = (
 /obj/item/stack/material/rods,
@@ -4184,7 +4280,7 @@
 /area/meatstation/dorm)
 "jL" = (
 /obj/random/single/meatstation/meatworm,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "jM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4199,7 +4295,7 @@
 	icon_state = "4-8"
 	},
 /obj/random/single/meatstation/meatworm,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "jN" = (
 /obj/structure/table/woodentable/ebony,
@@ -4519,17 +4615,17 @@
 /area/meatstation/mess)
 "kz" = (
 /obj/item/book/manual/detective,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "kA" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/item/paper,
 /obj/random/junk,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "kB" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "kC" = (
 /obj/structure/table/marble,
@@ -4548,7 +4644,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/book/manual/anomaly_testing,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "kE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4562,7 +4658,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "kF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4577,7 +4673,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/book/manual/chef_recipes,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "kG" = (
 /obj/structure/table/marble,
@@ -4690,7 +4786,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "kW" = (
 /obj/structure/closet,
@@ -4735,11 +4831,11 @@
 /area/meatstation/mess)
 "lb" = (
 /obj/random/trash,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/meatstation/kitchen)
 "lc" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "ld" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4814,7 +4910,7 @@
 "ln" = (
 /obj/item/storage/box/beakers,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "lo" = (
 /obj/structure/table/woodentable/ebony,
@@ -4844,7 +4940,7 @@
 	dir = 1
 	},
 /obj/item/book/manual/chemistry_recipes,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "lr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4859,7 +4955,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/device/flashlight/lamp,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "ls" = (
 /obj/structure/table/woodentable/ebony,
@@ -4879,7 +4975,7 @@
 	icon_state = "4-8"
 	},
 /obj/random/maintenance/clean,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "lu" = (
 /obj/structure/table/woodentable/ebony,
@@ -4921,7 +5017,7 @@
 	},
 /obj/structure/table/standard,
 /obj/item/book/manual/engineering_hacking,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "lB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4933,7 +5029,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/deck/tarot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/dorm)
 "lC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4952,7 +5048,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "lD" = (
 /obj/structure/table/gamblingtable,
@@ -4968,16 +5064,16 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "lF" = (
 /obj/structure/table/standard,
 /obj/random/junk,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "lG" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "lH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4992,12 +5088,12 @@
 	icon_state = "4-8"
 	},
 /obj/item/paper,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/dorm)
 "lI" = (
 /obj/structure/table/standard,
 /obj/random/toy,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "lJ" = (
 /obj/item/paper,
@@ -5007,7 +5103,7 @@
 /obj/structure/bed/chair/office/comfy/red{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/dorm)
 "lL" = (
 /obj/structure/bed/chair/office/comfy/black{
@@ -5019,12 +5115,12 @@
 /obj/structure/bed/chair/office/comfy/yellow{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/dorm)
 "lN" = (
 /obj/structure/table/standard,
 /obj/random/maintenance/clean,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "lO" = (
 /obj/random/junk,
@@ -5036,7 +5132,7 @@
 	level = 2
 	},
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "lQ" = (
 /obj/item/book/manual/research_and_development,
@@ -5050,7 +5146,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "lS" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -5064,17 +5160,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "lT" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "lU" = (
 /obj/structure/bed/chair/office/comfy/black,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "lV" = (
 /obj/item/pen,
@@ -5172,7 +5268,7 @@
 /area/meatstation/swhallway)
 "mk" = (
 /obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "ml" = (
 /obj/structure/mine,
@@ -5216,7 +5312,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "mq" = (
 /obj/structure/mine,
@@ -5242,7 +5338,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "ms" = (
 /obj/structure/closet/toolcloset,
@@ -5255,15 +5351,15 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/material/shard,
 /obj/effect/floor_decal/corner/purple/diagonal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mu" = (
 /obj/item/material/shard,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mv" = (
 /obj/effect/floor_decal/corner/purple/diagonal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mw" = (
 /obj/random/tool,
@@ -5273,7 +5369,7 @@
 /obj/structure/closet/toolcloset,
 /obj/machinery/door/window/northright,
 /obj/effect/floor_decal/corner/purple/diagonal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "my" = (
 /obj/structure/closet/toolcloset,
@@ -5283,7 +5379,7 @@
 /obj/machinery/door/window/northright,
 /obj/item/inflatable/door,
 /obj/effect/floor_decal/corner/purple/diagonal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mz" = (
 /obj/machinery/portable_atmospherics/canister/empty/air,
@@ -5293,15 +5389,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mB" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mC" = (
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "mD" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -5309,7 +5407,7 @@
 /area/space)
 "mE" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mF" = (
 /obj/machinery/portable_atmospherics/canister/phoron,
@@ -5321,7 +5419,7 @@
 /area/space)
 "mH" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mI" = (
 /obj/structure/closet/toolcloset,
@@ -5331,7 +5429,7 @@
 /obj/machinery/door/window/southleft,
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/effect/floor_decal/corner/purple/diagonal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5346,15 +5444,15 @@
 	icon_state = "4-8"
 	},
 /obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mK" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mL" = (
 /obj/random/single/meatstation/low/wormguard,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5369,7 +5467,7 @@
 	icon_state = "4-8"
 	},
 /obj/random/single/meatstation/low/wormguard,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mN" = (
 /obj/structure/table/woodentable/ebony,
@@ -5385,17 +5483,17 @@
 	},
 /obj/machinery/door/window/southright,
 /obj/effect/floor_decal/corner/purple/diagonal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mP" = (
 /obj/machinery/pipedispenser/disposal,
 /obj/effect/floor_decal/corner/purple/diagonal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mQ" = (
 /obj/machinery/pipedispenser,
 /obj/effect/floor_decal/corner/purple/diagonal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mR" = (
 /obj/structure/cable/cyan{
@@ -5408,18 +5506,18 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mS" = (
 /obj/item/cell/crap,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mT" = (
 /obj/structure/closet/toolcloset,
 /obj/machinery/door/window/southleft,
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/effect/floor_decal/corner/purple/diagonal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mU" = (
 /obj/structure/cable/cyan{
@@ -5428,16 +5526,18 @@
 	icon_state = "1-2"
 	},
 /obj/item/stack/material/aluminium/ten,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mV" = (
 /obj/item/stack/material/aluminium/ten,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mW" = (
 /obj/random/single/meatstation/meatworm,
 /obj/random/junk,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "mX" = (
 /obj/structure/cable/cyan{
@@ -5450,7 +5550,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "mY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -5465,7 +5565,7 @@
 /area/meatstation/swhallway)
 "mZ" = (
 /obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "na" = (
 /obj/item/stack/material/wood/ebony/twentyfive,
@@ -5478,7 +5578,7 @@
 "nc" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "nd" = (
 /obj/item/stack/material/gold/ten,
@@ -5486,7 +5586,7 @@
 /area/space)
 "ne" = (
 /obj/item/stack/material/steel/fifty,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "nf" = (
 /obj/structure/cable/cyan{
@@ -5495,19 +5595,19 @@
 	icon_state = "1-2"
 	},
 /obj/item/stack/material/plasteel/fifty,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "ng" = (
 /obj/item/stack/material/wood/ebony/twentyfive,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "nh" = (
 /obj/item/stack/material/glass/reinforced/ten,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "ni" = (
 /obj/item/stack/material/silver/ten,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "nj" = (
 /obj/structure/cable/cyan{
@@ -5519,15 +5619,15 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "nk" = (
 /obj/item/stack/material/plasteel/ten,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "nl" = (
 /obj/item/stack/material/phoron/ten,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "nm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5544,7 +5644,7 @@
 /obj/item/stack/material/steel/fifty,
 /obj/machinery/pipedispenser/disposal,
 /obj/effect/floor_decal/corner/purple/diagonal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "nn" = (
 /obj/structure/closet/wardrobe/pjs,
@@ -5567,24 +5667,24 @@
 /obj/structure/bed/chair/office/comfy/beige{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "nr" = (
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "ns" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "nt" = (
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/dorm)
 "nu" = (
 /obj/item/book/manual/engineering_construction,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "nv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5599,7 +5699,7 @@
 	icon_state = "4-8"
 	},
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "nw" = (
 /obj/random/junk,
@@ -5639,11 +5739,11 @@
 /area/meatstation/mess)
 "nC" = (
 /obj/random/junk,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/meatstation/kitchen)
 "nD" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "nE" = (
 /obj/structure/closet,
@@ -5655,17 +5755,17 @@
 /area/meatstation/bathroom)
 "nF" = (
 /obj/random/single/meatstation/meatworm,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "nG" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "nH" = (
 /obj/item/clothing/accessory/scarf,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "nI" = (
 /obj/random/junk,
@@ -5687,16 +5787,16 @@
 	icon_state = "1-2"
 	},
 /obj/random/toolbox,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "nM" = (
 /obj/structure/closet/toolcloset,
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "nN" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "nO" = (
 /obj/random/maintenance/clean,
@@ -5714,7 +5814,7 @@
 /obj/item/stack/cable_coil/green{
 	amount = 28
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "nQ" = (
 /obj/structure/closet/wardrobe/pjs,
@@ -5724,25 +5824,25 @@
 /area/meatstation/dorm)
 "nR" = (
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "nS" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "nT" = (
 /obj/item/paper,
 /obj/item/paper,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "nU" = (
 /obj/item/stack/material/steel/fifty,
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "nV" = (
 /obj/random/maintenance/clean,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "nW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5757,7 +5857,7 @@
 	icon_state = "4-8"
 	},
 /obj/random/junk,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "nX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5777,7 +5877,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "nY" = (
 /obj/structure/closet/wardrobe/pjs,
@@ -5799,7 +5899,7 @@
 /area/meatstation/mess)
 "oc" = (
 /obj/random/maintenance/clean,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "od" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -5815,7 +5915,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "oe" = (
 /obj/random/closet,
@@ -5841,7 +5941,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/bookcase,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "oh" = (
 /obj/random/maintenance/clean,
@@ -5869,7 +5969,7 @@
 	dir = 8
 	},
 /obj/item/cell/high,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "ol" = (
 /obj/random/maintenance/clean,
@@ -5909,7 +6009,7 @@
 /area/space)
 "or" = (
 /obj/item/inflatable/door,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "os" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5933,15 +6033,17 @@
 	dir = 1
 	},
 /obj/random/single/meatstation/low/wormguard,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "ou" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "ov" = (
 /obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/cargo)
 "ow" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -5956,7 +6058,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "ox" = (
 /obj/machinery/door/airlock{
@@ -5974,7 +6078,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/kitchen)
 "oy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6013,7 +6119,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/inflatable/door,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "oC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6031,7 +6139,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/cargo)
 "oE" = (
 /obj/effect/overmap/visitable/sector/meatstation,
@@ -6039,7 +6149,9 @@
 /area/space)
 "oF" = (
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "oG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6050,29 +6162,29 @@
 	icon_state = "1-2"
 	},
 /obj/structure/inflatable/door,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "oH" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/cargo)
 "oJ" = (
 /obj/item/book/manual/stasis,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "oK" = (
 /obj/structure/bookcase/manuals/xenoarchaeology,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "oL" = (
 /obj/structure/bookcase,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "oM" = (
 /obj/structure/bed/chair/office/comfy/lime,
 /obj/machinery/light/small/red{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "oN" = (
 /obj/item/book/manual/robotics_cyborgs,
@@ -6084,7 +6196,7 @@
 /area/space)
 "oP" = (
 /obj/structure/bookcase/manuals/research_and_development,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "oQ" = (
 /obj/item/book/manual/hydroponics_pod_people,
@@ -6102,12 +6214,12 @@
 "oT" = (
 /obj/structure/table/standard,
 /obj/item/paper_bin,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "oU" = (
 /obj/structure/table/standard,
 /obj/item/device/flashlight/lamp,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "oV" = (
 /obj/random/single/meatstation/low/wormscientist,
@@ -6139,13 +6251,13 @@
 /area/meatstation/mess)
 "oY" = (
 /obj/item/book/manual/excavation,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/dorm)
 "oZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/item/book/manual/barman_recipes,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/dorm)
 "pa" = (
 /obj/structure/bed/chair{
@@ -6168,14 +6280,16 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "pd" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	level = 2
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "pe" = (
 /obj/machinery/light/small/red{
@@ -6184,7 +6298,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "pf" = (
 /obj/structure/lattice,
@@ -6192,7 +6308,7 @@
 /area/meatstation/cargo)
 "pg" = (
 /obj/structure/girder,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/cargo)
 "ph" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6204,7 +6320,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "pi" = (
 /obj/item/extinguisher,
@@ -6241,7 +6359,7 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "pr" = (
 /obj/random/tech_supply,
@@ -6268,7 +6386,7 @@
 /area/meatstation/swhallway)
 "pu" = (
 /obj/item/paper/meatstation/weapon_note,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/dorm)
 "pv" = (
 /obj/effect/paint/meatstation,
@@ -6290,15 +6408,15 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "px" = (
 /obj/random/toy,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "py" = (
 /obj/item/storage/box/monkeycubes/farwacubes,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "pz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6313,21 +6431,21 @@
 	icon_state = "4-8"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "pA" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/corner/purple/border,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "pB" = (
 /obj/random/maintenance/clean,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "pC" = (
 /obj/item/storage/box/monkeycubes/spidercubes,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "pD" = (
 /obj/structure/bed/chair,
@@ -6335,50 +6453,50 @@
 /area/meatstation/mess)
 "pE" = (
 /obj/item/storage/box/lights/bulbs,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "pF" = (
 /obj/item/storage/box/lights/tubes/random,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "pG" = (
 /obj/item/reagent_containers/food/snacks/monkeycube/spidercube,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "pH" = (
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "pI" = (
 /obj/item/storage/box/lights/tubes/random,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/cargo)
 "pJ" = (
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "pK" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "pL" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/glasses/cocktail,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "pM" = (
 /obj/item/storage/box/beakers,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "pN" = (
 /obj/item/storage/box,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "pO" = (
 /obj/structure/table/rack,
@@ -6420,7 +6538,7 @@
 /area/meatstation/swhallway)
 "pR" = (
 /obj/item/storage/box/botanydisk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/cargo)
 "pS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6447,11 +6565,11 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "pU" = (
 /obj/item/storage/box/canned_tomato,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "pV" = (
 /obj/item/storage/box/canned_beef,
@@ -6459,7 +6577,7 @@
 /area/space)
 "pW" = (
 /obj/item/storage/box/canned_spinach,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/cargo)
 "pX" = (
 /obj/structure/window/reinforced{
@@ -6494,7 +6612,7 @@
 /area/space)
 "qb" = (
 /obj/item/storage/box/glowsticks,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/cargo)
 "qc" = (
 /obj/item/storage/box/glowsticks,
@@ -6502,7 +6620,7 @@
 /area/space)
 "qd" = (
 /obj/item/storage/box/detergent,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/cargo)
 "qe" = (
 /obj/item/storage/box/freezer,
@@ -6512,7 +6630,7 @@
 /obj/random/maintenance/clean,
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qg" = (
 /obj/machinery/light{
@@ -6521,15 +6639,15 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qh" = (
 /obj/item/storage/box/pillbottles,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qi" = (
 /obj/item/tape_roll,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qj" = (
 /obj/item/tape_roll,
@@ -6577,7 +6695,7 @@
 /area/space)
 "qo" = (
 /obj/item/towel/random,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qp" = (
 /obj/item/usedcryobag,
@@ -6624,11 +6742,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "qt" = (
 /obj/item/storage/backpack/dufflebag,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qu" = (
 /obj/item/shield/riot/metal,
@@ -6641,7 +6761,7 @@
 /area/space)
 "qw" = (
 /obj/item/storage/bag/trash,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qx" = (
 /obj/item/storage/bag/trash,
@@ -6661,7 +6781,7 @@
 /area/meatstation/storage)
 "qz" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qA" = (
 /obj/item/storage/fancy/egg_box/full,
@@ -6674,19 +6794,19 @@
 /area/meatstation/medical)
 "qC" = (
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qD" = (
 /obj/item/storage/box/lights/tubes/random,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/structure/stasis_cage,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6697,7 +6817,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/stasis_cage,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6719,7 +6839,7 @@
 "qH" = (
 /obj/item/storage/backpack/dufflebag,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qI" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -6756,7 +6876,7 @@
 /area/meatstation/mess)
 "qK" = (
 /obj/item/ammo_magazine/shotholder/empty,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6787,30 +6907,30 @@
 	dir = 1
 	},
 /obj/structure/inflatable/wall,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qN" = (
 /obj/item/clothing/accessory/fire_overpants,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qO" = (
 /obj/item/extinguisher,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qP" = (
 /obj/random/maintenance/clean,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qQ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qR" = (
 /obj/item/tape_roll,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6823,13 +6943,13 @@
 /obj/structure/closet/crate,
 /obj/item/stack/material/rods/fifty,
 /obj/item/stack/material/rods/fifty,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qT" = (
 /obj/structure/closet/crate,
 /obj/item/stack/material/steel/fifty,
 /obj/item/stack/material/steel/fifty,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qU" = (
 /obj/structure/closet/crate,
@@ -6838,11 +6958,11 @@
 /obj/item/stack/material/marble/fifty,
 /obj/item/stack/material/marble/fifty,
 /obj/random/single/meatstation/meatball,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qV" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "qW" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -6860,10 +6980,14 @@
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/spike,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "qY" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "qZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6877,7 +7001,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/centerhallway)
 "ra" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6892,7 +7016,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/inflatable/door,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "rb" = (
 /obj/structure/lattice,
@@ -6903,7 +7029,7 @@
 /obj/item/stack/material/glass/reinforced/fifty,
 /obj/item/stack/material/glass/reinforced/fifty,
 /obj/item/grenade/chem_grenade/metalfoam,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "rd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6936,7 +7062,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "rf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6946,11 +7074,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "rg" = (
 /obj/structure/girder,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/centerhallway)
 "rh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6972,12 +7102,12 @@
 /area/meatstation/centerhallway)
 "ri" = (
 /obj/structure/inflatable/wall,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/centerhallway)
 "rj" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/inflatable/wall,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "rk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6992,7 +7122,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/inflatable/door,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "rl" = (
 /obj/random/single/meatstation/meatworm,
@@ -7001,7 +7133,9 @@
 /area/meatstation/mess)
 "rm" = (
 /obj/structure/inflatable/wall,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "rn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7012,7 +7146,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/inflatable/door,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "ro" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -7068,11 +7204,13 @@
 /area/meatstation/storage)
 "rs" = (
 /obj/effect/floor_decal/corner/black/bordercorner,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "rt" = (
 /obj/random/single/meatstation/meatball,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "ru" = (
 /obj/structure/closet/emcloset,
@@ -7081,7 +7219,9 @@
 "rv" = (
 /obj/machinery/light/small/red,
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "rw" = (
 /obj/effect/decal/cleanable/blood,
@@ -7094,7 +7234,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "rx" = (
 /obj/effect/decal/cleanable/blood,
@@ -7113,7 +7255,9 @@
 	icon_state = "4-8"
 	},
 /obj/random/junk,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "rz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -7145,7 +7289,7 @@
 /area/meatstation/lab)
 "rC" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "rD" = (
 /obj/structure/cable/cyan{
@@ -7203,7 +7347,7 @@
 	},
 /obj/random/single/meatstation/wormguard,
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "rI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7224,7 +7368,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "rK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7239,7 +7385,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "rL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7254,21 +7400,23 @@
 	icon_state = "1-4"
 	},
 /obj/random/junk,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "rM" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "rN" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "rO" = (
 /obj/random/loot,
@@ -7282,7 +7430,7 @@
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/brown/border,
 /obj/structure/inflatable/wall,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "rR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7321,14 +7469,16 @@
 /area/space)
 "rX" = (
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "rY" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "rZ" = (
 /obj/effect/decal/cleanable/blood,
@@ -7348,7 +7498,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/vomit,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "sb" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -7374,7 +7526,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "sf" = (
 /obj/effect/decal/cleanable/filth,
@@ -7393,7 +7547,9 @@
 "sh" = (
 /obj/effect/floor_decal/corner/black/border,
 /obj/random/single/meatstation/low/wormguard,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "si" = (
 /obj/effect/decal/cleanable/cobweb2,
@@ -7457,7 +7613,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "ss" = (
 /obj/item/paper,
@@ -7502,12 +7660,12 @@
 "sx" = (
 /obj/item/storage/box/large/foam_gun/revolver,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "sy" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood/splatter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/cargo)
 "sz" = (
 /obj/structure/grille/broken,
@@ -7605,7 +7763,7 @@
 /area/meatstation/hydroponics)
 "sI" = (
 /obj/random/single/meatstation/low/wormguard,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "sJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7631,7 +7789,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "sL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -7651,7 +7811,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "sM" = (
 /obj/random/closet,
@@ -7666,11 +7828,13 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "sO" = (
 /obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/dorm)
 "sP" = (
 /obj/structure/closet/firecloset,
@@ -7678,7 +7842,9 @@
 	dir = 10
 	},
 /obj/random/single/meatstation/meatball,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "sQ" = (
 /obj/item/usedcryobag,
@@ -7771,11 +7937,11 @@
 /area/meatstation/storage)
 "tc" = (
 /obj/random/single/meatstation/meatworm,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "td" = (
 /obj/random/single/meatstation/meatworm,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/meatstation/kitchen)
 "te" = (
 /obj/structure/table/glass,
@@ -7792,7 +7958,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/single/meatstation/meatworm,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "tg" = (
 /obj/structure/table/glass,
@@ -7914,7 +8080,9 @@
 	icon_state = "1-2"
 	},
 /obj/random/single/meatstation/meatworm,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "tt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7936,13 +8104,17 @@
 /area/meatstation/swhallway)
 "tu" = (
 /obj/random/single/meatstation/meatball,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "tv" = (
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "tw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -7953,7 +8125,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "tx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7968,7 +8142,9 @@
 	icon_state = "4-8"
 	},
 /obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "ty" = (
 /obj/structure/bed/chair/office/comfy/black,
@@ -8018,7 +8194,7 @@
 "tC" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "tD" = (
 /obj/random/junk,
@@ -8027,7 +8203,9 @@
 /area/meatstation/storage)
 "tE" = (
 /obj/item/remains/human,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "tF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8039,7 +8217,9 @@
 	},
 /obj/random/single/meatstation/meatworm,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "tG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8054,11 +8234,15 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "tH" = (
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "tI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8087,7 +8271,7 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "tM" = (
 /obj/machinery/button/alternate/door/bolts{
@@ -8103,11 +8287,11 @@
 	pixel_y = 30
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "tN" = (
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "tO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8119,7 +8303,9 @@
 	},
 /obj/random/single/meatstation/meatball,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "tP" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -8194,14 +8380,18 @@
 	icon_state = "4-8"
 	},
 /obj/random/single/meatstation/low/wormguard,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "tW" = (
 /obj/effect/decal/cleanable/filth,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "tX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8247,35 +8437,45 @@
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "uc" = (
 /obj/structure/roller_bed,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "ud" = (
 /obj/random/single/meatstation/wormscientist,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "ue" = (
 /obj/random/junk,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "uf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "ug" = (
 /obj/random/junk,
@@ -8285,13 +8485,17 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "uh" = (
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "ui" = (
 /obj/effect/decal/cleanable/blood,
@@ -8312,7 +8516,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/closet/firecloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "ul" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8323,14 +8529,18 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "um" = (
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
 /obj/random/single/meatstation/meatworm,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "un" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -8339,7 +8549,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "uo" = (
 /obj/item/clothing/accessory/badge/press,
@@ -8381,7 +8593,9 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/random/single/meatstation/meatworm,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "uu" = (
 /obj/item/clothing/under/wetsuit,
@@ -8394,7 +8608,7 @@
 	},
 /obj/effect/floor_decal/corner/purple/border,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "uw" = (
 /obj/machinery/vending/lavatory,
@@ -8406,7 +8620,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "uy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8417,7 +8633,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/inflatable/door,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "uz" = (
 /obj/structure/inflatable/wall,
@@ -8436,7 +8652,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "uB" = (
 /obj/effect/decal/cleanable/blood,
@@ -8451,7 +8667,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "uD" = (
 /obj/structure/cable/cyan{
@@ -8472,25 +8688,25 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "uF" = (
 /obj/item/storage/box/monkeycubes/farwacubes,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "uG" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/lights/bulbs,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "uH" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/canned_beans,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "uI" = (
 /obj/structure/table/rack,
@@ -8509,20 +8725,20 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "uK" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/lights/tubes/random,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "uL" = (
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "uM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8533,7 +8749,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "uN" = (
 /obj/structure/closet/crate/trashcart,
@@ -8555,7 +8773,9 @@
 	},
 /obj/random/single/meatstation/meatball,
 /obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "uP" = (
 /obj/effect/floor_decal/corner/lightgrey/border{
@@ -8573,7 +8793,9 @@
 	},
 /obj/random/single/meatstation/meatworm,
 /obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "uR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8612,7 +8834,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "uU" = (
 /obj/machinery/light{
@@ -8632,7 +8856,7 @@
 /area/meatstation/centerhallway)
 "uW" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "uX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8648,7 +8872,9 @@
 	},
 /obj/random/junk,
 /obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "uY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -8661,7 +8887,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "uZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8677,7 +8905,9 @@
 	},
 /obj/random/single/meatstation/meatworm,
 /obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "va" = (
 /obj/item/storage/bag/trash,
@@ -8797,7 +9027,9 @@
 /obj/machinery/light/small/red{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "vo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8810,7 +9042,9 @@
 /obj/machinery/light/small/red{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/nwhallway)
 "vp" = (
 /obj/structure/table/rack,
@@ -8834,26 +9068,26 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "vr" = (
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "vs" = (
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "vt" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "vu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8868,14 +9102,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light/small/red,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "vv" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/lights/bulbs,
 /obj/random/maintenance/clean,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "vw" = (
 /obj/machinery/light{
@@ -9042,7 +9276,9 @@
 	dir = 8
 	},
 /obj/random/single/meatstation/meatworm,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "vR" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -9051,7 +9287,7 @@
 /obj/effect/floor_decal/corner/lime/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "vS" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -9059,7 +9295,7 @@
 	dir = 10
 	},
 /obj/structure/inflatable/wall,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "vT" = (
 /obj/machinery/light/small/red,
@@ -9133,7 +9369,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "wf" = (
 /obj/machinery/light/small/red,
@@ -9365,7 +9603,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "wG" = (
 /obj/machinery/artifact_scanpad,
@@ -9379,7 +9617,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "wI" = (
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary,
@@ -9398,36 +9636,36 @@
 "wK" = (
 /obj/random/toy,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "wL" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "wM" = (
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "wN" = (
 /obj/item/storage/box/swabs,
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "wO" = (
 /obj/structure/table/rack,
 /obj/item/extinguisher,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "wP" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/botanydisk,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "wQ" = (
 /obj/item/storage/box/monkeycubes,
@@ -9437,7 +9675,7 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "wR" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -9447,21 +9685,21 @@
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "wS" = (
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "wT" = (
 /obj/item/storage/box/monkeycubes/stokcubes,
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "wU" = (
 /obj/structure/table/rack,
@@ -9475,28 +9713,28 @@
 "wV" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/brown/border,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "wW" = (
 /obj/effect/floor_decal/corner/brown/border,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "wX" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
 /obj/effect/floor_decal/corner/brown/border,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "wY" = (
 /obj/item/stack/material/rods,
 /obj/structure/inflatable/wall,
 /obj/effect/floor_decal/corner/brown/border,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "wZ" = (
 /obj/effect/floor_decal/corner/brown/border{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "xa" = (
 /obj/effect/floor_decal/corner/lightgrey/border{
@@ -9615,7 +9853,7 @@
 /obj/machinery/door/window/southleft,
 /obj/effect/floor_decal/corner/purple/diagonal,
 /obj/item/cell/high,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "xq" = (
 /obj/machinery/floodlight,
@@ -9651,24 +9889,24 @@
 	},
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/lime/border,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "xw" = (
 /obj/machinery/smartfridge/drying_rack{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/lime/border,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "xx" = (
 /obj/machinery/gibber,
 /obj/effect/floor_decal/corner/lime/border,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "xy" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/lime/border,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/kitchen)
 "xz" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -9736,17 +9974,17 @@
 "xJ" = (
 /obj/machinery/vending/tool,
 /obj/effect/floor_decal/corner/purple/border,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "xK" = (
 /obj/machinery/vending/tool,
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/purple/border,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "xL" = (
 /obj/effect/floor_decal/corner/purple/border,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "xM" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -9755,7 +9993,7 @@
 	},
 /obj/machinery/door/window/northleft,
 /obj/effect/floor_decal/corner/purple/border,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "xN" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -9765,7 +10003,7 @@
 /obj/machinery/door/window/northright,
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/purple/border,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "xO" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -9774,7 +10012,7 @@
 	},
 /obj/machinery/door/window/northright,
 /obj/effect/floor_decal/corner/purple/border,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "xP" = (
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -9785,7 +10023,7 @@
 /obj/effect/floor_decal/corner/purple/border{
 	dir = 6
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "xQ" = (
 /obj/structure/closet/toolcloset,
@@ -9795,7 +10033,7 @@
 /obj/machinery/door/window/southleft,
 /obj/item/clothing/ring/material/gold,
 /obj/effect/floor_decal/corner/purple/diagonal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "xR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9811,7 +10049,7 @@
 	},
 /obj/machinery/pipedispenser,
 /obj/effect/floor_decal/corner/purple/diagonal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "xS" = (
 /obj/structure/table/glass,
@@ -9829,31 +10067,33 @@
 "xU" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "xV" = (
 /obj/structure/closet/crate,
 /obj/item/stack/material/glass/fifty,
 /obj/item/stack/material/glass/fifty,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "xW" = (
 /obj/item/storage/backpack/dufflebag,
 /obj/random/maintenance/clean,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "xX" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/floor_decal/corner/brown/diagonal,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "xY" = (
 /obj/effect/floor_decal/corner/black/border{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "xZ" = (
 /obj/machinery/light/small/red{
@@ -9862,20 +10102,26 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "ya" = (
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yb" = (
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9889,27 +10135,35 @@
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "ye" = (
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yg" = (
 /obj/random/single/meatstation/low/wormscientist,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yh" = (
 /obj/structure/barricade/spike{
@@ -9918,21 +10172,27 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yi" = (
 /obj/random/junk,
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yj" = (
 /obj/structure/inflatable/wall,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -9940,14 +10200,18 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yl" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "ym" = (
 /obj/machinery/light/small/red{
@@ -9956,7 +10220,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -9965,57 +10231,75 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yo" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yq" = (
 /obj/effect/floor_decal/corner/black/border{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yr" = (
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yt" = (
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yu" = (
 /obj/structure/barricade/spike,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yv" = (
 /obj/random/junk,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yx" = (
 /obj/structure/inflatable/wall,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yz" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small/red,
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10032,7 +10316,9 @@
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yB" = (
 /obj/structure/barricade/spike,
@@ -10042,28 +10328,36 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yC" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yD" = (
 /obj/random/junk,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yE" = (
 /obj/random/single/meatstation/meatworm,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yG" = (
 /obj/effect/decal/cleanable/blood,
@@ -10071,14 +10365,18 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yH" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10093,45 +10391,59 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/corner/black/bordercorner,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yL" = (
 /obj/structure/barricade/spike{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yM" = (
 /obj/random/single/meatstation/meatworm,
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yN" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yO" = (
 /obj/effect/floor_decal/corner/black/bordercorner,
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yP" = (
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10144,7 +10456,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yR" = (
 /obj/effect/floor_decal/corner/black/border{
@@ -10153,7 +10467,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10167,7 +10483,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yT" = (
 /obj/machinery/light/small/red{
@@ -10179,7 +10497,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yU" = (
 /obj/structure/barricade/spike,
@@ -10189,7 +10509,9 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "yV" = (
 /obj/structure/stasis_cage,
@@ -10204,7 +10526,7 @@
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "yX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10443,7 +10765,9 @@
 	name = "exterior lab bolt control";
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "zC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10469,7 +10793,9 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "zE" = (
 /obj/structure/cable/cyan{
@@ -10684,12 +11010,14 @@
 	dir = 4
 	},
 /obj/random/single/meatstation/low/wormguard,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "zZ" = (
 /obj/random/maintenance/clean,
 /obj/random/single/meatstation/meatball,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "Aa" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10705,12 +11033,14 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/random/single/meatstation/meatball,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "Ab" = (
 /obj/effect/floor_decal/corner/purple/border,
 /obj/random/single/meatstation/meatball,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "Ad" = (
 /obj/structure/cable/cyan{
@@ -10780,7 +11110,7 @@
 	id_tag = "meatstation_nairlockint";
 	locked = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/meatstation/engineering)
 "Ak" = (
 /obj/structure/hygiene/shower{
@@ -10802,7 +11132,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "Am" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10839,7 +11171,9 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/meatstation/centerhallway)
 "Ao" = (
 /obj/machinery/door/airlock/vault/bolted{
@@ -10886,7 +11220,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "Ar" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10903,18 +11237,18 @@
 "As" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/meatstation/kitchen)
 "At" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "Av" = (
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/meatstation/kitchen)
 "Aw" = (
 /obj/machinery/door/window/southleft,
@@ -11000,6 +11334,12 @@
 /obj/item/cell/high,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/meatstation/storage)
+"Ut" = (
+/obj/structure/girder,
+/turf/simulated/floor{
+	map_airless = 1
+	},
+/area/meatstation/centerhallway)
 
 (1,1,1) = {"
 aa
@@ -33907,7 +34247,7 @@ lX
 bs
 jB
 aa
-rg
+Ut
 rm
 qZ
 ri
@@ -35124,7 +35464,7 @@ aa
 aQ
 aa
 aa
-rg
+Ut
 ah
 ah
 ah
@@ -35523,7 +35863,7 @@ jA
 bs
 aa
 aa
-rg
+Ut
 qY
 re
 rf

--- a/maps/away/meatstation/meatstation_areas.dm
+++ b/maps/away/meatstation/meatstation_areas.dm
@@ -4,6 +4,7 @@
 /area/meatstation/cargo
 	name = "Cargo Dock"
 	icon_state = "mscargo"
+	turfs_airless = TRUE
 
 /area/meatstation/cargooffice
 	name = "Cargo Office"
@@ -16,10 +17,12 @@
 /area/meatstation/engineering
 	name = "Engineering"
 	icon_state = "msengineering"
+	turfs_airless = TRUE
 
 /area/meatstation/dorm
 	name = "Dorms"
 	icon_state = "msdorm"
+	turfs_airless = TRUE
 
 /area/meatstation/mess
 	name = "Mess"
@@ -32,6 +35,7 @@
 /area/meatstation/kitchen
 	name = "Kitchen"
 	icon_state = "mskitchen"
+	turfs_airless = TRUE
 
 /area/meatstation/storage
 	name = "Storage"

--- a/maps/away/mining/mining-asteroid.dmm
+++ b/maps/away/mining/mining-asteroid.dmm
@@ -17,49 +17,49 @@
 /area/mine/explored)
 "al" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "am" = (
 /obj/machinery/constructable_frame/computerframe,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "an" = (
 /obj/machinery/tele_projector,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "ao" = (
 /obj/machinery/tele_pad,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "ap" = (
 /obj/structure/table/glass,
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "aq" = (
 /obj/structure/table/glass,
 /obj/random/maintenance,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "ar" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "as" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "at" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "av" = (
 /obj/structure/table/glass,
 /obj/random/loot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "aw" = (
 /obj/random/closet,
 /obj/random/loot,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "ax" = (
 /obj/random/junk,
@@ -71,143 +71,143 @@
 	tag_exterior_door = "lp_north_outer";
 	tag_interior_door = "lp_north_inner"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "ay" = (
 /obj/machinery/constructable_frame/computerframe,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "az" = (
 /obj/structure/table/rack,
 /obj/random/maintenance,
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "aA" = (
 /obj/structure/table/reinforced,
 /obj/random/maintenance,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "aB" = (
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "aC" = (
 /obj/structure/table/reinforced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "aE" = (
 /obj/structure/table/reinforced,
 /obj/random/loot,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "aF" = (
 /obj/structure/table/reinforced,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "aG" = (
 /obj/random/maintenance,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "aH" = (
 /obj/structure/barricade,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "aI" = (
 /obj/random/closet,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "aJ" = (
 /obj/structure/table,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "aK" = (
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "aL" = (
 /turf/simulated/wall,
 /area/djstation)
 "aM" = (
 /obj/structure/grille,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "aN" = (
 /obj/structure/grille/broken,
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "aO" = (
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "aP" = (
 /obj/structure/grille/broken,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "aQ" = (
 /obj/random/medical,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "aR" = (
 /obj/structure/bed,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "aS" = (
 /turf/unsimulated/mask,
 /area/mine/explored)
 "aT" = (
 /obj/random/loot,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "aU" = (
 /obj/random/closet,
 /obj/random/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "aV" = (
 /obj/structure/flora/pottedplant/dead,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "aW" = (
 /obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "aX" = (
 /obj/structure/table/steel,
 /obj/random/maintenance,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "aY" = (
 /obj/random/closet,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "aZ" = (
 /obj/structure/table/rack,
 /obj/random/maintenance,
 /obj/random/maintenance,
 /obj/random/action_figure,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "ba" = (
 /obj/structure/table/rack,
 /obj/random/maintenance,
 /obj/random/maintenance,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "bb" = (
 /obj/structure/table/rack,
 /obj/random/junk,
 /obj/random/maintenance,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "bc" = (
 /obj/structure/girder,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "bd" = (
 /obj/structure/largecrate,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "be" = (
 /obj/random/maintenance,
@@ -260,7 +260,7 @@
 	id_tag = "lp_north_outer";
 	locked = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "lb" = (
 /turf/unsimulated/mask,
@@ -274,13 +274,13 @@
 	master_tag = "lp_north_airlock";
 	pixel_x = 24
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "nb" = (
 /obj/machinery/door/airlock/multi_tile{
 	name = "Glass Airlock"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "ob" = (
 /obj/machinery/door/airlock/external{
@@ -290,19 +290,19 @@
 	locked = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "qb" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "rb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "sb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -313,13 +313,13 @@
 	name = "interior access button";
 	pixel_y = 24
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "tb" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 9
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "ub" = (
 /obj/machinery/access_button{
@@ -330,7 +330,7 @@
 	pixel_x = 24;
 	req_access = null
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "vb" = (
 /obj/machinery/access_button{
@@ -353,7 +353,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "xb" = (
 /obj/random/trash,
@@ -365,7 +365,7 @@
 	dir = 8;
 	id_tag = "lp_east_pump"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "yb" = (
 /obj/random/maintenance,
@@ -377,7 +377,7 @@
 	tag_exterior_door = "lp_east_outer";
 	tag_interior_door = "lp_east_inner"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "zb" = (
 /obj/machinery/door/airlock/external{
@@ -386,23 +386,23 @@
 	id_tag = "lp_east_outer";
 	locked = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "Ab" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/djstation)
 "Db" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 "Eb" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/djstation)
 
 (1,1,1) = {"

--- a/maps/away/mining/mining-orb.dmm
+++ b/maps/away/mining/mining-orb.dmm
@@ -29,14 +29,14 @@
 /turf/simulated/wall/sandstone,
 /area/mine/unexplored)
 "aj" = (
-/turf/simulated/floor/airless/stone,
+/turf/simulated/floor/stone,
 /area/mine/explored)
 "ak" = (
-/turf/simulated/floor/fixed/alium/airless,
+/turf/simulated/floor/fixed/alium,
 /area/mine/explored)
 "al" = (
 /obj/structure/monolith,
-/turf/simulated/floor/fixed/alium/airless,
+/turf/simulated/floor/fixed/alium,
 /area/mine/explored)
 "am" = (
 /turf/simulated/wall/alium,
@@ -96,25 +96,25 @@
 /obj/effect/floor_decal/spline/fancy/wood/corner{
 	dir = 1
 	},
-/turf/simulated/floor/airless/stone,
+/turf/simulated/floor/stone,
 /area/mine/explored)
 "aM" = (
 /obj/item/stool/stone,
-/turf/simulated/floor/fixed/alium/airless,
+/turf/simulated/floor/fixed/alium,
 /area/mine/explored)
 "aN" = (
 /obj/machinery/door/unpowered/simple/sandstone{
 	desc = "It opens and closes. It's absolutely dominated by a huge engraving of some kind of bird.";
 	name = "engraved door"
 	},
-/turf/simulated/floor/airless/stone,
+/turf/simulated/floor/stone,
 /area/mine/explored)
 "aP" = (
 /turf/simulated/floor/exoplanet/water/shallow,
 /area/mine/explored)
 "aQ" = (
 /obj/machinery/door/unpowered/simple/sandstone,
-/turf/simulated/floor/airless/stone,
+/turf/simulated/floor/stone,
 /area/mine/explored)
 "aR" = (
 /obj/effect/shuttle_landmark/orb/nav3,
@@ -348,11 +348,11 @@
 "SY" = (
 /obj/structure/fountain/strange,
 /mob/living/simple_animal/hostile/retaliate/parrot/space,
-/turf/simulated/floor/airless/stone,
+/turf/simulated/floor/stone,
 /area/mine/explored)
 "TP" = (
 /obj/structure/totem,
-/turf/simulated/floor/fixed/alium/airless,
+/turf/simulated/floor/fixed/alium,
 /area/mine/explored)
 
 (1,1,1) = {"

--- a/maps/away/mining/mining-signal.dmm
+++ b/maps/away/mining/mining-signal.dmm
@@ -68,15 +68,15 @@
 /area/outpost/abandoned)
 "ar" = (
 /obj/machinery/constructable_frame/computerframe,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/outpost/abandoned)
 "as" = (
 /obj/machinery/tele_projector,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/outpost/abandoned)
 "at" = (
 /obj/machinery/tele_pad,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/outpost/abandoned)
 "au" = (
 /obj/structure/table,
@@ -565,7 +565,7 @@
 	dir = 8
 	},
 /obj/random/loot,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "cb" = (
 /obj/structure/table/steel,
@@ -573,7 +573,7 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "cc" = (
 /obj/machinery/optable,
@@ -585,7 +585,7 @@
 	icon_state = "bulb1"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "cd" = (
 /obj/machinery/computer/operating,
@@ -594,14 +594,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "ce" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/effect/floor_decal/corner/paleblue/three_quarters{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "cf" = (
 /obj/effect/floor_decal/corner/red/three_quarters{
@@ -713,24 +713,24 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "cv" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "cw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "cx" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "cy" = (
 /obj/effect/decal/cleanable/blood,
@@ -813,7 +813,7 @@
 "cU" = (
 /obj/effect/floor_decal/corner/paleblue/three_quarters,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "cV" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -821,11 +821,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "cW" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "cX" = (
 /obj/effect/decal/cleanable/blood,
@@ -834,14 +834,14 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/random/loot,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "cY" = (
 /obj/effect/floor_decal/corner/paleblue/three_quarters{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "cZ" = (
 /obj/effect/floor_decal/corner/red/three_quarters,
@@ -948,7 +948,7 @@
 	opacity = 0
 	},
 /obj/machinery/holosign/surgery,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "dt" = (
 /obj/structure/door_assembly{
@@ -988,7 +988,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/outpost/abandoned)
 "dD" = (
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "dE" = (
 /obj/effect/decal/remains,
@@ -997,7 +997,7 @@
 	icon_state = "shardlarge"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "dF" = (
 /obj/structure/table,
@@ -1008,16 +1008,16 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "dG" = (
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "dH" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "dI" = (
 /obj/effect/decal/cleanable/cobweb,
@@ -1026,18 +1026,18 @@
 	icon_state = "alarmx";
 	pixel_x = -23
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "dJ" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/structure/table/steel,
 /obj/random/bomb_supply,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "dK" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/structure/bed/chair,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "dL" = (
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -1046,18 +1046,18 @@
 	dir = 1;
 	icon_state = "bulb1"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "dM" = (
 /obj/structure/bed/chair,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "dN" = (
 /obj/machinery/vending/snack{
 	icon_state = "snack-broken";
 	reason_broken = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "dO" = (
 /obj/structure/ore_box,
@@ -1065,7 +1065,7 @@
 /area/outpost/abandoned)
 "dP" = (
 /obj/structure/closet/crate/large,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "dQ" = (
 /obj/structure/sign/directions/science{
@@ -1097,7 +1097,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "dV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1108,7 +1108,7 @@
 /area/outpost/abandoned)
 "dW" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "dY" = (
 /obj/structure/extinguisher_cabinet{
@@ -1120,7 +1120,7 @@
 	icon_state = "bulb1"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "dZ" = (
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -1130,7 +1130,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "eb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1142,28 +1142,28 @@
 "ec" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "ed" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/effect/decal/cleanable/blood/oil,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "ee" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "ef" = (
 /obj/machinery/light/small/emergency{
 	dir = 1;
 	icon_state = "bulb1"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "eg" = (
 /obj/effect/decal/cleanable/cobweb2,
 /obj/item/ammo_magazine/pistol/small,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "eh" = (
 /obj/structure/hygiene/sink/puddle,
@@ -1220,13 +1220,13 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "es" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "et" = (
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -1238,18 +1238,18 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "eu" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /mob/living/bot/medbot,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "ev" = (
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "ex" = (
 /obj/structure/sign/directions/medical{
@@ -1268,7 +1268,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/gibspawner/human,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "eB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/red,
@@ -1279,11 +1279,11 @@
 /area/outpost/abandoned)
 "eC" = (
 /obj/item/ammo_magazine/pistol/small,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "eD" = (
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "eE" = (
 /obj/machinery/door/blast/regular{
@@ -1343,7 +1343,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "eO" = (
 /obj/structure/table/glass,
@@ -1352,7 +1352,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/random/loot,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "eP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1364,7 +1364,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "eR" = (
 /obj/structure/door_assembly,
@@ -1372,7 +1372,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "eS" = (
 /obj/effect/decal/cleanable/blood,
@@ -1382,20 +1382,20 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "eT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
 /obj/random/trash,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "eU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "eV" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1413,7 +1413,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "eX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1423,7 +1423,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "eY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1432,21 +1432,21 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "eZ" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "fa" = (
 /obj/effect/decal/cleanable/ash,
 /obj/machinery/atmospherics/pipe/simple/hidden/green{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "fb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1462,15 +1462,15 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_magazine/pistol/small,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "fd" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/ammo_magazine/pistol/small,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "fe" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/mine/explored)
 "fh" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1498,7 +1498,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "fm" = (
 /turf/simulated/floor/plating{
@@ -1509,13 +1509,13 @@
 /obj/random/medical,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "fq" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "fr" = (
 /obj/structure/window/basic{
@@ -1530,7 +1530,7 @@
 "fs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/vomit,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "ft" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1542,12 +1542,12 @@
 "fu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mopbucket,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "fv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/remains,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "fw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1560,7 +1560,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_magazine/pistol/small,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "fy" = (
 /obj/effect/floor_decal/asteroid,
@@ -1606,7 +1606,7 @@
 /area/outpost/abandoned)
 "fE" = (
 /obj/effect/floor_decal/corner/paleblue/three_quarters,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "fF" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -1614,7 +1614,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "fG" = (
 /obj/structure/mech_wreckage/powerloader,
@@ -1623,11 +1623,11 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "fH" = (
 /obj/random/firstaid,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "fI" = (
 /turf/simulated/floor/grass,
@@ -1645,11 +1645,11 @@
 /area/outpost/abandoned)
 "fK" = (
 /obj/effect/decal/cleanable/blood/gibs/down,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "fL" = (
 /obj/item/newspaper,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "fM" = (
 /obj/machinery/firealarm{
@@ -1657,7 +1657,7 @@
 	icon_state = "firex";
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "fN" = (
 /obj/machinery/requests_console{
@@ -1665,7 +1665,7 @@
 	pixel_y = -32;
 	reason_broken = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "fO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1679,7 +1679,7 @@
 	name = "south bump";
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "fP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1690,15 +1690,15 @@
 	dir = 4;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "fQ" = (
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "fR" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/mine/explored)
 "fS" = (
 /obj/effect/decal/cleanable/blood,
@@ -1771,7 +1771,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "gb" = (
 /turf/simulated/floor/plating,
@@ -1811,7 +1811,7 @@
 /area/outpost/abandoned)
 "gi" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_broken0"
 	},
 /area/mine/explored)
@@ -1845,7 +1845,7 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "go" = (
 /obj/machinery/door/airlock/external,
@@ -1925,7 +1925,7 @@
 	dir = 8;
 	icon_state = "bulb1"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "gz" = (
 /obj/machinery/door/airlock/external{
@@ -1950,7 +1950,7 @@
 /turf/simulated/floor/plating,
 /area/outpost/abandoned)
 "gC" = (
-/turf/simulated/floor/tiled/airless{
+/turf/simulated/floor/tiled{
 	icon_state = "steel_broken4"
 	},
 /area/mine/explored)
@@ -1965,14 +1965,14 @@
 "gE" = (
 /obj/effect/decal/cleanable/blood/tracks/footprints,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "gF" = (
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "gH" = (
 /obj/structure/cable/orange{
@@ -2005,11 +2005,11 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "gL" = (
 /obj/effect/decal/cleanable/blood/tracks/footprints,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "gM" = (
 /obj/item/solar_assembly,
@@ -2023,7 +2023,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "gO" = (
 /obj/effect/decal/cleanable/blood/tracks/footprints,
@@ -2038,7 +2038,7 @@
 "gP" = (
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "gQ" = (
 /obj/structure/cable/orange{
@@ -2054,7 +2054,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "gS" = (
 /obj/machinery/firealarm{
@@ -2062,7 +2062,7 @@
 	icon_state = "firex";
 	pixel_x = 26
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "gT" = (
 /obj/effect/floor_decal/solarpanel,
@@ -2145,7 +2145,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "hb" = (
 /obj/structure/bed/chair,
@@ -2153,7 +2153,7 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "hc" = (
 /obj/structure/table/steel,
@@ -2163,7 +2163,7 @@
 	dir = 5;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "he" = (
 /obj/effect/floor_decal/solarpanel,
@@ -2193,11 +2193,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "hj" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "hk" = (
 /obj/structure/bed/chair{
@@ -2207,17 +2207,17 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "hl" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "hm" = (
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "hn" = (
 /obj/effect/floor_decal/solarpanel,
@@ -2248,7 +2248,7 @@
 /obj/structure/cable/orange{
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "hs" = (
 /obj/structure/cable/orange{
@@ -2257,7 +2257,7 @@
 	icon_state = "4-8"
 	},
 /obj/random/loot,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "ht" = (
 /obj/structure/cable/orange{
@@ -2265,7 +2265,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "hu" = (
 /obj/machinery/light/small/emergency,
@@ -2274,7 +2274,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "hv" = (
 /obj/item/gun/energy/plasmacutter,
@@ -2283,7 +2283,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "hw" = (
 /obj/structure/cable/orange{
@@ -2297,7 +2297,7 @@
 /obj/machinery/power/solar_control/autostart{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/outpost/abandoned)
 "hx" = (
 /obj/structure/cable/orange{
@@ -2530,7 +2530,7 @@
 "HD" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/outpost/abandoned)
 "IX" = (
 /obj/machinery/door/firedoor,

--- a/maps/away/mining/mining.dm
+++ b/maps/away/mining/mining.dm
@@ -235,9 +235,10 @@
 /obj/item/stool/stone/New(newloc)
 	..(newloc,"sandstone")
 
-/turf/simulated/floor/airless/stone
+/turf/simulated/floor/stone
 	name = "temple floor"
 	desc = "You can only imagine what once took place in these halls."
 	icon = 'icons/turf/flooring/cult.dmi'
 	icon_state = "cult_g"
 	color = "#c9ae5e"
+	map_airless = TRUE

--- a/maps/away/mining/mining_areas.dm
+++ b/maps/away/mining/mining_areas.dm
@@ -4,6 +4,7 @@
 	ambience = list('sound/ambience/ambimine.ogg', 'sound/ambience/song_game.ogg')
 	sound_env = ASTEROID
 	base_turf = /turf/simulated/floor/asteroid
+	turfs_airless = TRUE
 
 /area/mine/explored
 	name = "Mine"
@@ -17,7 +18,9 @@
 /area/outpost/abandoned
 	name = "Abandoned Outpost"
 	icon_state = "dark"
+	turfs_airless = TRUE
 
 /area/djstation
 	name = "\improper Listening Post"
 	icon_state = "LP"
+	turfs_airless = TRUE

--- a/maps/away/miningstation/miningstation.dmm
+++ b/maps/away/miningstation/miningstation.dmm
@@ -8,7 +8,9 @@
 /area/space)
 "ad" = (
 /obj/machinery/door/blast/regular,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "ae" = (
 /obj/machinery/door/blast/regular,
@@ -54,7 +56,9 @@
 	dir = 6
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "am" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -64,7 +68,9 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "an" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -74,7 +80,9 @@
 	dir = 10
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "ao" = (
 /obj/structure/lattice,
@@ -84,7 +92,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "aq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -98,45 +108,59 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "as" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "at" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "au" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "av" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "aw" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "ax" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "ay" = (
 /obj/machinery/alarm{
@@ -157,7 +181,9 @@
 	dir = 8
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "aB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -165,7 +191,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "aC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -206,7 +234,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "aH" = (
 /obj/machinery/power/terminal{
@@ -222,7 +252,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "aI" = (
 /obj/structure/grille,
@@ -244,10 +276,14 @@
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "aM" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "aN" = (
 /obj/structure/cable{
@@ -255,7 +291,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "aO" = (
 /obj/structure/cable{
@@ -263,7 +301,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "aP" = (
 /obj/structure/cable{
@@ -281,7 +321,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "aQ" = (
 /obj/machinery/power/tracker,
@@ -289,7 +331,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "aR" = (
 /obj/structure/cable{
@@ -297,7 +341,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "aS" = (
 /obj/structure/sign/warning/hot_exhaust,
@@ -310,7 +356,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "aV" = (
 /obj/structure/cable{
@@ -328,7 +376,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "aW" = (
 /obj/structure/cable{
@@ -343,11 +393,15 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "aX" = (
 /obj/machinery/atmospherics/unary/engine,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/fix)
 "aY" = (
 /obj/structure/fuel_port,
@@ -358,7 +412,9 @@
 	dir = 10;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "bc" = (
 /obj/structure/shuttle/engine/heater{
@@ -368,14 +424,18 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/fix)
 "bd" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "be" = (
 /obj/structure/window/reinforced,
@@ -383,7 +443,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/fix)
 "bf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -398,7 +460,9 @@
 	icon_state = "warning";
 	pixel_y = 6
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "bg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -413,7 +477,9 @@
 	icon_state = "warning";
 	pixel_y = 6
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "bh" = (
 /obj/structure/cable{
@@ -429,7 +495,9 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/light,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "bi" = (
 /obj/structure/cable{
@@ -444,7 +512,9 @@
 	dir = 9
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "bj" = (
 /obj/machinery/power/terminal{
@@ -455,7 +525,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "bk" = (
 /obj/structure/cable{
@@ -538,7 +610,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "br" = (
 /obj/structure/cable{
@@ -551,7 +625,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "bs" = (
 /obj/structure/cable{
@@ -564,7 +640,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "bt" = (
 /obj/structure/cable{
@@ -572,7 +650,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "bu" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -634,7 +714,7 @@
 "bE" = (
 /obj/structure/catwalk,
 /obj/structure/closet/toolcloset,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "bF" = (
 /obj/structure/cable{
@@ -643,12 +723,12 @@
 	icon_state = "1-2"
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "bG" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "bH" = (
 /obj/structure/cable{
@@ -666,7 +746,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "bI" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -695,7 +777,7 @@
 /area/miningstation/prep2)
 "bO" = (
 /obj/structure/catwalk,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "bP" = (
 /obj/effect/paint/black,
@@ -781,10 +863,14 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 9
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/fix)
 "ch" = (
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/fix)
 "ci" = (
 /turf/simulated/floor/tiled/white,
@@ -890,14 +976,18 @@
 /area/miningstation/power)
 "cy" = (
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "cz" = (
 /obj/structure/catwalk,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "cA" = (
 /obj/item/device/radio/intercom,
@@ -914,7 +1004,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "cD" = (
 /obj/machinery/power/solar/improved,
@@ -923,7 +1015,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "cE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -935,7 +1029,9 @@
 	icon_state = "warning";
 	pixel_y = 6
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "cF" = (
 /obj/structure/catwalk,
@@ -944,7 +1040,9 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "cG" = (
 /obj/machinery/power/solar_control,
@@ -953,7 +1051,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "cH" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -1012,12 +1112,16 @@
 /obj/random/tool,
 /obj/random/tool,
 /obj/random/toolbox,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "cR" = (
 /obj/structure/catwalk,
 /obj/machinery/computer/atmos_alert,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "cS" = (
 /obj/structure/cable{
@@ -1029,7 +1133,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "cT" = (
 /obj/structure/cable{
@@ -1044,12 +1150,16 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "cU" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "cV" = (
 /obj/structure/catwalk,
@@ -1066,14 +1176,18 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/smes/buildable/outpost_substation,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "cW" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "cX" = (
 /obj/machinery/alarm{
@@ -1268,26 +1382,34 @@
 "dr" = (
 /obj/structure/closet/crate/solar_assembly,
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "ds" = (
 /obj/structure/catwalk,
 /obj/structure/bed/chair/office{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "dt" = (
 /obj/structure/catwalk,
 /obj/structure/table/steel,
 /obj/item/paper_bin,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "du" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /mob/living/simple_animal/hostile/meat/strippedhuman,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "dv" = (
 /obj/structure/cable{
@@ -1544,7 +1666,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "dP" = (
 /obj/structure/cable{
@@ -1560,7 +1684,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "dQ" = (
 /obj/structure/cable{
@@ -1577,7 +1703,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "dR" = (
 /obj/structure/cable{
@@ -1592,7 +1720,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "dS" = (
 /obj/structure/cable{
@@ -1602,7 +1732,9 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "dT" = (
 /obj/machinery/power/solar/improved,
@@ -1615,7 +1747,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "dV" = (
 /obj/machinery/firealarm{
@@ -2142,7 +2276,9 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/light,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "fc" = (
 /obj/structure/cable{
@@ -2174,7 +2310,9 @@
 	icon_state = "warning";
 	pixel_y = 6
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "fg" = (
 /turf/simulated/floor/tiled/techfloor,
@@ -2365,7 +2503,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/atmos)
 "fK" = (
 /obj/structure/table/rack,
@@ -2463,7 +2603,9 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/fix)
 "gb" = (
 /obj/structure/bed/chair/shuttle/blue{
@@ -2518,7 +2660,9 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/fix)
 "gi" = (
 /obj/effect/paint/black,
@@ -2583,7 +2727,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/operationshall2)
 "gr" = (
 /obj/effect/paint/black,
@@ -2607,7 +2753,9 @@
 	icon_state = "warning";
 	pixel_y = 6
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "gu" = (
 /obj/item/device/radio/intercom,
@@ -2691,7 +2839,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "gG" = (
 /obj/structure/filingcabinet/filingcabinet,
@@ -2726,7 +2876,9 @@
 "gL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/atmos)
 "gM" = (
 /obj/machinery/alarm,
@@ -2763,7 +2915,9 @@
 	dir = 4;
 	start_pressure = 4559.63
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/atmos)
 "gT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -2777,7 +2931,9 @@
 	},
 /obj/structure/catwalk,
 /mob/living/simple_animal/hostile/meat/strippedhuman,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/atmos)
 "gU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3026,7 +3182,9 @@
 "hm" = (
 /obj/structure/catwalk,
 /obj/machinery/computer/atmos_alert,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/atmos)
 "hn" = (
 /obj/machinery/door/airlock/civilian,
@@ -3055,7 +3213,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/atmos)
 "hp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3077,7 +3237,9 @@
 	pixel_x = 24
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/atmos)
 "hq" = (
 /obj/machinery/cryopod{
@@ -3268,14 +3430,18 @@
 "hJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/atmos)
 "hK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/atmos)
 "hL" = (
 /obj/structure/catwalk,
@@ -3285,7 +3451,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/atmos)
 "hM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3587,7 +3755,9 @@
 /area/miningstation/intensive)
 "iw" = (
 /obj/item/pipe/injector,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/atmos)
 "ix" = (
 /obj/machinery/power/terminal,
@@ -4743,7 +4913,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/dorms3)
 "lj" = (
 /obj/machinery/light{
@@ -5220,7 +5392,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/dorms2)
 "md" = (
 /obj/structure/cable{
@@ -5253,7 +5427,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/dorms)
 "mh" = (
 /obj/machinery/door/airlock/civilian,
@@ -5313,7 +5489,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/mess)
 "mn" = (
 /obj/item/device/radio/intercom,
@@ -5342,7 +5520,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/mess)
 "mr" = (
 /obj/effect/paint/black,
@@ -5358,7 +5538,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/kitchen)
 "mt" = (
 /obj/structure/table/steel,
@@ -5698,7 +5880,9 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/mess)
 "nr" = (
 /obj/effect/floor_decal/corner/blue{
@@ -5959,7 +6143,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/atmos)
 "nW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -6014,7 +6200,9 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/mess)
 "oc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6316,7 +6504,9 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/mess)
 "oF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6385,7 +6575,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/kitchen)
 "oK" = (
 /obj/effect/floor_decal/corner/blue{
@@ -6556,7 +6748,9 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/mess)
 "pg" = (
 /obj/structure/table/marble,
@@ -6635,7 +6829,9 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/mess)
 "pq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7545,7 +7741,9 @@
 	icon_state = "0-8"
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "rj" = (
 /obj/structure/catwalk,
@@ -7554,7 +7752,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "rk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -7562,13 +7762,17 @@
 	dir = 1
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/atmos)
 "rl" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/atmos)
 "rm" = (
 /obj/structure/catwalk,
@@ -7581,7 +7785,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "rn" = (
 /obj/machinery/power/terminal,
@@ -7603,7 +7809,9 @@
 	name = "south bump";
 	pixel_y = -28
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "ro" = (
 /obj/structure/catwalk,
@@ -7616,7 +7824,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "rp" = (
 /obj/structure/table/steel,
@@ -7634,7 +7844,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/light,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "rt" = (
 /obj/structure/cable{
@@ -7648,7 +7860,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/miningstation/power)
 "ru" = (
 /obj/structure/table/woodentable/maple,
@@ -7773,7 +7987,9 @@
 	dir = 4;
 	name = "Exterior Vent"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/atmos)
 "rL" = (
 /obj/machinery/light{
@@ -7828,7 +8044,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "vE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7880,7 +8096,9 @@
 	pixel_y = 6
 	},
 /obj/machinery/light,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "xO" = (
 /obj/structure/cable{
@@ -7917,7 +8135,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "yC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7925,7 +8143,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/atmos)
 "yI" = (
 /obj/effect/gibspawner/human,
@@ -7951,7 +8171,9 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "zI" = (
 /obj/effect/paint/black,
@@ -7979,7 +8201,9 @@
 	pixel_y = 6
 	},
 /obj/machinery/light,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "AL" = (
 /obj/machinery/light{
@@ -8272,7 +8496,9 @@
 /area/miningstation/cryo)
 "JX" = (
 /obj/effect/shuttle_landmark/nav_miningstation/hangar,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/miningstation/hangar)
 "Kd" = (
 /obj/machinery/light{

--- a/maps/away/miningstation/miningstation_areas.dm
+++ b/maps/away/miningstation/miningstation_areas.dm
@@ -108,6 +108,7 @@
 	always_unpowered = 1
 	area_flags = AREA_FLAG_EXTERNAL
 	has_gravity = 0
+	turfs_airless = TRUE
 
 /area/miningstation/cryo
 	name = "Cryogenic Storage"

--- a/maps/away/scavver/scavver_gantry-1.dmm
+++ b/maps/away/scavver/scavver_gantry-1.dmm
@@ -5,7 +5,9 @@
 /area/space)
 "ak" = (
 /obj/machinery/suspension_gen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "aL" = (
 /obj/machinery/optable,
@@ -17,7 +19,7 @@
 /area/scavver/calypso)
 "aO" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central7,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "bq" = (
 /obj/structure/railing/mapped{
@@ -38,11 +40,11 @@
 /obj/item/device/oxycandle,
 /obj/item/device/oxycandle,
 /obj/item/storage/box/glowsticks,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "bw" = (
 /obj/structure/ladder/up,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "bC" = (
 /obj/machinery/light/small{
@@ -50,7 +52,9 @@
 	},
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "bG" = (
 /obj/machinery/atmospherics/pipe/cap/visible/fuel{
@@ -69,7 +73,9 @@
 	input_turf = 2
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "bN" = (
 /obj/structure/cable{
@@ -80,7 +86,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "bQ" = (
 /obj/machinery/power/smes/buildable/preset/scavver/smes{
@@ -90,7 +98,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "cg" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
@@ -116,13 +124,13 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "cu" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central4{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "cv" = (
 /obj/structure/lattice,
@@ -139,22 +147,14 @@
 /obj/random/medical,
 /obj/random/medical,
 /obj/random/medical,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "cE" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central4{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
-"cP" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/tiled/white/airless,
-/area/scavver/calypso)
 "db" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -164,7 +164,7 @@
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "dk" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -174,7 +174,7 @@
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 5
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "dv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -183,7 +183,7 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "dM" = (
 /obj/structure/cable{
@@ -202,7 +202,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "ec" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -222,7 +224,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/blue{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "em" = (
 /obj/effect/shuttle_landmark/scavver_gantry/generic/three,
@@ -233,7 +237,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "ev" = (
 /obj/structure/lattice,
@@ -254,7 +258,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "eJ" = (
 /obj/structure/railing/mapped{
@@ -263,21 +269,20 @@
 	},
 /obj/item/device/paint_sprayer,
 /obj/structure/table/rack,
-/obj/item/device/cable_painter,
 /obj/item/hand_labeler,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "eY" = (
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "fc" = (
 /obj/machinery/computer/ship/engines{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "fr" = (
 /obj/structure/cable{
@@ -285,7 +290,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "fs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
@@ -293,7 +298,9 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "fy" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -306,7 +313,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "fA" = (
 /obj/structure/cable{
@@ -316,7 +323,9 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "fE" = (
 /obj/effect/floor_decal/corner/blue/mono,
@@ -357,11 +366,13 @@
 /obj/effect/floor_decal/industrial/loading{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "gf" = (
 /obj/machinery/power/breakerbox,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "gk" = (
 /obj/structure/cable{
@@ -372,11 +383,11 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "gs" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/calypso)
 "gv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
@@ -390,7 +401,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "gA" = (
 /obj/machinery/light/spot,
@@ -402,7 +415,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "gU" = (
 /obj/structure/cable{
@@ -412,7 +425,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/machinery/meter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "gV" = (
 /obj/structure/cable{
@@ -423,13 +436,13 @@
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 6
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "gZ" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "hr" = (
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide{
@@ -443,12 +456,16 @@
 "hu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "hB" = (
 /obj/random/ammo,
 /obj/machinery/atmospherics/pipe/manifold4w/visible/blue,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "hC" = (
 /obj/effect/floor_decal/corner/blue{
@@ -471,7 +488,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "hM" = (
 /obj/structure/cable{
@@ -482,7 +499,9 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "it" = (
 /obj/structure/railing/mapped,
@@ -492,25 +511,25 @@
 /obj/item/storage/briefcase/inflatable,
 /obj/item/storage/briefcase/inflatable,
 /obj/item/device/spaceflare,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "iB" = (
 /obj/structure/cable,
 /obj/machinery/power/solar,
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "iI" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "iK" = (
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "iL" = (
 /obj/structure/railing/mapped,
@@ -522,7 +541,7 @@
 	d2 = 0;
 	icon_state = "16-0"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "iM" = (
 /obj/structure/cable{
@@ -534,7 +553,7 @@
 	dir = 9
 	},
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "jg" = (
 /obj/machinery/atmospherics/pipe/cap/visible/fuel{
@@ -551,18 +570,18 @@
 	tag_west = 1;
 	tag_west_con = 0.15
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "jm" = (
 /obj/effect/shuttle_landmark/lift/gantry/bottom,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "jr" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "jt" = (
 /obj/structure/lattice,
@@ -574,11 +593,11 @@
 /area/space)
 "ju" = (
 /obj/machinery/floodlight,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "jx" = (
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "jy" = (
 /obj/structure/lattice,
@@ -611,14 +630,18 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "jR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/blue,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "jZ" = (
 /obj/structure/cable{
@@ -640,7 +663,7 @@
 	pixel_y = 24;
 	req_access = list()
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "kl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -650,7 +673,9 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen/engine_setup,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "kt" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -664,7 +689,9 @@
 /turf/simulated/floor/wood/yew,
 /area/scavver/yachtdown)
 "kx" = (
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "ky" = (
 /obj/structure/cable{
@@ -672,7 +699,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "kK" = (
 /obj/effect/floor_decal/corner/blue/mono,
@@ -692,7 +721,7 @@
 	},
 /obj/machinery/power/solar,
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "kW" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
@@ -702,7 +731,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/inflatable/door,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "la" = (
 /obj/structure/railing/mapped,
@@ -718,7 +747,7 @@
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/item/module/power_control,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "lz" = (
 /obj/structure/closet/crate/plastic,
@@ -741,7 +770,7 @@
 /obj/item/reagent_containers/glass/bottle/eznutrient,
 /obj/item/reagent_containers/glass/bottle/eznutrient,
 /obj/item/reagent_containers/glass/bottle/eznutrient,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "lD" = (
 /obj/structure/lattice,
@@ -809,7 +838,9 @@
 /area/scavver/calypso)
 "na" = (
 /obj/machinery/anomaly_container,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "nb" = (
 /turf/simulated/wall/titanium,
@@ -830,7 +861,7 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/scavver/calypso)
 "ny" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "nC" = (
 /obj/effect/shuttle_landmark/scavver_gantry/six,
@@ -848,11 +879,11 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "nU" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "oe" = (
 /obj/structure/railing/mapped{
@@ -860,19 +891,21 @@
 	icon_state = "railing0-1"
 	},
 /obj/machinery/mech_recharger,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "ox" = (
 /obj/machinery/floodlight,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "oC" = (
 /obj/machinery/atmospherics/binary/pump,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "oE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "oG" = (
 /obj/machinery/power/apc{
@@ -882,7 +915,7 @@
 	req_access = list()
 	},
 /obj/structure/cable,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "oH" = (
 /obj/effect/floor_decal/corner/blue/mono,
@@ -909,7 +942,7 @@
 /obj/item/clamp,
 /obj/item/clamp,
 /obj/item/clamp,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "oW" = (
 /obj/structure/cable{
@@ -927,7 +960,7 @@
 	id_tag = "scavver_burn_sensor";
 	pixel_x = -24
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "oX" = (
 /obj/machinery/computer/mining,
@@ -941,13 +974,13 @@
 /obj/machinery/atmospherics/valve{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "pq" = (
 /obj/machinery/atmospherics/binary/passive_gate{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "pG" = (
 /obj/structure/cable{
@@ -959,7 +992,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/cap/visible/fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "pL" = (
 /obj/effect/shuttle_landmark/scavver_gantry/generic,
@@ -975,16 +1008,20 @@
 /area/scavver/calypso)
 "pQ" = (
 /obj/structure/girder,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "qe" = (
 /obj/machinery/microwave,
 /obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "qf" = (
 /obj/structure/closet/toolcloset/excavation/awaysite,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "qC" = (
 /turf/simulated/floor/wood/yew,
@@ -1010,7 +1047,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "qQ" = (
 /obj/structure/inflatable/wall,
@@ -1019,13 +1056,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white/monotile,
+/turf/simulated/floor/tiled/white{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "qY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "rb" = (
 /obj/machinery/hologram/holopad/longrange,
@@ -1043,7 +1082,9 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/external/bolted,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "rs" = (
 /obj/structure/cable{
@@ -1065,7 +1106,7 @@
 	pixel_x = -24;
 	req_access = list()
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "ry" = (
 /turf/simulated/wall/titanium,
@@ -1080,7 +1121,7 @@
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "rW" = (
 /obj/structure/lattice,
@@ -1094,7 +1135,7 @@
 /obj/machinery/portable_atmospherics/hydroponics{
 	closed_system = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "sj" = (
 /obj/structure/lattice,
@@ -1112,7 +1153,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "sL" = (
 /obj/machinery/atmospherics/pipe/cap/visible{
@@ -1141,7 +1184,9 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/railing/mapped,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "to" = (
 /obj/structure/railing/mapped{
@@ -1149,7 +1194,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/structure/closet/firecloset,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "tE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
@@ -1157,7 +1202,9 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "tL" = (
 /obj/structure/lattice,
@@ -1169,14 +1216,14 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "tX" = (
 /obj/structure/railing/mapped{
 	dir = 4;
 	icon_state = "railing0-1"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "ua" = (
 /obj/structure/lattice,
@@ -1186,7 +1233,7 @@
 /area/space)
 "uo" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "uq" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
@@ -1206,7 +1253,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "uM" = (
 /obj/structure/lattice,
@@ -1229,7 +1276,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/calypso)
 "uR" = (
 /obj/effect/catwalk_plated/dark,
@@ -1246,7 +1293,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/tech_supply,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "vf" = (
 /obj/effect/floor_decal/corner/blue{
@@ -1259,7 +1306,7 @@
 	dir = 8;
 	icon_state = "railing0-1"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "vs" = (
 /obj/structure/inflatable/wall,
@@ -1289,7 +1336,7 @@
 /obj/machinery/portable_atmospherics/hydroponics{
 	closed_system = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "vU" = (
 /obj/structure/lattice,
@@ -1323,11 +1370,11 @@
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/gloves/insulated,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "wQ" = (
 /obj/machinery/atmospherics/pipe/cap/visible/fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "wS" = (
 /obj/structure/lattice,
@@ -1361,7 +1408,7 @@
 	pixel_x = -23;
 	pixel_y = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "xm" = (
 /obj/machinery/door/airlock/external{
@@ -1383,7 +1430,9 @@
 	output_turf = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "xw" = (
 /obj/structure/cable{
@@ -1391,7 +1440,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "xA" = (
 /obj/structure/railing/mapped{
@@ -1402,11 +1453,11 @@
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "xE" = (
 /obj/machinery/atmospherics/binary/passive_gate,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "xK" = (
 /obj/structure/railing/mapped{
@@ -1415,7 +1466,7 @@
 	},
 /obj/structure/table/rack,
 /obj/random/toolbox,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "xL" = (
 /obj/structure/bed/chair/shuttle/white{
@@ -1427,7 +1478,7 @@
 "xQ" = (
 /obj/structure/railing/mapped,
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "yb" = (
 /obj/structure/lattice,
@@ -1441,7 +1492,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "yo" = (
 /obj/effect/floor_decal/corner/blue{
@@ -1456,20 +1509,20 @@
 	icon_state = "1-2"
 	},
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "zf" = (
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 6
 	},
 /obj/random/assembly,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "zx" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "zV" = (
 /obj/structure/lattice,
@@ -1484,7 +1537,7 @@
 	dir = 8
 	},
 /obj/item/stool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "Aj" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -1532,7 +1585,7 @@
 	id_tag = "scavver_vent";
 	name = "Vent"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtdown)
 "AS" = (
 /obj/structure/railing/mapped{
@@ -1546,7 +1599,7 @@
 /obj/item/stack/material/glass/fifty,
 /obj/item/stack/material/glass/fifty,
 /obj/item/stack/material/plasteel/fifty,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "AV" = (
 /obj/structure/cable{
@@ -1559,7 +1612,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "Ba" = (
 /obj/effect/floor_decal/industrial/loading{
@@ -1567,7 +1620,9 @@
 	},
 /obj/structure/ore_box,
 /obj/structure/railing/mapped,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "Bd" = (
 /obj/structure/cable{
@@ -1576,14 +1631,14 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central1,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "Bi" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central1,
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "Br" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/blue,
@@ -1595,12 +1650,14 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "BA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "BJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
@@ -1626,7 +1683,7 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "BP" = (
 /obj/structure/cable{
@@ -1637,7 +1694,7 @@
 	charge = 100000;
 	input_level = 80000
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "BR" = (
 /obj/structure/cable{
@@ -1660,7 +1717,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "Cl" = (
 /obj/structure/lattice,
@@ -1677,18 +1736,20 @@
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "Cr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/machinery/meter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "Cx" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel,
 /obj/machinery/light/spot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "Cz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
@@ -1706,7 +1767,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "CE" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -1728,7 +1789,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "CZ" = (
 /obj/effect/paint/black,
@@ -1742,7 +1803,9 @@
 	dir = 10
 	},
 /obj/machinery/sleeper,
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "DF" = (
 /obj/structure/railing/mapped{
@@ -1751,7 +1814,7 @@
 	},
 /obj/structure/ladder/up,
 /obj/effect/floor_decal/corner_steel_grid,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "DK" = (
 /obj/structure/cable{
@@ -1759,13 +1822,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "DW" = (
 /obj/structure/railing/mapped,
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/effect/floor_decal/corner_steel_grid,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "Ee" = (
 /obj/structure/railing/mapped{
@@ -1776,13 +1839,13 @@
 	dir = 4
 	},
 /obj/machinery/light/spot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "Eg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "Eq" = (
 /obj/structure/cable{
@@ -1793,7 +1856,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 5
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "Es" = (
 /obj/item/towel/random,
@@ -1808,13 +1871,15 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "EU" = (
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "Fj" = (
 /obj/structure/sign/warning/docking_area{
@@ -1830,7 +1895,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/machinery/meter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "Fz" = (
 /obj/structure/cable{
@@ -1848,7 +1913,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "FJ" = (
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide{
@@ -1875,7 +1940,9 @@
 	dir = 1
 	},
 /obj/structure/railing/mapped,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "FS" = (
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide{
@@ -1884,7 +1951,7 @@
 /turf/simulated/floor/wood/yew,
 /area/scavver/yachtdown)
 "Ga" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "Gl" = (
 /obj/structure/cable{
@@ -1897,7 +1964,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "Gq" = (
 /obj/machinery/alarm{
@@ -1917,18 +1984,20 @@
 /area/scavver/calypso)
 "Gr" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "Gu" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/radio_beacon,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "Gz" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "GB" = (
 /obj/machinery/pointdefense{
@@ -1938,23 +2007,23 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "GK" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "GM" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "Hb" = (
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "Hn" = (
 /obj/machinery/computer/ship/helm,
@@ -1968,7 +2037,7 @@
 	},
 /obj/structure/table/rack,
 /obj/random/toolbox,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "Hs" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -1977,12 +2046,12 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "Ht" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "HH" = (
 /obj/machinery/atmospherics/unary/vent_pump/tank{
@@ -2000,7 +2069,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtdown)
 "HJ" = (
 /obj/machinery/door/airlock/hatch,
@@ -2012,7 +2081,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 5
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "HY" = (
 /obj/effect/floor_decal/corner/blue{
@@ -2057,7 +2126,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtdown)
 "IV" = (
 /obj/structure/lattice,
@@ -2071,11 +2140,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "Ja" = (
 /obj/structure/ore_box,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "JF" = (
 /obj/structure/lattice,
@@ -2094,7 +2165,7 @@
 /obj/random/advdevice,
 /obj/random/advdevice,
 /obj/random/advdevice,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "JP" = (
 /obj/structure/lattice,
@@ -2110,7 +2181,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "Kv" = (
 /obj/structure/table/rack,
@@ -2121,7 +2192,7 @@
 /obj/random/powercell,
 /obj/random/powercell,
 /obj/random/accessory,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "KL" = (
 /obj/structure/lattice,
@@ -2138,7 +2209,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "Lg" = (
 /obj/structure/sign/warning/docking_area{
@@ -2151,7 +2222,7 @@
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "Ly" = (
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide{
@@ -2183,7 +2254,7 @@
 	pixel_y = 24;
 	req_access = list()
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "LD" = (
 /obj/structure/railing/mapped,
@@ -2191,7 +2262,9 @@
 	dir = 5
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen/engine_setup,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "LR" = (
 /obj/structure/railing/mapped{
@@ -2207,7 +2280,7 @@
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "Me" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel,
@@ -2245,14 +2318,16 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "NP" = (
 /obj/structure/cable,
 /obj/machinery/power/solar_control/autostart{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "Om" = (
 /obj/effect/floor_decal/corner/blue/mono,
@@ -2263,24 +2338,24 @@
 /turf/simulated/floor/tiled/monotile,
 /area/scavver/calypso)
 "Oq" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "Or" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "OD" = (
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "OS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
 /obj/structure/inflatable/door,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "Pd" = (
 /obj/structure/railing/mapped,
@@ -2288,7 +2363,9 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "Pn" = (
 /obj/structure/cable{
@@ -2297,7 +2374,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "PA" = (
 /obj/structure/bed/chair/shuttle/white{
@@ -2323,14 +2400,16 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "PO" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtdown)
 "PT" = (
 /obj/structure/lattice,
@@ -2338,7 +2417,9 @@
 /turf/space,
 /area/scavver/yachtdown)
 "PY" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "Qf" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
@@ -2350,20 +2431,20 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtdown)
 "QD" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
 /obj/item/device/flashlight/lantern,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "QF" = (
 /obj/machinery/atmospherics/valve{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "QL" = (
 /obj/machinery/door/airlock/external{
@@ -2395,7 +2476,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/corner_steel_grid,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "Rc" = (
 /obj/machinery/power/terminal{
@@ -2405,7 +2486,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "RC" = (
 /obj/machinery/atmospherics/binary/pump/on,
@@ -2418,7 +2499,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/hydrogen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "RQ" = (
 /obj/structure/railing/mapped{
@@ -2429,7 +2510,7 @@
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "RT" = (
 /obj/structure/table/rack,
@@ -2466,18 +2547,20 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "Sq" = (
 /obj/structure/inflatable/wall,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "Ss" = (
 /obj/structure/railing/mapped,
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "St" = (
 /obj/effect/floor_decal/corner/blue{
@@ -2506,7 +2589,9 @@
 	dir = 4
 	},
 /obj/machinery/light/small,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "SF" = (
 /turf/simulated/wall/titanium,
@@ -2532,7 +2617,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "SZ" = (
 /obj/structure/cable{
@@ -2540,7 +2625,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "Tm" = (
 /obj/structure/cable{
@@ -2551,7 +2636,7 @@
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "TK" = (
 /obj/machinery/atmospherics/binary/passive_gate{
@@ -2579,7 +2664,7 @@
 	id_tag = "scav_calypso_pump";
 	power_rating = 25000
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/calypso)
 "TV" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -2592,7 +2677,7 @@
 /area/scavver/yachtdown/thrusters)
 "TZ" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central1,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "Uh" = (
 /obj/structure/cable{
@@ -2605,12 +2690,12 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "Uk" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
 /obj/machinery/meter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "Up" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -2621,7 +2706,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "Uv" = (
 /obj/structure/cable{
@@ -2629,19 +2714,19 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/tracker,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "UH" = (
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 9
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "UJ" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "UM" = (
 /turf/space,
@@ -2651,7 +2736,7 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/hydrogen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "UU" = (
 /obj/structure/cable{
@@ -2659,14 +2744,16 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "UV" = (
 /obj/machinery/recharge_station,
 /obj/structure/fireaxecabinet{
 	pixel_x = 32
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "UY" = (
 /obj/structure/lattice,
@@ -2694,7 +2781,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/girder/displaced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "Vs" = (
 /obj/structure/railing/mapped{
@@ -2702,7 +2789,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down2)
 "Vx" = (
 /obj/structure/cable{
@@ -2715,7 +2802,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "VT" = (
 /obj/machinery/sparker{
@@ -2726,7 +2813,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtdown)
 "Wo" = (
 /obj/structure/cable{
@@ -2734,14 +2821,16 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/white{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "Wp" = (
 /obj/structure/inflatable/door,
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "WI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
@@ -2751,17 +2840,17 @@
 	id_tag = "scavver_window";
 	name = "Window Blast Door"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtdown)
 "WM" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "WQ" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 8
 	},
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtdown)
 "Xb" = (
 /obj/machinery/light/small{
@@ -2784,7 +2873,7 @@
 "Xp" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
 /obj/machinery/portable_atmospherics/canister/hydrogen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "XA" = (
 /obj/effect/catwalk_plated/dark,
@@ -2806,7 +2895,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "XE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -2817,7 +2906,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown)
 "XH" = (
 /obj/structure/railing/mapped{
@@ -2825,7 +2914,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/structure/closet/crate/freezer/rations,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 "XN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/blue,
@@ -2842,7 +2931,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/blue{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/calypso)
 "XV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -2903,7 +2994,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "ZS" = (
 /obj/structure/railing/mapped{
@@ -2913,7 +3004,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/down1)
 
 (1,1,1) = {"
@@ -16231,7 +16322,7 @@ gs
 ry
 ry
 qe
-cP
+Wo
 kx
 yb
 ry

--- a/maps/away/scavver/scavver_gantry-2.dmm
+++ b/maps/away/scavver/scavver_gantry-2.dmm
@@ -7,7 +7,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ab" = (
 /obj/item/device/radio/intercom/map_preset/scavver{
@@ -22,7 +22,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/machinery/fabricator/hacked,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "ae" = (
 /obj/structure/cable{
@@ -30,18 +30,18 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "ai" = (
 /obj/machinery/atmospherics/unary/tank{
 	dir = 4
 	},
 /obj/structure/railing/mapped,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "aq" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central1,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "as" = (
 /obj/structure/curtain/black,
@@ -57,9 +57,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "aA" = (
 /obj/structure/cable{
@@ -70,15 +68,13 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "aB" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "aI" = (
 /obj/structure/railing/mapped{
@@ -87,7 +83,7 @@
 	},
 /obj/structure/closet/firecloset,
 /obj/random/drinkbottle,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "aJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -97,9 +93,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "aK" = (
 /obj/structure/railing/mapped{
@@ -112,7 +106,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "aM" = (
 /obj/structure/railing/mapped{
@@ -125,9 +119,7 @@
 /area/space)
 "aZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "bc" = (
 /obj/structure/cable{
@@ -135,7 +127,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "bl" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
@@ -143,14 +135,14 @@
 /obj/structure/railing/mapped/no_density{
 	icon_state = "railing0-0"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "bs" = (
 /obj/structure/cable{
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "bA" = (
 /obj/effect/wallframe_spawn/reinforced_phoron,
@@ -159,14 +151,14 @@
 	id_tag = "scavver_window_teg";
 	name = "Window Blast Door"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtup)
 "bE" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "bI" = (
 /obj/effect/catwalk_plated,
@@ -188,13 +180,13 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "bV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "bX" = (
 /obj/structure/lattice,
@@ -223,7 +215,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "ce" = (
 /obj/machinery/computer/ship/helm{
@@ -235,7 +227,7 @@
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "cf" = (
 /obj/effect/paint/red,
@@ -252,7 +244,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "ck" = (
@@ -278,7 +270,9 @@
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/techfloor/grid{
+	map_airless = 1
+	},
 /area/scavver/lifepod)
 "cy" = (
 /obj/machinery/firealarm{
@@ -286,7 +280,7 @@
 	pixel_y = -24
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central6,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "cA" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
@@ -305,7 +299,7 @@
 	pressure_checks_default = 2;
 	pump_direction = 0
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtup)
 "cC" = (
 /obj/structure/fuel_port,
@@ -316,7 +310,7 @@
 /obj/machinery/atmospherics/pipe/cap/visible{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "cS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
@@ -326,9 +320,7 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "cT" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -349,7 +341,7 @@
 	pixel_y = 23
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "df" = (
@@ -358,7 +350,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "dj" = (
 /turf/simulated/floor/tiled/monotile,
@@ -370,7 +362,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/inflatable/door,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "dw" = (
 /obj/structure/cable{
@@ -400,7 +392,7 @@
 	},
 /obj/machinery/atmospherics/portables_connector,
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "dy" = (
 /obj/structure/railing/mapped{
@@ -408,7 +400,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "dA" = (
 /obj/machinery/atmospherics/unary/vent_pump/tank{
@@ -427,7 +419,7 @@
 /obj/structure/handrail{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "dD" = (
 /obj/structure/cable{
@@ -449,7 +441,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "dO" = (
 /obj/structure/cable{
@@ -458,7 +450,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "dR" = (
 /obj/machinery/light/spot{
@@ -476,12 +468,12 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "dS" = (
 /obj/machinery/atmospherics/omni/filter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "dV" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -512,7 +504,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "eb" = (
 /obj/structure/railing/mapped{
@@ -523,13 +515,13 @@
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "ef" = (
 /obj/machinery/shipsensors{
 	use_power = 0
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/escapepod)
 "ek" = (
 /obj/structure/cable{
@@ -540,7 +532,7 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "er" = (
 /obj/effect/floor_decal/corner/lightgrey{
@@ -565,15 +557,13 @@
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "eH" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "eN" = (
 /turf/space,
@@ -605,7 +595,9 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/lifepod)
 "fD" = (
 /obj/structure/railing/mapped{
@@ -622,7 +614,7 @@
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "fE" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -635,7 +627,7 @@
 	id = "scavver_teg_in_fuel";
 	use_power = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtup)
 "fF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -650,7 +642,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "fL" = (
 /obj/effect/floor_decal/techfloor{
@@ -670,7 +662,7 @@
 	dir = 1
 	},
 /obj/machinery/light/spot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "fQ" = (
 /obj/structure/railing/mapped{
@@ -682,14 +674,14 @@
 	icon_state = "warning"
 	},
 /obj/machinery/light/spot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "fS" = (
 /obj/random/tool,
 /obj/effect/floor_decal/steeldecal/steel_decals_central4{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "fV" = (
 /obj/machinery/power/solar,
@@ -704,13 +696,15 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/lifepod)
 "fX" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "gc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
@@ -734,7 +728,7 @@
 	id_tag = "scavver_window_teg";
 	name = "Window Blast Door"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtup)
 "gk" = (
 /obj/effect/floor_decal/corner/lightgrey/mono,
@@ -757,7 +751,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/structure/reagent_dispensers/fueltank,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "gq" = (
 /obj/structure/railing/mapped{
@@ -767,7 +761,7 @@
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "gr" = (
 /obj/structure/cable,
@@ -783,7 +777,7 @@
 /area/scavver/hab)
 "gx" = (
 /obj/machinery/atmospherics/valve,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "gL" = (
 /obj/structure/cable{
@@ -792,7 +786,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "gM" = (
 /obj/structure/cable{
@@ -801,7 +795,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/inflatable/door,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "gN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
@@ -826,7 +820,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "hp" = (
 /obj/structure/cable{
@@ -837,7 +831,7 @@
 /obj/machinery/power/generator{
 	anchored = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "ht" = (
 /obj/structure/table/rack,
@@ -846,7 +840,7 @@
 /area/scavver/hab)
 "hv" = (
 /obj/effect/wallframe_spawn/reinforced/no_grille,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "hw" = (
 /obj/structure/railing/mapped{
@@ -885,7 +879,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "hH" = (
@@ -902,7 +896,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "hX" = (
 /obj/structure/lattice,
@@ -913,7 +907,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtup)
 "ih" = (
 /obj/effect/floor_decal/corner/lightgrey{
@@ -928,7 +922,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "in" = (
@@ -942,11 +936,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "io" = (
 /obj/machinery/atmospherics/omni/filter,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/scavver/harvestpod)
 "iq" = (
 /obj/structure/cable{
@@ -957,7 +951,7 @@
 /obj/structure/bed/chair/shuttle/white{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "it" = (
 /obj/effect/shuttle_landmark/scavver_gantry/generic/five,
@@ -982,7 +976,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "iI" = (
 /obj/structure/railing/mapped{
@@ -995,7 +989,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "iT" = (
 /obj/effect/shuttle_landmark/scavver_gantry/generic/desperado,
@@ -1013,7 +1007,7 @@
 	scrubbing = "siphon"
 	},
 /obj/effect/floor_decal/corner/grey/half,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "iW" = (
 /obj/machinery/atmospherics/omni/filter{
@@ -1023,7 +1017,7 @@
 	},
 /obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "iY" = (
@@ -1046,7 +1040,7 @@
 /obj/structure/handrail{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "jb" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -1064,7 +1058,7 @@
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "jj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1101,9 +1095,7 @@
 /obj/machinery/power/solar_control/autostart{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "jt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -1125,7 +1117,7 @@
 "ju" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/machinery/meter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "jw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1143,13 +1135,13 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "jz" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtup)
 "jA" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -1172,9 +1164,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "jG" = (
 /obj/structure/railing/mapped{
@@ -1185,7 +1175,7 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "jJ" = (
 /obj/structure/cable{
@@ -1210,7 +1200,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 5
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "jO" = (
 /obj/structure/cable{
@@ -1223,14 +1213,14 @@
 	},
 /obj/machinery/portable_atmospherics/canister/empty,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "jS" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/hydrogen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "ka" = (
 /obj/structure/cable{
@@ -1238,9 +1228,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "kb" = (
 /obj/effect/paint/red,
@@ -1278,7 +1266,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "kq" = (
 /obj/item/stack/material/steel/fifty,
@@ -1289,9 +1277,7 @@
 /obj/item/stack/material/plasteel/fifty,
 /obj/structure/closet/crate/plastic,
 /obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "ks" = (
 /obj/structure/table/steel_reinforced,
@@ -1308,7 +1294,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "kC" = (
 /obj/structure/railing/mapped{
@@ -1317,9 +1303,7 @@
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "kD" = (
 /obj/machinery/button/blast_door{
@@ -1330,7 +1314,7 @@
 /obj/machinery/atmospherics/valve{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "kJ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/red,
@@ -1341,16 +1325,14 @@
 	dir = 1
 	},
 /obj/structure/table/rack,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "kP" = (
 /obj/effect/wallframe_spawn/reinforced/no_grille,
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "la" = (
 /obj/structure/cable{
@@ -1358,7 +1340,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "ls" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
@@ -1379,7 +1361,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "lw" = (
 /obj/structure/cable{
@@ -1387,7 +1369,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "lB" = (
 /obj/machinery/computer/shuttle_control/explore/scavver_gantry/two,
@@ -1397,7 +1379,7 @@
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "lG" = (
 /obj/structure/railing/mapped,
@@ -1405,9 +1387,7 @@
 	dir = 4
 	},
 /obj/structure/closet/crate/plastic,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "lH" = (
 /obj/structure/railing/mapped,
@@ -1415,19 +1395,17 @@
 	dir = 8
 	},
 /obj/item/mop,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "lP" = (
 /obj/machinery/atmospherics/unary/tank{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "lU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "lW" = (
 /obj/machinery/mech_recharger,
@@ -1449,7 +1427,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "me" = (
 /obj/structure/cable{
@@ -1462,7 +1440,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "mh" = (
 /obj/structure/closet/crate/plastic,
@@ -1474,9 +1452,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "mi" = (
 /obj/machinery/power/terminal{
@@ -1491,9 +1467,7 @@
 	icon_state = "0-8"
 	},
 /obj/effect/floor_decal/industrial/hatch/orange,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "ml" = (
 /obj/structure/bed,
@@ -1504,13 +1478,13 @@
 /area/scavver/hab)
 "mq" = (
 /obj/random/trash,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "mu" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "mx" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -1521,7 +1495,9 @@
 	id_tag = "dropodeast_interior_door";
 	locked = 1
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/techfloor/grid{
+	map_airless = 1
+	},
 /area/scavver/lifepod)
 "mB" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -1529,7 +1505,7 @@
 	},
 /obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "mC" = (
@@ -1540,7 +1516,7 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "mM" = (
@@ -1549,7 +1525,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "mN" = (
@@ -1574,7 +1550,7 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "mX" = (
 /obj/structure/railing/mapped{
@@ -1582,7 +1558,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/effect/floor_decal/corner_steel_grid,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "mZ" = (
 /obj/structure/cable{
@@ -1594,7 +1570,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "nc" = (
 /obj/item/device/radio/intercom/map_preset/scavver{
@@ -1607,7 +1583,7 @@
 /area/scavver/lifepod)
 "nd" = (
 /obj/machinery/power/breakerbox,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "ne" = (
 /obj/effect/floor_decal/techfloor/orange{
@@ -1617,7 +1593,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "nf" = (
@@ -1628,7 +1604,7 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/scavver/harvestpod)
 "nj" = (
 /obj/effect/floor_decal/techfloor/orange,
@@ -1636,7 +1612,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "nl" = (
@@ -1650,9 +1626,7 @@
 /area/scavver/hab)
 "nw" = (
 /obj/machinery/mining/drill,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "nE" = (
 /obj/machinery/air_sensor{
@@ -1661,12 +1635,12 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtup)
 "nH" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/effect/paint/silver,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "nI" = (
 /obj/effect/floor_decal/techfloor{
@@ -1689,7 +1663,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "nM" = (
 /obj/structure/handrail{
@@ -1698,7 +1672,7 @@
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "nN" = (
 /obj/effect/floor_decal/corner_steel_grid{
@@ -1709,7 +1683,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "nS" = (
 /obj/structure/cable{
@@ -1720,28 +1694,26 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "nZ" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central4{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "ok" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtup)
 "om" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 6
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "oo" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -1751,7 +1723,7 @@
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 5
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "oq" = (
 /obj/effect/floor_decal/techfloor/orange{
@@ -1761,14 +1733,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "os" = (
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/corner_steel_grid,
 /obj/structure/closet/crate/solar,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "ov" = (
 /obj/item/device/radio/intercom/map_preset/scavver{
@@ -1790,15 +1762,13 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "oB" = (
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "oE" = (
 /obj/effect/floor_decal/techfloor/orange{
@@ -1808,7 +1778,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "oH" = (
@@ -1839,10 +1809,10 @@
 	dir = 8
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "oN" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "oO" = (
 /obj/structure/cable{
@@ -1854,13 +1824,11 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "pa" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/red,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "pc" = (
 /obj/machinery/alarm{
@@ -1875,7 +1843,9 @@
 /area/scavver/hab)
 "pd" = (
 /obj/machinery/atmospherics/unary/engine,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/scavver/lifepod)
 "pl" = (
 /obj/structure/cable{
@@ -1902,7 +1872,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "pq" = (
@@ -1913,24 +1883,20 @@
 	dir = 5
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "pr" = (
 /obj/machinery/atmospherics/valve,
 /obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "ps" = (
 /obj/structure/railing/mapped{
 	dir = 4
 	},
 /obj/structure/table/rack,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "pu" = (
 /turf/simulated/wall/ocp_wall,
@@ -1943,7 +1909,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/paint/palegreengray,
-/turf/simulated/floor/plating,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/lifepod)
 "pK" = (
 /obj/structure/bed/chair/shuttle/black{
@@ -1953,13 +1921,13 @@
 /area/scavver/lifepod)
 "pO" = (
 /obj/structure/closet/crate/hydroponics/prespawned,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "pQ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "pV" = (
 /obj/structure/lattice,
@@ -1973,7 +1941,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "qh" = (
 /obj/structure/handrail{
@@ -2005,9 +1973,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/light/spot,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "qk" = (
 /obj/machinery/computer/air_control{
@@ -2017,7 +1983,7 @@
 	sensor_name = "Yacht Burn Chamber";
 	sensor_tag = "scavver_teg_sensor"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "qn" = (
 /obj/effect/floor_decal/techfloor/orange{
@@ -2027,7 +1993,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "qt" = (
@@ -2056,7 +2022,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen/engine_setup,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "qD" = (
 /obj/structure/lattice,
@@ -2085,7 +2051,7 @@
 /obj/effect/floor_decal/corner/grey/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "qK" = (
 /obj/machinery/atmospherics/omni/filter{
@@ -2095,7 +2061,7 @@
 	},
 /obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "qN" = (
@@ -2116,7 +2082,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "qS" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue{
@@ -2127,18 +2093,18 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "qT" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "qU" = (
 /obj/structure/ladder,
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "qV" = (
 /obj/machinery/light,
@@ -2178,7 +2144,7 @@
 /obj/machinery/meter,
 /obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "ro" = (
@@ -2188,7 +2154,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "rp" = (
 /obj/structure/closet/emcloset,
@@ -2202,9 +2168,7 @@
 "rr" = (
 /obj/machinery/mining/brace,
 /obj/structure/railing/mapped,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "rt" = (
 /obj/structure/cable{
@@ -2212,7 +2176,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "rB" = (
 /obj/structure/cable{
@@ -2220,7 +2184,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "rJ" = (
 /obj/item/storage/bag/trash,
@@ -2243,7 +2207,7 @@
 /obj/machinery/atmospherics/binary/passive_gate{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "rO" = (
 /obj/machinery/door/airlock/external{
@@ -2267,11 +2231,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "rU" = (
 /obj/structure/railing/mapped,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "rW" = (
 /obj/machinery/light/spot{
@@ -2285,14 +2249,14 @@
 	icon_state = "railing0-0"
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "rX" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "sc" = (
 /obj/effect/paint/silver,
@@ -2301,14 +2265,16 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/escapepod)
 "si" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/techfloor/grid{
+	map_airless = 1
+	},
 /area/scavver/lifepod)
 "so" = (
 /turf/simulated/floor/tiled,
@@ -2320,14 +2286,16 @@
 /obj/structure/handrail{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/scavver/lifepod)
 "sq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 10
 	},
 /obj/machinery/portable_atmospherics/powered/pump/filled,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "st" = (
 /obj/effect/floor_decal/corner/lightgrey{
@@ -2346,7 +2314,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "sB" = (
@@ -2371,7 +2339,7 @@
 	},
 /obj/structure/table/rack,
 /obj/item/stack/material/wood/fifty,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "sE" = (
 /obj/machinery/atmospherics/omni/mixer{
@@ -2381,7 +2349,7 @@
 	tag_west = 1;
 	tag_west_con = 0.15
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "sF" = (
 /obj/structure/lattice,
@@ -2428,7 +2396,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "sW" = (
 /obj/structure/lattice,
@@ -2443,7 +2411,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "sY" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -2458,9 +2426,7 @@
 /obj/structure/railing/mapped{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "ta" = (
 /obj/machinery/hologram/holopad/longrange/remoteship,
@@ -2487,7 +2453,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "tp" = (
@@ -2506,7 +2472,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "tx" = (
 /turf/simulated/floor/tiled/steel_grid{
@@ -2525,7 +2491,7 @@
 	},
 /obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "tN" = (
@@ -2585,7 +2551,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "tW" = (
 /obj/structure/bed/chair/shuttle/white{
@@ -2597,7 +2563,7 @@
 /obj/effect/floor_decal/corner/grey/border{
 	dir = 10
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "tX" = (
 /obj/structure/lattice,
@@ -2618,7 +2584,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "ug" = (
 /obj/structure/cable{
@@ -2629,13 +2595,13 @@
 /obj/effect/wallframe_spawn/reinforced/titanium,
 /obj/effect/paint/silver,
 /obj/effect/paint_stripe/white,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/escapepod)
 "ui" = (
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 9
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "uq" = (
 /obj/structure/table/steel_reinforced,
@@ -2651,7 +2617,7 @@
 	},
 /obj/effect/floor_decal/techfloor/orange/corner,
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "uu" = (
@@ -2667,7 +2633,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/solar/improved,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/escapepod)
 "uz" = (
 /obj/machinery/portable_atmospherics/canister/air,
@@ -2696,7 +2662,9 @@
 /obj/structure/handrail{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/techfloor/grid{
+	map_airless = 1
+	},
 /area/scavver/lifepod)
 "uN" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
@@ -2708,7 +2676,7 @@
 /obj/effect/floor_decal/corner/grey/diagonal{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "uU" = (
 /obj/structure/cable,
@@ -2721,13 +2689,13 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/tracker,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/escapepod)
 "uV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
 /obj/effect/floor_decal/techfloor/orange,
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "uZ" = (
@@ -2743,7 +2711,7 @@
 "va" = (
 /obj/structure/cable,
 /obj/machinery/power/solar/improved,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/escapepod)
 "vb" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -2781,7 +2749,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "vq" = (
 /obj/machinery/light/spot,
@@ -2792,7 +2760,7 @@
 	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "vs" = (
@@ -2807,13 +2775,13 @@
 "vt" = (
 /obj/machinery/atmospherics/omni/filter,
 /obj/effect/overmap/visitable/ship/landable/scavver_gantry/three,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/scavver/harvestpod)
 "vy" = (
 /obj/effect/floor_decal/steeldecal/steel_decals_central4{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "vA" = (
 /obj/structure/lattice,
@@ -2838,7 +2806,7 @@
 /obj/item/storage/med_pouch/radiation,
 /obj/item/storage/med_pouch/radiation,
 /obj/structure/closet/crate/plastic,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "vE" = (
 /obj/effect/paint/palegreengray,
@@ -2856,7 +2824,7 @@
 /obj/machinery/power/solar_control{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "vL" = (
 /obj/structure/railing/mapped{
@@ -2865,7 +2833,7 @@
 	},
 /obj/structure/table/steel_reinforced,
 /obj/machinery/recharger,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "vM" = (
 /obj/structure/railing/mapped{
@@ -2876,7 +2844,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/corner_steel_grid,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "vP" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -2884,7 +2852,7 @@
 	anchored = 1;
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "vU" = (
 /obj/structure/railing/mapped{
@@ -2898,7 +2866,7 @@
 /obj/item/stack/material/glass/fifty,
 /obj/item/stack/material/plasteel/fifty,
 /obj/random/contraband,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "vY" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/vulcan{
@@ -2911,7 +2879,7 @@
 /obj/structure/handrail{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/escapepod)
 "vZ" = (
 /obj/structure/railing/mapped{
@@ -2919,14 +2887,14 @@
 	icon_state = "railing0-1"
 	},
 /obj/machinery/mining/brace,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "wa" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen/engine_setup,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "wd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2945,7 +2913,7 @@
 	dir = 4;
 	target_pressure = 25
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "wl" = (
 /obj/effect/paint/silver,
@@ -2954,7 +2922,7 @@
 	},
 /obj/effect/paint_stripe/red,
 /obj/effect/wallframe_spawn/reinforced/titanium,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/escapepod)
 "wz" = (
 /obj/structure/lattice,
@@ -2989,7 +2957,7 @@
 /area/space)
 "wG" = (
 /obj/structure/cable,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "wI" = (
 /obj/structure/closet/secure_closet/freezer/fridge/scavver,
@@ -3010,9 +2978,7 @@
 	dir = 8
 	},
 /obj/structure/table/rack,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "wT" = (
 /obj/effect/paint/silver,
@@ -3021,11 +2987,11 @@
 	},
 /obj/effect/paint_stripe/red,
 /obj/effect/wallframe_spawn/reinforced/titanium,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/escapepod)
 "wU" = (
 /obj/structure/girder/displaced,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "xg" = (
 /obj/structure/table/reinforced,
@@ -3045,9 +3011,7 @@
 	},
 /obj/structure/railing/mapped,
 /obj/structure/ore_box,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "xu" = (
 /obj/effect/floor_decal/corner/lightgrey{
@@ -3079,7 +3043,7 @@
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "xR" = (
 /obj/effect/catwalk_plated/dark,
@@ -3088,7 +3052,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "xU" = (
 /obj/effect/shuttle_landmark/scavver_gantry/generic/charon,
@@ -3118,7 +3082,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/scavver/hab)
 "yf" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtup)
 "yn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3134,13 +3098,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/hab)
 "yr" = (
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "ys" = (
 /obj/structure/cable{
@@ -3149,7 +3113,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/steeldecal/steel_decals_central1,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "yx" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3181,7 +3145,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "yI" = (
 /obj/structure/flora/pottedplant/minitree,
@@ -3197,7 +3161,7 @@
 /obj/random/smokes,
 /obj/random/snack,
 /obj/random/soap,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "yN" = (
 /obj/structure/table/steel_reinforced,
@@ -3206,18 +3170,18 @@
 	dir = 6
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "yR" = (
 /obj/structure/wall_frame,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "yT" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/escapepod)
 "yZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
@@ -3231,7 +3195,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "zf" = (
@@ -3240,7 +3204,7 @@
 	id_tag = "scavver_vent_teg_service";
 	name = "Service Vent"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "zl" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -3300,7 +3264,7 @@
 /obj/machinery/power/solar_control{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Ad" = (
 /obj/structure/lattice,
@@ -3318,7 +3282,9 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/lifepod)
 "Ag" = (
 /obj/effect/floor_decal/techfloor/orange{
@@ -3331,7 +3297,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "Ah" = (
@@ -3355,11 +3321,11 @@
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Ar" = (
 /obj/random/tool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "Aw" = (
 /obj/effect/catwalk_plated,
@@ -3395,7 +3361,7 @@
 /obj/item/tracker_electronics,
 /obj/item/device/scanner/gas,
 /obj/item/device/multitool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "AW" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3429,9 +3395,7 @@
 	dir = 4
 	},
 /obj/structure/table/rack,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "Bh" = (
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -3444,7 +3408,9 @@
 /obj/structure/handrail{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/lifepod)
 "Br" = (
 /obj/structure/railing/mapped{
@@ -3455,7 +3421,7 @@
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "Bw" = (
 /obj/machinery/door/airlock/hatch,
@@ -3471,14 +3437,14 @@
 "Bx" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
 /obj/machinery/meter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "BA" = (
 /obj/machinery/portable_atmospherics/hydroponics,
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "BB" = (
 /obj/machinery/button/blast_door{
@@ -3501,7 +3467,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 9
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "BE" = (
 /obj/structure/handrail,
@@ -3530,9 +3496,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "BP" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3555,13 +3519,13 @@
 /area/space)
 "Ca" = (
 /obj/structure/girder,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Ce" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Ck" = (
 /obj/structure/lattice,
@@ -3577,7 +3541,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/visible/red,
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "CJ" = (
@@ -3609,7 +3573,7 @@
 	id_tag = "scavver_teg_sensor";
 	pixel_x = 24
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "CT" = (
 /obj/effect/floor_decal/techfloor/orange,
@@ -3617,7 +3581,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "CU" = (
@@ -3636,7 +3600,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "Db" = (
 /obj/structure/cable{
@@ -3649,7 +3613,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Dc" = (
 /obj/structure/railing/mapped{
@@ -3663,7 +3627,7 @@
 /obj/item/reagent_containers/food/snacks/liquidfood,
 /obj/item/reagent_containers/food/snacks/liquidfood,
 /obj/random/firstaid,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "Df" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -3671,7 +3635,7 @@
 	anchored = 1;
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Dk" = (
 /obj/structure/ladder,
@@ -3689,7 +3653,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Ds" = (
 /obj/structure/lattice,
@@ -3704,7 +3668,7 @@
 	dir = 8;
 	target_pressure = 15000
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "DE" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
@@ -3718,9 +3682,7 @@
 /obj/item/storage/briefcase/inflatable,
 /obj/item/storage/briefcase/inflatable,
 /obj/item/inflatable_dispenser,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "DI" = (
 /obj/structure/cable{
@@ -3741,7 +3703,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/machinery/mech_recharger,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "DY" = (
 /obj/effect/paint/sun,
@@ -3751,20 +3713,22 @@
 "Ef" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /obj/machinery/meter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Eg" = (
 /obj/structure/handrail{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/scavver/lifepod)
 "Ek" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Eo" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -3782,7 +3746,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/wallframe_spawn/reinforced/no_grille,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "EA" = (
 /obj/structure/cable{
@@ -3793,7 +3757,7 @@
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "EL" = (
 /obj/structure/cable{
@@ -3803,7 +3767,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "EM" = (
 /obj/structure/lattice,
@@ -3817,7 +3781,7 @@
 /area/space)
 "ES" = (
 /obj/random/toolbox,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "ET" = (
 /obj/structure/cable{
@@ -3831,7 +3795,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "EU" = (
 /obj/effect/catwalk_plated,
@@ -3844,7 +3808,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen/engine_setup,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Fh" = (
 /obj/structure/railing/mapped{
@@ -3852,14 +3816,14 @@
 	icon_state = "railing0-1"
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "Fk" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 1
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Fl" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -3897,7 +3861,7 @@
 /area/space)
 "FF" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "FK" = (
 /obj/machinery/computer/ship/sensors/spacer{
@@ -3915,7 +3879,7 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtup)
 "FN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -3949,7 +3913,7 @@
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "FT" = (
@@ -3984,7 +3948,7 @@
 /obj/effect/floor_decal/corner/grey/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "Gj" = (
 /obj/structure/flora/pottedplant/subterranean,
@@ -4020,7 +3984,7 @@
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "GH" = (
 /obj/structure/railing/mapped{
@@ -4032,7 +3996,7 @@
 /obj/item/stock_parts/circuitboard/shuttle_console/explore,
 /obj/item/stock_parts/circuitboard/solar_control,
 /obj/random/storage,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "GL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
@@ -4042,7 +4006,7 @@
 	name = "Access Blast Door"
 	},
 /obj/structure/inflatable/wall,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "GR" = (
 /obj/structure/cable{
@@ -4053,7 +4017,7 @@
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 6
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "GV" = (
 /obj/structure/table/rack,
@@ -4072,17 +4036,17 @@
 /area/scavver/hab)
 "GZ" = (
 /obj/machinery/atmospherics/omni/mixer,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Ha" = (
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Hj" = (
 /obj/random/masks,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "HC" = (
 /obj/structure/railing/mapped{
@@ -4090,7 +4054,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/item/device/flashlight/lantern,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "HF" = (
 /obj/structure/cable{
@@ -4101,7 +4065,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "HM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4137,13 +4101,13 @@
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "HY" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Ib" = (
 /obj/machinery/power/port_gen/pacman{
@@ -4154,7 +4118,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Ic" = (
 /obj/structure/cable{
@@ -4168,7 +4132,7 @@
 /obj/effect/floor_decal/corner/grey/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "Id" = (
 /obj/structure/cable{
@@ -4176,13 +4140,13 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "Ii" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Im" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -4191,7 +4155,7 @@
 /turf/space,
 /area/space)
 "In" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "Iy" = (
 /obj/structure/lattice,
@@ -4207,7 +4171,7 @@
 	},
 /obj/structure/handrail,
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "IH" = (
@@ -4218,7 +4182,7 @@
 	req_access = list()
 	},
 /obj/structure/cable,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "IK" = (
 /obj/effect/floor_decal/techfloor/orange{
@@ -4229,7 +4193,7 @@
 	icon_state = "railing0-0"
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "IP" = (
@@ -4237,7 +4201,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "IS" = (
 /obj/machinery/door/blast/regular{
@@ -4245,7 +4209,7 @@
 	id_tag = "scavver_vent_teg";
 	name = "Vent"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtup)
 "IX" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
@@ -4255,7 +4219,7 @@
 	name = "Access Blast Door"
 	},
 /obj/structure/inflatable/door,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "Jc" = (
 /obj/machinery/door/blast/regular/open{
@@ -4280,7 +4244,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "Js" = (
@@ -4292,7 +4256,7 @@
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/item/grenade/chem_grenade/metalfoam,
 /obj/item/grenade/chem_grenade/metalfoam,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "Jt" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
@@ -4354,7 +4318,9 @@
 	id_tag = "dropodeast_interior_door";
 	locked = 1
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/techfloor/grid{
+	map_airless = 1
+	},
 /area/scavver/lifepod)
 "Ko" = (
 /obj/structure/reagent_dispensers/water_cooler{
@@ -4370,7 +4336,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "KI" = (
@@ -4405,7 +4371,7 @@
 /obj/item/device/scanner/gas,
 /obj/structure/table/rack,
 /obj/item/tank/hydrogen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "KX" = (
 /obj/effect/wallframe_spawn/reinforced/no_grille,
@@ -4430,7 +4396,7 @@
 /obj/random/powercell,
 /obj/random/powercell,
 /obj/item/stack/material/plasteel/fifty,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "Lp" = (
 /obj/effect/floor_decal/techfloor{
@@ -4467,16 +4433,14 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch/blue,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "LF" = (
 /obj/machinery/power/smes/buildable/preset/scavver/smes{
 	charge = 100000
 	},
 /obj/structure/cable,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "LJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4495,11 +4459,11 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/empty/air,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "LP" = (
 /obj/item/stack/material/wood/ebony/twentyfive,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "LS" = (
 /obj/structure/handrail,
@@ -4550,7 +4514,7 @@
 	pixel_x = -18
 	},
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtup)
 "MI" = (
 /obj/structure/cable{
@@ -4574,7 +4538,7 @@
 /turf/simulated/floor/plating,
 /area/scavver/hab)
 "ML" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "MO" = (
 /obj/structure/cable{
@@ -4596,7 +4560,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/grey/half,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "MP" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -4625,7 +4589,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "Nf" = (
@@ -4638,11 +4602,11 @@
 /obj/effect/floor_decal/corner/grey/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "Ng" = (
 /obj/machinery/portable_atmospherics/canister/hydrogen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Ni" = (
 /obj/effect/floor_decal/corner/lightgrey{
@@ -4656,7 +4620,7 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Nq" = (
 /obj/structure/cable{
@@ -4668,7 +4632,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "Nr" = (
@@ -4727,7 +4691,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "NK" = (
 /obj/item/gun/energy/plasmacutter,
@@ -4765,7 +4729,7 @@
 /obj/random/single/color/cable_coil,
 /obj/random/single/color/cable_coil,
 /obj/item/device/multitool,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "NQ" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -4792,11 +4756,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "Ob" = (
 /obj/machinery/atmospherics/pipe/manifold/visible,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Og" = (
 /obj/structure/cable{
@@ -4804,13 +4768,13 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "Oj" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Oy" = (
 /obj/machinery/airlock_sensor{
@@ -4833,7 +4797,7 @@
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Pd" = (
 /obj/effect/floor_decal/techfloor/orange/corner{
@@ -4841,7 +4805,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold4w/visible/red,
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "Pf" = (
@@ -4862,7 +4826,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "Pk" = (
 /obj/effect/floor_decal/corner/lightgrey/mono,
@@ -4877,7 +4841,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "PD" = (
 /obj/structure/railing/mapped{
@@ -4885,7 +4849,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/machinery/portable_atmospherics/canister/hydrogen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "PW" = (
 /obj/machinery/atmospherics/pipe/zpipe/down/fuel{
@@ -4905,7 +4869,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "Qc" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/vulcan{
@@ -4920,7 +4884,7 @@
 	dir = 4
 	},
 /obj/structure/handrail,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/escapepod)
 "Qd" = (
 /obj/structure/cable,
@@ -4928,7 +4892,9 @@
 /obj/structure/railing/mapped{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/lifepod)
 "Qh" = (
 /obj/effect/floor_decal/techfloor/orange{
@@ -4939,7 +4905,7 @@
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "Qn" = (
@@ -4951,7 +4917,7 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "Qt" = (
 /obj/effect/floor_decal/corner/grey/border{
@@ -4959,7 +4925,7 @@
 	},
 /obj/machinery/atmospherics/valve,
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "Qu" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -4979,7 +4945,7 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "QB" = (
 /obj/effect/catwalk_plated,
@@ -5003,9 +4969,7 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "QU" = (
 /obj/effect/floor_decal/corner/lightgrey{
@@ -5022,12 +4986,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/red,
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "Rj" = (
 /obj/machinery/atmospherics/pipe/cap/visible,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Rl" = (
 /obj/machinery/air_sensor{
@@ -5037,7 +5001,7 @@
 	dir = 8
 	},
 /obj/structure/inflatable/door,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "Rm" = (
 /obj/effect/paint/black,
@@ -5053,9 +5017,7 @@
 	},
 /obj/machinery/light/spot,
 /obj/effect/floor_decal/industrial/hatch/orange,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "Rv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -5070,7 +5032,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "RN" = (
 /obj/item/tank/jetpack/oxygen,
@@ -5091,14 +5053,12 @@
 /obj/random/cash,
 /obj/random/plushie,
 /obj/random/single/lighter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "RY" = (
 /obj/structure/closet/crate/solar,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "Sa" = (
 /obj/structure/railing/mapped{
@@ -5107,11 +5067,11 @@
 	},
 /obj/structure/ladder,
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "Sj" = (
 /obj/machinery/pipedispenser,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Sm" = (
 /obj/structure/railing/mapped,
@@ -5120,7 +5080,7 @@
 /obj/item/storage/briefcase/inflatable,
 /obj/item/storage/briefcase/inflatable,
 /obj/item/storage/briefcase/inflatable,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "Sn" = (
 /obj/machinery/light{
@@ -5141,7 +5101,7 @@
 	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "SA" = (
@@ -5151,7 +5111,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "SF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red,
@@ -5162,21 +5122,19 @@
 	dir = 8
 	},
 /obj/structure/table/rack,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "SS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 6
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "SU" = (
 /obj/machinery/atmospherics/unary/tank{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "SX" = (
 /obj/structure/cable{
@@ -5184,7 +5142,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "SY" = (
 /obj/structure/cable{
@@ -5195,12 +5153,10 @@
 /obj/machinery/atmospherics/binary/pump{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "Tf" = (
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "TR" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5222,7 +5178,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "Ud" = (
 /obj/structure/handrail{
@@ -5231,7 +5187,7 @@
 /obj/machinery/atmospherics/binary/pump/high_power{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "Uf" = (
 /obj/structure/cable{
@@ -5244,7 +5200,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "Ug" = (
 /obj/effect/shuttle_landmark/scavver_gantry/generic/four,
@@ -5260,7 +5216,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "UM" = (
 /obj/effect/floor_decal/corner/lightgrey{
@@ -5280,7 +5236,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "UT" = (
 /obj/effect/catwalk_plated/dark,
@@ -5296,7 +5252,7 @@
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "Vb" = (
 /obj/effect/landmark/map_data{
@@ -5373,7 +5329,9 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/lifepod)
 "VP" = (
 /obj/machinery/light/small{
@@ -5385,7 +5343,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "VQ" = (
 /obj/structure/handrail{
@@ -5404,7 +5362,7 @@
 	pressure_checks_default = 2;
 	pump_direction = 0
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/harvestpod)
 "VS" = (
 /obj/structure/cable{
@@ -5417,11 +5375,11 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "VW" = (
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "VX" = (
 /turf/simulated/wall,
@@ -5446,7 +5404,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Wf" = (
 /obj/structure/bed,
@@ -5476,13 +5434,13 @@
 	dir = 1
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "WA" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "WD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -5511,26 +5469,26 @@
 	icon_state = "railing0-1"
 	},
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "WG" = (
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 10
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up1)
 "WP" = (
 /obj/effect/floor_decal/techfloor/orange,
 /obj/machinery/atmospherics/pipe/manifold/visible/blue,
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "WR" = (
 /obj/effect/floor_decal/corner_steel_grid{
 	dir = 6
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/gantry/up2)
 "WW" = (
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -5540,7 +5498,9 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/scavver/lifepod)
 "WX" = (
 /obj/machinery/door/airlock/external/bolted_open,
@@ -5550,11 +5510,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Xb" = (
 /obj/machinery/seed_storage/garden,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Xd" = (
 /obj/effect/paint/silver,
@@ -5563,7 +5523,7 @@
 "Xj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Xm" = (
 /obj/structure/cable{
@@ -5572,7 +5532,7 @@
 	icon_state = "4-8"
 	},
 /obj/item/stock_parts/circuitboard/broken,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Xr" = (
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller{
@@ -5601,7 +5561,7 @@
 /area/scavver/lifepod)
 "Xs" = (
 /obj/machinery/vending/hydronutrients,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Xz" = (
 /obj/effect/floor_decal/corner/grey/diagonal,
@@ -5618,7 +5578,7 @@
 	id_tag = "scavpod_shuttle_interior_sensor";
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "XA" = (
 /obj/structure/cable{
@@ -5629,19 +5589,19 @@
 /obj/machinery/atmospherics/pipe/manifold4w/visible,
 /obj/machinery/meter,
 /obj/effect/floor_decal/corner/grey/diagonal,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "XF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "XG" = (
 /obj/machinery/atmospherics/binary/passive_gate{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "XI" = (
 /obj/effect/catwalk_plated,
@@ -5677,7 +5637,7 @@
 	dir = 4;
 	icon_state = "railing0-0"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/escapepod)
 "XZ" = (
 /obj/structure/cable{
@@ -5696,7 +5656,7 @@
 	pixel_y = 24;
 	req_access = list()
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "Yd" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5717,7 +5677,7 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor/grid{
-	initial_gas = newlist()
+	map_airless = 1
 	},
 /area/scavver/lifepod)
 "Yg" = (
@@ -5742,7 +5702,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "YE" = (
 /obj/structure/cable{
@@ -5751,7 +5711,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "YL" = (
 /obj/structure/lattice,
@@ -5770,9 +5730,7 @@
 	dir = 8
 	},
 /obj/structure/table/rack,
-/turf/simulated/floor/tiled/techfloor{
-	initial_gas = newlist()
-	},
+/turf/simulated/floor/tiled/techfloor,
 /area/scavver/lifepod)
 "Zd" = (
 /obj/machinery/access_button/airlock_interior{
@@ -5793,25 +5751,25 @@
 /area/space)
 "Zx" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "ZB" = (
 /obj/effect/decal/cleanable/liquid_fuel,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/scavver/yachtup)
 "ZI" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "ZK" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4;
 	target_pressure = 15000
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 "ZL" = (
 /obj/structure/cable{
@@ -5830,7 +5788,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/scavver/yachtup)
 
 (1,1,1) = {"

--- a/maps/away/scavver/scavver_gantry.dm
+++ b/maps/away/scavver/scavver_gantry.dm
@@ -103,18 +103,22 @@
 /area/scavver/gantry/up1
 	name = "\improper Upper Salvage Gantry Arm"
 	icon_state = "gantry_up_1"
+	turfs_airless = TRUE
 
 /area/scavver/gantry/up2
 	name = "\improper Upper Salvage Gantry Spine"
 	icon_state = "gantry_up_2"
+	turfs_airless = TRUE
 
 /area/scavver/gantry/down1
 	name = "\improper Lower Salvage Gantry Arm"
 	icon_state = "gantry_down_1"
+	turfs_airless = TRUE
 
 /area/scavver/gantry/down2
 	name = "\improper Lower Salvage Gantry Spine"
 	icon_state = "gantry_down_2"
+	turfs_airless = TRUE
 
 /area/scavver/gantry/lift
 	name = "\improper Salvage Gantry Lift"
@@ -124,10 +128,12 @@
 /area/scavver/yachtup
 	name = "\improper Private Yacht Upper Deck"
 	icon_state = "gantry_yacht_up"
+	turfs_airless = TRUE
 
 /area/scavver/yachtdown
 	name = "\improper Private Yacht Lower Deck"
 	icon_state = "gantry_yacht_down"
+	turfs_airless = TRUE
 
 /area/scavver/yachtdown/thrusters
 	name = "\improper Private Yacht Lower Deck Thrusters"
@@ -152,11 +158,13 @@
 	name = "\improper ITV Vulcan"
 	icon_state = "gantry_pod"
 	area_flags = AREA_FLAG_RAD_SHIELDED
+	turfs_airless = TRUE
 
 /area/scavver/harvestpod
 	name = "\improper ITV Spiritus"
 	icon_state = "gantry_yacht_down"
 	area_flags = AREA_FLAG_RAD_SHIELDED
+	turfs_airless = TRUE
 
 
 //smes

--- a/maps/away/scavver/scavver_gantry_shuttles.dm
+++ b/maps/away/scavver/scavver_gantry_shuttles.dm
@@ -215,7 +215,7 @@
 	landmark_tag = "nav_scavver_gantry_lift_bottom"
 	flags = SLANDMARK_FLAG_AUTOSET
 	base_area = /area/scavver/gantry/down1
-	base_turf = /turf/simulated/floor/airless
+	base_turf = /turf/simulated/floor/plating
 
 /singleton/stock_part_preset/radio/receiver/vent_pump/vulcan
 	frequency = 1431

--- a/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
@@ -1700,7 +1700,9 @@
 /obj/machinery/ion_engine{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/ship/skrellscoutship/maintenance/atmos)
 "fH" = (
 /obj/structure/table/rack,
@@ -1940,7 +1942,9 @@
 /obj/machinery/ion_engine{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/ship/skrellscoutship/hangar)
 "gp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1999,12 +2003,6 @@
 	},
 /turf/simulated/floor/tiled/skrell/red,
 /area/ship/skrellscoutship/hangar)
-"gu" = (
-/obj/machinery/ion_engine{
-	dir = 8
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/skrellscoutship/command/armory)
 "gw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
@@ -2818,7 +2816,9 @@
 /area/ship/skrellscoutship/wings/port)
 "iE" = (
 /obj/machinery/shipsensors,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/ship/skrellscoutship/wings/port)
 "iF" = (
 /obj/structure/bed/chair/comfy/red{
@@ -3516,8 +3516,10 @@
 /obj/machinery/ion_engine{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/ship/skrellscoutship/robotics)
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
+/area/ship/skrellscoutship/command/armory)
 "kG" = (
 /obj/effect/landmark/map_data,
 /obj/effect/overmap/visitable/sector/skrellscoutspace,
@@ -14010,7 +14012,7 @@ Fl
 Fl
 Fl
 Fl
-PT
+Fl
 Gw
 Gw
 Gw
@@ -14107,11 +14109,11 @@ RB
 Nh
 Fl
 Fl
-gu
-gu
-gu
-gu
-gu
+kF
+kF
+kF
+kF
+kF
 kF
 Gw
 Gw

--- a/maps/away/slavers/slavers_base.dmm
+++ b/maps/away/slavers/slavers_base.dmm
@@ -19,10 +19,10 @@
 /area/space)
 "af" = (
 /turf/simulated/mineral,
-/area/space)
+/area/mine/unexplored)
 "ag" = (
 /turf/simulated/floor/asteroid,
-/area/space)
+/area/mine/explored)
 "ah" = (
 /turf/simulated/wall,
 /area/slavers_base/mort)
@@ -35,34 +35,34 @@
 	desc = "A heavy box covered with dried blood.";
 	name = "Big dirty box"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "ak" = (
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "al" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "am" = (
 /obj/structure/crematorium,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "an" = (
 /obj/effect/decal/cleanable/ash,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "ao" = (
 /obj/structure/table/standard,
 /obj/item/wirecutters,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "ap" = (
 /obj/structure/table/standard,
 /obj/effect/landmark/corpse/slavers_base/slave,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "aq" = (
 /obj/structure/table/standard,
@@ -73,62 +73,62 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "ar" = (
 /obj/structure/table/standard,
 /obj/item/material/knife/table,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "as" = (
 /obj/structure/table/rack,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "at" = (
 /obj/effect/gibspawner/human,
 /turf/simulated/floor/asteroid,
-/area/space)
+/area/mine/explored)
 "au" = (
 /obj/structure/table/rack,
 /obj/item/wirecutters,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "av" = (
 /obj/item/shovel,
 /turf/simulated/floor/asteroid,
-/area/space)
+/area/mine/explored)
 "aw" = (
 /obj/item/remains/human,
 /turf/simulated/floor/asteroid,
-/area/space)
+/area/mine/explored)
 "ax" = (
 /obj/item/remains/human,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "ay" = (
 /obj/item/bodybag,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "az" = (
 /obj/item/material/knife/table,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "aA" = (
 /obj/structure/table/rack,
 /obj/item/material/hatchet,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "aB" = (
 /obj/structure/closet/crate/freezer,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "aC" = (
 /obj/effect/gibspawner/human,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "aD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "aE" = (
 /obj/structure/cable{
@@ -141,30 +141,30 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "aF" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "aG" = (
 /obj/machinery/gibber,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "aH" = (
 /obj/structure/kitchenspike,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "aI" = (
 /obj/structure/kitchenspike,
 /obj/machinery/light/small,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "aJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "aK" = (
 /obj/structure/cable{
@@ -176,13 +176,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "aL" = (
 /obj/machinery/door/airlock{
 	name = "Mortuary backyard"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/mort)
 "aM" = (
 /turf/simulated/wall,
@@ -198,31 +198,31 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "aO" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "aP" = (
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "aQ" = (
 /obj/machinery/light/small/red{
 	dir = 1
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "aR" = (
 /obj/structure/mattress/dirty,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "aS" = (
 /obj/structure/mattress/dirty,
 /obj/item/reagent_containers/glass/rag,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "aT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -234,39 +234,39 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "aU" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "aV" = (
 /obj/random/trash,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "aW" = (
 /obj/item/reagent_containers/glass/rag,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "aX" = (
 /obj/structure/hygiene/shower{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "aY" = (
 /obj/item/reagent_containers/glass/rag,
 /obj/random/trash,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "aZ" = (
 /obj/structure/mattress/dirty,
 /obj/item/reagent_containers/food/drinks/cans/waterbottle,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "ba" = (
 /obj/item/remains/human,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bb" = (
 /obj/effect/decal/cleanable/dirt,
@@ -277,7 +277,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bc" = (
 /obj/machinery/flasher{
@@ -285,24 +285,24 @@
 	name = "Floor mounted flash"
 	},
 /obj/item/reagent_containers/glass/rag,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bd" = (
 /obj/structure/mattress/dirty,
 /obj/item/trash/liquidfood,
 /obj/effect/landmark/corpse/slavers_base/slave,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "be" = (
 /obj/machinery/flasher{
 	id_tag = "permentryflash";
 	name = "Floor mounted flash"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bf" = (
 /obj/item/reagent_containers/food/drinks/cans/waterbottle,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bg" = (
 /obj/machinery/flasher{
@@ -310,7 +310,7 @@
 	name = "Floor mounted flash"
 	},
 /obj/random/trash,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bh" = (
 /obj/structure/mattress/dirty,
@@ -318,11 +318,11 @@
 	id_tag = "permentryflash";
 	name = "Floor mounted flash"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bi" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bj" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -330,16 +330,16 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bk" = (
 /obj/machinery/door/window/brigdoor/southright,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bl" = (
 /obj/machinery/door/window/brigdoor/southright,
 /obj/random/trash,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bm" = (
 /obj/effect/decal/cleanable/dirt,
@@ -354,7 +354,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -369,7 +369,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bo" = (
 /obj/machinery/door/airlock{
@@ -387,7 +387,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -412,7 +412,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -421,7 +421,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "br" = (
 /obj/effect/decal/cleanable/dirt,
@@ -440,7 +440,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bs" = (
 /obj/machinery/flasher{
@@ -453,7 +453,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -467,23 +467,23 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bu" = (
 /obj/structure/mattress/dirty,
 /obj/effect/landmark/corpse/slavers_base/slave,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bv" = (
 /obj/structure/closet/crate/freezer/rations,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bw" = (
 /obj/item/paper/spacer{
 	info = "Tonight, when lights are out. Prepare shivs, pieces of glass, whatever you might find.";
 	name = "Note"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bx" = (
 /obj/effect/decal/cleanable/dirt,
@@ -492,11 +492,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "by" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bz" = (
 /obj/structure/closet/crate/freezer/rations,
@@ -509,7 +509,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bA" = (
 /obj/random/trash,
@@ -519,12 +519,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bB" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/remains/human,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bC" = (
 /obj/machinery/light{
@@ -536,15 +536,15 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bD" = (
 /obj/random/shoes,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bE" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -555,26 +555,26 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bG" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/structure/cable/cyan,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bH" = (
 /obj/machinery/door/window/brigdoor/northright,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bI" = (
 /obj/random/trash,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bJ" = (
 /obj/item/storage/bag/trash,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bK" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -582,7 +582,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bL" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -600,7 +600,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bM" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -608,7 +608,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bN" = (
 /obj/machinery/door/airlock{
@@ -616,22 +616,22 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bO" = (
 /obj/machinery/light/small/red,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bP" = (
 /obj/machinery/light/small/red,
 /obj/structure/mattress/dirty,
 /obj/effect/landmark/corpse/slavers_base/slave,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bQ" = (
 /obj/structure/mattress/dirty,
 /obj/random/junk,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "bR" = (
 /obj/machinery/light{
@@ -639,7 +639,7 @@
 	icon_state = "tube1"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bS" = (
 /obj/effect/decal/cleanable/dirt,
@@ -653,7 +653,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -672,7 +672,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bU" = (
 /obj/structure/cable/cyan{
@@ -680,7 +680,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bV" = (
 /obj/random/trash,
@@ -700,7 +700,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bW" = (
 /obj/machinery/flasher{
@@ -729,7 +729,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bX" = (
 /obj/machinery/door/airlock{
@@ -747,7 +747,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bY" = (
 /obj/effect/decal/cleanable/dirt,
@@ -769,7 +769,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "bZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -784,7 +784,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "ca" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -802,7 +802,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cb" = (
 /obj/machinery/door/airlock{
@@ -810,7 +810,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cc" = (
 /obj/effect/decal/cleanable/dirt,
@@ -821,55 +821,55 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "cd" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
 	},
 /obj/item/reagent_containers/food/snacks/liquidfood,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "ce" = (
 /obj/machinery/light/small/red{
 	dir = 1
 	},
 /obj/structure/mattress/dirty,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cf" = (
 /obj/structure/mattress/dirty,
 /obj/random/snack,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cg" = (
 /obj/machinery/light/small/red{
 	dir = 1
 	},
 /obj/random/medical/lite,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "ch" = (
 /obj/structure/mattress/dirty,
 /obj/item/remains/human,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "ci" = (
 /obj/random/junk,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "ck" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -881,7 +881,7 @@
 /obj/item/device/flashlight,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "cm" = (
 /turf/simulated/wall,
@@ -905,7 +905,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "co" = (
 /obj/machinery/door/airlock{
@@ -928,7 +928,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "cp" = (
 /obj/effect/decal/cleanable/dirt,
@@ -953,7 +953,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "cq" = (
 /obj/effect/decal/cleanable/dirt,
@@ -972,7 +972,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "cr" = (
 /obj/effect/decal/cleanable/dirt,
@@ -986,26 +986,26 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "cs" = (
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hangar)
 "ct" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hangar)
 "cu" = (
 /obj/machinery/door/blast/regular{
 	id_tag = "service_hangar"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hangar)
 "cv" = (
 /obj/effect/landmark/corpse/slavers_base/slave,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1017,16 +1017,16 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "cx" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/structure/cable/cyan,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "cy" = (
 /obj/random/medical/lite,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cz" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1041,7 +1041,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "cA" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1059,101 +1059,101 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/cells)
 "cB" = (
 /obj/machinery/door/window/brigdoor/northright,
 /obj/item/reagent_containers/glass/rag,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cC" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hangar)
 "cD" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hangar)
 "cE" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hangar)
 "cF" = (
 /obj/item/paper,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cG" = (
 /obj/item/trash/liquidfood,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cH" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hangar)
 "cI" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hangar)
 "cJ" = (
 /obj/item/paper/spacer{
 	info = "Doc who checked us told implants won't explode our heads. Gotta make guys know. Seems I see a silver lining.";
 	name = "Note"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cK" = (
 /obj/machinery/light/small/red,
 /obj/item/remains/human,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cL" = (
 /obj/random/snack,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cM" = (
 /obj/structure/mattress/dirty,
 /obj/item/reagent_containers/food/drinks/cans/waterbottle,
 /obj/random/junk,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cN" = (
 /obj/machinery/light/small/red,
 /obj/random/trash,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cO" = (
 /obj/structure/mattress/dirty,
 /obj/item/reagent_containers/glass/rag,
 /obj/item/reagent_containers/food/drinks/cans/waterbottle,
 /obj/effect/landmark/corpse/slavers_base/slave,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cP" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
 	},
 /obj/item/trash/liquidfood,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cQ" = (
 /obj/machinery/light/small/red,
 /obj/structure/mattress/dirty,
 /obj/item/reagent_containers/glass/rag,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/cells)
 "cR" = (
 /turf/simulated/wall,
@@ -1173,7 +1173,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "cU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1185,7 +1185,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "cV" = (
 /turf/simulated/wall,
@@ -1196,59 +1196,59 @@
 /area/space)
 "cX" = (
 /obj/machinery/atmospherics/unary/tank/air,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "cY" = (
 /obj/machinery/atmospherics/unary/tank/air,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "cZ" = (
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "da" = (
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "db" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "dc" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "dd" = (
 /obj/structure/bed,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/secwing)
 "de" = (
 /obj/structure/closet,
 /obj/random/snack,
 /obj/random/projectile,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/secwing)
 "df" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/secwing)
 "dg" = (
 /obj/structure/bed,
 /obj/random/projectile,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/secwing)
 "dh" = (
 /obj/structure/closet,
 /obj/random/smokes,
 /obj/random/masks,
 /obj/random/suit,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/secwing)
 "di" = (
 /obj/structure/table/rack,
@@ -1316,7 +1316,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/secwing)
 "ds" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1336,7 +1336,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "dt" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1356,7 +1356,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "du" = (
 /obj/machinery/door/airlock{
@@ -1373,7 +1373,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "dv" = (
 /obj/machinery/flasher{
@@ -1391,7 +1391,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "dw" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1404,81 +1404,81 @@
 	name = "Medical room";
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "dx" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "dy" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "dz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/hygiene/shower{
 	pixel_y = 30
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "dA" = (
 /obj/machinery/door/airlock{
 	name = "Storage"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "dB" = (
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/med)
 "dC" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/med)
 "dD" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/med)
 "dE" = (
 /obj/structure/closet/crate/freezer/rations,
 /obj/item/reagent_containers/food/snacks/liquidfood,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/med)
 "dF" = (
 /obj/structure/closet/crate/freezer/rations,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/med)
 "dG" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow{
 	dir = 8
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "dH" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "dI" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "dJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 10
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "dK" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "dL" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/secwing)
 "dM" = (
 /obj/structure/cable/green{
@@ -1550,7 +1550,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/secwing)
 "dT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1568,7 +1568,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "dU" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1578,78 +1578,78 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "dV" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "dW" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/junk,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "dX" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/random/medical/lite,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "dY" = (
 /obj/structure/bed,
 /obj/item/remains/human,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "dZ" = (
 /obj/item/reagent_containers/food/snacks/liquidfood,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/med)
 "ea" = (
 /obj/structure/closet/crate/trashcart,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/med)
 "eb" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hangar)
 "ec" = (
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hangar)
 "ed" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hangar)
 "ee" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 1;
 	name = "waste pump"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "ef" = (
 /obj/machinery/atmospherics/binary/pump,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "eg" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "eh" = (
 /obj/random/junk,
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/secwing)
 "ei" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/secwing)
 "ej" = (
 /obj/structure/cable/green{
@@ -1702,25 +1702,25 @@
 /area/slavers_base/secwing)
 "eq" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/secwing)
 "er" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "es" = (
 /obj/item/ammo_casing/shotgun/beanbag,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "et" = (
 /obj/structure/window/basic{
 	dir = 1
 	},
 /obj/item/clothing/gloves/latex,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "eu" = (
 /obj/structure/window/basic{
@@ -1729,46 +1729,46 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/corpse/slavers_base/slaver5,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "ev" = (
 /obj/structure/window/basic{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "ew" = (
 /obj/structure/window/basic{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "ex" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/ammo_casing/shotgun/beanbag,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "ey" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "ez" = (
 /obj/structure/bed,
 /obj/item/handcuffs,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "eA" = (
 /obj/item/beartrap,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/med)
 "eB" = (
 /obj/item/mop,
 /obj/structure/mopbucket,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/med)
 "eC" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hangar)
 "eD" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -1777,47 +1777,47 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "eE" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "eF" = (
 /obj/random/tool,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "eG" = (
 /obj/machinery/atmospherics/binary/pump{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "eH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "eI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "eJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "eK" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "eL" = (
 /obj/structure/cable/green{
@@ -1831,7 +1831,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/secwing)
 "eM" = (
 /obj/structure/cable/green{
@@ -1845,7 +1845,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/secwing)
 "eN" = (
 /obj/structure/cable/green{
@@ -1862,7 +1862,7 @@
 /obj/machinery/door/airlock{
 	name = "Slave hold hallway"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/secwing)
 "eO" = (
 /obj/structure/cable/green{
@@ -1909,14 +1909,14 @@
 "eT" = (
 /obj/item/gun/projectile/shotgun/pump,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "eU" = (
 /obj/machinery/optable,
 /obj/item/scalpel,
 /obj/effect/decal/cleanable/blood,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "eV" = (
 /obj/structure/window/basic{
@@ -1927,14 +1927,14 @@
 /obj/item/implantcase/tracking,
 /obj/item/surgicaldrill,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "eW" = (
 /obj/machinery/optable,
 /obj/effect/decal/cleanable/blood,
 /obj/item/screwdriver,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "eX" = (
 /obj/structure/window/basic{
@@ -1943,14 +1943,14 @@
 /obj/structure/table/standard,
 /obj/item/implantpad,
 /obj/item/reagent_containers/pill/spaceacillin,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "eY" = (
 /obj/structure/table/standard,
 /obj/item/storage/firstaid/empty,
 /obj/item/handcuffs,
 /obj/item/melee/baton,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "eZ" = (
 /obj/structure/table/standard,
@@ -1961,46 +1961,46 @@
 	name = "Note"
 	},
 /obj/item/pen,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "fa" = (
 /obj/structure/table/standard,
 /obj/item/storage/firstaid/regular,
 /obj/item/material/hatchet,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "fb" = (
 /obj/item/roller_bed,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "fc" = (
 /obj/structure/bed,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/med)
 "fd" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/handcuffs,
 /obj/item/storage/box/handcuffs,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/med)
 "fe" = (
 /obj/structure/table/standard,
 /obj/item/storage/box/bodybags,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/med)
 "ff" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/med)
 "fg" = (
 /obj/structure/reagent_dispensers/water_cooler,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/med)
 "fh" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 8
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hangar)
 "fi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -2011,7 +2011,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hangar)
 "fj" = (
 /obj/structure/cable{
@@ -2022,11 +2022,11 @@
 	name = "Slavers hangar";
 	pixel_y = -24
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hangar)
 "fk" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hangar)
 "fl" = (
 /obj/effect/decal/cleanable/generic,
@@ -2034,14 +2034,14 @@
 	dir = 4;
 	level = 2
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "fm" = (
 /obj/effect/decal/cleanable/generic,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "fn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2054,16 +2054,16 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/secwing)
 "fo" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "fp" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hangar)
 "fq" = (
 /obj/machinery/door/airlock/external,
@@ -2072,7 +2072,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hangar)
 "fr" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2082,7 +2082,7 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "fs" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2096,7 +2096,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "ft" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2114,7 +2114,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hallway)
 "fu" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -2133,7 +2133,7 @@
 	icon_state = "0-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "fv" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2148,7 +2148,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "fw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2166,7 +2166,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "fx" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -2178,7 +2178,7 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "fy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2193,7 +2193,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "fz" = (
 /obj/machinery/door/airlock{
@@ -2210,7 +2210,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/maint)
 "fA" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2224,7 +2224,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "fB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2235,13 +2235,13 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "fC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "fD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2250,13 +2250,13 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "fE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "fF" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -2265,19 +2265,19 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "fG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "fH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
 	dir = 9
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "fI" = (
 /obj/structure/cable{
@@ -2285,45 +2285,45 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "fJ" = (
 /turf/simulated/wall,
 /area/slavers_base/maint)
 "fK" = (
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "fL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 6
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "fM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "fN" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 10
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "fO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "fP" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "fQ" = (
 /obj/structure/cable/green{
@@ -2331,14 +2331,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "fR" = (
 /obj/machinery/door/airlock{
 	name = "Power/atmos"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/hallway)
 "fS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2349,31 +2349,31 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "fT" = (
 /obj/item/wrench,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "fU" = (
 /obj/machinery/light,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "fV" = (
 /obj/machinery/door/airlock{
 	name = "West hallway"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "fW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "fX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2383,7 +2383,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "fY" = (
 /obj/structure/cable{
@@ -2395,7 +2395,7 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/smes/buildable,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "fZ" = (
 /obj/structure/cable{
@@ -2403,7 +2403,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "ga" = (
 /obj/structure/cable{
@@ -2411,36 +2411,36 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "gb" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
 	dir = 8
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "gc" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "gd" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "ge" = (
 /obj/machinery/atmospherics/omni/filter{
 	dir = 8
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "gf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "gg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2451,7 +2451,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "gh" = (
 /obj/structure/cable/green{
@@ -2468,7 +2468,7 @@
 	name = "Slavers atmos and power room";
 	pixel_x = 24
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "gi" = (
 /turf/simulated/wall,
@@ -2484,7 +2484,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "gk" = (
 /obj/machinery/door/airlock{
@@ -2492,13 +2492,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "gl" = (
 /obj/machinery/door/airlock{
 	name = "Southern hallway"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "gm" = (
 /obj/machinery/door/airlock{
@@ -2511,22 +2511,22 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "gn" = (
 /obj/machinery/atmospherics/binary/pump,
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "go" = (
 /obj/machinery/portable_atmospherics/canister,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "gp" = (
 /obj/item/crowbar,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "gq" = (
 /obj/structure/cable{
@@ -2534,7 +2534,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "gr" = (
 /obj/structure/table/steel,
@@ -2549,7 +2549,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "gs" = (
 /obj/structure/cable/green{
@@ -2562,7 +2562,7 @@
 /turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "gt" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "gu" = (
 /obj/machinery/vending/wallmed2{
@@ -2570,61 +2570,61 @@
 	},
 /obj/structure/table/standard,
 /obj/random/cash,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "gv" = (
 /obj/structure/bed,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "gw" = (
 /obj/structure/closet,
 /obj/random/smokes,
 /obj/random/loot,
 /obj/random/contraband,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "gx" = (
 /obj/structure/table/standard,
 /obj/random/coin,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "gy" = (
 /obj/structure/bed,
 /obj/random/plushie,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "gz" = (
 /obj/structure/closet,
 /obj/random/smokes,
 /obj/random/loot,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "gA" = (
 /obj/structure/table/standard,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "gB" = (
 /obj/structure/closet,
 /obj/random/loot,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "gC" = (
 /obj/structure/table/standard,
 /obj/random/contraband,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "gD" = (
 /obj/structure/bed,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "gE" = (
 /obj/structure/closet,
 /obj/random/smokes,
 /obj/random/cash,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "gF" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2632,14 +2632,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "gG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "gH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -2649,30 +2649,30 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "gI" = (
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "gJ" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "gK" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "gL" = (
 /obj/machinery/atmospherics/portables_connector{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "gM" = (
 /obj/structure/table/steel,
@@ -2682,11 +2682,11 @@
 	icon_state = "1-2"
 	},
 /obj/item/storage/toolbox/mechanical,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "gN" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "gO" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2704,7 +2704,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "gP" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2718,7 +2718,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "gQ" = (
 /obj/random/junk,
@@ -2736,7 +2736,7 @@
 	name = "Slavers Maintenance";
 	pixel_y = -24
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "gR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2745,7 +2745,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "gS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2755,7 +2755,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "gT" = (
 /obj/machinery/door/airlock{
@@ -2767,7 +2767,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "gU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2776,17 +2776,17 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "gV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "gW" = (
 /obj/machinery/floodlight,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "gX" = (
 /obj/structure/table/steel,
@@ -2801,7 +2801,7 @@
 /obj/item/stack/material/phoron{
 	amount = 25
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "gY" = (
 /obj/machinery/light{
@@ -2818,11 +2818,11 @@
 /area/slavers_base/dorms)
 "gZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "ha" = (
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "hb" = (
 /obj/machinery/light{
@@ -2831,7 +2831,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "hc" = (
 /obj/machinery/light{
@@ -2844,7 +2844,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "hd" = (
 /turf/simulated/wall,
@@ -2853,22 +2853,18 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "hf" = (
 /obj/machinery/light/small{
 	dir = 4;
 	pixel_y = 8
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
-"hg" = (
-/obj/item/coilgun_assembly,
-/turf/simulated/floor/airless/ceiling,
-/area/slavers_base/powatm)
 "hh" = (
 /obj/random/junk,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "hi" = (
 /obj/structure/table/steel,
@@ -2880,58 +2876,58 @@
 /obj/item/stack/material/phoron{
 	amount = 25
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "hj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "hk" = (
 /obj/structure/table/standard,
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "hl" = (
 /obj/structure/bed,
 /obj/item/device/radio,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "hm" = (
 /obj/structure/closet,
 /obj/random/projectile,
 /obj/random/loot,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "hn" = (
 /obj/structure/table/standard,
 /obj/random/loot,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "ho" = (
 /obj/structure/table/standard,
 /obj/random/gloves,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "hp" = (
 /obj/structure/closet,
 /obj/random/loot,
 /obj/random/contraband,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "hq" = (
 /obj/structure/closet,
 /obj/random/projectile,
 /obj/random/ammo,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "hr" = (
 /obj/structure/safe,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/demo)
 "hs" = (
 /obj/machinery/light{
@@ -2939,12 +2935,12 @@
 	},
 /obj/structure/safe,
 /obj/item/storage/bag/cash,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/demo)
 "ht" = (
 /obj/structure/safe,
 /obj/item/storage/bag/cash,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/demo)
 "hu" = (
 /obj/machinery/light{
@@ -2953,36 +2949,36 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "hv" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "hw" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "hx" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "hy" = (
 /obj/random/junk,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "hz" = (
 /obj/machinery/vending/engineering{
 	req_access = list()
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "hA" = (
 /obj/item/stock_parts/computer/card_slot,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "hB" = (
 /obj/structure/cable{
@@ -2990,11 +2986,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "hC" = (
 /obj/machinery/power/smes/buildable,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "hD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3002,7 +2998,7 @@
 /obj/machinery/door/airlock{
 	name = "Slave hold hallway"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "hE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -3016,7 +3012,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "hF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3025,7 +3021,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "hG" = (
 /obj/machinery/door/airlock{
@@ -3037,7 +3033,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/demo)
 "hH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3046,7 +3042,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/demo)
 "hI" = (
 /obj/random/coin,
@@ -3056,7 +3052,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/demo)
 "hJ" = (
 /obj/machinery/door/airlock{
@@ -3068,7 +3064,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/demo)
 "hK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3077,14 +3073,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "hL" = (
 /obj/structure/bed/chair{
 	dir = 4
 	},
 /obj/item/device/radio,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "hM" = (
 /obj/structure/table/reinforced,
@@ -3093,18 +3089,18 @@
 	icon_state = "pdoor0";
 	id_tag = "SC BD"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "hN" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "hO" = (
 /obj/structure/table/woodentable,
 /obj/item/device/radio,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "hP" = (
 /obj/structure/table/woodentable,
@@ -3112,13 +3108,13 @@
 /obj/random/cash,
 /obj/random/cash,
 /obj/random/cash,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "hQ" = (
 /obj/structure/bed/chair/comfy/beige{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "hR" = (
 /obj/machinery/power/terminal{
@@ -3128,7 +3124,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "hS" = (
 /obj/structure/cable/green{
@@ -3213,45 +3209,45 @@
 "id" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "ie" = (
 /obj/structure/closet/secure_closet/guncabinet,
 /obj/random/projectile,
 /obj/random/projectile,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/demo)
 "if" = (
 /obj/structure/closet/secure_closet/guncabinet,
 /obj/random/projectile,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/demo)
 "ig" = (
 /obj/random/coin,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/demo)
 "ih" = (
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/demo)
 "ii" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "ij" = (
 /obj/structure/table/woodentable,
 /obj/item/storage/bag/cash,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "ik" = (
 /obj/structure/table/woodentable,
 /obj/random/cash,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "il" = (
 /obj/structure/ore_box,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "im" = (
 /obj/structure/ore_box,
@@ -3264,7 +3260,7 @@
 /obj/item/stack/material/phoron{
 	amount = 25
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "in" = (
 /obj/structure/closet/crate,
@@ -3286,7 +3282,7 @@
 /obj/item/stack/material/phoron{
 	amount = 25
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "io" = (
 /obj/structure/closet/crate,
@@ -3306,7 +3302,7 @@
 	amount = 25
 	},
 /obj/machinery/light/small,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "ip" = (
 /obj/structure/closet/crate,
@@ -3322,7 +3318,7 @@
 /obj/item/stack/material/phoron{
 	amount = 25
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "iq" = (
 /obj/machinery/power/port_gen/pacman/super,
@@ -3330,7 +3326,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "ir" = (
 /obj/machinery/power/port_gen/pacman/super,
@@ -3342,7 +3338,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "is" = (
 /obj/machinery/power/port_gen/pacman/super,
@@ -3355,7 +3351,7 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/light/small,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "it" = (
 /obj/structure/cable/green{
@@ -3363,7 +3359,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/powatm)
 "iu" = (
 /obj/structure/cable/green{
@@ -3392,13 +3388,13 @@
 	info = "<center><b> Contract </b></center> <br>This contract describes exchanging of monetary pieces for the right o? the ownership for following examples: <list><*> Human, age 17. Price - 1500 thalers. <*> Human, age 49. Price - 1100 thalers. <*> Unathi, age 28. Good fist fighter. Price - 2400 thalers. <*> Human, age 34. Expirienced medic. Price - 6800 thalers. </list> <b> Overall price: 11800 thalers</b><br><small>Place for signatures</small>";
 	name = "Contract"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "iz" = (
 /obj/structure/table/woodentable,
 /obj/random/coin,
 /obj/item/pen,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "iA" = (
 /obj/machinery/light{
@@ -3444,7 +3440,7 @@
 "iG" = (
 /obj/random/junk,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "iH" = (
 /obj/machinery/light{
@@ -3457,23 +3453,23 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "iI" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "iJ" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "iK" = (
 /obj/item/clothing/suit/nun,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "iL" = (
 /obj/machinery/light{
@@ -3481,7 +3477,7 @@
 	},
 /obj/item/clothing/suit/unathi/robe,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "iM" = (
 /obj/structure/cable{
@@ -3606,7 +3602,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "iX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3620,7 +3616,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "iY" = (
 /obj/machinery/door/airlock{
@@ -3637,7 +3633,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "iZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3652,25 +3648,25 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "ja" = (
 /obj/item/clothing/shoes/brown,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "jb" = (
 /obj/item/clothing/under/bluepyjamas,
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "jc" = (
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "jd" = (
 /obj/machinery/light,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "je" = (
 /obj/machinery/door/airlock{
@@ -3681,7 +3677,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/dorms)
 "jf" = (
 /obj/structure/cable{
@@ -3733,17 +3729,17 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "jn" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "jo" = (
 /obj/machinery/door/airlock{
 	name = "Private office"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "jp" = (
 /obj/structure/cable/green{
@@ -3751,7 +3747,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/dorms)
 "jq" = (
 /obj/structure/table/standard,
@@ -3761,7 +3757,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/dorms)
 "jr" = (
 /obj/structure/bed/chair{
@@ -3792,14 +3788,14 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "ju" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "jv" = (
 /turf/simulated/floor/tiled,
@@ -3823,12 +3819,12 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/dorms)
 "jz" = (
 /obj/structure/cable,
 /obj/machinery/power/smes/buildable,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/dorms)
 "jA" = (
 /obj/effect/decal/cleanable/blood,
@@ -3866,7 +3862,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "jG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3877,14 +3873,14 @@
 	icon_state = "1-8"
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "jH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "jI" = (
 /obj/structure/table/standard,
@@ -3929,7 +3925,7 @@
 	name = "Restroom"
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/dorms)
 "jQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3937,7 +3933,7 @@
 /obj/machinery/door/airlock{
 	name = "Southern hallway"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "jR" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -3986,13 +3982,13 @@
 /obj/structure/hygiene/shower{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/slavers_base/dorms)
 "jY" = (
 /obj/machinery/door/airlock{
 	name = "Shower"
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/slavers_base/dorms)
 "jZ" = (
 /obj/effect/landmark/corpse/slavers_base/slaver3,
@@ -4015,14 +4011,14 @@
 /obj/machinery/door/airlock{
 	name = "Toilet"
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/slavers_base/dorms)
 "ke" = (
 /obj/structure/hygiene/toilet{
 	dir = 8
 	},
 /obj/random/junk,
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/slavers_base/dorms)
 "kf" = (
 /turf/simulated/wall,
@@ -4034,7 +4030,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "kh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -4043,7 +4039,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "ki" = (
 /obj/machinery/door/airlock{
@@ -4055,7 +4051,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "kj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4094,16 +4090,16 @@
 /area/slavers_base/dorms)
 "kp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "kq" = (
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "kr" = (
 /obj/machinery/door/airlock{
 	name = "Slave trade area"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/demo)
 "ks" = (
 /obj/structure/cable{
@@ -4151,111 +4147,111 @@
 	name = "Customers entry"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "kB" = (
 /obj/machinery/door/airlock{
 	name = "Customers entry"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/slavers_base/hallway)
 "kC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kE" = (
 /obj/machinery/door/airlock{
 	name = "Exchange area"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kF" = (
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/decal/cleanable/generic,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kH" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kJ" = (
 /obj/effect/wallframe_spawn/reinforced,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kK" = (
 /obj/machinery/door/airlock{
 	name = "Exchange point"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kL" = (
 /obj/machinery/atmospherics/binary/pump,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kM" = (
 /obj/structure/table/standard,
 /obj/item/device/radio,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kN" = (
 /obj/structure/table/standard,
 /obj/random/handgun,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kO" = (
 /obj/machinery/door/airlock/external,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kP" = (
 /obj/machinery/door/airlock/external,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kQ" = (
 /obj/structure/table/standard,
 /obj/random/junk,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kR" = (
 /obj/structure/bed/chair{
 	dir = 1
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kS" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kT" = (
 /obj/structure/table/standard,
 /obj/random/loot,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kU" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
 	dir = 1;
 	id_tag = "solar_port_pump"
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/slavers_base/maint)
 "kW" = (
 /obj/effect/overmap/visitable/sector/slavers_base,
@@ -15114,7 +15110,7 @@ gd
 da
 go
 da
-hg
+da
 da
 da
 in

--- a/maps/away/slavers/slavers_base_areas.dm
+++ b/maps/away/slavers/slavers_base_areas.dm
@@ -40,3 +40,4 @@
 /area/slavers_base/hangar
 	name = "\improper Slavers Base Hangar"
 	icon_state = "hangar"
+	turfs_airless = TRUE

--- a/maps/away/smugglers/smugglers.dmm
+++ b/maps/away/smugglers/smugglers.dmm
@@ -26,9 +26,6 @@
 	},
 /turf/simulated/floor,
 /area/smugglers/base)
-"ah" = (
-/turf/simulated/floor/asteroid,
-/area/space)
 "aj" = (
 /obj/item/ammo_casing/pistol/magnum{
 	pixel_x = 5;
@@ -70,15 +67,12 @@
 "an" = (
 /turf/unsimulated/mask,
 /area/mine/explored)
-"ao" = (
-/turf/space,
-/area/mine/unexplored)
 "ap" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	injecting = 1;
 	use_power = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "aq" = (
 /obj/machinery/door/airlock/external{
@@ -95,7 +89,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/smugglers/base)
 "au" = (
 /obj/item/device/flashlight/flare/glowstick/yellow{
@@ -904,7 +898,7 @@
 /area/smugglers/dorms)
 "cj" = (
 /obj/effect/decal/cleanable/cobweb,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/smugglers/dorms)
 "cl" = (
 /obj/effect/decal/cleanable/dirt,
@@ -935,13 +929,13 @@
 "cp" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/random/medical/lite,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/smugglers/dorms)
 "cq" = (
 /obj/structure/hygiene/toilet{
 	dir = 8
 	},
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/smugglers/dorms)
 "cr" = (
 /obj/structure/bed/chair{
@@ -1038,7 +1032,7 @@
 	pixel_y = 30
 	},
 /obj/random/soap,
-/turf/simulated/floor/airless/ceiling,
+/turf/simulated/floor/ceiling,
 /area/smugglers/dorms)
 
 (1,1,1) = {"
@@ -4436,7 +4430,7 @@ aa
 aa
 aa
 aa
-ah
+ab
 af
 ay
 aQ
@@ -4537,7 +4531,7 @@ aa
 aa
 aa
 aa
-ah
+ab
 an
 af
 az
@@ -4640,7 +4634,7 @@ aa
 aa
 aa
 aa
-ao
+aa
 af
 aA
 aO

--- a/maps/away/voxship/voxship-2.dmm
+++ b/maps/away/voxship/voxship-2.dmm
@@ -22,13 +22,17 @@
 /obj/machinery/atmospherics/unary/engine{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/thrusters)
 "ag" = (
 /obj/machinery/atmospherics/pipe/vent/high_volume{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/engineering)
 "ah" = (
 /turf/simulated/floor/plating/vox,
@@ -413,7 +417,9 @@
 /turf/simulated/wall/r_wall/hull/vox,
 /area/voxship/thrusters)
 "be" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/fore)
 "bf" = (
 /obj/item/reagent_containers/food/drinks/glass2/flute,
@@ -616,7 +622,9 @@
 /area/voxship/thrusters)
 "bF" = (
 /obj/machinery/shipsensors,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/fore)
 "bG" = (
 /obj/random/junk,
@@ -883,19 +891,25 @@
 /area/space)
 "cp" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/thrusters)
 "cq" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/thrusters)
 "cr" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/thrusters)
 "cs" = (
 /obj/machinery/computer/ship/engines{
@@ -1184,14 +1198,18 @@
 /area/voxship/thrusters)
 "cP" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/thrusters)
 "cQ" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
 /obj/machinery/igniter{
 	id_tag = "Voxship_igniter"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/thrusters)
 "cR" = (
 /obj/machinery/door/blast/regular{
@@ -1199,13 +1217,17 @@
 	id_tag = "vox_fusion"
 	},
 /obj/structure/grille,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/thrusters)
 "cS" = (
 /obj/machinery/atmospherics/pipe/vent/high_volume{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/fore)
 "cT" = (
 /obj/effect/wallframe_spawn/reinforced/hull/vox,
@@ -1452,20 +1474,26 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/thrusters)
 "do" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/vent/high_volume,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/thrusters)
 "dp" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/thrusters)
 "dq" = (
 /obj/machinery/computer/ship/sensors/vox{
@@ -1644,7 +1672,9 @@
 	id_tag = "vox_engineview";
 	opacity = 0
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/thrusters)
 "dL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -1652,7 +1682,9 @@
 	id_tag = "voxengine";
 	locked = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/thrusters)
 "dN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1670,7 +1702,9 @@
 /obj/machinery/atmospherics/pipe/vent/high_volume{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/thrusters)
 "dQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1717,7 +1751,9 @@
 /obj/machinery/atmospherics/pipe/vent/high_volume{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/scavship)
 "dW" = (
 /obj/machinery/vending/engivend{
@@ -2461,7 +2497,7 @@
 /area/voxship/engineering)
 "fD" = (
 /obj/effect/wallframe_spawn/reinforced/hull/vox,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/voxship/scavship)
 "fE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
@@ -2520,7 +2556,7 @@
 /area/voxship/scavship)
 "fO" = (
 /obj/item/material/shard,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "fP" = (
 /obj/structure/lattice,
@@ -2529,11 +2565,11 @@
 /area/space)
 "fQ" = (
 /obj/item/stack/material/rods,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "fR" = (
 /obj/item/reagent_containers/food/snacks/clownburger,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "fS" = (
 /obj/item/material/shard,
@@ -2562,7 +2598,7 @@
 /area/voxship/fore)
 "fW" = (
 /obj/random/advdevice,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "fX" = (
 /turf/space,
@@ -2571,7 +2607,9 @@
 /obj/machinery/atmospherics/pipe/vent/high_volume{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/engineering)
 "fZ" = (
 /obj/machinery/door/window,
@@ -2643,7 +2681,9 @@
 /obj/machinery/atmospherics/pipe/vent/high_volume{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/shuttle)
 "gh" = (
 /obj/structure/lattice,
@@ -2713,7 +2753,7 @@
 	name = "Window Shutters";
 	opacity = 0
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/voxship/engineering)
 "go" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -2726,11 +2766,13 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/universal{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/voxship/scavship)
 "gq" = (
 /obj/machinery/atmospherics/pipe/vent/high_volume,
-/turf/simulated/floor/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/engineering)
 "gr" = (
 /obj/machinery/seed_extractor,
@@ -2738,7 +2780,7 @@
 /area/voxship/scavship)
 "gs" = (
 /obj/random/loot,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "gt" = (
 /obj/random/hat,
@@ -2892,7 +2934,9 @@
 /obj/machinery/atmospherics/unary/engine{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/shuttle)
 "gL" = (
 /obj/machinery/computer/ship/helm{
@@ -3033,7 +3077,9 @@
 /area/voxship/shuttle)
 "hf" = (
 /obj/machinery/shipsensors,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/voxship/shuttle)
 "hg" = (
 /obj/machinery/atmospherics/portables_connector{

--- a/maps/away/yacht/yacht.dmm
+++ b/maps/away/yacht/yacht.dmm
@@ -12,8 +12,8 @@
 /area/yacht/bridge)
 "ad" = (
 /obj/machinery/shipsensors,
-/turf/simulated/floor/airless{
-	icon_state = "dmg2"
+/turf/simulated/floor{
+	map_airless = 1
 	},
 /area/yacht/bridge)
 "ae" = (
@@ -177,8 +177,10 @@
 /obj/structure/disposaloutlet{
 	dir = 4
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor{
+	map_airless = 1
+	},
+/area/yacht/engine)
 "aB" = (
 /turf/simulated/wall/titanium,
 /area/yacht/living)
@@ -714,7 +716,9 @@
 	},
 /obj/machinery/power/solar,
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/yacht/engine)
 "cd" = (
 /obj/structure/closet/crate/hydroponics,
@@ -824,8 +828,8 @@
 /obj/effect/decal/cleanable/blood/oil/streak,
 /obj/effect/decal/cleanable/generic,
 /obj/effect/decal/cleanable/molten_item,
-/turf/simulated/floor/airless{
-	icon_state = "dmg2"
+/turf/simulated/floor{
+	map_airless = 1
 	},
 /area/yacht/engine)
 "cq" = (
@@ -845,8 +849,8 @@
 	icon_state = "1-8"
 	},
 /obj/item/stock_parts/circuitboard/broken,
-/turf/simulated/floor/airless{
-	icon_state = "dmg2"
+/turf/simulated/floor{
+	map_airless = 1
 	},
 /area/yacht/engine)
 "cr" = (
@@ -866,8 +870,8 @@
 	icon_state = "1-8"
 	},
 /obj/item/storage/toolbox/syndicate,
-/turf/simulated/floor/airless{
-	icon_state = "dmg2"
+/turf/simulated/floor{
+	map_airless = 1
 	},
 /area/yacht/engine)
 "cs" = (
@@ -887,7 +891,9 @@
 	icon_state = "1-8"
 	},
 /obj/item/plastique,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/yacht/engine)
 "ct" = (
 /obj/structure/cable{
@@ -905,7 +911,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/yacht/engine)
 "cu" = (
 /obj/effect/decal/cleanable/dirt,
@@ -914,7 +922,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/yacht/engine)
 "cC" = (
 /obj/structure/cable,
@@ -962,13 +972,17 @@
 	dir = 8;
 	use_power = 1
 	},
-/turf/space,
-/area/space)
+/turf/simulated/floor{
+	map_airless = 1
+	},
+/area/yacht/engine)
 "cL" = (
 /obj/structure/cable,
 /obj/machinery/power/solar,
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/yacht/engine)
 "cN" = (
 /obj/structure/closet/toolcloset,
@@ -1216,7 +1230,9 @@
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/yacht/engine)
 "dF" = (
 /obj/effect/shuttle_landmark/nav_yacht/nav3,
@@ -1306,7 +1322,9 @@
 	frequency = 1439;
 	id_tag = "yacht_outer"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/yacht/engine)
 "kb" = (
 /obj/structure/cable{
@@ -1333,7 +1351,7 @@
 	id_tag = "yacht_sensor";
 	pixel_y = -24
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/yacht/engine)
 "lb" = (
 /obj/structure/cable{

--- a/maps/event/iccgn_ship/icgnv_hound.dmm
+++ b/maps/event/iccgn_ship/icgnv_hound.dmm
@@ -166,7 +166,9 @@
 /obj/machinery/porta_turret{
 	req_access = list("ACCESS_SYNDICATE")
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/map_template/icgnv_hound)
 "ll" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -232,14 +234,18 @@
 /area/map_template/icgnv_hound)
 "mA" = (
 /obj/machinery/shipsensors,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/map_template/icgnv_hound)
 "mK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	icon_state = "map_vent_in";
 	pump_direction = 0
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/map_template/icgnv_hound)
 "mT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -965,7 +971,9 @@
 	density = 1;
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/icgnv_hound)
 "RX" = (
 /obj/effect/floor_decal/techfloor{
@@ -1208,6 +1216,11 @@
 	},
 /obj/machinery/telecomms/allinone/iccgn,
 /turf/simulated/floor/tiled/techfloor/grid,
+/area/map_template/icgnv_hound)
+"Zx" = (
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/map_template/icgnv_hound)
 "ZS" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -1553,7 +1566,7 @@ av
 av
 av
 av
-nT
+Zx
 PQ
 vw
 yo

--- a/maps/event/sfv_arbiter/sfv_arbiter.dmm
+++ b/maps/event/sfv_arbiter/sfv_arbiter.dmm
@@ -351,7 +351,9 @@
 /area/map_template/sfv_arbiter)
 "ld" = (
 /obj/machinery/shipsensors,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/map_template/sfv_arbiter)
 "ll" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -544,7 +546,9 @@
 	icon_state = "map_vent_in";
 	pump_direction = 0
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/map_template/sfv_arbiter)
 "qy" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -685,7 +689,9 @@
 	icon_state = "map_vent_in";
 	pump_direction = 0
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/map_template/sfv_arbiter)
 "vc" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{
@@ -1728,7 +1734,9 @@
 /obj/machinery/porta_turret{
 	req_access = list("ACCESS_SYNDICATE")
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/plating{
+	map_airless = 1
+	},
 /area/map_template/sfv_arbiter)
 "Pj" = (
 /turf/simulated/floor/tiled/dark,
@@ -2216,7 +2224,9 @@
 /obj/machinery/ion_engine{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/sfv_arbiter)
 "VT" = (
 /obj/effect/floor_decal/corner/grey{
@@ -2481,7 +2491,7 @@
 	pixel_x = 7;
 	pixel_y = -4
 	},
-/turf/simulated/floor/tiled/white/airless,
+/turf/simulated/floor/tiled/white,
 /area/map_template/sfv_arbiter)
 "YN" = (
 /obj/effect/floor_decal/corner/grey/mono,

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dmm
@@ -29,7 +29,9 @@
 	pixel_y = 20;
 	pixel_z = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/crashed_pod)
 "bk" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -59,7 +61,7 @@
 	id_tag = "crashedpodEast_sensor_chamber";
 	pixel_x = -22
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/crashed_pod)
 "bm" = (
 /obj/machinery/door/airlock/external{
@@ -67,7 +69,9 @@
 	id_tag = "crashedpodEast_exterior_door";
 	locked = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/crashed_pod)
 "bn" = (
 /obj/machinery/airlock_sensor/airlock_exterior{
@@ -81,7 +85,9 @@
 	pixel_y = 20;
 	pixel_z = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/crashed_pod)
 "bo" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -102,7 +108,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/crashed_pod)
 "bq" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -117,7 +123,7 @@
 	frequency = 1380;
 	id_tag = "crashedpodEast_interior_door"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/crashed_pod)
 "bt" = (
 /obj/machinery/access_button/airlock_interior{
@@ -137,7 +143,9 @@
 	id_tag = "crashedpodWest_pump_out_external";
 	power_rating = 25000
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/crashed_pod)
 "bE" = (
 /obj/machinery/door/airlock/external{
@@ -145,7 +153,9 @@
 	id_tag = "crashedpodWest_exterior_door";
 	locked = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/crashed_pod)
 "bF" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -164,7 +174,7 @@
 	tag_exterior_sensor = "crashedpodWest_sensor_external";
 	tag_interior_door = "crashedpodWest_interior_door"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/crashed_pod)
 "bG" = (
 /obj/machinery/airlock_sensor{
@@ -175,7 +185,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/crashed_pod)
 "bH" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -222,7 +232,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/crashed_pod)
 "ca" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -248,7 +258,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/crashed_pod)
 "ej" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/crashed_pod)
 "ek" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
@@ -256,14 +268,16 @@
 	id_tag = "crashedpodEast_pump_out_external";
 	power_rating = 25000
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/crashed_pod)
 "el" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "crashedpodWest_pump";
 	power_rating = 25000
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/crashed_pod)
 "em" = (
 /obj/machinery/door/airlock/external{
@@ -271,7 +285,7 @@
 	id_tag = "crashedpodWest_interior_door"
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/blue,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/crashed_pod)
 "en" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -317,7 +331,9 @@
 /area/map_template/crashed_pod)
 "eE" = (
 /obj/machinery/atmospherics/unary/engine,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/crashed_pod)
 "eG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -1055,7 +1071,9 @@
 /obj/machinery/air_sensor{
 	id_tag = "crashed_pod_out"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/crashed_pod)
 "RN" = (
 /obj/structure/table/steel_reinforced,

--- a/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dm
@@ -16,6 +16,7 @@
 /area/map_template/datacapsule
 	name = "\improper Ejected Data Capsule"
 	icon_state = "blue"
+	turfs_airless = TRUE
 
 
 

--- a/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dmm
+++ b/maps/random_ruins/exoplanet_ruins/datacapsule/datacapsule.dmm
@@ -14,15 +14,12 @@
 /obj/machinery/door/blast/shutters,
 /turf/simulated/floor/reinforced,
 /area/map_template/datacapsule)
-"e" = (
-/turf/simulated/wall/ocp_wall,
-/area/map_template/datacapsule)
 "f" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/datacapsule)
 "g" = (
 /obj/effect/landmark/map_load_mark/ejected_datapod,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/datacapsule)
 
 (1,1,1) = {"
@@ -52,7 +49,7 @@ b
 (3,1,1) = {"
 c
 c
-e
+b
 b
 f
 f

--- a/maps/random_ruins/exoplanet_ruins/ec_old_crash/ec_old_crash.dm
+++ b/maps/random_ruins/exoplanet_ruins/ec_old_crash/ec_old_crash.dm
@@ -14,6 +14,7 @@
 /area/map_template/ecship/crew
 	name = "\improper Crew Area"
 	icon_state = "crew_quarters"
+	turfs_airless = TRUE
 
 /area/map_template/ecship/science
 	name = "\improper Science Module"
@@ -30,11 +31,11 @@
 /area/map_template/ecship/engine
 	name = "\improper Engine Exterior"
 	icon_state = "engine"
-	area_flags = AREA_FLAG_EXTERNAL
 
 /area/map_template/ecship/cockpit
 	name = "\improper Cockpit"
 	icon_state = "bridge"
+	turfs_airless = TRUE
 
 //Low pressure setup
 /obj/machinery/atmospherics/unary/vent_pump/low

--- a/maps/random_ruins/exoplanet_ruins/ec_old_crash/ec_old_crash.dmm
+++ b/maps/random_ruins/exoplanet_ruins/ec_old_crash/ec_old_crash.dmm
@@ -29,7 +29,7 @@
 /area/map_template/ecship/cockpit)
 "af" = (
 /obj/machinery/computer/modular/preset/cardslot/command,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/ecship/cockpit)
 "ag" = (
 /obj/structure/grille,
@@ -39,7 +39,7 @@
 "ak" = (
 /obj/structure/table/standard,
 /obj/item/device/radio,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/ecship/cockpit)
 "al" = (
 /obj/structure/table/standard,
@@ -57,7 +57,7 @@
 	dir = 1;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/ecship/cockpit)
 "am" = (
 /obj/machinery/atmospherics/unary/vent_pump/low{
@@ -68,7 +68,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/ecship/cockpit)
 "an" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -78,7 +78,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/ecship/cockpit)
 "ao" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -87,7 +87,7 @@
 /turf/simulated/floor,
 /area/map_template/ecship/science)
 "ap" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/ecship/cockpit)
 "aq" = (
 /turf/simulated/wall/r_wall/hull,
@@ -126,7 +126,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "aw" = (
 /obj/structure/sign/ecplaque{
@@ -136,14 +136,14 @@
 	dir = 5
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "ax" = (
 /obj/effect/floor_decal/corner/purple{
 	dir = 5
 	},
 /obj/machinery/suit_storage_unit/standard_unit,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "ay" = (
 /obj/machinery/light{
@@ -151,13 +151,15 @@
 	icon_state = "tube1"
 	},
 /obj/structure/closet/walllocker/emerglocker/west,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "az" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/ecship/cryo)
 "aA" = (
 /turf/simulated/wall/r_wall/hull,
@@ -171,7 +173,7 @@
 	level = 2
 	},
 /obj/item/stool/padded,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "aD" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -186,7 +188,7 @@
 /obj/item/reagent_containers/chem_disp_cartridge/coffee{
 	name = "coffee canister"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "aE" = (
 /obj/structure/broken_cryo,
@@ -201,7 +203,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "aG" = (
 /obj/machinery/light{
@@ -209,7 +211,7 @@
 	icon_state = "tube1"
 	},
 /obj/item/stool/padded,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "aI" = (
 /obj/structure/broken_cryo,
@@ -248,14 +250,14 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "aN" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/effect/floor_decal/corner/paleblue/diagonal{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "aO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -264,7 +266,7 @@
 	icon_state = "1-2"
 	},
 /obj/item/deck/cards,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "aP" = (
 /obj/structure/closet/crate/freezer/rations,
@@ -275,7 +277,7 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "aQ" = (
 /obj/structure/handrail{
@@ -290,7 +292,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "aR" = (
 /obj/structure/curtain/open/shower{
@@ -303,7 +305,9 @@
 	icon_state = "bulb1"
 	},
 /obj/structure/closet/walllocker/emerglocker/west,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/map_template/ecship/cryo)
 "aS" = (
 /obj/effect/floor_decal/industrial/warning/full,
@@ -319,7 +323,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/ecship/cryo)
 "aT" = (
 /obj/structure/sign/ecplaque{
@@ -382,7 +388,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/ecship/cryo)
 "bb" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -406,7 +414,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/map_template/ecship/cryo)
 "bd" = (
 /obj/structure/table/standard,
@@ -414,14 +424,16 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "be" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/map_template/ecship/cryo)
 "bf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -429,7 +441,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "bg" = (
 /obj/structure/hygiene/sink{
@@ -446,7 +458,9 @@
 	pixel_x = -24
 	},
 /obj/machinery/power/apc/derelict,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/map_template/ecship/cryo)
 "bh" = (
 /obj/structure/hygiene/sink{
@@ -460,7 +474,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/low{
 	dir = 1
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/map_template/ecship/cryo)
 "bi" = (
 /obj/structure/catwalk,
@@ -477,7 +493,7 @@
 /obj/effect/floor_decal/corner/paleblue/diagonal{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "bk" = (
 /obj/structure/catwalk,
@@ -529,7 +545,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/ecship/crew)
 "bp" = (
 /obj/effect/floor_decal/corner/purple{
@@ -612,7 +628,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "by" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -630,7 +646,7 @@
 	icon_state = "2-4"
 	},
 /obj/item/board,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "bz" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
@@ -645,7 +661,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "bA" = (
 /obj/structure/handrail{
@@ -664,7 +680,7 @@
 	dir = 1;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "bB" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/scrubbers,
@@ -683,7 +699,7 @@
 	icon_state = "2-8"
 	},
 /obj/item/stool/padded,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "bC" = (
 /obj/structure/catwalk,
@@ -836,7 +852,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "bR" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -854,18 +870,18 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled,
 /area/map_template/ecship/crew)
 "bS" = (
 /obj/structure/bed,
 /obj/structure/curtain/open/bed,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/map_template/ecship/crew)
 "bT" = (
 /obj/structure/bed,
 /obj/structure/curtain/open/bed,
 /obj/machinery/light,
-/turf/simulated/floor/tiled/dark/airless,
+/turf/simulated/floor/tiled/dark,
 /area/map_template/ecship/crew)
 "bV" = (
 /obj/structure/catwalk,
@@ -1016,7 +1032,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/ecship/science)
 "ci" = (
 /obj/structure/catwalk,
@@ -1708,7 +1726,7 @@
 	dir = 4;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/ecship/engine)
 "dz" = (
 /obj/structure/catwalk,
@@ -1734,7 +1752,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/ecship/engine)
 "dB" = (
 /obj/machinery/power/solar,
@@ -1743,7 +1761,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/ecship/engine)
 "dD" = (
 /obj/effect/floor_decal/corner/yellow/full,
@@ -1788,7 +1806,7 @@
 	dir = 4;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/ecship/engine)
 "dI" = (
 /obj/structure/catwalk,
@@ -1831,7 +1849,7 @@
 	},
 /obj/effect/landmark/scorcher,
 /obj/effect/landmark/clear,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/ecship/engine)
 "dR" = (
 /turf/simulated/wall/r_wall/hull,
@@ -1841,7 +1859,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/effect/landmark/scorcher,
 /obj/effect/landmark/clear,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/ecship/engine)
 "dT" = (
 /obj/machinery/air_sensor{
@@ -1853,7 +1871,9 @@
 /obj/machinery/air_sensor{
 	id_tag = "sev_oxygen"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/ecship/engine)
 "dV" = (
 /turf/simulated/floor/reinforced/hydrogen,
@@ -1871,7 +1891,7 @@
 	},
 /obj/effect/landmark/scorcher,
 /obj/effect/landmark/clear,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/ecship/engine)
 "dY" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -1907,10 +1927,14 @@
 	pump_direction = 0;
 	use_power = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/ecship/engine)
 "ec" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/ecship/engine)
 "ed" = (
 /obj/machinery/atmospherics/unary/vent_pump/engine{
@@ -1958,7 +1982,7 @@
 "ei" = (
 /obj/structure/catwalk,
 /obj/effect/landmark/clear,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/ecship/engine)
 "ej" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -2007,10 +2031,66 @@
 /obj/effect/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
+"fK" = (
+/obj/machinery/power/solar,
+/obj/effect/floor_decal/solarpanel,
+/obj/structure/cable{
+	dir = 4;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d1 = 16;
+	d2 = 0;
+	dir = 4;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor{
+	map_airless = 1
+	},
+/area/map_template/ecship/engine)
+"km" = (
+/obj/machinery/power/solar,
+/obj/effect/floor_decal/solarpanel,
+/obj/structure/cable{
+	d1 = 16;
+	d2 = 0;
+	dir = 4;
+	icon_state = "0-2"
+	},
+/turf/simulated/floor{
+	map_airless = 1
+	},
+/area/map_template/ecship/engine)
 "qB" = (
 /obj/effect/landmark/clear,
 /turf/template_noop,
 /area/template_noop)
+"wa" = (
+/obj/machinery/power/solar,
+/obj/effect/floor_decal/solarpanel,
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor{
+	map_airless = 1
+	},
+/area/map_template/ecship/engine)
+"ym" = (
+/obj/machinery/power/solar,
+/obj/effect/floor_decal/solarpanel,
+/obj/structure/cable{
+	dir = 4;
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor{
+	map_airless = 1
+	},
+/area/map_template/ecship/engine)
 "yZ" = (
 /obj/structure/grille,
 /obj/effect/landmark/scorcher,
@@ -2042,7 +2122,7 @@
 /obj/structure/catwalk,
 /obj/effect/landmark/scorcher,
 /obj/effect/landmark/clear,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/ecship/engine)
 "ZF" = (
 /obj/effect/landmark/scorcher,
@@ -3228,11 +3308,11 @@ bV
 aa
 aa
 aa
-dH
+km
 aa
-dH
-dH
-dH
+km
+km
+km
 aa
 aa
 aa
@@ -3264,14 +3344,14 @@ bV
 aa
 aa
 aa
-dy
-dy
-dy
-dy
-dy
+fK
+fK
+fK
+fK
+fK
 aa
 aa
-dy
+fK
 aa
 "}
 (35,1,1) = {"
@@ -3333,17 +3413,17 @@ aa
 aa
 aa
 aa
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
-dA
+ym
+ym
+ym
+ym
+ym
+ym
+ym
+ym
+ym
+ym
+ym
 aa
 "}
 (37,1,1) = {"
@@ -3370,16 +3450,16 @@ aa
 aa
 aa
 aa
-dB
-dB
-dB
+wa
+wa
+wa
 aa
 aa
 aa
-dB
-dB
-dB
-dB
+wa
+wa
+wa
+wa
 aa
 "}
 (38,1,1) = {"

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dm
@@ -22,6 +22,7 @@
 /area/map_template/hydrobase/solars
 	name = "\improper X207 Solar Array"
 	icon_state = "solar"
+	turfs_airless = TRUE
 
 /area/map_template/hydrobase/station/processing
 	name = "\improper X207 Processing Area"

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dmm
@@ -1069,7 +1069,7 @@
 /turf/simulated/floor/tiled,
 /area/map_template/hydrobase/station/growF)
 "cL" = (
-/turf/simulated/floor/fixed/alium/airless,
+/turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/solars)
 "cM" = (
 /obj/machinery/power/solar{
@@ -1082,13 +1082,13 @@
 	dir = 4;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/fixed/alium/airless,
+/turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/solars)
 "cN" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/fixed/alium/airless,
+/turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/solars)
 "cO" = (
 /obj/structure/catwalk,
@@ -1229,7 +1229,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/fixed/alium/airless,
+/turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/solars)
 "di" = (
 /obj/machinery/light{
@@ -1444,7 +1444,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/fixed/alium/airless,
+/turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/solars)
 "dE" = (
 /obj/structure/catwalk,
@@ -1612,7 +1612,7 @@
 	desc = "A flexible superconducting cable for heavy-duty power transfer. It's been labeled 'chaos reigns'.";
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/fixed/alium/airless,
+/turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/solars)
 "dX" = (
 /obj/structure/catwalk,
@@ -1756,19 +1756,19 @@
 /area/map_template/hydrobase/station/solarlock)
 "es" = (
 /obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/fixed/alium/airless,
-/area/template_noop)
+/turf/simulated/floor/fixed/alium,
+/area/map_template/hydrobase/solars)
 "et" = (
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/fixed/alium/airless,
-/area/template_noop)
+/turf/simulated/floor/fixed/alium,
+/area/map_template/hydrobase/solars)
 "eu" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/floor/fixed/alium/airless,
-/area/template_noop)
+/turf/simulated/floor/fixed/alium,
+/area/map_template/hydrobase/solars)
 "ev" = (
 /obj/machinery/alarm{
 	dir = 4;
@@ -1963,16 +1963,8 @@
 	dir = 4;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/fixed/alium/airless,
+/turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/solars)
-"eJ" = (
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/simulated/floor/fixed/alium/airless,
-/area/template_noop)
 "eK" = (
 /obj/structure/cable{
 	d1 = 4;
@@ -1983,8 +1975,8 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/fixed/alium/airless,
-/area/template_noop)
+/turf/simulated/floor/fixed/alium,
+/area/map_template/hydrobase/solars)
 "eL" = (
 /obj/machinery/power/tracker{
 	id = "hydrosolar"
@@ -1993,14 +1985,14 @@
 	dir = 4
 	},
 /turf/simulated/floor/exoplanet/concrete,
-/area/template_noop)
+/area/map_template/hydrobase/solars)
 "eM" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/fixed/alium/airless,
-/area/template_noop)
+/turf/simulated/floor/fixed/alium,
+/area/map_template/hydrobase/solars)
 "eN" = (
 /turf/simulated/wall/alium,
 /area/map_template/hydrobase/station/growB)
@@ -2173,21 +2165,21 @@
 	dir = 4;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/floor/fixed/alium/airless,
-/area/template_noop)
+/turf/simulated/floor/fixed/alium,
+/area/map_template/hydrobase/solars)
 "ff" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/fixed/alium/airless,
-/area/template_noop)
+/turf/simulated/floor/fixed/alium,
+/area/map_template/hydrobase/solars)
 "fg" = (
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/floor/fixed/alium/airless,
-/area/template_noop)
+/turf/simulated/floor/fixed/alium,
+/area/map_template/hydrobase/solars)
 "fh" = (
 /obj/machinery/light{
 	dir = 8;
@@ -2404,7 +2396,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/fixed/alium/airless,
+/turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/solars)
 "fH" = (
 /obj/structure/cable{
@@ -2412,7 +2404,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/fixed/alium/airless,
+/turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/solars)
 "fI" = (
 /obj/structure/cable{
@@ -2425,7 +2417,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/fixed/alium/airless,
+/turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/solars)
 "fJ" = (
 /obj/structure/catwalk,
@@ -2880,7 +2872,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/fixed/alium/airless,
+/turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/solars)
 "gE" = (
 /obj/structure/cable{
@@ -2888,7 +2880,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/fixed/alium/airless,
+/turf/simulated/floor/fixed/alium,
 /area/map_template/hydrobase/solars)
 "gF" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -4465,7 +4457,7 @@ aa
 aa
 aa
 aa
-eJ
+fH
 aa
 aa
 aa

--- a/maps/random_ruins/exoplanet_ruins/icarus/icarus.dm
+++ b/maps/random_ruins/exoplanet_ruins/icarus/icarus.dm
@@ -50,6 +50,7 @@
 	name = "SEV Icarus"
 	icon = 'maps/random_ruins/exoplanet_ruins/icarus/icarus.dmi'
 	icon_state = "icarus"
+	turfs_airless = TRUE
 
 /area/map_template/icarus/bridge
 	name = "SEV Icarus Bridge"

--- a/maps/random_ruins/exoplanet_ruins/icarus/icarus.dmm
+++ b/maps/random_ruins/exoplanet_ruins/icarus/icarus.dmm
@@ -75,7 +75,7 @@
 /area/map_template/icarus/sec)
 "aT" = (
 /obj/structure/grille,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/icarus/driver/east)
 "aV" = (
 /obj/machinery/door/airlock/sol{
@@ -122,7 +122,7 @@
 	icon_state = "pdoor0";
 	opacity = 0
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/icarus/driver/east)
 "bK" = (
 /obj/random/junk,
@@ -172,7 +172,7 @@
 /area/map_template/icarus/driver/east)
 "cZ" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/icarus/driver/west)
 "dn" = (
 /obj/random/trash,
@@ -449,7 +449,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/map_template/icarus/bridge)
 "lv" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/icarus/driver/west)
 "lA" = (
 /obj/machinery/door/airlock/sol{
@@ -783,7 +783,7 @@
 	opacity = 0
 	},
 /obj/structure/ship_munition/ap_slug,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/icarus/driver/west)
 "wr" = (
 /obj/machinery/computer/modular/preset,
@@ -950,7 +950,7 @@
 	opacity = 0
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/icarus/driver/west)
 "Ck" = (
 /obj/structure/girder,
@@ -1019,7 +1019,7 @@
 /area/map_template/icarus/eng)
 "Ew" = (
 /obj/structure/grille,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/icarus/driver/west)
 "EB" = (
 /obj/random/obstruction,
@@ -1151,7 +1151,7 @@
 /area/map_template/icarus/sec)
 "Jk" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/icarus/driver/east)
 "JO" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1325,7 +1325,7 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/map_template/icarus/eng)
 "QL" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/map_template/icarus/driver/east)
 "Rm" = (
 /obj/effect/decal/cleanable/dirt,

--- a/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
@@ -1220,7 +1220,9 @@
 /area/map_template/oldlab2/office)
 "gC" = (
 /obj/structure/largecrate,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/oldlab2/Airlock)
 "gG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1548,7 +1550,9 @@
 	dir = 4
 	},
 /obj/structure/largecrate,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/oldlab2/Airlock)
 "iE" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1599,7 +1603,9 @@
 	locked = 1;
 	name = "Lab Exterior Airlock"
 	},
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/techfloor{
+	map_airless = 1
+	},
 /area/map_template/oldlab2/Airlock)
 "iZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -2398,7 +2404,9 @@
 /area/map_template/oldlab2/office)
 "nw" = (
 /obj/machinery/floodlight,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/oldlab2/Airlock)
 "nx" = (
 /turf/simulated/wall/titanium,
@@ -3016,7 +3024,9 @@
 /area/map_template/oldlab2/medical)
 "qJ" = (
 /obj/machinery/light/spot,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/oldlab2/Airlock)
 "qL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3178,7 +3188,9 @@
 	pixel_x = 24;
 	pixel_y = -24
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/oldlab2/Airlock)
 "rt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -4459,7 +4471,9 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/oldlab2/Airlock)
 "xy" = (
 /obj/machinery/power/smes/buildable/outpost_substation,
@@ -6335,7 +6349,9 @@
 	id_tag = "oldlab_sensor_exterior";
 	pixel_y = -32
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/oldlab2/Airlock)
 "GX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6465,7 +6481,9 @@
 "HC" = (
 /obj/structure/largecrate,
 /obj/machinery/light/spot,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/oldlab2/Airlock)
 "HF" = (
 /obj/structure/cable/yellow{
@@ -7577,7 +7595,9 @@
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/mess)
 "Nz" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/oldlab2/Airlock)
 "NC" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -251,7 +251,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/colony/command)
 "aI" = (
 /turf/simulated/wall,

--- a/maps/random_ruins/exoplanet_ruins/playablecolony2/colony2.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony2/colony2.dmm
@@ -14,15 +14,6 @@
 /obj/effect/catwalk_plated/dark,
 /turf/simulated/floor/plating,
 /area/map_template/colony2/engineering)
-"an" = (
-/obj/machinery/light/spot{
-	dir = 1
-	},
-/turf/simulated/floor/reinforced/airless,
-/area/map_template/colony2/external)
-"aB" = (
-/turf/simulated/floor/reinforced/airless,
-/area/map_template/colony2/external)
 "aK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/structure/cable{
@@ -72,7 +63,9 @@
 "bt" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/red,
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "bE" = (
 /obj/effect/paint/ocean,
@@ -127,7 +120,9 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "cz" = (
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -501,7 +496,9 @@
 /obj/machinery/computer/mining{
 	pixel_y = 32
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "hj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -519,7 +516,9 @@
 /obj/item/device/radio/intercom/map_preset/playablecolony2{
 	pixel_y = 21
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "hT" = (
 /obj/effect/catwalk_plated/dark,
@@ -619,7 +618,9 @@
 	dir = 8;
 	pixel_x = 21
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "kb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -648,13 +649,17 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "kn" = (
 /obj/machinery/atmospherics/unary/tank/nitrogen{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "lj" = (
 /obj/machinery/fabricator/hacked,
@@ -705,14 +710,18 @@
 	dir = 1;
 	id_tag = "playablecolonymain2_pump_out_external"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "nE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
 	dir = 6
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "nU" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/scrubbers,
@@ -888,7 +897,9 @@
 "rr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /obj/machinery/meter,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "rL" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -896,7 +907,9 @@
 	input_turf = 8;
 	output_turf = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "rM" = (
 /obj/machinery/conveyor{
@@ -907,13 +920,17 @@
 /obj/machinery/computer/mining{
 	pixel_x = 32
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "rO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 5
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "so" = (
 /obj/machinery/door/airlock/civilian,
@@ -949,7 +966,9 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "sO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
@@ -959,7 +978,9 @@
 	name = "Atmospheric Pod Blast Shutter"
 	},
 /obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "sZ" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -1012,18 +1033,24 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 6
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "uq" = (
 /obj/machinery/atmospherics/valve,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "ux" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/mineral/unloading_machine{
 	input_turf = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "uT" = (
 /obj/machinery/light{
@@ -1055,13 +1082,17 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "vj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "vn" = (
 /obj/effect/paint/ocean,
@@ -1214,14 +1245,18 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "zk" = (
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "zv" = (
 /obj/effect/catwalk_plated/dark,
@@ -1238,7 +1273,9 @@
 "zZ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/red,
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Af" = (
 /obj/machinery/light{
@@ -1252,7 +1289,9 @@
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Ap" = (
 /obj/machinery/cryopod{
@@ -1375,7 +1414,9 @@
 /obj/machinery/mining/brace{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "BU" = (
 /obj/effect/catwalk_plated/dark,
@@ -1385,7 +1426,9 @@
 /turf/simulated/floor/plating,
 /area/map_template/colony2/storage)
 "BZ" = (
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Ch" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
@@ -1441,7 +1484,9 @@
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "CA" = (
 /obj/machinery/alarm{
@@ -1501,7 +1546,9 @@
 	dir = 4;
 	start_pressure = 120
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "DD" = (
 /obj/machinery/light,
@@ -1526,12 +1573,16 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "DJ" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/blue,
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "DQ" = (
 /obj/effect/floor_decal/corner/paleblue/mono,
@@ -1585,7 +1636,9 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "ED" = (
 /obj/effect/floor_decal/corner/paleblue/mono,
@@ -1610,7 +1663,9 @@
 	name = "Atmospheric Pod Blast Shutter"
 	},
 /obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Fm" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -1659,7 +1714,9 @@
 	dir = 4;
 	id = "colonymine2"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Gq" = (
 /obj/machinery/door/blast/regular{
@@ -1672,13 +1729,17 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Gt" = (
 /obj/effect/floor_decal/industrial/loading,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/ore_box,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "GS" = (
 /obj/structure/table/steel_reinforced,
@@ -1711,7 +1772,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel,
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Hw" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -1725,7 +1788,9 @@
 	dir = 8;
 	start_pressure = 120
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "HK" = (
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
@@ -1733,7 +1798,9 @@
 	dir = 1
 	},
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "HQ" = (
 /obj/structure/table/rack,
@@ -1760,7 +1827,9 @@
 /obj/item/wrench,
 /obj/item/device/spaceflare,
 /obj/item/device/spaceflare,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "HS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1777,7 +1846,9 @@
 /obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Is" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -1787,7 +1858,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Iz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1823,19 +1896,9 @@
 /obj/machinery/atmospherics/unary/tank/oxygen{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
-/area/map_template/colony2/external)
-"Jq" = (
-/obj/machinery/atmospherics/pipe/simple/visible/fuel{
-	dir = 4
+/turf/simulated/floor/reinforced{
+	map_airless = 1
 	},
-/obj/machinery/door/blast/regular{
-	dir = 4;
-	id_tag = "colony2atmos";
-	name = "Atmospheric Pod Blast Shutter"
-	},
-/obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/reinforced,
 /area/map_template/colony2/external)
 "Jr" = (
 /obj/item/stool/bar/padded,
@@ -1880,7 +1943,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Kz" = (
 /obj/structure/table/steel_reinforced,
@@ -1907,7 +1972,9 @@
 	name = "Atmospheric Pod Blast Shutter"
 	},
 /obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "KU" = (
 /obj/machinery/atmospherics/pipe/simple/visible/universal{
@@ -1920,7 +1987,9 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Ls" = (
 /obj/effect/paint/ocean,
@@ -1973,7 +2042,9 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "MN" = (
 /obj/structure/closet/crate/freezer/rations,
@@ -2030,7 +2101,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Oc" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -2137,7 +2210,9 @@
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "PF" = (
 /obj/effect/floor_decal/corner/paleblue/mono,
@@ -2153,7 +2228,9 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "PU" = (
 /obj/effect/paint/ocean,
@@ -2161,7 +2238,9 @@
 /area/map_template/colony2/ship)
 "Qi" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Qq" = (
 /obj/effect/floor_decal/corner_steel_grid/diagonal{
@@ -2256,7 +2335,9 @@
 	name = "Atmospheric Pod Blast Shutter"
 	},
 /obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Rs" = (
 /obj/structure/cable,
@@ -2301,17 +2382,23 @@
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "RE" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/blue,
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "RL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
 /obj/machinery/meter,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Sl" = (
 /obj/machinery/power/terminal{
@@ -2333,7 +2420,9 @@
 	name = "Atmospheric Pod Blast Shutter"
 	},
 /obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "SA" = (
 /obj/machinery/power/port_gen/pacman{
@@ -2355,13 +2444,17 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "SO" = (
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
 	dir = 10
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "SP" = (
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -2418,7 +2511,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel,
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Tr" = (
 /obj/effect/catwalk_plated/dark,
@@ -2439,7 +2534,9 @@
 	name = "Atmospheric Pod Blast Shutter"
 	},
 /obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Tw" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -2482,13 +2579,17 @@
 /obj/machinery/atmospherics/unary/tank/oxygen{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "UX" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Vb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -2516,14 +2617,18 @@
 /obj/machinery/atmospherics/pipe/simple/visible/supply{
 	dir = 5
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Vp" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers{
 	dir = 9
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Vt" = (
 /obj/structure/cable{
@@ -2568,7 +2673,9 @@
 	name = "Atmospheric Pod Blast Shutter"
 	},
 /obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "VD" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
@@ -2585,7 +2692,9 @@
 /obj/machinery/air_sensor{
 	id_tag = "Halifax_out"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "VL" = (
 /obj/machinery/access_button/airlock_exterior{
@@ -2599,7 +2708,9 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "VM" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -2638,7 +2749,9 @@
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
 /obj/machinery/atmospherics/pipe/simple/visible/scrubbers,
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Wn" = (
 /obj/effect/catwalk_plated/dark,
@@ -2647,7 +2760,9 @@
 "Wo" = (
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
 /obj/machinery/meter,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Wu" = (
 /obj/machinery/portable_atmospherics/hydroponics,
@@ -2661,7 +2776,9 @@
 /obj/machinery/atmospherics/valve{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Xc" = (
 /obj/structure/hygiene/toilet{
@@ -2687,13 +2804,17 @@
 /obj/machinery/mineral/stacking_machine{
 	input_turf = 2
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Xm" = (
 /obj/machinery/atmospherics/pipe/simple/visible/supply,
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
 /obj/effect/catwalk_plated/dark,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Xt" = (
 /obj/machinery/atmospherics/unary/tank/carbon_dioxide{
@@ -2703,7 +2824,9 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "XB" = (
 /obj/machinery/door/blast/regular{
@@ -2712,19 +2835,25 @@
 	name = "Atmospheric Pod Blast Shutter"
 	},
 /obj/effect/floor_decal/industrial/hatch,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "XO" = (
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "XU" = (
 /obj/machinery/atmospherics/unary/tank/nitrogen{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "XX" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -2744,7 +2873,9 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "YQ" = (
 /obj/machinery/light{
@@ -2764,7 +2895,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/map_template/colony2/external)
 "Za" = (
 /obj/effect/floor_decal/corner_steel_grid/diagonal,
@@ -2872,14 +3005,14 @@ Dw
 Dw
 Dw
 Ls
-an
+XO
 Ls
 UW
 UW
 UW
 UW
 Ls
-aB
+BZ
 Ls
 UW
 UW
@@ -2950,7 +3083,7 @@ Hw
 UM
 QH
 vn
-an
+XO
 Ls
 HD
 HD
@@ -2958,14 +3091,14 @@ Xt
 HD
 WM
 Ls
-aB
+BZ
 Ls
 Jg
 Jg
 Jg
 Jg
 Ls
-an
+XO
 Ls
 Jg
 Jg
@@ -3085,7 +3218,7 @@ Og
 Ls
 Ls
 Ls
-Jq
+VC
 Ls
 XO
 Ls
@@ -3124,7 +3257,7 @@ vn
 Ls
 Ls
 VF
-aB
+BZ
 Ls
 YI
 BR
@@ -3167,14 +3300,14 @@ QY
 Rw
 YV
 ni
-aB
+BZ
 XB
-aB
-aB
+BZ
+BZ
 vj
-aB
-aB
-aB
+BZ
+BZ
+BZ
 DH
 Pp
 Kr
@@ -3210,10 +3343,10 @@ Vt
 SR
 vh
 ni
-aB
+BZ
 XB
-aB
-aB
+BZ
+BZ
 NX
 jy
 Qi
@@ -3253,7 +3386,7 @@ AE
 Ls
 Ls
 VL
-aB
+BZ
 Ls
 PS
 BR
@@ -3300,7 +3433,7 @@ Og
 Ls
 Ls
 Ls
-Jq
+VC
 Ls
 XO
 Ls
@@ -3386,7 +3519,7 @@ Ls
 Ls
 Ls
 Ls
-Jq
+VC
 Ls
 Og
 Ls
@@ -3423,7 +3556,7 @@ Tr
 Wn
 SA
 AE
-an
+XO
 Ls
 Dw
 Dw
@@ -3431,17 +3564,17 @@ cw
 Dw
 WM
 Ls
-aB
+BZ
 Ls
 kn
 kn
 kn
 kn
 Ls
-an
+XO
 Ls
 hN
-aB
+BZ
 Gt
 ux
 Ls
@@ -3481,7 +3614,7 @@ bt
 bt
 zZ
 Ls
-aB
+BZ
 Ls
 gV
 Cu
@@ -3517,14 +3650,14 @@ HD
 HD
 HD
 Ls
-an
+XO
 Ls
 XU
 XU
 XU
 XU
 Ls
-aB
+BZ
 Ls
 Xl
 sK

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -114,7 +114,9 @@
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/toxins)
 "ar" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -209,7 +211,9 @@
 /obj/machinery/air_sensor{
 	id_tag = "toxins_sensor"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/toxins)
 "aA" = (
 /obj/effect/wallframe_spawn/reinforced/titanium,
@@ -436,7 +440,7 @@
 	name = "Mixing Chamber Blast Shutters";
 	opacity = 0
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/shuttle/petrov/toxins)
 "aW" = (
 /turf/simulated/wall/prepainted,
@@ -486,7 +490,7 @@
 	name = "Mixing Chamber Blast Shutters";
 	opacity = 0
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/shuttle/petrov/toxins)
 "bf" = (
 /obj/machinery/computer/shuttle_control/explore/exploration_shuttle,
@@ -638,7 +642,9 @@
 	pixel_w = 1;
 	pixel_z = -23
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/toxins)
 "bt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9091,7 +9097,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/control)
 "tU" = (
 /obj/structure/railing/mapped,
@@ -9782,7 +9790,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/isolation)
 "vA" = (
 /obj/structure/cable/cyan{
@@ -10163,7 +10173,9 @@
 	id_tag = "toxin_exhaust";
 	name = "Toxins Exhaust Blast Doors"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/toxins)
 "wW" = (
 /obj/structure/disposalpipe/segment{
@@ -10524,7 +10536,9 @@
 /area/maintenance/fifthdeck/aftstarboard)
 "yf" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/toxins)
 "yi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -11510,7 +11524,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/custodial)
 "BY" = (
 /obj/machinery/atmospherics/portables_connector,
@@ -11719,7 +11735,9 @@
 /area/shuttle/petrov/custodial)
 "CT" = (
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/rd)
 "CV" = (
 /obj/structure/table/standard,
@@ -12065,7 +12083,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/equipment)
 "DY" = (
 /obj/structure/railing/mapped{
@@ -13339,7 +13359,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/cockpit)
 "Jl" = (
 /obj/effect/paint/silver,
@@ -13665,7 +13687,9 @@
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/custodial)
 "Ku" = (
 /obj/structure/cable/cyan{
@@ -14033,7 +14057,9 @@
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/isolation)
 "LN" = (
 /obj/effect/paint/silver,
@@ -14069,7 +14095,9 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/toxins)
 "LW" = (
 /obj/effect/wallframe_spawn/reinforced/polarized{
@@ -14179,7 +14207,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/control)
 "Mt" = (
 /obj/structure/handrail{
@@ -14666,7 +14696,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/toxins)
 "Oi" = (
 /obj/machinery/atmospherics/binary/pump,
@@ -14849,7 +14881,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/analysis)
 "Pm" = (
 /obj/structure/cable/cyan{
@@ -14957,7 +14991,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/toxins)
 "PK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -15369,7 +15405,9 @@
 /area/maintenance/fifthdeck/fore)
 "Rn" = (
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/rnd)
 "Rp" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -16114,7 +16152,9 @@
 	pump_direction = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/toxins)
 "Ur" = (
 /obj/machinery/vending/generic,
@@ -16485,7 +16525,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/isolation)
 "VT" = (
 /turf/simulated/floor/lino,
@@ -16741,7 +16783,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "Xi" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "Xk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -17037,7 +17079,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/shuttle/petrov/eva)
 "Ys" = (
 /obj/machinery/door/airlock/research{

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -99,7 +99,9 @@
 /area/quartermaster/deckchief)
 "av" = (
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/maintenance/fourthdeck/port)
 "aw" = (
 /turf/simulated/wall/r_titanium,
@@ -548,7 +550,9 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/maintenance/fourthdeck/starboard)
 "bY" = (
 /obj/structure/catwalk,
@@ -2821,7 +2825,7 @@
 /area/hallway/primary/fourthdeck/aft)
 "jX" = (
 /obj/machinery/door/blast/regular/escape_pod,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/maintenance/fourthdeck/port)
 "jY" = (
 /obj/machinery/door/firedoor,
@@ -4380,7 +4384,9 @@
 /area/crew_quarters/head/deck4)
 "pp" = (
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/maintenance/fourthdeck/aft)
 "pr" = (
 /obj/structure/table/rack,
@@ -5363,7 +5369,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/center)
 "sJ" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "sK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6588,7 +6594,7 @@
 /area/hallway/primary/fourthdeck/center)
 "wp" = (
 /obj/machinery/door/blast/regular/escape_pod,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/maintenance/fourthdeck/aft)
 "wq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6824,14 +6830,16 @@
 /area/maintenance/fourthdeck/port)
 "wW" = (
 /obj/machinery/door/blast/regular/escape_pod,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/maintenance/fourthdeck/starboard)
 "wX" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/maintenance/fourthdeck/aft)
 "xb" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden{

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -23,7 +23,9 @@
 /turf/simulated/wall/r_wall/hull,
 /area/vacant/brig)
 "ae" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/brig)
 "af" = (
 /obj/machinery/computer/arcade,
@@ -46,11 +48,15 @@
 /area/crew_quarters/gym)
 "ak" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/brig)
 "al" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/brig)
 "am" = (
 /obj/machinery/shieldwallgen{
@@ -80,18 +86,24 @@
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/brig)
 "aq" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/brig)
 "ar" = (
 /obj/effect/decal/cleanable/vomit,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/brig)
 "as" = (
 /obj/structure/hygiene/toilet{
@@ -121,22 +133,30 @@
 	dir = 1
 	},
 /obj/machinery/constructable_frame/computerframe,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/brig)
 "ay" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 1
 	},
 /obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/brig)
 "az" = (
 /obj/structure/door_assembly,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/brig)
 "aA" = (
 /obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/brig)
 "aB" = (
 /obj/structure/closet{
@@ -158,7 +178,9 @@
 /obj/machinery/door/airlock/security{
 	name = "Old Brig"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/brig)
 "aF" = (
 /obj/random/obstruction,
@@ -169,23 +191,29 @@
 	dir = 9
 	},
 /obj/structure/closet/secure_closet/brig,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/brig)
 "aH" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/brig)
 "aI" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "aJ" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/brig)
 "aK" = (
 /obj/structure/cable/green{
@@ -193,7 +221,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/brig)
 "aL" = (
 /obj/machinery/power/apc{
@@ -232,7 +262,9 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/green,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "aQ" = (
 /turf/simulated/wall/r_wall/hull,
@@ -248,7 +280,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "aS" = (
 /obj/structure/cable/green{
@@ -259,7 +293,9 @@
 /obj/machinery/door/airlock/security{
 	name = "Old Brig"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/brig)
 "aT" = (
 /turf/simulated/wall/r_wall/hull,
@@ -307,7 +343,9 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "bd" = (
 /turf/simulated/wall/r_wall/hull,
@@ -354,7 +392,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "bn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -421,7 +461,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "by" = (
 /obj/machinery/alarm{
@@ -431,7 +473,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "bz" = (
 /obj/structure/closet/crate,
@@ -471,14 +515,18 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "bC" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
 /obj/machinery/smartfridge/drying_rack,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "bD" = (
 /obj/machinery/alarm{
@@ -692,7 +740,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/janitor/storage)
 "bS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -706,7 +756,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/chief_steward)
 "bT" = (
 /obj/structure/table/standard,
@@ -768,7 +820,9 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/green,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "cd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -788,7 +842,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "ce" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -813,7 +869,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "cf" = (
 /obj/structure/cable/green{
@@ -839,17 +897,23 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "cg" = (
 /obj/effect/floor_decal/corner/yellow/half{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "ch" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "ci" = (
 /obj/machinery/button/blast_door{
@@ -974,7 +1038,9 @@
 /obj/effect/floor_decal/corner/green/half{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "cz" = (
 /obj/machinery/photocopier,
@@ -1100,7 +1166,9 @@
 "cN" = (
 /obj/machinery/smartfridge,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/galley)
 "cO" = (
 /obj/machinery/door/firedoor,
@@ -1149,7 +1217,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "cS" = (
 /obj/structure/cable/green{
@@ -1218,7 +1288,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "cY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1238,7 +1310,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "cZ" = (
 /obj/machinery/door/firedoor,
@@ -1327,7 +1401,9 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "dd" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/maintenance/thirddeck/starboard)
 "de" = (
 /obj/item/beach_ball,
@@ -1499,13 +1575,17 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "dC" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "dD" = (
 /turf/simulated/floor/tiled/techfloor,
@@ -1572,7 +1652,9 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/green,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "dI" = (
 /obj/structure/catwalk,
@@ -1616,7 +1698,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "dM" = (
 /obj/machinery/suit_storage_unit/atmos/alt/sol,
@@ -1636,7 +1720,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "dO" = (
 /obj/machinery/field_generator,
@@ -1652,7 +1738,9 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/green,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "dQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1685,7 +1773,9 @@
 /area/maintenance/thirddeck/starboard)
 "dS" = (
 /obj/machinery/washing_machine,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/maintenance/thirddeck/starboard)
 "dT" = (
 /obj/machinery/alarm{
@@ -2019,7 +2109,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/commissary)
 "eM" = (
 /obj/machinery/door/firedoor,
@@ -2130,7 +2222,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/chief_steward)
 "fb" = (
 /turf/simulated/wall/r_wall/hull,
@@ -2156,7 +2250,9 @@
 /obj/structure/table/rack{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/maintenance/thirddeck/starboard)
 "ff" = (
 /obj/machinery/door/firedoor,
@@ -2172,7 +2268,9 @@
 	id_tag = "cs_door";
 	name = "Chief Steward's Office"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/chief_steward)
 "fg" = (
 /obj/structure/railing/mapped{
@@ -2298,7 +2396,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "ft" = (
 /obj/machinery/firealarm{
@@ -2353,7 +2453,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "fy" = (
 /obj/structure/closet/secure_closet/freezer/meat,
@@ -2589,7 +2691,9 @@
 /obj/structure/table/steel,
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/maintenance/thirddeck/starboard)
 "fV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2810,7 +2914,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "gv" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
@@ -3504,7 +3610,9 @@
 /area/crew_quarters/head/sauna)
 "hM" = (
 /obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/command/disperser)
 "hN" = (
 /obj/random/junk,
@@ -3548,7 +3656,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "hY" = (
 /obj/machinery/door/firedoor,
@@ -3734,7 +3844,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "iq" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -3801,7 +3913,9 @@
 /area/command/disperser)
 "ix" = (
 /obj/machinery/light,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/command/disperser)
 "iy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3939,7 +4053,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "iN" = (
 /obj/structure/table/standard,
@@ -4107,7 +4223,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/gym)
 "jc" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
@@ -4126,7 +4244,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "jf" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
@@ -4217,7 +4337,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "jn" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
@@ -4334,7 +4456,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "jG" = (
 /obj/structure/ore_box,
@@ -4411,7 +4535,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/gym)
 "jO" = (
 /obj/machinery/light/small{
@@ -4746,7 +4872,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "kC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -4999,7 +5127,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "ld" = (
 /turf/simulated/open,
@@ -5186,7 +5316,9 @@
 /obj/item/material/hatchet,
 /obj/item/material/minihoe,
 /obj/item/screwdriver,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "lB" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
@@ -5245,7 +5377,9 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "lK" = (
 /obj/machinery/light{
@@ -5589,12 +5723,14 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "mw" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/commissary)
 "mx" = (
 /obj/machinery/light{
@@ -5633,7 +5769,9 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "mF" = (
 /obj/structure/table/rack,
@@ -5706,13 +5844,17 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "mV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "mW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -5859,7 +6001,9 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/holocontrol)
 "nm" = (
 /obj/structure/table/steel,
@@ -5895,7 +6039,9 @@
 /obj/structure/bed/chair/office/comfy/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/commissary)
 "nt" = (
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -5904,7 +6050,9 @@
 	linkedholodeck_area = /area/holodeck/alphadeck;
 	programs_list_id = "TorchMainPrograms"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/holocontrol)
 "nu" = (
 /obj/structure/disposalpipe/segment{
@@ -6001,7 +6149,9 @@
 	icon_state = "4-8"
 	},
 /obj/structure/hygiene/drain,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "nP" = (
 /obj/item/device/radio/intercom{
@@ -6012,7 +6162,9 @@
 	c_tag = "Third Deck Hallway - Fore Starboard";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "nQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -6053,7 +6205,9 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "nS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6174,7 +6328,9 @@
 /area/hydroponics)
 "oa" = (
 /obj/structure/stairs/west,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "ob" = (
 /obj/effect/floor_decal/corner/green/half{
@@ -6220,7 +6376,9 @@
 	dir = 8;
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "og" = (
 /obj/structure/cable/green{
@@ -6263,7 +6421,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/holocontrol)
 "ol" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -6272,7 +6432,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/holocontrol)
 "om" = (
 /obj/machinery/door/firedoor,
@@ -6344,7 +6506,9 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "ow" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6356,7 +6520,9 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "oy" = (
 /obj/effect/floor_decal/corner/red{
@@ -6365,7 +6531,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "oz" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -6375,7 +6543,9 @@
 /obj/structure/sign/warning/moving_parts{
 	pixel_y = 32
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/command/disperser)
 "oA" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -6407,7 +6577,9 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "oJ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -6432,7 +6604,9 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "oL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -6514,7 +6688,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "oX" = (
 /obj/structure/bed/chair/wood{
@@ -6731,7 +6907,9 @@
 	dir = 4;
 	pixel_x = -21
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/holocontrol)
 "pk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -6740,7 +6918,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/holocontrol)
 "pl" = (
 /obj/random/obstruction,
@@ -6769,7 +6949,9 @@
 /area/hallway/primary/thirddeck/center)
 "pp" = (
 /obj/structure/fitness/weightlifter,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/gym)
 "pq" = (
 /obj/structure/cable/green{
@@ -6786,7 +6968,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "pr" = (
 /obj/structure/cable/green{
@@ -6913,7 +7097,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/gym)
 "pI" = (
 /turf/simulated/wall/r_wall/hull,
@@ -6937,7 +7123,9 @@
 	pixel_x = 24
 	},
 /obj/effect/floor_decal/corner/paleblue,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "pO" = (
 /turf/simulated/open,
@@ -7096,7 +7284,9 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/galleybackroom)
 "qo" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/crew_quarters/service_break_room)
 "qp" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -7130,7 +7320,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "qs" = (
 /obj/structure/table/woodentable,
@@ -7141,7 +7333,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "qt" = (
 /obj/effect/floor_decal/corner/lime/three_quarters{
@@ -7150,7 +7344,9 @@
 /obj/machinery/vending/cola{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "qu" = (
 /turf/simulated/floor/carpet,
@@ -7197,7 +7393,9 @@
 	dir = 4;
 	pixel_x = -25
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/commissary)
 "qB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7243,11 +7441,15 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "qL" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "qM" = (
 /obj/structure/catwalk,
@@ -7280,14 +7482,18 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "qS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "qT" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -7303,7 +7509,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "qV" = (
 /obj/machinery/atm{
@@ -7312,7 +7520,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "qW" = (
 /obj/machinery/atmospherics/valve/digital{
@@ -7361,7 +7571,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "rc" = (
 /obj/effect/floor_decal/corner/green{
@@ -7369,14 +7581,20 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "re" = (
 /obj/effect/floor_decal/corner/green/half,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "rf" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "rh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -7386,7 +7604,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "ri" = (
 /obj/machinery/light{
@@ -7404,7 +7624,9 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "rl" = (
 /obj/machinery/alarm{
@@ -7413,7 +7635,9 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "rm" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -7452,7 +7676,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "rt" = (
 /obj/machinery/camera/network/third_deck{
@@ -7473,7 +7699,9 @@
 /obj/machinery/atm{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "rv" = (
 /obj/machinery/hologram/holopad,
@@ -7494,7 +7722,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "rx" = (
 /obj/machinery/newscaster{
@@ -7503,7 +7733,9 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "rz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7543,7 +7775,9 @@
 /obj/effect/floor_decal/corner/lime/three_quarters{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "rC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7663,7 +7897,9 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "rS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7796,7 +8032,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "sh" = (
 /obj/structure/cable/green{
@@ -8041,7 +8279,9 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "sB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8194,7 +8434,9 @@
 /area/crew_quarters/recreation)
 "sM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/cryolocker)
 "sN" = (
 /obj/structure/disposalpipe/segment{
@@ -8211,7 +8453,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "sP" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -8259,10 +8503,14 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/tele_beacon,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "sW" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "sX" = (
 /obj/effect/floor_decal/corner/lime{
@@ -8273,7 +8521,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "sZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8322,7 +8572,9 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "th" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8342,7 +8594,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "ti" = (
 /obj/random/junk,
@@ -8391,14 +8645,18 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "ts" = (
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Hallway - Fore Central";
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "tt" = (
 /obj/machinery/door/firedoor,
@@ -8416,7 +8674,9 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "tw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -8425,7 +8685,9 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "tx" = (
 /obj/machinery/camera/network/third_deck{
@@ -8439,7 +8701,9 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "ty" = (
 /obj/effect/floor_decal/corner/blue{
@@ -8462,14 +8726,18 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "tC" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "tD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -8482,7 +8750,9 @@
 	dir = 1;
 	pixel_y = -28
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "tE" = (
 /obj/machinery/firealarm{
@@ -8499,7 +8769,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "tG" = (
 /obj/effect/floor_decal/techfloor{
@@ -8525,7 +8797,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "tJ" = (
 /obj/machinery/atm{
@@ -8534,7 +8808,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "tK" = (
 /obj/structure/lattice,
@@ -8548,7 +8824,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "tN" = (
 /obj/structure/bed/chair/pew/left/mahogany,
@@ -8571,7 +8849,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "tS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -8583,7 +8863,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "tT" = (
 /obj/structure/cable/green{
@@ -8591,7 +8873,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/commissary)
 "tU" = (
 /obj/structure/cable/green{
@@ -8613,7 +8897,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "tX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8646,7 +8932,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "ub" = (
 /turf/simulated/wall/walnut,
@@ -8717,7 +9005,9 @@
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "ul" = (
 /obj/effect/floor_decal/corner/lime{
@@ -8727,14 +9017,18 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "um" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "un" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -8748,7 +9042,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "up" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -8810,14 +9106,18 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "uz" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "uA" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -8827,7 +9127,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/command/disperser)
 "uB" = (
 /obj/machinery/computer/arcade,
@@ -8854,7 +9156,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/commissary)
 "uG" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -9155,7 +9459,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "vw" = (
 /obj/structure/bed/chair/padded/green{
@@ -9187,7 +9493,9 @@
 /turf/simulated/floor/grass,
 /area/crew_quarters/observation)
 "vF" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/gym)
 "vG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9320,7 +9628,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "wa" = (
 /obj/effect/floor_decal/techfloor{
@@ -9372,13 +9682,17 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "wk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "wl" = (
 /turf/simulated/wall/prepainted,
@@ -9393,7 +9707,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "wp" = (
 /turf/simulated/floor/lino,
@@ -9503,7 +9819,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "wC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9545,7 +9863,9 @@
 /obj/machinery/vending/fitness{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/gym)
 "wK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -9559,7 +9879,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "wM" = (
 /obj/structure/bed/chair/comfy/black,
@@ -9572,7 +9894,9 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "wO" = (
 /obj/machinery/atm{
@@ -9581,7 +9905,9 @@
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Hallway - Teleporter"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "wP" = (
 /obj/structure/extinguisher_cabinet{
@@ -9596,7 +9922,9 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "wR" = (
 /obj/effect/floor_decal/industrial/warning/fulltile,
@@ -9624,7 +9952,9 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "wU" = (
 /obj/structure/sign/warning/vent_port{
@@ -9640,7 +9970,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "wW" = (
 /turf/simulated/wall/walnut,
@@ -9686,7 +10018,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/green,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "xg" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -9698,7 +10032,9 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "xi" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -9749,7 +10085,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "xo" = (
 /obj/structure/table/standard,
@@ -9841,7 +10179,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "xF" = (
 /turf/simulated/floor/tiled/steel_grid,
@@ -9851,7 +10191,9 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "xI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -9860,7 +10202,9 @@
 /obj/structure/sign/directions/janitor{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "xJ" = (
 /obj/structure/cable/green{
@@ -9906,7 +10250,9 @@
 "xN" = (
 /obj/structure/table/marble,
 /obj/machinery/recharger,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/commissary)
 "xO" = (
 /obj/structure/cable/green{
@@ -9937,7 +10283,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/chief_steward)
 "xQ" = (
 /obj/structure/cable/green{
@@ -9987,7 +10335,9 @@
 	dir = 8;
 	icon_state = "railing0-1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "xT" = (
 /obj/structure/cable/green{
@@ -10008,7 +10358,9 @@
 	dir = 4;
 	icon_state = "pipe-j2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "xU" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -10058,7 +10410,9 @@
 /obj/effect/floor_decal/corner/red/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/emcloset,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "xY" = (
 /obj/structure/bed/padded,
@@ -10190,7 +10544,9 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "yq" = (
 /obj/machinery/computer/modular/preset/civilian{
@@ -10238,7 +10594,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "yz" = (
 /obj/effect/floor_decal/spline/fancy/black{
@@ -10489,7 +10847,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/gym)
 "zl" = (
 /obj/structure/cable/green{
@@ -10502,7 +10862,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "zn" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -10643,7 +11005,9 @@
 /obj/structure/reagent_dispensers/water_cooler{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/gym)
 "zL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10659,7 +11023,9 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "zQ" = (
 /obj/structure/railing/mapped{
@@ -10774,7 +11140,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Aq" = (
 /obj/machinery/firealarm{
@@ -10903,7 +11271,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/storage/tools)
 "AJ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -10912,7 +11282,9 @@
 /obj/machinery/air_sensor{
 	id_tag = "cChamber3s"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d3starboard)
 "AK" = (
 /obj/structure/table/rack{
@@ -10999,7 +11371,9 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "AV" = (
 /obj/effect/floor_decal/spline/fancy/black{
@@ -11054,7 +11428,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "Bi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -11203,7 +11579,9 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/storage/tools)
 "BD" = (
 /obj/effect/floor_decal/corner/green/half{
@@ -11227,7 +11605,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "BH" = (
 /obj/machinery/firealarm{
@@ -11242,19 +11622,25 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "BK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/storage/tools)
 "BL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/storage/tools)
 "BM" = (
 /obj/random/junk,
@@ -11398,7 +11784,9 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Cj" = (
 /obj/machinery/light/spot{
@@ -11661,7 +12049,9 @@
 "CP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/largecrate,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/maintenance/thirddeck/starboard)
 "CQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -11675,7 +12065,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "CT" = (
 /obj/random/trash,
@@ -11889,7 +12279,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "Du" = (
 /obj/machinery/door/firedoor,
@@ -11921,7 +12313,9 @@
 	dir = 4;
 	pixel_x = 26
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/commissary)
 "Dx" = (
 /obj/structure/disposalpipe/segment{
@@ -11939,7 +12333,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Dy" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -12164,12 +12560,16 @@
 	},
 /obj/structure/bed/chair/comfy/lime,
 /obj/random/junk,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/cabin)
 "DW" = (
 /obj/effect/floor_decal/corner/lime,
 /obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/cabin)
 "DX" = (
 /obj/machinery/atmospherics/valve/digital{
@@ -12434,7 +12834,9 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/cabin)
 "ED" = (
 /turf/simulated/floor/plating,
@@ -12658,7 +13060,9 @@
 	dir = 8
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/maintenance/thirddeck/port)
 "Ff" = (
 /obj/machinery/door/airlock/maintenance{
@@ -12676,7 +13080,9 @@
 "Fh" = (
 /obj/effect/floor_decal/corner/lime,
 /obj/random/trash,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/cabin)
 "Fi" = (
 /obj/structure/bed/chair/office/light{
@@ -12823,14 +13229,18 @@
 	pressure_checks_default = 2;
 	use_power = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/thruster/d3port)
 "FB" = (
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Hallway - Fore Port";
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "FC" = (
 /obj/machinery/door/firedoor,
@@ -12898,7 +13308,9 @@
 /area/vacant/cabin)
 "FL" = (
 /obj/effect/floor_decal/corner/lime,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/cabin)
 "FM" = (
 /obj/structure/table/steel,
@@ -13077,7 +13489,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Gt" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -13231,7 +13645,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "GD" = (
 /obj/structure/catwalk,
@@ -13350,13 +13766,17 @@
 /area/maintenance/thirddeck/foreport)
 "GY" = (
 /obj/structure/hygiene/drain,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "GZ" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/cryolocker)
 "Ha" = (
 /obj/structure/disposalpipe/segment,
@@ -13395,7 +13815,9 @@
 /obj/machinery/light_switch{
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/commissary)
 "Hh" = (
 /obj/structure/cable/green{
@@ -13494,7 +13916,9 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/storage/tools)
 "Hv" = (
 /obj/effect/floor_decal/techfloor{
@@ -13697,7 +14121,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/command/disperser)
 "HU" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -13724,7 +14150,9 @@
 /area/command/disperser)
 "HZ" = (
 /obj/effect/floor_decal/industrial/loading,
-/turf/simulated/floor/tiled/airless,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/command/disperser)
 "Ia" = (
 /obj/effect/wallframe_spawn/reinforced/hull,
@@ -13755,13 +14183,17 @@
 	dir = 1;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/command/disperser)
 "Id" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/command/disperser)
 "Ie" = (
 /obj/structure/table/steel,
@@ -13803,7 +14235,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "Il" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -13816,31 +14250,41 @@
 	id_tag = "bsa-core";
 	name = "OFD Blast Door"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/command/disperser)
 "In" = (
 /obj/machinery/disperser/front{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/command/disperser)
 "Io" = (
 /obj/machinery/disperser/middle{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/command/disperser)
 "Ip" = (
 /obj/machinery/disperser/back{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/command/disperser)
 "Iq" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Ir" = (
 /obj/machinery/camera/network/command{
@@ -13932,7 +14376,9 @@
 /area/hallway/primary/thirddeck/fore)
 "ID" = (
 /obj/random_multi/single_item/punitelly,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/brig)
 "IE" = (
 /obj/random_multi/single_item/punitelly,
@@ -14189,7 +14635,9 @@
 /area/hallway/primary/thirddeck/center)
 "Jc" = (
 /obj/effect/floor_decal/corner/green,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "Je" = (
 /obj/structure/disposalpipe/segment,
@@ -14200,14 +14648,18 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "Jg" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 8
 	},
 /obj/structure/flora/pottedplant/dead,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/commissary)
 "Jh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -14593,7 +15045,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "JR" = (
 /obj/structure/cable/green{
@@ -14836,7 +15290,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "Ku" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -14927,7 +15383,7 @@
 	initial_id_tag = "torch_primary_pd"
 	},
 /obj/structure/cable/green,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "KC" = (
 /turf/simulated/open,
@@ -15049,7 +15505,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "KS" = (
 /obj/structure/table/steel,
@@ -15093,7 +15549,9 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d3starboard)
 "KW" = (
 /obj/structure/railing/mapped{
@@ -15147,7 +15605,9 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d3port)
 "Lh" = (
 /obj/structure/closet/emcloset,
@@ -15159,13 +15619,17 @@
 	id_tag = "cChamber3pV";
 	name = "Chamber Vent"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d3port)
 "Lj" = (
 /obj/effect/landmark{
 	name = "lightsout"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "Lk" = (
 /obj/structure/catwalk,
@@ -15302,7 +15766,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/green/half,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "Lz" = (
 /obj/machinery/door/firedoor,
@@ -15369,7 +15835,9 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "LE" = (
 /obj/machinery/computer/air_control{
@@ -15395,7 +15863,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "LG" = (
 /turf/simulated/wall/prepainted,
@@ -15472,7 +15942,9 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d3port)
 "LP" = (
 /obj/structure/cable/green{
@@ -15485,7 +15957,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "LQ" = (
 /obj/item/flame/candle{
@@ -15582,7 +16054,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Ma" = (
 /obj/machinery/atmospherics/valve/shutoff/supply,
@@ -15668,7 +16142,9 @@
 /area/engineering/hardstorage)
 "Mi" = (
 /obj/effect/floor_decal/corner/green,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "Mj" = (
 /obj/structure/cable/green{
@@ -15684,7 +16160,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Mn" = (
 /obj/structure/disposalpipe/segment{
@@ -15739,7 +16217,9 @@
 	injecting = 1;
 	use_power = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/thruster/d3starboard)
 "Mu" = (
 /obj/structure/catwalk,
@@ -15752,7 +16232,9 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/galleybackroom)
 "Mx" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "My" = (
 /obj/machinery/jukebox/old,
@@ -15767,7 +16249,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "MB" = (
 /obj/structure/disposalpipe/segment,
@@ -15827,7 +16311,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/commissary)
 "MI" = (
 /obj/structure/cable/green{
@@ -15899,7 +16385,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "MU" = (
 /obj/effect/floor_decal/corner/yellow/half,
@@ -15994,7 +16482,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "Ni" = (
 /obj/structure/table/rack,
@@ -16126,7 +16616,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "NF" = (
 /obj/machinery/door/firedoor,
@@ -16144,7 +16636,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/commissary)
 "NH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16216,7 +16710,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "NO" = (
 /obj/random_multi/single_item/punitelly,
@@ -16232,7 +16728,9 @@
 	pressure_checks_default = 2;
 	use_power = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/thruster/d3starboard)
 "NR" = (
 /obj/machinery/light/small{
@@ -16261,7 +16759,9 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "NV" = (
 /obj/structure/cable/green{
@@ -16305,7 +16805,9 @@
 	volume_rate = 4000
 	},
 /obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d3port)
 "Ob" = (
 /obj/effect/shuttle_landmark/torch/deck4/aquila{
@@ -16317,7 +16819,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/commissary)
 "Od" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -16366,7 +16870,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "Oj" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -16412,7 +16918,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "Oq" = (
 /obj/effect/floor_decal/corner/green{
@@ -16425,7 +16933,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "Or" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
@@ -16477,7 +16987,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "Oz" = (
 /obj/machinery/light/small{
@@ -16517,7 +17029,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "OE" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -16637,7 +17151,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "OW" = (
 /obj/structure/sign/directions/engineering{
@@ -16690,7 +17206,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/gym)
 "Pc" = (
 /obj/structure/table/rack,
@@ -16725,7 +17243,9 @@
 	dir = 1;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/command/disperser)
 "Pn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16746,7 +17266,9 @@
 	dir = 10
 	},
 /obj/machinery/beehive,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "Po" = (
 /obj/structure/disposalpipe/segment{
@@ -16816,7 +17338,9 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "PA" = (
 /obj/structure/sign/directions/science{
@@ -16876,7 +17400,9 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "PH" = (
 /obj/effect/floor_decal/corner/green/half,
@@ -16913,7 +17439,9 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d3starboard)
 "PN" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -16977,7 +17505,9 @@
 /obj/machinery/vending/coffee{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "PV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -17012,7 +17542,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d3starboard)
 "Qd" = (
 /obj/structure/table/rack,
@@ -17095,7 +17627,9 @@
 /obj/structure/hygiene/sink/kitchen{
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "Qq" = (
 /turf/simulated/wall/r_wall/hull,
@@ -17191,7 +17725,9 @@
 	dir = 5
 	},
 /obj/machinery/ship_map,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "QE" = (
 /obj/structure/table/rack,
@@ -17221,7 +17757,9 @@
 /area/crew_quarters/office)
 "QJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "QK" = (
 /obj/machinery/firealarm{
@@ -17249,7 +17787,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "QQ" = (
 /obj/effect/wallframe_spawn/no_grille,
@@ -17344,7 +17884,9 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Re" = (
 /obj/structure/cable/green{
@@ -17366,7 +17908,9 @@
 /obj/machinery/camera/network/third_deck{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/gym)
 "Rh" = (
 /obj/structure/bed/chair/padded/green{
@@ -17389,7 +17933,9 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Rl" = (
 /obj/effect/floor_decal/industrial/hatch,
@@ -17443,7 +17989,9 @@
 /obj/item/reagent_containers/glass/beaker{
 	pixel_x = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "Ro" = (
 /obj/effect/floor_decal/corner/green/half,
@@ -17509,7 +18057,9 @@
 /obj/structure/table/rack,
 /obj/item/towel/random,
 /obj/item/towel/random,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/gym)
 "RB" = (
 /obj/structure/catwalk,
@@ -17525,7 +18075,9 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "RE" = (
 /obj/machinery/alarm{
@@ -17538,7 +18090,9 @@
 /area/crew_quarters/head)
 "RF" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/maintenance/thirddeck/starboard)
 "RG" = (
 /turf/simulated/wall/prepainted,
@@ -17649,13 +18203,17 @@
 	id_tag = "shop_shutters";
 	name = "Commissary Shutters"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/commissary)
 "Sb" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d3port)
 "Sc" = (
 /obj/effect/floor_decal/corner/green{
@@ -17675,13 +18233,17 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Sd" = (
 /obj/structure/closet/hydrant{
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Sf" = (
 /obj/machinery/light{
@@ -17690,14 +18252,18 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/gym)
 "Sg" = (
 /obj/machinery/door/blast/regular{
 	id_tag = "cChamber3sV";
 	name = "Chamber Vent"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d3starboard)
 "Sh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -17780,7 +18346,9 @@
 	pixel_y = -26
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "So" = (
 /obj/structure/cable/green{
@@ -17803,7 +18371,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "Sq" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -17881,7 +18449,9 @@
 	dir = 1
 	},
 /obj/random/vendor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "SA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -17991,7 +18561,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "SP" = (
 /obj/structure/table/standard,
@@ -18144,13 +18714,17 @@
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "Tn" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "To" = (
 /obj/structure/lattice,
@@ -18165,7 +18739,9 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Tr" = (
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -18256,7 +18832,9 @@
 /area/maintenance/thirddeck/port)
 "TC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "TE" = (
 /turf/simulated/wall/prepainted,
@@ -18422,7 +19000,9 @@
 	injecting = 1;
 	use_power = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/thruster/d3port)
 "Ug" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -18448,7 +19028,9 @@
 /area/crew_quarters/observation)
 "Ui" = (
 /obj/machinery/meter/turf,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/command/disperser)
 "Um" = (
 /obj/machinery/light{
@@ -18465,7 +19047,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "Un" = (
 /obj/machinery/status_display,
@@ -18630,7 +19214,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/commissary)
 "UD" = (
 /obj/structure/grille,
@@ -18743,7 +19329,9 @@
 	name = "Sanitation Supplies"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/janitor/storage)
 "UP" = (
 /obj/structure/fitness/weightlifter,
@@ -18751,7 +19339,9 @@
 	dir = 8;
 	pixel_x = 25
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/gym)
 "UQ" = (
 /obj/item/device/radio/intercom{
@@ -18762,7 +19352,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "UR" = (
 /obj/machinery/sparker{
@@ -18775,7 +19367,9 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d3starboard)
 "UU" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -18789,7 +19383,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 8
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "UX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -18845,7 +19441,9 @@
 /obj/machinery/vending/fitness{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/gym)
 "Vd" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -18915,7 +19513,9 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Vm" = (
 /obj/structure/cable/green{
@@ -18923,7 +19523,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "Vn" = (
 /obj/effect/floor_decal/corner/lime{
@@ -18937,7 +19539,9 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "Vo" = (
 /obj/effect/wallframe_spawn/reinforced/hull,
@@ -19036,7 +19640,9 @@
 /obj/effect/floor_decal/corner/green/half{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "VD" = (
 /obj/structure/catwalk,
@@ -19089,7 +19695,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "VI" = (
 /obj/structure/ladder,
@@ -19201,7 +19809,9 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "VU" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "VV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -19274,11 +19884,15 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/gym)
 "We" = (
 /obj/random_multi/single_item/poppy,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/vacant/brig)
 "Wg" = (
 /obj/random/trash,
@@ -19313,7 +19927,9 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Wo" = (
 /obj/machinery/meter,
@@ -19373,7 +19989,9 @@
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "Wy" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -19382,7 +20000,9 @@
 /obj/machinery/air_sensor{
 	id_tag = "cChamber3p"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d3port)
 "Wz" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -19408,7 +20028,9 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "WC" = (
 /turf/simulated/floor/reinforced/hydrogen,
@@ -19432,7 +20054,9 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "WF" = (
 /obj/effect/wallframe_spawn/reinforced_phoron,
@@ -19652,7 +20276,9 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Xj" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -19689,7 +20315,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "Xo" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -19715,7 +20343,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "Xs" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
@@ -19770,7 +20398,9 @@
 	pixel_x = -20;
 	pixel_y = -20
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/command/disperser)
 "Xz" = (
 /obj/structure/closet/crate/solar,
@@ -19905,7 +20535,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/center)
 "XR" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/cryolocker)
 "XS" = (
 /obj/random/torchcloset,
@@ -20015,7 +20647,9 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Ye" = (
 /obj/machinery/light/small,
@@ -20030,7 +20664,9 @@
 /obj/structure/reagent_dispensers/water_cooler{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Yj" = (
 /obj/structure/railing/mapped{
@@ -20092,7 +20728,9 @@
 	},
 /obj/structure/closet/crate/hydroponics/beekeeping,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hydroponics)
 "Yp" = (
 /obj/random/junk,
@@ -20118,13 +20756,17 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Yu" = (
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Hallway - Commissary"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "Yv" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -20180,7 +20822,9 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/gym)
 "YG" = (
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/commissary)
 "YH" = (
 /obj/structure/railing/mapped{
@@ -20195,7 +20839,9 @@
 /area/maintenance/thirddeck/port)
 "YJ" = (
 /obj/effect/floor_decal/corner/red,
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "YK" = (
 /turf/simulated/floor/tiled/freezer,
@@ -20243,7 +20889,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "YS" = (
 /obj/structure/table/woodentable,
@@ -20253,7 +20899,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "YT" = (
 /obj/machinery/atmospherics/binary/passive_gate/on{
@@ -20270,7 +20918,9 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/fore)
 "YV" = (
 /obj/item/stool,
@@ -20297,7 +20947,9 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/center)
 "YZ" = (
 /obj/machinery/door/airlock/maintenance{
@@ -20316,13 +20968,17 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/gym)
 "Zb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/gym)
 "Zc" = (
 /obj/machinery/atmospherics/binary/pump/on{
@@ -20374,7 +21030,9 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/storage/tools)
 "Zl" = (
 /obj/structure/cable/green{
@@ -20435,7 +21093,9 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/crew_quarters/commissary)
 "Zt" = (
 /obj/machinery/computer/modular/preset/civilian{
@@ -20556,7 +21216,9 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled,
+/turf/simulated/floor/tiled{
+	map_airless = 1
+	},
 /area/hallway/primary/thirddeck/aft)
 "ZF" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -20590,7 +21252,9 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d3port)
 "ZJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -20656,7 +21320,9 @@
 	volume_rate = 4000
 	},
 /obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d3starboard)
 "ZV" = (
 /obj/structure/railing/mapped,

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -37,7 +37,9 @@
 /obj/machinery/fusion_fuel_injector/mapped{
 	initial_id_tag = "aux_fusion_plant"
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "ae" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -69,7 +71,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/auxstarboard)
 "ai" = (
 /obj/structure/cable/yellow{
@@ -77,7 +79,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/auxstarboard)
 "aj" = (
 /obj/structure/cable/yellow{
@@ -89,7 +91,7 @@
 	name = "Starboard Auxiliary Solar Array"
 	},
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/auxstarboard)
 "ak" = (
 /obj/structure/cable/yellow{
@@ -102,7 +104,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/auxstarboard)
 "al" = (
 /obj/structure/cable/yellow{
@@ -120,7 +122,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/auxstarboard)
 "am" = (
 /obj/structure/cable/yellow{
@@ -128,7 +130,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/auxstarboard)
 "an" = (
 /obj/structure/cable/yellow{
@@ -146,7 +148,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/auxstarboard)
 "ao" = (
 /obj/structure/cable/yellow{
@@ -164,7 +166,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/auxstarboard)
 "ap" = (
 /obj/structure/cable/yellow{
@@ -177,7 +179,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/auxstarboard)
 "aq" = (
 /obj/structure/cable/yellow,
@@ -186,7 +188,7 @@
 	name = "Starboard Auxiliary Solar Array"
 	},
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/auxstarboard)
 "ar" = (
 /obj/machinery/power/solar{
@@ -195,7 +197,7 @@
 	},
 /obj/structure/cable/yellow,
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/auxstarboard)
 "as" = (
 /obj/structure/crematorium,
@@ -256,7 +258,7 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_bay)
 "av" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/space)
 "aw" = (
 /obj/machinery/conveyor_switch/oneway{
@@ -313,7 +315,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/auxstarboard)
 "aB" = (
 /obj/machinery/conveyor{
@@ -593,7 +595,9 @@
 	dir = 4;
 	id_tag = "prototype_exhaust"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "bh" = (
 /obj/structure/table/rack,
@@ -680,7 +684,9 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "bq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2156,7 +2162,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "ei" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -2276,7 +2284,9 @@
 	dir = 8;
 	initial_id_tag = "aux_fusion_plant"
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "eu" = (
 /obj/structure/cable{
@@ -2306,7 +2316,9 @@
 /obj/machinery/power/port_gen/pacman/mrs{
 	anchored = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "ex" = (
 /obj/random/torchcloset,
@@ -2409,7 +2421,9 @@
 	dir = 1;
 	initial_id_tag = "aux_fusion_plant"
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "eI" = (
 /obj/structure/cable/green{
@@ -3265,7 +3279,9 @@
 	id_tag = "engineroomvent";
 	name = "Engine room vent"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "gA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black{
@@ -4782,7 +4798,9 @@
 /area/teleporter/seconddeck)
 "ky" = (
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/torchexterior)
 "kz" = (
 /obj/structure/cable/green{
@@ -5104,7 +5122,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "lk" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/torchexterior)
 "ll" = (
 /obj/structure/extinguisher_cabinet{
@@ -5426,7 +5446,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "ma" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/port)
 "mb" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -5461,7 +5481,9 @@
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "mh" = (
 /obj/structure/cable/yellow{
@@ -5473,7 +5495,9 @@
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "mi" = (
 /obj/structure/cable/green{
@@ -6250,7 +6274,9 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_monitoring)
 "ox" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "oy" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -6881,7 +6907,9 @@
 	name = "Reactor Blast Door"
 	},
 /obj/effect/wallframe_spawn/reinforced_phoron,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "qe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6917,7 +6945,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "qi" = (
 /obj/effect/wallframe_spawn/reinforced/no_grille,
@@ -7377,7 +7407,9 @@
 	id_tag = "EngineAccess";
 	name = "Engine Access Hatch"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "ri" = (
 /obj/structure/cable{
@@ -7517,7 +7549,9 @@
 /area/maintenance/seconddeck/foreport)
 "rv" = (
 /obj/machinery/door/airlock/hatch,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "rw" = (
 /obj/effect/floor_decal/techfloor/corner,
@@ -8686,7 +8720,9 @@
 	id_tag = "WasteGate";
 	name = "Waste Gate"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/wastetank)
 "uY" = (
 /obj/effect/floor_decal/corner/yellow/half,
@@ -8695,7 +8731,9 @@
 /area/engineering/foyer)
 "uZ" = (
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/space)
 "vc" = (
 /obj/effect/catwalk_plated,
@@ -9487,7 +9525,9 @@
 	icon_state = "pdoor0";
 	id_tag = "prototype_chamber_blast"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "xy" = (
 /obj/machinery/light,
@@ -9949,7 +9989,9 @@
 	name = "Engine room vent"
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "zb" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -11114,7 +11156,9 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "Cl" = (
 /obj/structure/table/rack,
@@ -11371,10 +11415,14 @@
 	id_tag = "Incinerator";
 	pixel_x = -20
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/maintenance/incinerator)
 "CQ" = (
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/maintenance/incinerator)
 "CR" = (
 /obj/machinery/atmospherics/unary/vent_pump{
@@ -11393,7 +11441,9 @@
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/maintenance/incinerator)
 "CS" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -11700,7 +11750,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "DF" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/wastetank)
 "DG" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -11928,13 +11980,17 @@
 	id_tag = "prototype_chamber_blast"
 	},
 /obj/effect/wingrille_spawn/reinforced_phoron/full,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Ek" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/wastetank)
 "El" = (
 /obj/machinery/door/blast/regular{
@@ -11943,7 +11999,9 @@
 	name = "Reactor Blast Door"
 	},
 /obj/effect/wallframe_spawn/reinforced_phoron,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "Eo" = (
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -11986,7 +12044,9 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/wastetank)
 "Eu" = (
 /obj/machinery/atmospherics/unary/vent_pump/tank{
@@ -12002,7 +12062,9 @@
 	pressure_checks_default = 2;
 	pump_direction = 0
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/wastetank)
 "Ev" = (
 /obj/structure/cable/green{
@@ -12039,7 +12101,7 @@
 	pixel_y = 24;
 	req_access = list("ACCESS_ENGINE_EQUIP","ACCESS_EXTERNAL")
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/port)
 "EA" = (
 /obj/structure/cable/yellow{
@@ -12051,7 +12113,7 @@
 	name = "Port Auxiliary Solar Array"
 	},
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/port)
 "EB" = (
 /obj/structure/cable/yellow{
@@ -12059,7 +12121,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/port)
 "EC" = (
 /obj/structure/cable/yellow{
@@ -12072,7 +12134,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/port)
 "ED" = (
 /obj/structure/cable/yellow{
@@ -12090,7 +12152,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/port)
 "EE" = (
 /obj/structure/cable/yellow{
@@ -12098,7 +12160,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/port)
 "EF" = (
 /obj/structure/cable/yellow{
@@ -12116,7 +12178,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/port)
 "EG" = (
 /obj/structure/cable/yellow{
@@ -12134,7 +12196,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/port)
 "EH" = (
 /obj/structure/cable/yellow{
@@ -12147,7 +12209,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/port)
 "EI" = (
 /obj/structure/cable/yellow,
@@ -12156,7 +12218,7 @@
 	name = "Port Auxiliary Solar Array"
 	},
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/port)
 "EK" = (
 /obj/structure/cable/yellow{
@@ -12174,12 +12236,12 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/port)
 "EL" = (
 /obj/machinery/power/tracker,
 /obj/structure/cable/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/port)
 "EO" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -12319,11 +12381,15 @@
 /obj/machinery/air_sensor{
 	id_tag = "waste_sensor"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/wastetank)
 "Fg" = (
 /obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Fh" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -12652,7 +12718,9 @@
 /area/vacant/prototype/control)
 "Gg" = (
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Gh" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -12759,6 +12827,11 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
+"Gr" = (
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
+/area/torchexterior)
 "Gs" = (
 /obj/structure/cable{
 	d1 = 2;
@@ -12945,7 +13018,9 @@
 	dir = 8;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Hh" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -13074,7 +13149,9 @@
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/wastetank)
 "Hu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13527,7 +13604,9 @@
 /area/maintenance/seconddeck/central)
 "IR" = (
 /obj/structure/grille,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/space)
 "IU" = (
 /obj/structure/cable/green{
@@ -13544,7 +13623,9 @@
 /obj/machinery/air_sensor{
 	id_tag = "rust_sensor"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "IW" = (
 /obj/machinery/light_switch{
@@ -13846,6 +13927,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/disposal)
+"JO" = (
+/turf/simulated/floor/reinforced,
+/area/space)
 "JQ" = (
 /obj/structure/table/steel,
 /obj/machinery/recharger,
@@ -13917,9 +14001,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_smes)
-"Kf" = (
-/turf/simulated/floor/reinforced/airless,
-/area/vacant/prototype/engine)
 "Kg" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/structure/cable{
@@ -14154,7 +14235,9 @@
 	},
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "Lf" = (
 /obj/structure/disposalpipe/segment{
@@ -14188,7 +14271,9 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/seconddeck/fore)
 "Li" = (
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Lj" = (
 /obj/structure/cable/yellow,
@@ -14237,7 +14322,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "Ls" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/space)
 "Lt" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
@@ -14422,7 +14509,9 @@
 "Mh" = (
 /obj/machinery/shield_diffuser,
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Mi" = (
 /obj/machinery/button/blast_door{
@@ -14611,11 +14700,15 @@
 /obj/machinery/door/blast/regular/escape_pod{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/maintenance/seconddeck/foreport)
 "MS" = (
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "MW" = (
 /obj/structure/table/rack,
@@ -14632,7 +14725,9 @@
 	injecting = 1;
 	use_power = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Nd" = (
 /obj/machinery/power/terminal{
@@ -14690,7 +14785,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Ni" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -14821,7 +14918,9 @@
 	id = "waste_in";
 	use_power = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/wastetank)
 "ND" = (
 /obj/structure/sign/warning/airlock{
@@ -15062,7 +15161,9 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Oi" = (
 /obj/machinery/power/terminal{
@@ -15212,7 +15313,9 @@
 /area/engineering/bluespace)
 "OG" = (
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/wastetank)
 "OI" = (
 /obj/machinery/computer/modular/preset/engineering{
@@ -15374,7 +15477,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Pi" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -15570,7 +15675,9 @@
 /obj/machinery/door/blast/regular/escape_pod{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/maintenance/seconddeck/forestarboard)
 "PS" = (
 /obj/effect/floor_decal/floordetail/edgedrain{
@@ -15682,7 +15789,9 @@
 	dir = 1;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Qi" = (
 /obj/machinery/light,
@@ -15844,7 +15953,9 @@
 	dir = 1
 	},
 /obj/random/junk,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "QI" = (
 /obj/structure/closet/toolcloset,
@@ -15887,7 +15998,9 @@
 "QN" = (
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/wastetank)
 "QQ" = (
 /obj/structure/cable/green{
@@ -15966,7 +16079,9 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "Re" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -16008,7 +16123,9 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Ri" = (
 /obj/structure/cable/green{
@@ -16335,7 +16452,9 @@
 /obj/machinery/camera/network/engine{
 	c_tag = "Engine - Prototype Chamber One"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Sh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -16381,7 +16500,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "Sl" = (
 /obj/machinery/cryopod{
@@ -16655,7 +16776,9 @@
 	icon_state = "pdoor0";
 	id_tag = "prototype_chamber_blast"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Tl" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
@@ -16682,7 +16805,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "Tp" = (
 /obj/structure/sign/warning/vacuum,
@@ -16783,7 +16908,9 @@
 /area/engineering/shieldbay)
 "TK" = (
 /obj/structure/grille,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "TL" = (
 /obj/structure/railing/mapped{
@@ -16954,7 +17081,9 @@
 /obj/machinery/power/supermatter,
 /obj/effect/engine_setup/core,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/greengrid/airless,
+/turf/simulated/floor/greengrid{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "Up" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -17072,7 +17201,9 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Vf" = (
 /obj/machinery/computer/air_control{
@@ -17091,7 +17222,9 @@
 	locked = 1
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Vh" = (
 /obj/structure/cable{
@@ -17154,7 +17287,9 @@
 /area/engineering/engine_room)
 "Vo" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/greengrid/airless,
+/turf/simulated/floor/greengrid{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "Vq" = (
 /turf/simulated/wall/r_wall/hull,
@@ -17164,7 +17299,9 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/maintenance/seconddeck/foreport)
 "Vu" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
@@ -17261,7 +17398,9 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/maintenance/seconddeck/forestarboard)
 "VX" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -17320,7 +17459,9 @@
 /area/hallway/primary/seconddeck/fore)
 "Wg" = (
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Wh" = (
 /obj/structure/cable{
@@ -17405,7 +17546,9 @@
 	name = "Reactor Vent"
 	},
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "Wp" = (
 /turf/simulated/wall/r_wall/hull,
@@ -17735,7 +17878,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Xf" = (
 /obj/machinery/shield_diffuser,
@@ -17743,14 +17888,18 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Xg" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Xh" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -17778,7 +17927,9 @@
 	name = "Incinerator Vent"
 	},
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/maintenance/incinerator)
 "Xl" = (
 /obj/structure/catwalk,
@@ -17810,7 +17961,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "Xp" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -17919,6 +18072,12 @@
 "XP" = (
 /turf/simulated/wall/prepainted,
 /area/assembly/robotics)
+"XT" = (
+/obj/machinery/shield_diffuser,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
+/area/torchexterior)
 "XU" = (
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/effect/floor_decal/industrial/warning{
@@ -17986,7 +18145,9 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/vacant/prototype/engine)
 "Yg" = (
 /obj/structure/table/rack,
@@ -18263,7 +18424,9 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "Zi" = (
 /obj/structure/cable/yellow{
@@ -18347,7 +18510,9 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 "Zp" = (
 /obj/item/ammo_magazine/pistol/small/empty,
@@ -18471,7 +18636,9 @@
 /area/maintenance/seconddeck/central)
 "ZZ" = (
 /obj/machinery/light/small,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/engineering/engine_room)
 
 (1,1,1) = {"
@@ -27054,11 +27221,11 @@ qw
 mc
 ue
 Se
-Kf
+Li
 mg
 mg
 mg
-Kf
+Li
 Se
 ue
 dj
@@ -27256,11 +27423,11 @@ qw
 Lc
 ad
 Ej
-Kf
+Li
 Fg
 Xg
 Oh
-Kf
+Li
 Ej
 eH
 qj
@@ -27458,11 +27625,11 @@ qw
 md
 ad
 Ej
-Kf
+Li
 Gg
 eh
 Ph
-Kf
+Li
 Ej
 eH
 rj
@@ -27660,11 +27827,11 @@ qw
 Lc
 ad
 Ej
-Kf
+Li
 Hg
 mh
 Qh
-Kf
+Li
 Ej
 eH
 qj
@@ -27863,7 +28030,7 @@ ud
 Pe
 Se
 IV
-Kf
+Li
 qh
 Rh
 Na
@@ -32530,7 +32697,7 @@ Cn
 CP
 Xk
 lk
-ky
+XT
 aa
 aa
 aa
@@ -32732,7 +32899,7 @@ Co
 CQ
 EV
 lk
-ky
+XT
 aa
 aa
 aa
@@ -32934,7 +33101,7 @@ Cn
 CR
 Xk
 lk
-ky
+XT
 aa
 aa
 aa
@@ -45435,13 +45602,13 @@ ij
 ij
 jh
 YL
-Ls
+JO
 aa
 aa
-lk
+Gr
 aa
 aa
-Ls
+JO
 YL
 jh
 ij
@@ -45637,13 +45804,13 @@ ik
 ik
 ji
 ik
-Ls
+JO
 ag
 ag
-lk
+Gr
 ag
 ag
-Ls
+JO
 ik
 ji
 ik
@@ -46044,7 +46211,7 @@ ik
 aa
 aa
 aa
-lk
+Gr
 aa
 aa
 aa
@@ -46246,7 +46413,7 @@ ik
 ag
 ag
 oH
-lk
+Gr
 oH
 ag
 ag
@@ -46650,7 +46817,7 @@ ik
 aa
 aa
 aa
-lk
+Gr
 aa
 aa
 aa
@@ -46852,7 +47019,7 @@ ik
 aa
 aa
 aa
-lk
+Gr
 aa
 aa
 aa
@@ -47256,7 +47423,7 @@ jj
 ag
 ag
 aa
-lk
+Gr
 aa
 ag
 ag
@@ -47458,7 +47625,7 @@ fT
 fT
 ag
 aa
-lk
+Gr
 aa
 ag
 fT
@@ -47862,7 +48029,7 @@ fT
 fT
 ag
 aa
-lk
+Gr
 aa
 ag
 fT
@@ -48064,7 +48231,7 @@ af
 af
 ag
 ag
-lk
+Gr
 ag
 ag
 af

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -27,13 +27,13 @@
 /area/maintenance/firstdeck/centralstarboard)
 "aaf" = (
 /obj/machinery/atmospherics/unary/tank/hydrogen,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aag" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aah" = (
 /obj/machinery/alarm{
@@ -74,7 +74,7 @@
 /obj/machinery/light/spot{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aal" = (
 /obj/structure/cable/green{
@@ -94,22 +94,22 @@
 	pixel_y = 32;
 	req_access = list("ACCESS_CONSTRUCTION")
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aan" = (
 /obj/machinery/atmospherics/unary/tank/hydrogen{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aao" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aap" = (
 /obj/machinery/atmospherics/pipe/manifold4w/visible/fuel,
 /obj/machinery/meter,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aaq" = (
 /obj/machinery/atmospherics/valve{
@@ -119,7 +119,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aar" = (
 /obj/effect/shuttle_landmark/skipjack/deck2{
@@ -131,7 +131,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aat" = (
 /obj/machinery/atmospherics/valve{
@@ -141,29 +141,29 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aau" = (
 /obj/machinery/atmospherics/unary/tank/hydrogen{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aav" = (
 /obj/machinery/atmospherics/unary/tank/hydrogen{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aaw" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aax" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aay" = (
 /obj/structure/sign/warning/compressed_gas{
@@ -178,14 +178,14 @@
 /obj/machinery/light/spot{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aaA" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aaB" = (
 /obj/structure/disposalpipe/trunk{
@@ -202,13 +202,13 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aaD" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aaE" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -217,7 +217,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aaF" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -226,7 +226,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aaG" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -235,7 +235,7 @@
 /obj/machinery/light/spot{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aaH" = (
 /obj/structure/sign/warning/compressed_gas{
@@ -248,7 +248,7 @@
 /obj/machinery/atmospherics/unary/tank/hydrogen{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aaJ" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
@@ -257,7 +257,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aaK" = (
 /obj/machinery/access_button{
@@ -273,7 +273,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/binary/pump/high_power,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aaL" = (
 /obj/machinery/alarm{
@@ -290,7 +290,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aaN" = (
 /obj/machinery/shield_diffuser,
@@ -298,7 +298,7 @@
 	id_tag = "auxfuelvent";
 	name = "Auxiliary Fuel Storage Vent"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/engineering/fuelbay/aux)
 "aaO" = (
 /obj/machinery/door/airlock/external{
@@ -805,7 +805,9 @@
 /area/maintenance/firstdeck/forestarboard)
 "abF" = (
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/maintenance/firstdeck/forestarboard)
 "abG" = (
 /obj/effect/floor_decal/corner/beige{
@@ -897,7 +899,9 @@
 	req_access = list("ACCESS_MAINT")
 	},
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/maintenance/firstdeck/forestarboard)
 "abP" = (
 /turf/simulated/wall/r_wall/hull,
@@ -1033,10 +1037,12 @@
 	name = "Engineering External Access"
 	},
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/maintenance/firstdeck/forestarboard)
 "acd" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "ace" = (
 /obj/structure/closet/secure_closet/chemical,
@@ -1242,7 +1248,9 @@
 	volume_rate = 4000
 	},
 /obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d1starboard)
 "acw" = (
 /turf/simulated/wall/r_titanium,
@@ -1256,7 +1264,9 @@
 	volume_rate = 4000
 	},
 /obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d1port)
 "acy" = (
 /obj/effect/floor_decal/corner/pink{
@@ -3166,7 +3176,9 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d1starboard)
 "afx" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -3206,7 +3218,9 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d1starboard)
 "afB" = (
 /obj/structure/roller_bed,
@@ -3713,7 +3727,9 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d1starboard)
 "agx" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -4255,7 +4271,9 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d1starboard)
 "ahz" = (
 /obj/effect/floor_decal/spline/plain/beige{
@@ -5064,7 +5082,7 @@
 	injecting = 1;
 	use_power = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/thruster/d1starboard)
 "ajO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10585,7 +10603,7 @@
 /area/maintenance/firstdeck/centralport)
 "aLj" = (
 /obj/structure/grille,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "aLo" = (
 /turf/simulated/floor/tiled/white,
@@ -11368,7 +11386,9 @@
 	injecting = 1;
 	use_power = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/thruster/d1port)
 "aOE" = (
 /obj/structure/table/rack,
@@ -11822,7 +11842,9 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d1port)
 "aQm" = (
 /obj/machinery/light/small{
@@ -12119,13 +12141,17 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d1port)
 "aRh" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d1port)
 "aRj" = (
 /obj/machinery/atmospherics/binary/passive_gate/on{
@@ -12565,7 +12591,9 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d1port)
 "aSk" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -13183,7 +13211,9 @@
 	name = "Engineering External Access"
 	},
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/maintenance/firstdeck/foreport)
 "aUb" = (
 /obj/machinery/door/firedoor,
@@ -13343,7 +13373,9 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/maintenance/firstdeck/foreport)
 "aUp" = (
 /turf/simulated/wall/r_wall/hull,
@@ -13448,7 +13480,9 @@
 /area/thruster/d1port)
 "aUz" = (
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/maintenance/firstdeck/foreport)
 "aUA" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -14144,7 +14178,9 @@
 	id_tag = "cChamber1sV";
 	name = "Chamber Vent"
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d1starboard)
 "bhy" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -14394,7 +14430,9 @@
 	id_tag = "cChamber1pV";
 	name = "Chamber Vent"
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d1port)
 "btE" = (
 /turf/simulated/floor/tiled/dark,
@@ -14598,7 +14636,7 @@
 "bHb" = (
 /obj/effect/shuttle_landmark/escape_pod/start/pod12,
 /obj/effect/wallframe_spawn/reinforced/titanium,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/shuttle/escape_pod12/station)
 "bHp" = (
 /obj/structure/disposalpipe/segment{
@@ -14626,7 +14664,7 @@
 "bIb" = (
 /obj/effect/shuttle_landmark/escape_pod/start/pod13,
 /obj/effect/wallframe_spawn/reinforced/titanium,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/shuttle/escape_pod13/station)
 "bLb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -15663,7 +15701,9 @@
 	pressure_checks_default = 2;
 	use_power = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/thruster/d1port)
 "cYB" = (
 /obj/structure/dispenser,
@@ -23839,7 +23879,9 @@
 /obj/machinery/air_sensor{
 	id_tag = "cChamber1s"
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d1starboard)
 "otb" = (
 /obj/machinery/light{
@@ -24769,7 +24811,9 @@
 /obj/machinery/air_sensor{
 	id_tag = "cChamber1p"
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/thruster/d1port)
 "pBb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
@@ -26505,7 +26549,9 @@
 	pressure_checks_default = 2;
 	use_power = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/thruster/d1starboard)
 "rDb" = (
 /obj/machinery/atmospherics/portables_connector{

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -24,7 +24,7 @@
 /turf/simulated/floor/tiled/white,
 /area/aquila/medical)
 "ad" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "ae" = (
 /obj/structure/lattice,
@@ -46,7 +46,7 @@
 	name = "Bridge Auxiliary Solar Array"
 	},
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/solar/bridge)
 "ai" = (
 /obj/item/device/radio/intercom{
@@ -135,7 +135,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/bridge)
 "av" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -154,7 +154,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/bridge)
 "aw" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -168,7 +168,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/bridge)
 "ax" = (
 /obj/structure/cable/green{
@@ -321,7 +321,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/bridge)
 "aI" = (
 /obj/structure/cable/yellow,
@@ -330,7 +330,7 @@
 	name = "Bridge Auxiliary Solar Array"
 	},
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/solar/bridge)
 "aJ" = (
 /obj/structure/cable/green{
@@ -765,7 +765,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/bridge)
 "bF" = (
 /obj/structure/cable/green{
@@ -1586,7 +1586,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/bridge)
 "cP" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -1595,7 +1595,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/bridge)
 "cQ" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -1604,7 +1604,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/bridge)
 "cR" = (
 /obj/structure/catwalk,
@@ -2235,7 +2235,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "ec" = (
 /obj/effect/paint/hull,
@@ -2280,7 +2280,7 @@
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "ek" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2880,14 +2880,14 @@
 /area/maintenance/bridge/aftstarboard)
 "fj" = (
 /obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "fk" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "fl" = (
 /obj/structure/table/glass,
@@ -2936,7 +2936,7 @@
 	dir = 8;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "fu" = (
 /obj/structure/sign/warning/high_voltage{
@@ -3423,7 +3423,7 @@
 	pixel_x = -24;
 	req_access = list("ACCESS_MAINT")
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "go" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -3638,7 +3638,7 @@
 /area/hallway/primary/bridge/aft)
 "gY" = (
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "gZ" = (
 /obj/machinery/porta_turret{
@@ -3647,7 +3647,7 @@
 	lethal = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/aquila/cockpit)
 "ha" = (
 /obj/machinery/camera/network/aquila{
@@ -3680,7 +3680,7 @@
 	enabled = 0;
 	lethal = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/aquila/cockpit)
 "hi" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -4721,7 +4721,9 @@
 	pressure_checks_default = 2;
 	use_power = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/aquila/air)
 "kI" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -5655,7 +5657,7 @@
 	dir = 10;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "ns" = (
 /obj/structure/table/woodentable_reinforced/walnut,
@@ -5689,7 +5691,7 @@
 	dir = 1;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "nG" = (
 /obj/structure/filingcabinet/chestdrawer{
@@ -5839,7 +5841,7 @@
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/yellow,
 /obj/machinery/power/tracker,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "ob" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7390,7 +7392,9 @@
 /area/crew_quarters/heads/office/xo)
 "sm" = (
 /obj/machinery/shipsensors,
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/bridge/storage)
 "so" = (
 /obj/structure/table/standard,
@@ -8125,13 +8129,15 @@
 	dir = 1;
 	icon_state = "warningcee"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "uw" = (
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/aquila/medical)
 "uy" = (
 /turf/simulated/wall/walnut,
@@ -8329,7 +8335,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "vb" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -8340,7 +8346,7 @@
 	dir = 1;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "vd" = (
 /obj/machinery/power/shield_generator,
@@ -8551,14 +8557,14 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "vL" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "vO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -8931,7 +8937,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/bridge)
 "wu" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -8940,7 +8946,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/bridge)
 "ww" = (
 /obj/structure/closet/secure_closet/sea,
@@ -9515,7 +9521,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/bridge)
 "xU" = (
 /obj/structure/cable/green{
@@ -10958,7 +10964,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "El" = (
 /obj/structure/cable/green{
@@ -11143,7 +11149,9 @@
 	pixel_x = 23;
 	pixel_y = 6
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/aquila/airlock)
 "Ff" = (
 /obj/structure/table/rack,
@@ -13214,7 +13222,7 @@
 	pixel_x = 32;
 	pixel_y = -32
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced,
 /area/space)
 "Od" = (
 /obj/machinery/power/apc{
@@ -13441,7 +13449,7 @@
 "OX" = (
 /obj/machinery/shipsensors,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/aquila/air)
 "Pb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -14007,7 +14015,7 @@
 	pixel_x = -32;
 	pixel_y = 32
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/solar/bridge)
 "Rh" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -14405,7 +14413,9 @@
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/aquila/storage)
 "SU" = (
 /obj/structure/cable/green{
@@ -14618,7 +14628,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/bridge/forestarboard)
 "TB" = (
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/bridge/storage)
 "TI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -14992,7 +15004,9 @@
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/aquila/power)
 "Vw" = (
 /obj/effect/floor_decal/corner/blue{
@@ -15434,7 +15448,9 @@
 	id_tag = "bridge sensors";
 	name = "Sensor Shroud"
 	},
-/turf/simulated/floor/reinforced/airless,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/bridge/storage)
 "XR" = (
 /obj/structure/cable/green{

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -1,6 +1,6 @@
 /datum/map/torch
 
-	base_floor_type = /turf/simulated/floor/reinforced/airless
+	base_floor_type = /turf/simulated/floor/reinforced
 	base_floor_area = /area/torchexterior
 
 	post_round_safe_areas = list (
@@ -386,7 +386,7 @@
 /area/aquila
 	name = "\improper SEV Aquila"
 	icon_state = "shuttlered"
-	base_turf = /turf/simulated/floor/reinforced/airless
+	base_turf = /turf/simulated/floor/reinforced
 	requires_power = 1
 	dynamic_lighting = 1
 	area_flags = AREA_FLAG_RAD_SHIELDED | AREA_FLAG_ION_SHIELDED | AREA_FLAG_HIDE_FROM_HOLOMAP
@@ -1353,6 +1353,7 @@
 	has_gravity = FALSE
 	turf_initializer = /singleton/turf_initializer/maintenance/space
 	req_access = list(access_external_airlocks, access_maint_tunnels)
+	turfs_airless = TRUE
 
 // CentCom
 
@@ -1399,6 +1400,7 @@
 	has_gravity = FALSE
 	base_turf = /turf/space
 	req_access = list(access_engine_equip)
+	turfs_airless = TRUE
 
 /area/solar/auxstarboard
 	name = "\improper Fore Starboard Solar Array"

--- a/maps/torch/torch_shuttles.dm
+++ b/maps/torch/torch_shuttles.dm
@@ -7,7 +7,7 @@
 
 /obj/effect/shuttle_landmark/escape_pod/start
 	name = "Docked"
-	base_turf = /turf/simulated/floor/reinforced/airless
+	base_turf = /turf/simulated/floor/reinforced
 
 /obj/effect/shuttle_landmark/escape_pod/transit
 	name = "In transit"
@@ -451,7 +451,7 @@ TORCH_ESCAPE_POD(17)
 	name = "Aquila Hangar"
 	landmark_tag = "nav_hangar_aquila"
 	docking_controller = "aquila_shuttle_dock_airlock"
-	base_turf = /turf/simulated/floor/reinforced/airless
+	base_turf = /turf/simulated/floor/reinforced
 
 /obj/effect/shuttle_landmark/torch/deck1/aquila
 	name = "Space near Forth Deck"

--- a/maps/torch/z1_admin.dmm
+++ b/maps/torch/z1_admin.dmm
@@ -10170,10 +10170,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/merchant_station)
-"aUZ" = (
-/obj/structure/table/rack,
-/turf/simulated/floor/tiled/airless,
-/area/merchant_station)
 "aVk" = (
 /obj/structure/cable{
 	d2 = 2;
@@ -10181,7 +10177,9 @@
 	},
 /obj/machinery/power/solar,
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/merchant_station)
 "aVl" = (
 /obj/structure/table/steel,
@@ -10287,7 +10285,9 @@
 	},
 /obj/machinery/power/solar,
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/merchant_station)
 "aVG" = (
 /obj/structure/cable{
@@ -10300,7 +10300,9 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/merchant_station)
 "aVH" = (
 /obj/structure/cable/blue{
@@ -10438,7 +10440,9 @@
 	use_power = 1
 	},
 /obj/effect/floor_decal/industrial/warning/full,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/merchant_station)
 "aWg" = (
 /obj/structure/cable/blue{
@@ -10508,7 +10512,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/tracker,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/merchant_station)
 "aWz" = (
 /obj/structure/cable{
@@ -10516,7 +10522,9 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/merchant_station)
 "aWA" = (
 /obj/structure/cable{
@@ -10534,7 +10542,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/merchant_station)
 "aWB" = (
 /obj/structure/cable{
@@ -10545,7 +10555,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 5
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/merchant_station)
 "aWC" = (
 /obj/structure/cable{
@@ -10560,7 +10572,9 @@
 	dir = 4;
 	pixel_y = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/merchant_station)
 "aWD" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -10667,7 +10681,9 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/merchant_station)
 "aWW" = (
 /obj/machinery/power/solar_control/autostart,
@@ -10800,7 +10816,9 @@
 /obj/structure/cable,
 /obj/machinery/power/solar,
 /obj/effect/floor_decal/solarpanel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/merchant_station)
 "aZb" = (
 /obj/machinery/computer/modular/preset/civilian{
@@ -24783,7 +24801,7 @@ aTL
 aUf
 aUl
 aUF
-aUZ
+aVv
 aVx
 aVS
 aWp

--- a/packs/deepmaint/deepmaint_rooms/normal/ship_wreck.dmm
+++ b/packs/deepmaint/deepmaint_rooms/normal/ship_wreck.dmm
@@ -5,16 +5,16 @@
 "b" = (
 /obj/item/stack/cable_coil/single,
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/airless{
-	icon_state = "dmg2"
+/turf/simulated/floor{
+	map_airless = 1
 	},
 /area/map_template/deepmaint)
 "c" = (
 /obj/effect/landmark/scorcher,
 /obj/structure/closet/crate/plastic,
 /obj/item/material/twohanded/fireaxe,
-/turf/simulated/floor/airless{
-	icon_state = "dmg1"
+/turf/simulated/floor{
+	map_airless = 1
 	},
 /area/map_template/deepmaint)
 "d" = (
@@ -24,21 +24,28 @@
 "e" = (
 /obj/effect/landmark/scorcher,
 /obj/structure/closet/crate/plastic,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/deepmaint)
 "f" = (
 /obj/item/material/shard/shrapnel/titanium,
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/deepmaint)
 "g" = (
-/turf/simulated/floor/airless{
-	icon_state = "dmg2"
+/turf/simulated/floor{
+	icon_state = "dmg2";
+	map_airless = 1
 	},
 /area/map_template/deepmaint)
 "h" = (
 /obj/structure/door_assembly/door_assembly_ext,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/deepmaint)
 "i" = (
 /obj/item/material/shard/shrapnel/titanium,
@@ -51,40 +58,34 @@
 /obj/effect/landmark/scorcher,
 /obj/effect/decal/cleanable/liquid_fuel,
 /mob/living/simple_animal/hostile/carp,
-/turf/simulated/floor/airless{
-	icon_state = "dmg1"
+/turf/simulated/floor{
+	map_airless = 1
 	},
 /area/map_template/deepmaint)
 "k" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 8
 	},
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/deepmaint)
 "l" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mech_shield,
 /turf/simulated/floor,
 /area/map_template/deepmaint)
-"m" = (
-/obj/effect/landmark/scorcher,
-/turf/simulated/floor/airless{
-	icon_state = "dmg1"
-	},
-/area/map_template/deepmaint)
 "n" = (
 /obj/item/stack/material/rods,
 /obj/effect/landmark/scorcher,
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/airless,
-/area/map_template/deepmaint)
-"o" = (
-/obj/effect/landmark/scorcher,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/deepmaint)
 "p" = (
 /obj/item/stack/cable_coil/single,
-/turf/simulated/floor/asteroid,
+/turf/simulated/floor/asteroid{
+	map_airless = 1
+	},
 /area/map_template/deepmaint)
 "q" = (
 /obj/effect/mech_shield,
@@ -93,8 +94,8 @@
 "r" = (
 /obj/effect/landmark/scorcher,
 /obj/random/toolbox,
-/turf/simulated/floor/airless{
-	icon_state = "dmg1"
+/turf/simulated/floor{
+	map_airless = 1
 	},
 /area/map_template/deepmaint)
 "s" = (
@@ -103,10 +104,14 @@
 	},
 /obj/effect/gibspawner/robot,
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/deepmaint)
 "t" = (
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/deepmaint)
 "v" = (
 /obj/structure/lattice,
@@ -120,11 +125,13 @@
 /obj/structure/wall_frame/titanium,
 /obj/item/stack/material/rods,
 /obj/item/stack/material/rods,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/deepmaint)
 "y" = (
 /obj/structure/inflatable/door,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/deepmaint)
 "z" = (
 /obj/structure/mech_wreckage/powerloader,
@@ -132,12 +139,16 @@
 /area/map_template/deepmaint)
 "A" = (
 /mob/living/exosuit/premade/firefighter,
-/turf/simulated/floor/asteroid,
+/turf/simulated/floor/asteroid{
+	map_airless = 1
+	},
 /area/map_template/deepmaint)
 "B" = (
 /obj/item/material/shard,
 /obj/structure/door_assembly/door_assembly_ext,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/deepmaint)
 "C" = (
 /obj/structure/sign/warning/vacuum{
@@ -167,12 +178,6 @@
 /obj/effect/floor_decal/industrial/warning,
 /turf/simulated/floor,
 /area/map_template/deepmaint)
-"F" = (
-/obj/effect/landmark/scorcher,
-/turf/simulated/floor/airless{
-	icon_state = "dmg3"
-	},
-/area/map_template/deepmaint)
 "G" = (
 /turf/simulated/mineral,
 /area/map_template/deepmaint)
@@ -188,14 +193,16 @@
 /obj/structure/wall_frame/titanium,
 /obj/item/material/shard,
 /obj/item/stack/material/rods,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg1"
 	},
 /area/map_template/deepmaint)
 "M" = (
 /obj/item/stack/material/rods,
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/deepmaint)
 "N" = (
 /obj/item/stack/material/rods,
@@ -205,27 +212,31 @@
 "O" = (
 /obj/structure/wall_frame/titanium,
 /obj/item/material/shard,
-/turf/simulated/floor/airless{
-	icon_state = "dmg3"
+/turf/simulated/floor{
+	map_airless = 1
 	},
 /area/map_template/deepmaint)
 "P" = (
 /obj/item/material/shard,
 /obj/effect/landmark/scorcher,
 /obj/effect/decal/cleanable/liquid_fuel,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/deepmaint)
 "Q" = (
 /obj/item/extinguisher/empty,
 /turf/space,
 /area/map_template/deepmaint)
 "R" = (
-/turf/simulated/floor/asteroid,
+/turf/simulated/floor/asteroid{
+	map_airless = 1
+	},
 /area/map_template/deepmaint)
 "S" = (
 /obj/item/material/shard/shrapnel/titanium,
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/airless{
+/turf/simulated/floor{
 	icon_state = "dmg1"
 	},
 /area/map_template/deepmaint)
@@ -237,7 +248,9 @@
 	dir = 8
 	},
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/airless,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/map_template/deepmaint)
 "V" = (
 /obj/item/stack/material/titanium,
@@ -248,21 +261,21 @@
 /area/map_template/deepmaint)
 "X" = (
 /obj/effect/landmark/scorcher,
-/turf/simulated/floor/airless{
-	icon_state = "dmg2"
+/turf/simulated/floor{
+	map_airless = 1
 	},
 /area/map_template/deepmaint)
 "Y" = (
 /obj/effect/landmark/scorcher,
 /obj/item/stack/material/titanium,
-/turf/simulated/floor/airless{
-	icon_state = "dmg1"
+/turf/simulated/floor{
+	map_airless = 1
 	},
 /area/map_template/deepmaint)
 "Z" = (
 /obj/structure/wall_frame/titanium,
 /obj/item/stack/material/rods,
-/turf/simulated/floor/airless,
+/turf/simulated/floor,
 /area/map_template/deepmaint)
 
 (1,1,1) = {"
@@ -341,7 +354,7 @@ H
 t
 G
 S
-m
+X
 e
 H
 T
@@ -358,8 +371,8 @@ V
 H
 H
 G
-o
-m
+X
+X
 G
 T
 H
@@ -376,7 +389,7 @@ H
 T
 M
 Y
-F
+X
 H
 v
 H
@@ -392,7 +405,7 @@ y
 H
 T
 r
-S
+f
 f
 G
 v
@@ -408,7 +421,7 @@ q
 z
 v
 x
-o
+X
 X
 c
 T
@@ -425,10 +438,10 @@ W
 G
 H
 L
-F
+X
 s
 j
-o
+X
 O
 R
 R


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: The Errant Pisces south airlock is now connected to the ship's powernet.
maptweak: Crashed pod airlocks now start with atmosphere.
refactor: Airless turfs have been reworked. This should resolve planets catching fire due to airmix spawning in certain random ruin tiles.
tweak: Exterior mining asteroid turfs no longer have atmosphere.
/:cl:

## Other Changes
- Added `var/map_airless` to `/turf/simulated/floor`, for flagging a turf as airless when mapping.
- Added `var/turfs_airless` to `/area`, for flagging an area as having airless turfs during initialization.