### PR TITLE
Misc fixes 4-18-23

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -753,7 +753,7 @@
 
 	var/obj/item/check_slot
 	var/equip_to
-	var/obj/item/use_obj
+	var/obj/item/clothing/use_obj
 
 	if(!wearer)
 		return
@@ -796,8 +796,11 @@
 			use_obj.forceMove(wearer)
 			if(!wearer.equip_to_slot_if_possible(use_obj, equip_to, TRYEQUIP_REDRAW | TRYEQUIP_SILENT))
 				use_obj.forceMove(src)
+				if(wearer.species && use_obj.species_restricted && !(wearer.species in use_obj.species_restricted))
+					FEEDBACK_FAILURE(initiator, "You are unable to deploy \the [piece] as [use_obj.gender == PLURAL ? "they are" : "it is"] not compatible with the anatomy of your species.")
+					return
 				if(check_slot)
-					to_chat(initiator, SPAN_CLASS("danger", "You are unable to deploy \the [piece] as \the [check_slot] [check_slot.gender == PLURAL ? "are" : "is"] in the way."))
+					FEEDBACK_FAILURE(initiator, "You are unable to deploy \the [piece] as \the [check_slot] [check_slot.gender == PLURAL ? "are" : "is"] in the way.")
 					return
 			else
 				to_chat(wearer, SPAN_NOTICE("Your [use_obj.name] [use_obj.gender == PLURAL ? "deploy" : "deploys"] swiftly."))

--- a/code/modules/skrell/skrell_rigs.dm
+++ b/code/modules/skrell/skrell_rigs.dm
@@ -221,7 +221,10 @@
 	selectable = TRUE
 
 /obj/item/rig_module/device/multitool/skrell/IsMultitool()
-	return TRUE
+	if(holder)
+		return TRUE
+	else
+		return FALSE
 
 /obj/item/rig_module/device/cable_coil/skrell
 	name = "skrellian cable extruder"
@@ -333,6 +336,6 @@
 
 /obj/item/device/multitool/skrell
 	name = "skrellian multitool"
-	name = "An extreme sophisticated microcomputer capable of interfacing with practically any system."
+	desc = "An extreme sophisticated microcomputer capable of interfacing with practically any system."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "skrell_multitool"

--- a/maps/random_ruins/exoplanet_ruins/playablecolony2/playablecolony2.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony2/playablecolony2.dm
@@ -23,7 +23,7 @@
 	title = "Ship Colonist"
 	supervisors = "the trust of your fellow Colonists"
 	info = "You are a Colonist, living on the rim of explored, let alone inhabited, space in a recently landed colony ship."
-	total_positions = 3
+	total_positions = 4
 	outfit_type = /singleton/hierarchy/outfit/job/colonist2
 
 /singleton/hierarchy/outfit/job/colonist2
@@ -37,7 +37,7 @@
 
 /obj/effect/submap_landmark/joinable_submap/colony2
 	name = "Landed Colony Ship"
-	archetype = /singleton/submap_archetype/playablecolony
+	archetype = /singleton/submap_archetype/playablecolony2
 
 // Areas //
 /area/map_template/colony2


### PR DESCRIPTION
:cl: rootoo807
tweak: Hardsuits give feedback if they can't be worn due to species incompatibility.
bugfix: Integrated multitool modules can be installed in hardsuits now.
tweak: Landed ship colony away-site uses a distinct archetype (and job roles) from Established colony away-site.
/:cl:

Minor/Basically non-user facing: playablecolony2 uses the intended archetype

also bumps the pop count on playablecolony2 to match playablecolony's to avoid effectively removing a slot

Issues:

- Fixes #30945
- Fixes #32528
- Fixes #28718