### PR TITLE
Bug Fixes 2023-04-15

### DIFF
--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -308,7 +308,7 @@
 			degree = "significant"
 		if(50 to 75)
 			degree = "severe"
-		if(75 to 100)
+		if(75 to 99)
 			degree = "extreme"
 		else
 			if(can_heal_overkill)

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -300,15 +300,15 @@
 	var/degree
 
 	switch(damage_ratio)
-		if(0 to 0.1)
+		if(0 to 10)
 			degree = "minor"
-		if(0.1 to 0.25)
+		if(10 to 25)
 			degree = "moderate"
-		if(0.25 to 0.5)
+		if(25 to 50)
 			degree = "significant"
-		if(0.5 to 0.75)
+		if(50 to 75)
 			degree = "severe"
-		if(0.75 to 1)
+		if(75 to 100)
 			degree = "extreme"
 		else
 			if(can_heal_overkill)

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -186,6 +186,7 @@
 			USE_FEEDBACK_FAILURE("You fail to collect a sample from \the [src].")
 			return TRUE
 		var/obj/item/sample = new product(user.loc)
+		sample.add_fingerprint(user, tool = tool)
 		pruned = TRUE
 		user.visible_message(
 			SPAN_NOTICE("\The [user] collects \a [sample] from \the [src] with \a [tool]."),

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -93,7 +93,6 @@
 		desc = "[get_vague_name()]."
 		gender = NEUTER
 	if(reinf_material)
-		SetName("[reinf_material.use_name]-reinforced [name]")
 		desc += "\nIt is reinforced with the [reinf_material.use_name] lattice."
 
 /obj/item/stack/material/use(used)

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -95,7 +95,6 @@
 	if (istype(id))
 		if (open)
 			USE_FEEDBACK_FAILURE("\The [src]'s access panel must be closed before you can lock it.")
-			to_chat(user, SPAN_WARNING("\The [src]'s access panel must be closed before you can lock it."))
 			return TRUE
 		var/id_name = GET_ID_NAME(id, tool)
 		if (!access_scanner.check_access(id))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -811,7 +811,7 @@
 			SPAN_NOTICE("\The [user] starts repairing some of the dents on \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start repairing some of the dents on \the [src] with \the [tool]."),
 		)
-		if (!do_after(user, 1 SECOND, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check())
+		if (!do_after(user, 1 SECOND, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (!getBruteLoss())
 			USE_FEEDBACK_FAILURE("\The [src] has no physical damage to repair.")

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -702,7 +702,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		// slow healing
 		var/heal_amt = 0
 		// if damage >= 50 AFTER treatment then it's probably too severe to heal within the timeframe of a round.
-		if (!owner.chem_effects[CE_TOXIN] && W.can_autoheal() && W.wound_damage() && brute_ratio < 0.5 && burn_ratio < 0.5)
+		if (!owner.chem_effects[CE_TOXIN] && W.can_autoheal() && W.wound_damage() && brute_ratio < 50 && burn_ratio < 50)
 			heal_amt += 0.5
 
 		//we only update wounds once in [wound_update_accuracy] ticks so have to emulate realtime
@@ -763,9 +763,9 @@ Note that amputating the affected organ does in fact remove the infection from t
 	update_damage_ratios()
 
 /obj/item/organ/external/proc/update_damage_ratios()
-	var/limb_loss_threshold = max_damage
-	brute_ratio = brute_dam / (limb_loss_threshold * 2)
-	burn_ratio = burn_dam / (limb_loss_threshold * 2)
+	var/limb_loss_threshold = max_damage * 2
+	brute_ratio = Percent(brute_dam, limb_loss_threshold, 0)
+	burn_ratio = Percent(burn_ratio, limb_loss_threshold, 0)
 
 //Returns 1 if damage_state changed
 /obj/item/organ/external/proc/update_damstate()
@@ -1147,7 +1147,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 	return 0
 
 /obj/item/organ/external/is_usable()
-	return ..() && !is_stump() && !(status & ORGAN_TENDON_CUT) && (!can_feel_pain() || get_pain() < pain_disability_threshold) && brute_ratio < 1 && burn_ratio < 1
+	return ..() && !is_stump() && !(status & ORGAN_TENDON_CUT) && (!can_feel_pain() || get_pain() < pain_disability_threshold) && brute_ratio < 100 && burn_ratio < 100
 
 /obj/item/organ/external/proc/is_malfunctioning()
 	return (BP_IS_ROBOTIC(src) && (brute_dam + burn_dam) >= 10 && prob(brute_dam + burn_dam))

--- a/code/modules/organs/external/wounds/wound.dm
+++ b/code/modules/organs/external/wounds/wound.dm
@@ -149,9 +149,9 @@
 	if(LAZYLEN(embedded_objects))
 		return amount // heal nothing
 	if(parent_organ)
-		if (damage_type == INJURY_TYPE_BURN && !(parent_organ.burn_ratio < 1 || (parent_organ.limb_flags & ORGAN_FLAG_HEALS_OVERKILL)))
+		if (damage_type == INJURY_TYPE_BURN && !(parent_organ.burn_ratio < 100 || (parent_organ.limb_flags & ORGAN_FLAG_HEALS_OVERKILL)))
 			return amount	//We don't want to heal wounds on irreparable organs.
-		else if(!(parent_organ.brute_ratio < 1 || (parent_organ.limb_flags & ORGAN_FLAG_HEALS_OVERKILL)))
+		else if(!(parent_organ.brute_ratio < 100 || (parent_organ.limb_flags & ORGAN_FLAG_HEALS_OVERKILL)))
 			return amount
 
 	var/healed_damage = min(src.damage, amount)

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -422,7 +422,7 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 	flick("[icon_state]-flush", src)
 
 	var/wrapcheck = 0
-	var/obj/structure/disposalholder/H = new()	// virtual holder object which actually
+	var/obj/structure/disposalholder/H = new(src)	// virtual holder object which actually
 												// travels through the pipes.
 
 	// handle vomit transportation

--- a/code/modules/recycling/disposalholder.dm
+++ b/code/modules/recycling/disposalholder.dm
@@ -37,6 +37,8 @@
 	// now everything inside the disposal gets put into the holder
 	// note AM since can contain mobs or objs
 	for(var/atom/movable/AM in stuff)
+		if (AM == src)
+			continue
 		AM.forceMove(src)
 		if(istype(AM, /obj/structure/bigDelivery) && !hasmob)
 			var/obj/structure/bigDelivery/T = AM


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Performing crafting on an item inside a storage container (Backpack, box, etc) now properly removes the targeted object and places the new crafted item in the bag, if applicable.
bugfix: Reinforced material stacks no longer display their reinforcement material twice in their name. `Steel-Reinforced Steel-Reinforced Glass Sheets` -> `Steel-Reinforced Glass Sheets`.
bugfix: Maintenance drones no longer die when traveling through disposals.
bugfix: Using an ID on a bot with an open panel no longer displays two feedback messages.
bugfix: Blob tendrils now have fingerprints added to them when successfully harvested.
bugfix: Repairing borgs now actually works, instead of always saying 'The object does not exist'.
bugfix: External limb that are right on the edge of being irrepairable now actually display as such when scanned, instead of showing 'Extreme'.
/:cl:

## Other Changes
- Changed `burn_ratio` and `brute_ratio` for `/obj/item/organ/external` to use integers (0 - 100) instead of floats (0.00 - 1.00). Floats are bad for comparisons and may be the cause of a few edge case bugs.
- Explanation for the external limb damage fix: Effectively, a ratio value of 100% is irrepairable. However, the switch was considering 100% to still be a valid value for repair when displaying injuries in scans. This sets the switch to instead look at 99% as the highest possible repairable ratio.

## Bug Fixes
- Fixes #33243
- Fixes #33210
- Fixes #25430