### PR TITLE
Assorted borg tweaks

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -101,8 +101,8 @@
 	for AI shift, ctrl, and alt clicking.
 */
 
-/mob/living/silicon/ai/CtrlAltClickOn(atom/A)
-	if(!control_disabled && A.AICtrlAltClick(src))
+/mob/living/silicon/ai/CtrlShiftClickOn(atom/A)
+	if(!control_disabled && A.AICtrlShiftClick(src))
 		return
 	..()
 
@@ -131,9 +131,9 @@
 	I have no idea why it was in atoms.dm instead of respective files.
 */
 
-/atom/proc/AICtrlAltClick()
+/atom/proc/AICtrlShiftClick()
 
-/obj/machinery/door/airlock/AICtrlAltClick() // Electrifies doors.
+/obj/machinery/door/airlock/AICtrlShiftClick() // Electrifies doors.
 	if(usr.incapacitated())
 		return
 	if(!electrified_until)
@@ -144,7 +144,7 @@
 		Topic(src, list("command"="electrify_permanently", "activate" = "0"))
 	return 1
 
-/atom/proc/AICtrlShiftClick()
+/atom/proc/AICtrlAltClick()
 	return
 
 /atom/proc/AIShiftClick()

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -103,8 +103,10 @@
 
 //Give cyborgs hotkey clicks without breaking existing uses of hotkey clicks
 // for non-doors/apcs
-/mob/living/silicon/robot/CtrlShiftClickOn(atom/A)
-	A.BorgCtrlShiftClick(src)
+/mob/living/silicon/robot/CtrlAltClickOn(atom/A)
+	if(A.BorgCtrlAltClick(src))
+		return
+	pointed(A)
 
 /mob/living/silicon/robot/ShiftClickOn(atom/A)
 	A.BorgShiftClick(src)
@@ -115,14 +117,14 @@
 /mob/living/silicon/robot/AltClickOn(atom/A)
 	A.BorgAltClick(src)
 
-/mob/living/silicon/robot/CtrlAltClickOn(atom/A)
-	A.BorgCtrlAltClick(src)
+/mob/living/silicon/robot/CtrlShiftClickOn(atom/A)
+	A.BorgCtrlShiftClick(src)
 
-/atom/proc/BorgCtrlShiftClick(mob/living/silicon/robot/user) //forward to human click if not overriden
-	CtrlShiftClick(user)
+/atom/proc/BorgCtrlAltClick(mob/living/silicon/robot/user) //forward to human click if not overriden
+	CtrlAltClick(user)
 
-/obj/machinery/door/airlock/BorgCtrlShiftClick()
-	AICtrlShiftClick()
+///obj/machinery/door/airlock/BorgCtrlAltClick()
+//	AICtrlAltClick()
 
 /atom/proc/BorgShiftClick(mob/living/silicon/robot/user) //forward to human click if not overriden
 	ShiftClick(user)
@@ -146,9 +148,9 @@
 	AltClick(user)
 	return
 
-/obj/machinery/door/airlock/BorgAltClick() // Eletrifies doors. Forwards to AI code.
+/obj/machinery/door/airlock/BorgCtrlShiftClick() // Eletrifies doors. Forwards to AI code.
 	if (usr.a_intent != I_HELP)
-		AICtrlAltClick()
+		AICtrlShiftClick()
 	else
 		..()
 
@@ -158,8 +160,8 @@
 /obj/machinery/atmospherics/binary/pump/BorgAltClick()
 	return AltClick()
 
-/atom/proc/BorgCtrlAltClick(mob/living/silicon/robot/user)
-	CtrlAltClick(user)
+/atom/proc/BorgCtrlShiftClick(mob/living/silicon/robot/user)
+	CtrlShiftClick(user)
 
 /*
 	As with AI, these are not used in click code,

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -112,7 +112,7 @@
 		/obj/item/disk/botany
 	)
 
-/obj/item/gripper/service //Used to handle food, drinks, and seeds.
+/obj/item/gripper/service //Used to handle food, drinks, seeds, and service fabricator items.
 	name = "service gripper"
 	icon_state = "gripper"
 	desc = "A simple grasping tool used to perform tasks in the service sector, such as handling food, drinks, and seeds."
@@ -120,7 +120,12 @@
 		/obj/item/reagent_containers/glass,
 		/obj/item/reagent_containers/food,
 		/obj/item/seeds,
-		/obj/item/glass_extra
+		/obj/item/glass_extra,
+		/obj/item/clothing/mask/smokable,
+		/obj/item/paper,
+		/obj/item/pen,
+		/obj/item/storage/pill_bottle/dice,
+		/obj/item/dice
 	)
 
 /obj/item/gripper/organ //Used to handle organs.

--- a/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
@@ -38,7 +38,7 @@
 		/obj/item/tray/robotray,
 		/obj/item/reagent_containers/borghypo/service
 	)
-	emag = /obj/item/reagent_containers/food/drinks/bottle/small/beer
+	emag = /obj/item/reagent_containers/food/drinks/bottle/small/beer/fake
 	skills = list(
 		SKILL_BUREAUCRACY         = SKILL_PROF,
 		SKILL_COMPUTER            = SKILL_EXPERT,
@@ -57,15 +57,12 @@
 
 /obj/item/robot_module/clerical/butler/finalize_emag()
 	. = ..()
-	if(emag)
-		var/datum/reagents/R = emag.create_reagents(50)
-		R.add_reagent(/datum/reagent/chloralhydrate/beer2, 50)
-		emag.SetName("Mickey Finn's Special Brew")
+	emag.SetName("Mickey Finn's Special Brew")
 
 /obj/item/robot_module/clerical/butler/respawn_consumable(mob/living/silicon/robot/R, amount)
 	..()
 	if(emag)
-		var/obj/item/reagent_containers/food/drinks/bottle/small/beer/B = emag
+		var/obj/item/reagent_containers/food/drinks/bottle/small/beer/fake/B = emag
 		B.reagents.add_reagent(/datum/reagent/chloralhydrate/beer2, 2 * amount)
 
 /obj/item/robot_module/clerical/general

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -717,6 +717,14 @@
 	reagents.add_reagent(/datum/reagent/ethanol/beer, 30)
 
 
+/obj/item/reagent_containers/food/drinks/bottle/small/beer/fake
+
+
+/obj/item/reagent_containers/food/drinks/bottle/small/beer/fake/Initialize()
+	. = ..()
+	reagents.add_reagent(/datum/reagent/chloralhydrate/beer2, 50)
+
+
 /obj/item/reagent_containers/food/drinks/bottle/small/ale
 	name = "\improper Magm-Ale"
 	desc = "A true dorf's drink of choice."

--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -111,7 +111,7 @@
 \tCtrl + Click = drag
 \tShift + Click = examine
 \tAlt + Click = show entities on turf
-\tCtrl + Alt + Click = interact with certain items"})
+\tCtrl + Alt + Click = point"})
 
 	var/robot_hotkey_mode = SPAN_COLOR("purple", {"Hotkey-Mode: (hotkey-mode must be on)
 \tTAB = toggle hotkey-mode
@@ -156,7 +156,8 @@
 \tCtrl + Click = drag or bolt doors
 \tShift + Click = examine or open doors
 \tAlt + Click = show entities on turf
-\tCtrl + Alt + Click = electrify doors"})
+\tCtrl + Shift + Click = electrify doors
+\tCtrl + Alt + Click = point"})
 
 	if(isrobot(src.mob))
 		to_chat(src, robot_hotkey_mode)


### PR DESCRIPTION
:cl: rootoo807
tweak: Service borgs can hold smokeables (pipes/cigarettes/etc.) and other objects from the Rapid Service Fabricator.
tweak: Borgs can use Ctrl+Alt+Click as a shortcut to point at things. The shortcut for borgs and AI to electrocute doors has been moved to Ctrl+Shift+Click (on harm intent).
/:cl:

Non-User Facing: Service borgs don't generate debug logs on creation anymore.

Issues:
- Fixes #30816
- Fixes #30384
- Fixes #30383
- Fixes #30001