### PR TITLE
Chemical triggers are now more accepting of chemicals

### DIFF
--- a/code/modules/xenoarcheaology/triggers/chemical.dm
+++ b/code/modules/xenoarcheaology/triggers/chemical.dm
@@ -5,7 +5,7 @@
 /datum/artifact_trigger/chemical/New()
 	if(isnull(required_chemicals))
 		name = "presence of either an acid, toxin, or water"
-		required_chemicals = list(pick(/datum/reagent/acid, /datum/reagent/toxin, /datum/reagent/water))
+		required_chemicals = typesof(pick(/datum/reagent/acid, /datum/reagent/toxin, /datum/reagent/water))
 
 /datum/artifact_trigger/chemical/on_hit(obj/O, mob/user)
 	. = ..()
@@ -15,11 +15,9 @@
 
 /datum/artifact_trigger/chemical/water
 	name = "presence of water"
-	required_chemicals = list(
-		/datum/reagent/water,
-		/datum/reagent/water/boiling,
-		/datum/reagent/drink/ice
-	)
+
+/datum/artifact_trigger/chemical/water/New()
+	required_chemicals = typesof(/datum/reagent/water)
 
 /datum/artifact_trigger/chemical/water/on_water_act(depth)
 	if(depth > FLUID_EVAPORATION_POINT)
@@ -27,26 +25,25 @@
 
 /datum/artifact_trigger/chemical/acid
 	name = "presence of acid"
-	required_chemicals = list(
-		/datum/reagent/acid,
-		/datum/reagent/acid/polyacid,
-		/datum/reagent/diethylamine
-	)
 
+/datum/artifact_trigger/chemical/acid/New()
+	required_chemicals = typesof(/datum/reagent/acid)
 /datum/artifact_trigger/chemical/volatile
 	name = "presence of volatile chemicals"
 	required_chemicals = list(
 		/datum/reagent/toxin/phoron,
 		/datum/reagent/thermite,
-		/datum/reagent/fuel
+		/datum/reagent/fuel,
+		/datum/reagent/toxin/pyrotoxin,
+		/datum/reagent/potassium,
+		/datum/reagent/napalm,
+		/datum/reagent/napalm/b,
+		/datum/reagent/nitroglycerin,
+		/datum/reagent/toxin/phoron/oxygen
 	)
 
 /datum/artifact_trigger/chemical/toxic
 	name = "presence of toxins"
-	required_chemicals = list(
-		/datum/reagent/toxin,
-		/datum/reagent/toxin/cyanide,
-		/datum/reagent/toxin/amatoxin,
-		/datum/reagent/toxin/venom,
-		/datum/reagent/toxin/chlorine
-	)
+
+/datum/artifact_trigger/chemical/toxic/New()
+	required_chemicals = typesof(/datum/reagent/toxin)


### PR DESCRIPTION
🆑Jux
bugfix: The acid chemical artifact trigger now accepts all acids.
bugfix: The acid chemical artifact trigger now accepts all toxins. There's a lot.
tweak: The volatile chemical artifact trigger now accepts more chemicals.
/🆑 

For the volatile chemicals, I went with my gut as to what we could count as "volatile", although for all but three of them it's basically just flammable/explosive. 

Edit: Updated list of volatile chemicals to remove the mutation-inducing ones.