### PR TITLE
Item Icon Updates Update Mob Icons

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -129,6 +129,23 @@
 		else if(M.r_hand == src)
 			M.update_inv_r_hand()
 
+
+/obj/item/update_icon()
+	var/prior_icon_state = icon_state
+	var/prior_item_state = item_state
+	var/prior_overlays = length(overlays)
+	. = ..()
+	if (item_state != prior_item_state || (!item_state && icon_state != prior_icon_state) || prior_overlays || length(overlays))
+		update_held_icon()
+
+
+/obj/item/set_color(color)
+	var/update_held = color != src.color
+	. = ..()
+	if (update_held)
+		update_held_icon()
+
+
 /obj/item/proc/is_held_twohanded(mob/living/M)
 
 	if(istype(loc, /obj/item/rig_module) || istype(loc, /obj/item/rig))

--- a/code/game/objects/items/devices/oxycandle.dm
+++ b/code/game/objects/items/devices/oxycandle.dm
@@ -47,7 +47,6 @@
 		STOP_PROCESSING(SSprocessing, src)
 		on = 2
 		update_icon()
-		update_held_icon()
 		SetName("burnt oxygen candle")
 		desc += "This tube has exhausted its chemicals."
 		return
@@ -79,7 +78,6 @@
 		icon_state = "oxycandle"
 		item_state = icon_state
 		set_light(0)
-	update_held_icon()
 
 /obj/item/device/oxycandle/Destroy()
 	QDEL_NULL(air_contents)

--- a/code/game/objects/items/devices/paint_sprayer.dm
+++ b/code/game/objects/items/devices/paint_sprayer.dm
@@ -83,7 +83,6 @@
 /obj/item/device/paint_sprayer/on_update_icon()
 	overlays.Cut()
 	overlays += overlay_image(icon, "paint_sprayer_color", paint_color)
-	update_held_icon()
 
 /obj/item/device/paint_sprayer/get_mob_overlay(mob/user_mob, slot, bodypart)
 	var/image/ret = ..()

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -63,7 +63,6 @@
 	playsound(src.loc, 'sound/weapons/empty.ogg', 50, 1)
 	add_fingerprint(user)
 	update_icon()
-	update_held_icon()
 
 /obj/item/melee/telebaton/on_update_icon()
 	if(on)

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -103,4 +103,3 @@
 			icon_state = "[modifystate][ratio]"
 		else
 			icon_state = "[initial(icon_state)][ratio]"
-		update_held_icon()

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -133,8 +133,6 @@
 		icon_state = "pneumatic"
 		item_state = "pneumatic"
 
-	update_held_icon()
-
 /obj/item/gun/launcher/pneumatic/small
 	name = "small pneumatic cannon"
 	desc = "It looks smaller than your garden variety cannon."

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -41,7 +41,7 @@ exactly 2 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 2 ">> uses" '(?<!>)>>(?!>)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 25 "text2path uses" 'text2path'
-exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
+exactly 4 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 5 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
 exactly 348 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P


### PR DESCRIPTION
Updates to the `update_icon()` and `set_color()` logic for items to also automatically update the mob's icons if relevant vars changed (`item_state`, `icon_state` (if `item_state` is null), `color`, `overlays`, etc).

## Changelog
NUFC

## Other Changes
- Added overrides to `update_icon()`, `update_overlays()`, and `set_color()` for `/obj/item` to call `update_held_item()` if certain vars changed.
- Removed calls to `update_held_item()` that are now redundant.