### PR TITLE
`do_skilled()` for skilled interactions

### DIFF
--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -99,7 +99,7 @@ var/global/list/empty_playable_ai_cores = list()
 			SPAN_NOTICE("You start wiring \the [src] with \the [tool].")
 		)
 		playsound(loc, 'sound/items/Deconstruct.ogg', 50, TRUE)
-		if (!do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(2 SECONDS, SKILL_ELECTRICAL, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (state < STATE_CIRCUIT)
 			USE_FEEDBACK_FAILURE("\The [src] has no circuit to wire.")
@@ -274,7 +274,7 @@ var/global/list/empty_playable_ai_cores = list()
 			SPAN_NOTICE("\The [user] starts installing a panel into \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start installing a panel into \the [src] with \the [tool].")
 		)
-		if (!do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(2 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (state < STATE_WIRED)
 			USE_FEEDBACK_FAILURE("\The [src] needs to be wired before you can install a glass panel.")
@@ -363,7 +363,7 @@ var/global/list/empty_playable_ai_cores = list()
 				SPAN_NOTICE("You start dismantling \the [src] with \the [tool].")
 			)
 			playsound(src, 'sound/items/Welder.ogg', 50, TRUE)
-			if (!do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			if (!user.do_skilled(SKILL_CONSTRUCTION, 2 SECONDS, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 				return TRUE
 			if (!welder.remove_fuel(1, user))
 				return TRUE

--- a/code/game/machinery/doors/firedoor_assembly.dm
+++ b/code/game/machinery/doors/firedoor_assembly.dm
@@ -48,7 +48,7 @@
 			SPAN_NOTICE("\The [user] starts wiring \the [src] with \a [cable]."),
 			SPAN_NOTICE("You start wiring \the [src] with \a [cable.singular_name] of \the [cable].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_ELECTRICAL, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (wired)
 			USE_FEEDBACK_FAILURE("\The [src] is already wired.")
@@ -77,7 +77,7 @@
 			SPAN_NOTICE("\The [user] starts dismantling \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start dismantling \the [src] with \the [tool].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		var/obj/item/stack/material/steel/stack = new (loc, 4)
 		transfer_fingerprints_to(stack)
@@ -98,7 +98,7 @@
 			SPAN_NOTICE("\The [user] starts cutting \the [src]'s wires with \a [tool]."),
 			SPAN_NOTICE("You start cutting \the [src]'s wires with \the [tool].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_ELECTRICAL, src, do_flags = DO_REPAIR_CONSTRUCT) || user.use_sanity_check(src, tool))
 			return TRUE
 		if (!wired)
 			USE_FEEDBACK_FAILURE("\The [src] has no wires to cut.")

--- a/code/game/objects/structures/barricade.dm
+++ b/code/game/objects/structures/barricade.dm
@@ -39,7 +39,7 @@
 			SPAN_NOTICE("\The [user] starts adding some [tool.name] to \the [src]."),
 			SPAN_NOTICE("You start adding some [tool.name] to \the [src].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (spiky)
 			USE_FEEDBACK_FAILURE("\The [src] already has spikes on it.")
@@ -73,7 +73,7 @@
 			SPAN_NOTICE("\The [user] starts repairing \the [src] with some [tool.name]."),
 			SPAN_NOTICE("You start repairing \the [src] with some [tool.name].")
 		)
-		if (!do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(2 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (!get_damage_value())
 			USE_FEEDBACK_FAILURE("\The [src] doesn't need repairs.")

--- a/code/game/objects/structures/catwalk.dm
+++ b/code/game/objects/structures/catwalk.dm
@@ -118,7 +118,7 @@
 			SPAN_NOTICE("\The [user] starts plating \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start plating \the [src] with \the [tool].")
 		)
-		if (!do_after(user, 1 SECOND, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(1 SECOND, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (!stack.use(1))
 			USE_FEEDBACK_STACK_NOT_ENOUGH(stack, 1, "to plate \the [src].")

--- a/code/game/objects/structures/crates_lockers/closets/coffin.dm
+++ b/code/game/objects/structures/crates_lockers/closets/coffin.dm
@@ -29,7 +29,7 @@
 			SPAN_NOTICE("\The [user] begins screwing \the [src]'s lid [locked ? "open" : "shut"] with \a [tool]."),
 			SPAN_NOTICE("You begin screwing \the [src]'s lid [locked ? "open" : "shut"] with \the [tool].")
 		)
-		if (!do_after(user, screwdriver_time_needed, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(screwdriver_time_needed, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (opened)
 			USE_FEEDBACK_FAILURE("\The [src] needs to be closed before you can screw the lid shut.")

--- a/code/game/objects/structures/door_assembly.dm
+++ b/code/game/objects/structures/door_assembly.dm
@@ -126,7 +126,7 @@
 			SPAN_NOTICE("\The [user] starts installing \a [tool] into \the [src]."),
 			SPAN_NOTICE("You start installing \the [tool] into \the [src].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (state < ASSEMBLY_STATE_WIRED)
 			USE_FEEDBACK_FAILURE("\The [src] needs to be wired before you can install \the [src].")
@@ -163,7 +163,7 @@
 			SPAN_NOTICE("\The [user] starts wiring \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start wiring \the [src] with \the [tool].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_ELECTRICAL, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (state != ASSEMBLY_STATE_FRAME)
 			USE_FEEDBACK_FAILURE("\The [src] is already wired.")
@@ -192,7 +192,7 @@
 			SPAN_NOTICE("\The [user] starts removing \the [src]'s [electronics.name] with \a [tool]."),
 			SPAN_NOTICE("You start removing \the [src]'s [electronics.name] with \the [tool].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (!electronics)
 			USE_FEEDBACK_FAILURE("\The [src] has no circuit to remove.")
@@ -229,7 +229,7 @@
 				SPAN_NOTICE("\The [user] starts installing a glass panel into \the [src]."),
 				SPAN_NOTICE("You start installing a glass panel into \the [src].")
 			)
-			if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 				return TRUE
 			if (glass)
 				USE_FEEDBACK_FAILURE("\The [src] already has \a [istext(glass) ? "[glass] plating" : "glass panel"] installed.")
@@ -258,7 +258,7 @@
 				SPAN_NOTICE("\The [user] starts installing \a [material_name] plating into \the [src]."),
 				SPAN_NOTICE("You start installing \a [material_name] plating into \the [src].")
 			)
-			if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 				return TRUE
 			if (glass)
 				USE_FEEDBACK_FAILURE("\The [src] already has \a [istext(glass) ? "[glass] plating" : "glass panel"] installed.")
@@ -301,7 +301,7 @@
 			SPAN_NOTICE("\The [user] starts finishing \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start finishing \the [src] with \the [tool].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (state != ASSEMBLY_STATE_CIRCUIT)
 			USE_FEEDBACK_FAILURE("\The [src] needs a circuit before you can finish it.")
@@ -339,7 +339,7 @@
 				SPAN_NOTICE("\The [user] starts welding \the [src]'s [glass_noun] off with \a [tool]."),
 				SPAN_NOTICE("You start welding \the [src]'s [glass_noun] off with \the [tool].")
 			)
-			if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 				return TRUE
 			if (!glass)
 				USE_FEEDBACK_FAILURE("\The [src]'s state has changed.")
@@ -373,7 +373,7 @@
 			SPAN_NOTICE("\The [user] starts dismantling \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start dismantling \the [src] with \the [tool].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (anchored)
 			USE_FEEDBACK_FAILURE("\The [src] must be unanchored before you can dismantle it.")
@@ -404,7 +404,7 @@
 			SPAN_NOTICE("\The [user] starts cutting \the [src]'s wires with \a [tool]."),
 			SPAN_NOTICE("You start cutting \the [src]'s wires with \the [tool].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_ELECTRICAL, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (state < ASSEMBLY_STATE_WIRED)
 			USE_FEEDBACK_FAILURE("\The [src] has no wiring to remove.")

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -65,7 +65,7 @@
 			SPAN_NOTICE("\The [user] starts dislodging \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start dislodging \the [src] with \the [tool].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (!can_anchor(tool, user))
 			return TRUE
@@ -89,7 +89,7 @@
 			SPAN_NOTICE("\The [user] starts cutting \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start cutting \the [src] with \the [tool].")
 		)
-		if (!do_after(user, (reinf_material ? 4 : 2) SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled((reinf_material ? 4 : 2) SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		playsound(loc, 'sound/items/Welder.ogg', 50, TRUE)
 		user.visible_message(
@@ -134,7 +134,7 @@
 					SPAN_NOTICE("\The [user] starts securing \the [src]'s support struts with \a [tool]."),
 					SPAN_NOTICE("You starts securing \the [src]'s support struts with \the [tool].")
 				)
-				if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+				if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 					return TRUE
 				if (state != GIRDER_STATE_REINFORCEMENT_UNSECURED)
 					USE_FEEDBACK_FAILURE("\The [src]'s state has changed.")
@@ -151,7 +151,7 @@
 					SPAN_NOTICE("\The [user] starts unsecuring \the [src]'s support struts with \a [tool]."),
 					SPAN_NOTICE("You starts unsecuring \the [src]'s support struts with \the [tool].")
 				)
-				if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+				if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 					return TRUE
 				if (state != GIRDER_STATE_REINFORCED)
 					USE_FEEDBACK_FAILURE("\The [src]'s state has changed.")
@@ -176,7 +176,7 @@
 					SPAN_NOTICE("\The [user] starts removing \the [src]'s support struts with \a [tool]."),
 					SPAN_NOTICE("You start removing \the [src]'s support struts with \the [tool].")
 				)
-				if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+				if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 					return TRUE
 				if (state != GIRDER_STATE_REINFORCEMENT_UNSECURED)
 					USE_FEEDBACK_FAILURE("\The [src]'s state has changed.")
@@ -203,7 +203,7 @@
 				SPAN_NOTICE("\The [user] starts dismantling \the [src] with \a [tool]."),
 				SPAN_NOTICE("You start dismantling \the [src] with \the [tool].")
 			)
-			if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 				return TRUE
 			if (state != GIRDER_STATE_NORMAL || !anchored)
 				USE_FEEDBACK_FAILURE("\The [src]'s state has changed.")
@@ -220,7 +220,7 @@
 			SPAN_NOTICE("\The [user] starts securing \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start securing \the [src] with \the [tool].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (state != GIRDER_STATE_NORMAL || anchored)
 			USE_FEEDBACK_FAILURE("\The [src]'s state has changed.")

--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -16,7 +16,7 @@
 			SPAN_NOTICE("\The [user] starts [open ? "filling" : "digging open"] \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start [open ? "filling" : "digging open"] \the [src] with \the [tool].")
 		)
-		if (!do_after(user, 5 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(5 SECONDS, SKILL_HAULING, src) || !user.use_sanity_check(src, tool))
 			return TRUE
 		user.visible_message(
 			SPAN_NOTICE("\The [user] [open ? "fills" : "digs open"] \the [src] with \a [tool]."),
@@ -45,7 +45,7 @@
 			SPAN_NOTICE("\The [user] starts making a grave marker on top of \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start making a grave marker on top of \the [src] with \the [tool].")
 		)
-		if (!do_after(user, 5 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(5 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (grave)
 			USE_FEEDBACK_FAILURE("\The [src] already has \a [grave].")
@@ -193,7 +193,7 @@
 			SPAN_NOTICE("\The [user] starts hacking away at \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start hacking away at \the [src] with \the [tool].")
 		)
-		if (!do_after(user, 3 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(2 SECONDS, list(SKILL_CONSTRUCTION, SKILL_HAULING), src) || !user.use_sanity_check(src, tool))
 			return TRUE
 		var/obj/item/stack/material/wood/stack = new(loc, 1)
 		transfer_fingerprints_to(stack)

--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -240,7 +240,7 @@
 			SPAN_NOTICE("\The [user] starts repairing \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start repairing \the [src] with \the [tool].")
 		)
-		if (!do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(2 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (!health_damaged())
 			USE_FEEDBACK_FAILURE("\The [src] doesn't require repairs.")
@@ -272,7 +272,7 @@
 			SPAN_NOTICE("\The [user] starts dismantling \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start dismantling \the [src] with \the [tool].")
 		)
-		if (!do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(2 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (anchored)
 			USE_FEEDBACK_FAILURE("\The [src]'s state has changed.")
@@ -297,7 +297,7 @@
 			SPAN_NOTICE("\The [user] starts [anchored ? "un" : null]fastening \the [src] [anchored ? "from" : "to"] the floor with \a [tool]."),
 			SPAN_NOTICE("You start [anchored ? "un" : null]fastening \the [src] [anchored ? "from" : "to"] the floor with \the [tool].")
 		)
-		if (!do_after(user, 1 SECOND, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(1 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (!density)
 			USE_FEEDBACK_FAILURE("\The [src] needs to be closed before you can unanchor it.")

--- a/code/game/objects/structures/rubble.dm
+++ b/code/game/objects/structures/rubble.dm
@@ -71,7 +71,7 @@
 			SPAN_NOTICE("\The [user] starts clearing away \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start clearing away \the [src] with \the [tool].")
 		)
-		if (!do_after(user, pickaxe.digspeed, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(pickaxe.digspeed, SKILL_HAULING, src) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (lootleft && prob(1))
 			var/booty = pickweight(loot)

--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -113,7 +113,7 @@
 			SPAN_NOTICE("\The [user] starts slicing \the [src] apart with \a [tool]."),
 			SPAN_NOTICE("You start slicing \the [src] apart with \the [tool].")
 		)
-		if (!do_after(user, 2 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(2 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		playsound(src, 'sound/items/Welder.ogg', 50, TRUE)
 		user.visible_message(

--- a/code/game/objects/structures/windoor_assembly.dm
+++ b/code/game/objects/structures/windoor_assembly.dm
@@ -96,7 +96,7 @@
 			SPAN_NOTICE("\The [user] starts installing \a [tool] into \the [src]."),
 			SPAN_NOTICE("You start installing \the [tool] into \the [src].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (state != WINDOOR_STATE_WIRED)
 			USE_FEEDBACK_FAILURE("\The [src] needs to be wired before you can install \the [tool].")
@@ -132,7 +132,7 @@
 			SPAN_NOTICE("\The [user] starts wiring \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start wiring \the [src] with \the [tool].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_ELECTRICAL, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (state != WINDOOR_STATE_FRAME)
 			USE_FEEDBACK_FAILURE("\The [src] is already wired.")
@@ -167,7 +167,7 @@
 			SPAN_NOTICE("\The [user] starts reinforcing \the [src] with some [tool.name]."),
 			SPAN_NOTICE("You start reinforcing \the [src] with some [tool.name].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (state != WINDOOR_STATE_FRAME)
 			USE_FEEDBACK_FAILURE("\The [src]'s wiring must be removed before you can reinforce it.")
@@ -197,7 +197,7 @@
 			SPAN_NOTICE("\The [user] starts removing \the [src]'s circuits with \a [tool]."),
 			SPAN_NOTICE("You start removing \the [src]'s circuits with \the [tool].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (!electronics)
 			USE_FEEDBACK_FAILURE("\The [src] has no circuit to remove.")
@@ -226,7 +226,7 @@
 			SPAN_NOTICE("\The [user] starts cutting \the [src]'s wiring with \a [tool]."),
 			SPAN_NOTICE("You start cutting \the [src]'s wiring with \the [tool].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_ELECTRICAL, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (state != WINDOOR_STATE_WIRED)
 			USE_FEEDBACK_FAILURE("\The [src] has no wiring to remove.")
@@ -261,7 +261,7 @@
 			SPAN_NOTICE("\The [user] starts dismantling \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start dismantling \the [src] with \the [tool].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (state != WINDOOR_STATE_FRAME)
 			USE_FEEDBACK_FAILURE("\The [src]'s wiring must be removed before you can dismantle it.")
@@ -294,7 +294,7 @@
 			SPAN_NOTICE("\The [user] starts prying \the [src] into its frame with \a [tool]."),
 			SPAN_NOTICE("You start prying \the [src] into its frame with \the [tool].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (!electronics)
 			USE_FEEDBACK_FAILURE("\The [src] needs a circuit board before you can complete it.")

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -361,7 +361,7 @@
 			SPAN_NOTICE("\The [user] starts slicing \the [src] apart with \a [tool]."),
 			SPAN_NOTICE("You start slicing \the [src] apart with \the [tool].")
 		)
-		if (!do_after(user, 2 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(2 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		playsound(src, 'sound/items/Welder.ogg', 50, TRUE)
 		user.visible_message(

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -56,7 +56,7 @@
 			SPAN_NOTICE("\The [user] begins dismantling \the [src] with \a [tool]."),
 			SPAN_NOTICE("You begin dismantling \the [src] with \a [tool].")
 		)
-		if (!do_after(user, 2.5 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(2.5 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		var/obj/item/stack/material/wood/wood = new (loc, 5)
 		transfer_fingerprints_to(wood)

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -348,8 +348,7 @@
 			SPAN_WARNING("\The [user] starts forcing \the [src]'s emergency [body.hatch_descriptor] release using \a [tool]."),
 			SPAN_WARNING("You start forcing \the [src]'s emergency [body.hatch_descriptor] release using \the [tool].")
 		)
-		var/delay = min(50 * user.skill_delay_mult(SKILL_DEVICES), 50 * user.skill_delay_mult(SKILL_EVA))
-		if (!do_after(user, delay, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(5 SECONDS, list(SKILL_DEVICES, SKILL_EVA), src) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (!body)
 			USE_FEEDBACK_FAILURE("\The [src] has no cockpit to force.")
@@ -470,8 +469,7 @@
 			SPAN_NOTICE("\The [user] starts removing \the [src]'s power cell with \a [tool]."),
 			SPAN_NOTICE("You start removing \the [src]'s power cell with \the [tool].")
 		)
-		var/delay = 2 SECONDS * user.skill_delay_mult(SKILL_DEVICES)
-		if (!do_after(user, delay, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(2 SECONDS, SKILL_DEVICES, src) || !user.use_sanity_check(src, tool))
 			return
 		if (!maintenance_protocols)
 			USE_FEEDBACK_FAILURE("\The [src]'s maintenance protocols must be enabled to access the power cell.")
@@ -516,8 +514,7 @@
 			SPAN_NOTICE("\The [user] starts removing \the [src]'s securing bolts with \a [tool]."),
 			SPAN_NOTICE("You start removing \the [src]'s securing bolts with \the [tool].")
 		)
-		var/delay = 6 SECONDS * user.skill_delay_mult(SKILL_DEVICES)
-		if (!do_after(user, delay, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(6 SECONDS, SKILL_DEVICES, src) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (!maintenance_protocols)
 			USE_FEEDBACK_FAILURE("\The [src]'s maintenance protocols must be enabled to access the securing bolts.")

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -626,7 +626,7 @@ var/global/list/ai_verbs_default = list(
 			SPAN_NOTICE("\The [user] starts [anchored ? "unbolting" : "bolting"] \the [src] from the floor with \a [tool]."),
 			SPAN_NOTICE("You start [anchored ? "unbolting" : "bolting"] \the [src] from the floor with \the [tool].")
 		)
-		if (!do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		anchored = !anchored
 		user.visible_message(

--- a/code/modules/mob/living/simple_animal/defense.dm
+++ b/code/modules/mob/living/simple_animal/defense.dm
@@ -88,7 +88,7 @@
 			SPAN_WARNING("\The [user] begins butchering \the [src]'s corpse with \a [tool]."),
 			SPAN_WARNING("You begin \the [src]'s corpse with \the [tool].")
 		)
-		if (!do_after(user, time_to_butcher, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check())
+		if (!user.do_skilled(time_to_butcher, SKILL_COOKING, src) || !user.use_sanity_check())
 			USE_FEEDBACK_FAILURE("Some of \the [src]'s meat is ruined.")
 			subtract_meat(user)
 			return TRUE

--- a/code/modules/mob/skills/skillset.dm
+++ b/code/modules/mob/skills/skillset.dm
@@ -123,8 +123,31 @@
 		else
 			return max(0, 1 + (SKILL_DEFAULT - points) * factor)
 
-/mob/proc/do_skilled(base_delay, skill_path , atom/target = null, factor = 0.3, do_flags = DO_PUBLIC_UNIQUE)
-	return do_after(src, base_delay * skill_delay_mult(skill_path, factor), target, do_flags)
+
+/**
+ * Performs a do_after timer, with a modifier applied to the delay time based on the user's skill in the given skill path.
+ *
+ * **Parameters**
+ * - `base_delay` Integer (Seconds) - Base delay for the timer. This is added to the final delay time.
+ * - `skill_path` Path or list of paths (Subtypes of `/singleton/hierarchy/skill`; Any of `SKILL_*`) - The skill used to modify the delay time. If provided as a list, the skill that produces the smallest timer is used. Passed to `skill_delay_mult()`.
+ * - `target` (Default `null`) - The atom being interacted with. Passed directly to `do_after()`.
+ * - `factor` Float (Default `0.3`) - Modifier factor used to modify the delay applied to the action. Passed to `skill_delay_mult()`.
+ * - `do_flags` Bitflag (Any of `DO_*`; Default `DO_PUBLIC_UNIQUE`) - Flags passed on to `do_after()`.
+ *
+ * Returns boolean. Whether or not the do after check passed.
+ */
+/mob/proc/do_skilled(base_delay, skill_path, atom/target = null, factor = 0.3, do_flags = DO_PUBLIC_UNIQUE)
+	var/final_delay
+	if (islist(skill_path))
+		for (var/path as anything in skill_path)
+			var/check_delay = skill_delay_mult(path, factor)
+			if (check_delay < final_delay)
+				final_delay = check_delay
+	else
+		final_delay = skill_delay_mult(skill_path)
+	final_delay += base_delay
+	return do_after(src, final_delay, target, do_flags)
+
 
 // A generic way of modifying success probabilities via skill values. Higher factor means skills have more effect. fail_chance is the chance at SKILL_NONE.
 /mob/proc/skill_fail_chance(skill_path, fail_chance, no_more_fail = SKILL_MAX, factor = 1)

--- a/code/modules/persistence/graffiti.dm
+++ b/code/modules/persistence/graffiti.dm
@@ -56,7 +56,7 @@
 			SPAN_NOTICE("\The [user] starts burning away \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start burning away \the [src] with \the [tool].")
 		)
-		if (!do_after(user, 0.5 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool) || !welder.can_use(1, user, "to remove \the [src]"))
+		if (!user.do_skilled(1 SECOND, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool) || !welder.can_use(1, user, "to remove \the [src]"))
 			return TRUE
 		user.visible_message(
 			SPAN_NOTICE("\The [user] clears away \the [src] with \a [tool]."),

--- a/code/modules/persistence/noticeboards.dm
+++ b/code/modules/persistence/noticeboards.dm
@@ -138,7 +138,7 @@
 			SPAN_NOTICE("\The [user] starts dismantling \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start dismantling \the [src] with \a [tool].")
 		)
-		if (!do_after(user, 5 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(5 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		playsound(src, 'sound/items/Ratchet.ogg', 50, TRUE)
 		user.visible_message(

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -224,7 +224,7 @@
 			SPAN_NOTICE("\The [user] starts attaching \a [tool] to \the [src]."),
 			SPAN_NOTICE("You start attaching \the [tool] to \the [src].")
 		)
-		if (!do_after(user, 2 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool, SANITY_CHECK_TOOL_UNEQUIP))
+		if (!user.do_skilled(2 SECONDS, SKILL_DEVICES, src) || !user.use_sanity_check(src, tool, SANITY_CHECK_TOOL_UNEQUIP))
 			return TRUE
 		if (rig)
 			USE_FEEDBACK_FAILURE("\The [src] already has \a [rig] attached.")

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -152,7 +152,7 @@
 			SPAN_NOTICE("You start welding \the [src] down with \the [tool]."),
 			SPAN_ITALIC("You hear welding.")
 		)
-		if (!do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool) || !welder.remove_fuel(1, user))
+		if (!user.do_skilled(2 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool) || !welder.remove_fuel(1, user))
 			return TRUE
 		playsound(src, 'sound/items/Welder2.ogg', 50, TRUE)
 		user.visible_message(

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -655,7 +655,7 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 			SPAN_NOTICE("You start slicing \the [src]'s floorweld with \the [tool]."),
 			SPAN_ITALIC("You hear the sound of welding.")
 		)
-		if (!do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool) || !welder.remove_fuel(1, user))
+		if (!user.do_skilled(2 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool) || !welder.remove_fuel(1, user))
 			return TRUE
 		playsound(src, 'sound/items/Welder2.ogg', 50, TRUE)
 		user.visible_message(

--- a/code/modules/recycling/disposalpipe.dm
+++ b/code/modules/recycling/disposalpipe.dm
@@ -209,7 +209,7 @@
 			SPAN_NOTICE("\The [user] starts slicing \the [src] with \a [tool]."),
 			SPAN_NOTICE("You start slicing \the [src] with \the [tool].")
 		)
-		if (!do_after(user, 3 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool) || !welder.remove_fuel(1, user))
+		if (!user.do_skilled(3 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool) || !welder.remove_fuel(1, user))
 			return TRUE
 		welded()
 		user.visible_message(

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -166,7 +166,7 @@
 			SPAN_NOTICE("\The [user] starts repairing \the [src] with \a [weapon]."),
 			SPAN_NOTICE("You start repairing \the [src] with \the [weapon].")
 		)
-		if (!do_after(user, 2 SECONDS, src, DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, weapon) || !welder.remove_fuel(1))
+		if (!user.do_skilled(2 SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, weapon) || !welder.remove_fuel(1))
 			return TRUE
 		playsound(src, 'sound/items/Welder.ogg', 50, TRUE)
 		restore_health(get_max_health() / 5) // 20% repair per application

--- a/code/modules/xenoarcheaology/boulder.dm
+++ b/code/modules/xenoarcheaology/boulder.dm
@@ -43,7 +43,7 @@
 			SPAN_NOTICE("\The [user] extends \a [tool] towards \the [src]."),
 			SPAN_NOTICE("You extend \the [tool] towards \the [src].")
 		)
-		if (!do_after(user, 1.5 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+		if (!user.do_skilled(1.5 SECONDS, SKILL_SCIENCE, src) || !user.use_sanity_check(src, tool))
 			return TRUE
 		to_chat(user, SPAN_INFO("\The [src] has been excavated to a depth of [excavation_level]cm."))
 		return TRUE


### PR DESCRIPTION
Primary intent of changes is to replace any `do_after()` calls in existing `use_*()` overrides with `user.do_skilled()`, where applicable.

References in `attackby()` will be updated as I convert those over the `use_*` in future PRs.

## Changelog
NUFC

## Other Changes
- Added documentation to `/mob/proc/do_skilled()`.
- Updated `/mob/proc/do_skilled()` to accept a list of skills in the `skill_path` parameter. Providing a list for the parameter results in using the skill that provides the shortest delay time.