### PR TITLE
Reduces hardsuit chem injection amount to 5u

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -220,7 +220,7 @@
 	if(!charge)
 		return 0
 
-	var/chems_to_use = 10
+	var/chems_to_use = 5
 	if(charge.charges <= 0)
 		to_chat(H, SPAN_DANGER("Insufficient chems!"))
 		return 0


### PR DESCRIPTION
Drops injection amount from 10u to 5u.
There's no way to select an amount in the UI, so chemicals with an OD of lower than 10 were unusable.

Ninjas can use Synaptizine without ODing.
15u overdose chems can be used more easily.

![image](https://user-images.githubusercontent.com/8376059/232768525-25f60be4-5faa-47bf-86bd-406f1f8cf3de.png)

:cl: Fenodyree
bugfix: Reduces the amount hardsuit injectors inject to 5u
/:cl: