### PR TITLE
Fixes table slamming, three eye overlay

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -89,7 +89,7 @@
 
 /obj/structure/use_grab(obj/item/grab/grab, list/click_params)
 	// Harm intent - Slam face against the structure
-	if (grab.assailant == I_HURT)
+	if (grab.assailant.a_intent == I_HURT)
 		if (!grab.force_danger())
 			USE_FEEDBACK_GRAB_MUST_UPGRADE("to slam their face on \the [src]")
 			return TRUE

--- a/code/modules/client/client_color.dm
+++ b/code/modules/client/client_color.dm
@@ -90,7 +90,7 @@
 	priority = 200
 
 /datum/client_color/thirdeye
-	client_color = list(0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.05, 0.05, 0.05)
+	client_color = list(0.1, 0.1, 0.1, 0.3, 0.3, 0.3, 0.3, 0.3, 0.7)
 	priority = 300
 
 //Disabilities, could be hooked to brain damage or chargen if so desired.


### PR DESCRIPTION
:cl: PurplePineapple
bugfix: Table slamming now works on harm intent with an aggressive grab.
bugfix: Three-Eye's overlay is no longer unintentionally a black screen.
/:cl:

Table slamming now works again on harm intent. Three-eye overlay works as intended and no longer is just a black screen.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->