### PR TITLE
Bug fixes 2023 04 16

### DIFF
--- a/code/datums/browser.dm
+++ b/code/datums/browser.dm
@@ -28,9 +28,6 @@
 		height = nheight
 	if (nref)
 		ref = nref
-	// If a client exists, but they have disabled fancy windowing, disable it!
-	if(user && user.client && user.client.get_preference_value(/datum/client_preference/browser_style) == GLOB.PREF_PLAIN)
-		return
 	add_stylesheet("common", 'html/browser/common.css') // this CSS sheet is common to all UIs
 
 /datum/browser/proc/set_title(ntitle)

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -34,7 +34,7 @@
 /obj/structure/closet/crate/use_tool(obj/item/tool, mob/user, list/click_params)
 	// Below interactions only apply if the crate is closed
 	if (opened)
-		return TRUE
+		return ..()
 
 	// Assembly - Attach to rigged crate
 	if (istype(tool, /obj/item/device/assembly_holder) || istype(tool, /obj/item/device/assembly))

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -279,9 +279,9 @@
 			return
 
 	isSwitchingStates = 1
+	set_density(TRUE)
 	flick("door_closing",src)
 	sleep(10)
-	set_density(1)
 	set_opacity(0)
 	state = 0
 	update_icon()

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -8,8 +8,6 @@ GLOBAL_VAR_CONST(PREF_SHORT, "Short")
 GLOBAL_VAR_CONST(PREF_LONG, "Long")
 GLOBAL_VAR_CONST(PREF_SHOW, "Show")
 GLOBAL_VAR_CONST(PREF_HIDE, "Hide")
-GLOBAL_VAR_CONST(PREF_FANCY, "Fancy")
-GLOBAL_VAR_CONST(PREF_PLAIN, "Plain")
 GLOBAL_VAR_CONST(PREF_PRIMARY, "Primary")
 GLOBAL_VAR_CONST(PREF_ALL, "All")
 GLOBAL_VAR_CONST(PREF_OFF, "Off")
@@ -204,11 +202,6 @@ var/global/list/_client_preferences_by_type
 	description ="Progress Bar"
 	key = "SHOW_PROGRESS"
 	options = list(GLOB.PREF_SHOW, GLOB.PREF_HIDE)
-
-/datum/client_preference/browser_style
-	description = "Fake NanoUI Browser Style"
-	key = "BROWSER_STYLED"
-	options = list(GLOB.PREF_FANCY, GLOB.PREF_PLAIN)
 
 /datum/client_preference/autohiss
 	description = "Autohiss"

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -179,7 +179,7 @@
 	// Wrench - Remove material
 	if (isWrench(weapon))
 		if (!material)
-			USE_FEEDBACK_FAILURE("\The [src] has no plating to remove.")
+			dismantle(weapon, user)
 			return TRUE
 		if (reinforced)
 			USE_FEEDBACK_FAILURE("\The [src]'s reinforcements need to be removed before you can remove the plating.")

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -143,7 +143,7 @@
 	// Material - Plate table
 	if (istype(weapon, /obj/item/stack/material))
 		if (material)
-			USE_FEEDBACK_FAILURE("\The [src] is already plated.")
+			reinforce_table(weapon, user)
 			return TRUE
 		material = common_material_add(weapon, user, "plat")
 		if (material)

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -3322,10 +3322,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/obj/machinery/alarm/server{
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"));
-	pixel_x = 22;
-	dir = 8
+/obj/machinery/alarm{
+	dir = 8;
+	pixel_x = 25
 	},
 /turf/simulated/floor/tiled/dark,
 /area/tcommsat/chamber)
@@ -11450,8 +11449,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/button/windowtint{
-	pixel_x = 24;
 	id = "diplomatic_office";
+	pixel_x = 24;
 	pixel_y = 6
 	},
 /obj/machinery/light_switch{


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Fixed an exploit that allowed you to close inflatable doors on yourself.
bugfix: Table frames can now be dismantled again with a wrench on harm intent.
bugfix: Tables can now be reinforced with a stack of material on harm intent.
bugfix: You can place items in open crates again.
bugfix: The Telecomms air alarm no longer requires Research Director access to unlock.
rscdel: Removed the 'Plain' fake nano-ui browser style.
/:cl:

## Bug Fixes
- Closes #13164
- Fixes #33302

## Notes
- The plain browser style was removed because building and maintaining a second stylesheet for a UI that, as far as I'm aware, is completely unused is unnecessary.