### PR TITLE
fix torch chef closet to correct closet

### DIFF
--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -1379,7 +1379,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/structure/closet/chefcloset,
+/obj/structure/closet/chefcloset_torch,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/galleybackroom)
 "dl" = (


### PR DESCRIPTION
:cl:
bugfix: The torch kitchen back room closet once again contains silverware and food safety clothing.
/:cl: