### PR TITLE
Remove `T_BOARD` Defines

### DIFF
--- a/code/__defines/research.dm
+++ b/code/__defines/research.dm
@@ -15,5 +15,3 @@
 #define PROTOLATHE    FLAG(1)  //New stuff. Uses glass/metal/chemicals
 #define MECHFAB       FLAG(2)  //Mechfab
 #define CHASSIS       FLAG(3)  //For protolathe, but differently
-
-#define T_BOARD(name)	"circuit board (" + (name) + ")"

--- a/code/datums/extensions/multitool/circuitboards/buildtype_select.dm
+++ b/code/datums/extensions/multitool/circuitboards/buildtype_select.dm
@@ -24,6 +24,6 @@
 		if(path && (path in board.get_buildable_types()))
 			board.build_path = path
 			var/obj/thing = path
-			board.SetName(T_BOARD(initial(thing.name)))
+			board.SetName("circuit board ([initial(thing.name)])")
 			return MT_REFRESH
 	return ..()

--- a/code/game/objects/items/weapons/circuitboards/circuitboard.dm
+++ b/code/game/objects/items/weapons/circuitboards/circuitboard.dm
@@ -81,4 +81,4 @@
 	if(buildtype_select && machine)
 		build_path = machine.base_type || machine.type
 		var/obj/machinery/thing = build_path
-		SetName(T_BOARD(initial(thing.name)))
+		SetName("circuit board ([initial(thing.name)])")

--- a/code/game/objects/items/weapons/circuitboards/computer/air_management.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/air_management.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/air_management
-	name = T_BOARD("atmosphere monitoring console")
+	name = "circuit board (atmosphere monitoring console)"
 	build_path = /obj/machinery/computer/air_control
 	var/console_name
 	var/frequency = 1441
@@ -8,7 +8,7 @@
 	var/list/sensor_information = list()
 
 /obj/item/stock_parts/circuitboard/air_management/supermatter_core
-	name = T_BOARD("core control")
+	name = "circuit board (core control)"
 	build_path = /obj/machinery/computer/air_control/supermatter_core
 	frequency = 1438
 	var/input_tag
@@ -21,7 +21,7 @@
 	var/pressure_setting = 100
 
 /obj/item/stock_parts/circuitboard/air_management/injector_control
-	name = T_BOARD("injector control")
+	name = "circuit board (injector control)"
 	build_path = /obj/machinery/computer/air_control/fuel_injection
 	var/device_tag
 	var/list/device_info

--- a/code/game/objects/items/weapons/circuitboards/computer/computer.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/computer.dm
@@ -1,112 +1,112 @@
 /obj/item/stock_parts/circuitboard/message_monitor
-	name = T_BOARD("message monitor console")
+	name = "circuit board (message monitor console)"
 	build_path = /obj/machinery/computer/message_monitor
 	origin_tech = list(TECH_DATA = 3)
 
 /obj/item/stock_parts/circuitboard/aiupload
-	name = T_BOARD("AI upload console")
+	name = "circuit board (AI upload console)"
 	build_path = /obj/machinery/computer/upload/ai
 	origin_tech = list(TECH_DATA = 4)
 
 /obj/item/stock_parts/circuitboard/borgupload
-	name = T_BOARD("cyborg upload console")
+	name = "circuit board (cyborg upload console)"
 	build_path = /obj/machinery/computer/upload/robot
 	origin_tech = list(TECH_DATA = 4)
 
 /obj/item/stock_parts/circuitboard/teleporter
-	name = T_BOARD("teleporter control console")
+	name = "circuit board (teleporter control console)"
 	build_path = /obj/machinery/computer/teleporter
 	origin_tech = list(TECH_DATA = 2, TECH_BLUESPACE = 4)
 
 /obj/item/stock_parts/circuitboard/atmos_alert
-	name = T_BOARD("atmospheric alert console")
+	name = "circuit board (atmospheric alert console)"
 	build_path = /obj/machinery/computer/atmos_alert
 
 /obj/item/stock_parts/circuitboard/robotics
-	name = T_BOARD("robotics control console")
+	name = "circuit board (robotics control console)"
 	build_path = /obj/machinery/computer/robotics
 	origin_tech = list(TECH_DATA = 3)
 
 /obj/item/stock_parts/circuitboard/drone_control
-	name = T_BOARD("drone control console")
+	name = "circuit board (drone control console)"
 	build_path = /obj/machinery/computer/drone_control
 	origin_tech = list(TECH_DATA = 3)
 
 /obj/item/stock_parts/circuitboard/arcade/battle
-	name = T_BOARD("battle arcade machine")
+	name = "circuit board (battle arcade machine)"
 	build_path = /obj/machinery/computer/arcade/battle
 	origin_tech = list(TECH_DATA = 1)
 
 /obj/item/stock_parts/circuitboard/arcade/orion_trail
-	name = T_BOARD("orion trail arcade machine")
+	name = "circuit board (orion trail arcade machine)"
 	build_path = /obj/machinery/computer/arcade/orion_trail
 	origin_tech = list(TECH_DATA = 1)
 
 /obj/item/stock_parts/circuitboard/turbine_control
-	name = T_BOARD("turbine control console")
+	name = "circuit board (turbine control console)"
 	build_path = /obj/machinery/computer/turbine_computer
 
 /obj/item/stock_parts/circuitboard/solar_control
-	name = T_BOARD("solar control console")
+	name = "circuit board (solar control console)"
 	build_path = /obj/machinery/power/solar_control
 	origin_tech = list(TECH_DATA = 2, TECH_POWER = 2)
 
 /obj/item/stock_parts/circuitboard/powermonitor
-	name = T_BOARD("power monitoring console")
+	name = "circuit board (power monitoring console)"
 	build_path = /obj/machinery/computer/power_monitor
 
 /obj/item/stock_parts/circuitboard/prisoner
-	name = T_BOARD("prisoner management console")
+	name = "circuit board (prisoner management console)"
 	build_path = /obj/machinery/computer/prisoner
 
 /obj/item/stock_parts/circuitboard/rdservercontrol
-	name = T_BOARD("R&D server control console")
+	name = "circuit board (R&D server control console)"
 	build_path = /obj/machinery/computer/rdservercontrol
 
 /obj/item/stock_parts/circuitboard/crew
-	name = T_BOARD("crew monitoring console")
+	name = "circuit board (crew monitoring console)"
 	build_path = /obj/machinery/computer/crew
 	origin_tech = list(TECH_DATA = 3, TECH_BIO = 2, TECH_MAGNET = 2)
 
 /obj/item/stock_parts/circuitboard/operating
-	name = T_BOARD("patient monitoring console")
+	name = "circuit board (patient monitoring console)"
 	build_path = /obj/machinery/computer/operating
 	origin_tech = list(TECH_DATA = 2, TECH_BIO = 2)
 
 /obj/item/stock_parts/circuitboard/helm
-	name = T_BOARD("helm control console")
+	name = "circuit board (helm control console)"
 	build_path = /obj/machinery/computer/ship/helm
 
 /obj/item/stock_parts/circuitboard/engine
-	name = T_BOARD("engine control console")
+	name = "circuit board (engine control console)"
 	build_path = /obj/machinery/computer/ship/engines
 
 /obj/item/stock_parts/circuitboard/nav
-	name = T_BOARD("navigation console")
+	name = "circuit board (navigation console)"
 	build_path = /obj/machinery/computer/ship/navigation
 
 /obj/item/stock_parts/circuitboard/nav/tele
-	name = T_BOARD("navigation telescreen")
+	name = "circuit board (navigation telescreen)"
 	build_path = /obj/machinery/computer/ship/navigation/telescreen
 
 /obj/item/stock_parts/circuitboard/sensors
-	name = T_BOARD("sensors console")
+	name = "circuit board (sensors console)"
 	build_path = /obj/machinery/computer/ship/sensors
 
 /obj/item/stock_parts/circuitboard/area_atmos
-	name = T_BOARD("area air control console")
+	name = "circuit board (area air control console)"
 	build_path = /obj/machinery/computer/area_atmos
 	origin_tech = list(TECH_DATA = 2)
 
 /obj/item/stock_parts/circuitboard/rcon_console
-	name = T_BOARD("RCON remote control console")
+	name = "circuit board (RCON remote control console)"
 	build_path = /obj/machinery/computer/rcon
 	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3, TECH_POWER = 5)
 
 /obj/item/stock_parts/circuitboard/account_database
-	name = T_BOARD("accounts uplink terminal")
+	name = "circuit board (accounts uplink terminal)"
 	build_path = /obj/machinery/computer/account_database
 
 /obj/item/stock_parts/circuitboard/guestpass
-	name = T_BOARD("guest pass terminal")
+	name = "circuit board (guest pass terminal)"
 	build_path = /obj/machinery/computer/guestpass

--- a/code/game/objects/items/weapons/circuitboards/computer/holodeckcontrol.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/holodeckcontrol.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/holodeckcontrol
-	name = T_BOARD("holodeck control console")
+	name = "circuit board (holodeck control console)"
 	build_path = /obj/machinery/computer/HolodeckControl
 	origin_tech = list(TECH_DATA = 2, TECH_BLUESPACE = 2)
 	var/last_to_emag

--- a/code/game/objects/items/weapons/circuitboards/computer/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/research.dm
@@ -1,16 +1,16 @@
 /obj/item/stock_parts/circuitboard/rdconsole
-	name = T_BOARD("R&D control console")
+	name = "circuit board (R&D control console)"
 	build_path = /obj/machinery/computer/rdconsole/core
 
 /obj/item/stock_parts/circuitboard/rdconsole/attackby(obj/item/I as obj, mob/user as mob)
 	if(isScrewdriver(I))
 		user.visible_message(SPAN_NOTICE("\The [user] adjusts the jumper on \the [src]'s access protocol pins."), SPAN_NOTICE("You adjust the jumper on the access protocol pins."))
 		if(src.build_path == /obj/machinery/computer/rdconsole/core)
-			src.SetName(T_BOARD("RD Console - Robotics"))
+			src.SetName("circuit board (RD Console - Robotics)")
 			src.build_path = /obj/machinery/computer/rdconsole/robotics
 			to_chat(user, SPAN_NOTICE("Access protocols set to robotics."))
 		else
-			src.SetName(T_BOARD("RD Console"))
+			src.SetName("circuit board (RD Console)")
 			src.build_path = /obj/machinery/computer/rdconsole/core
 			to_chat(user, SPAN_NOTICE("Access protocols set to default."))
 	return

--- a/code/game/objects/items/weapons/circuitboards/computer/shuttle.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/shuttle.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/shuttle_console
-	name = T_BOARD("basic shuttle console")
+	name = "circuit board (basic shuttle console)"
 	build_path = /obj/machinery/computer/shuttle_control
 	origin_tech = list(TECH_DATA = 3)
 	var/shuttle_tag
@@ -18,7 +18,7 @@
 	return TRUE
 
 /obj/item/stock_parts/circuitboard/shuttle_console/explore
-	name = T_BOARD("long range shuttle console")
+	name = "circuit board (long range shuttle console)"
 	build_path = /obj/machinery/computer/shuttle_control/explore
 
 /obj/item/stock_parts/circuitboard/shuttle_console/explore/is_valid_shuttle(datum/shuttle/shuttle)

--- a/code/game/objects/items/weapons/circuitboards/computer/station_alert.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/station_alert.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/stationalert
-	name = T_BOARD("alert console")
+	name = "circuit board (alert console)"
 	build_path = /obj/machinery/computer/station_alert
 	var/list/alarm_handlers
 

--- a/code/game/objects/items/weapons/circuitboards/computer/telecomms.dm
+++ b/code/game/objects/items/weapons/circuitboards/computer/telecomms.dm
@@ -1,9 +1,9 @@
 /obj/item/stock_parts/circuitboard/comm_monitor
-	name = T_BOARD("telecommunications monitor console")
+	name = "circuit board (telecommunications monitor console)"
 	build_path = /obj/machinery/computer/telecomms/monitor
 	origin_tech = list(TECH_DATA = 3)
 
 /obj/item/stock_parts/circuitboard/comm_server
-	name = T_BOARD("telecommunications server monitor console")
+	name = "circuit board (telecommunications server monitor console)"
 	build_path = /obj/machinery/computer/telecomms/server
 	origin_tech = list(TECH_DATA = 3)

--- a/code/game/objects/items/weapons/circuitboards/machinery/biogenerator.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/biogenerator.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/biogenerator
-	name = T_BOARD("biogenerator")
+	name = "circuit board (biogenerator)"
 	build_path = /obj/machinery/biogenerator
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 2)

--- a/code/game/objects/items/weapons/circuitboards/machinery/chemistry.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/chemistry.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/reagent_heater
-	name = T_BOARD("chemical heater")
+	name = "circuit board (chemical heater)"
 	build_path = /obj/machinery/reagent_temperature
 	board_type = "machine"
 	origin_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 1)
@@ -14,11 +14,11 @@
 	)
 
 /obj/item/stock_parts/circuitboard/reagent_heater/cooler
-	name = T_BOARD("chemical cooler")
+	name = "circuit board (chemical cooler)"
 	build_path = /obj/machinery/reagent_temperature/cooler
 
 /obj/item/stock_parts/circuitboard/sublimator
-	name = T_BOARD("reagent sublimator")
+	name = "circuit board (reagent sublimator)"
 	build_path = /obj/machinery/portable_atmospherics/reagent_sublimator
 	board_type = "machine"
 	origin_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 1)
@@ -32,12 +32,12 @@
 	)
 
 /obj/item/stock_parts/circuitboard/sublimator/sauna
-	name = T_BOARD("sauna sublimator")
+	name = "circuit board (sauna sublimator)"
 	build_path = /obj/machinery/portable_atmospherics/reagent_sublimator/sauna
 
 
 /obj/item/stock_parts/circuitboard/reagentgrinder
-	name = T_BOARD("reagent grinder")
+	name = "circuit board (reagent grinder)"
 	build_path = /obj/machinery/reagentgrinder
 	board_type = "machine"
 	origin_tech = list(TECH_BIO = 1, TECH_MATERIAL = 2, TECH_ENGINEERING = 2)
@@ -51,7 +51,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/juicer
-	name = T_BOARD("blender")
+	name = "circuit board (blender)"
 	build_path = /obj/machinery/reagentgrinder/juicer
 	board_type = "machine"
 	origin_tech = list(TECH_BIO = 1, TECH_MATERIAL = 1, TECH_ENGINEERING = 1)

--- a/code/game/objects/items/weapons/circuitboards/machinery/cloning.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/cloning.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/bioprinter
-	name = T_BOARD("bioprinter")
+	name = "circuit board (bioprinter)"
 	build_path = /obj/machinery/organ_printer/flesh
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 1, TECH_BIO = 3, TECH_DATA = 3)
@@ -15,7 +15,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/roboprinter
-	name = T_BOARD("prosthetic organ fabricator")
+	name = "circuit board (prosthetic organ fabricator)"
 	build_path = /obj/machinery/organ_printer/robot
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 3)

--- a/code/game/objects/items/weapons/circuitboards/machinery/commsantenna.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/commsantenna.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/bluespacerelay
-	name = T_BOARD("bluespacerelay")
+	name = "circuit board (bluespacerelay)"
 	build_path = /obj/machinery/bluespacerelay
 	board_type = "machine"
 	origin_tech = list(TECH_BLUESPACE = 2, TECH_DATA = 2)

--- a/code/game/objects/items/weapons/circuitboards/machinery/engineering_circuits.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/engineering_circuits.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/floodlight
-	name = T_BOARD("emergency floodlight")
+	name = "circuit board (emergency floodlight)"
 	build_path = /obj/machinery/floodlight
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 1)
@@ -11,7 +11,7 @@
 		/obj/item/cell/crap = 1)
 
 /obj/item/stock_parts/circuitboard/pipedispensor
-	name = T_BOARD("pipe dispenser")
+	name = "circuit board (pipe dispenser)"
 	build_path = /obj/machinery/pipedispenser
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 6, TECH_MATERIAL = 5)
@@ -24,5 +24,5 @@
 		/obj/item/stock_parts/power/apc/buildable = 1)
 
 /obj/item/stock_parts/circuitboard/pipedispensor/disposal
-	name = T_BOARD("disposal pipe dispenser")
+	name = "circuit board (disposal pipe dispenser)"
 	build_path = /obj/machinery/pipedispenser/disposal

--- a/code/game/objects/items/weapons/circuitboards/machinery/household.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/household.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/microwave
-	name = T_BOARD("microwave")
+	name = "circuit board (microwave)"
 	build_path = /obj/machinery/microwave
 	board_type = "machine"
 	origin_tech = list(TECH_BIO = 2, TECH_ENGINEERING = 2)
@@ -14,7 +14,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/gibber
-	name = T_BOARD("meat gibber")
+	name = "circuit board (meat gibber)"
 	build_path = /obj/machinery/gibber
 	board_type = "machine"
 	origin_tech = list(TECH_BIO = 2, TECH_MATERIAL = 2)
@@ -28,7 +28,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/cooker
-	name = T_BOARD("candy machine")
+	name = "circuit board (candy machine)"
 	build_path = /obj/machinery/cooker/candy
 	board_type = "machine"
 	origin_tech = list(TECH_BIO = 1, TECH_MATERIAL = 1)
@@ -47,7 +47,7 @@
 	return subtypesof(/obj/machinery/cooker)
 
 /obj/item/stock_parts/circuitboard/honey
-	name = T_BOARD("honey extractor")
+	name = "circuit board (honey extractor)"
 	build_path = /obj/machinery/honey_extractor
 	board_type = "machine"
 	origin_tech = list(TECH_BIO = 2, TECH_ENGINEERING = 1)
@@ -56,12 +56,12 @@
 		/obj/item/stock_parts/matter_bin = 2)
 
 /obj/item/stock_parts/circuitboard/honey/seed
-	name = T_BOARD("seed extractor")
+	name = "circuit board (seed extractor)"
 	build_path = /obj/machinery/seed_extractor
 	board_type = "machine"
 
 /obj/item/stock_parts/circuitboard/washer
-	name = T_BOARD("washing machine")
+	name = "circuit board (washing machine)"
 	build_path = /obj/machinery/washing_machine
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 1)
@@ -72,7 +72,7 @@
 		/obj/item/pipe = 1)
 
 /obj/item/stock_parts/circuitboard/vending
-	name = T_BOARD("vending machine")
+	name = "circuit board (vending machine)"
 	build_path = /obj/machinery/vending/generic
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 2)
@@ -95,7 +95,7 @@
 		. |= base_type
 
 /obj/item/stock_parts/circuitboard/shipmap
-	name = T_BOARD("ship holomap")
+	name = "circuit board (ship holomap)"
 	board_type = "machine"
 	build_path = /obj/machinery/ship_map
 	origin_tech = list(TECH_ENGINEERING = 1)

--- a/code/game/objects/items/weapons/circuitboards/machinery/mech_recharger.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/mech_recharger.dm
@@ -1,9 +1,9 @@
 /obj/item/stock_parts/circuitboard/mech_recharger
-	name = T_BOARD("mech recharger")
+	name = "circuit board (mech recharger)"
 	build_path = /obj/machinery/mech_recharger
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 2, TECH_POWER = 2, TECH_ENGINEERING = 2)
 	req_components = list(
 							/obj/item/stock_parts/capacitor = 2,
 							/obj/item/stock_parts/scanning_module = 1,
-							/obj/item/stock_parts/manipulator = 2) 
+							/obj/item/stock_parts/manipulator = 2)

--- a/code/game/objects/items/weapons/circuitboards/machinery/medical.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/medical.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/optable
-	name = T_BOARD("operating table")
+	name = "circuit board (operating table)"
 	build_path = /obj/machinery/optable
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 1, TECH_BIO = 3, TECH_DATA = 3)
@@ -12,7 +12,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/bodyscanner
-	name = T_BOARD("body scanner")
+	name = "circuit board (body scanner)"
 	build_path = /obj/machinery/bodyscanner
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_BIO = 4, TECH_DATA = 4)
@@ -25,7 +25,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/body_scanconsole
-	name = T_BOARD("body scanner console")
+	name = "circuit board (body scanner console)"
 	build_path = /obj/machinery/body_scanconsole
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_BIO = 4, TECH_DATA = 4)
@@ -37,12 +37,12 @@
 	)
 
 /obj/item/stock_parts/circuitboard/body_scanconsole/display
-	name = T_BOARD("body scanner display")
+	name = "circuit board (body scanner display)"
 	build_path = /obj/machinery/body_scan_display
 	origin_tech = list(TECH_BIO = 2, TECH_DATA = 2)
 
 /obj/item/stock_parts/circuitboard/sleeper
-	name = T_BOARD("sleeper")
+	name = "circuit board (sleeper)"
 	build_path = /obj/machinery/sleeper
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_BIO = 5, TECH_DATA = 3)
@@ -57,7 +57,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/cryo_cell
-	name = T_BOARD("cryo cell")
+	name = "circuit board (cryo cell)"
 	build_path = /obj/machinery/atmospherics/unary/cryo_cell
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_BIO = 6, TECH_DATA = 3)

--- a/code/game/objects/items/weapons/circuitboards/machinery/mining.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/mining.dm
@@ -1,10 +1,10 @@
 /obj/item/stock_parts/circuitboard/mineral_processing
-	name = T_BOARD("mineral processing console")
+	name = "circuit board (mineral processing console)"
 	build_path = /obj/machinery/computer/mining
 	origin_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
 
 /obj/item/stock_parts/circuitboard/mining_processor
-	name = T_BOARD("ore processor")
+	name = "circuit board (ore processor)"
 	build_path = /obj/machinery/mineral/processing_unit
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
@@ -19,7 +19,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/mining_unloader
-	name = T_BOARD("unloading machine")
+	name = "circuit board (unloading machine)"
 	build_path = /obj/machinery/mineral/unloading_machine
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)
@@ -33,7 +33,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/mining_stacker
-	name = T_BOARD("stacking machine")
+	name = "circuit board (stacking machine)"
 	build_path = /obj/machinery/mineral/stacking_machine
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 2, TECH_ENGINEERING = 2)

--- a/code/game/objects/items/weapons/circuitboards/machinery/mining_drill.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/mining_drill.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/miningdrill
-	name = T_BOARD("mining drill head")
+	name = "circuit board (mining drill head)"
 	build_path = /obj/machinery/mining/drill
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
@@ -10,10 +10,10 @@
 	additional_spawn_components = list(
 		/obj/item/stock_parts/power/battery/buildable/stock,
 		/obj/item/cell/standard = 1
-	)	
+	)
 
 /obj/item/stock_parts/circuitboard/miningdrillbrace
-	name = T_BOARD("mining drill brace")
+	name = "circuit board (mining drill brace)"
 	build_path = /obj/machinery/mining/brace
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)

--- a/code/game/objects/items/weapons/circuitboards/machinery/oxyregenerator.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/oxyregenerator.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/oxyregenerator
-	name = T_BOARD("oxygen regenerator")
+	name = "circuit board (oxygen regenerator)"
 	build_path = /obj/machinery/atmospherics/binary/oxyregenerator
 	board_type = "machine"
 	origin_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)

--- a/code/game/objects/items/weapons/circuitboards/machinery/pacman.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/pacman.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/pacman
-	name = T_BOARD("PACMAN-type generator")
+	name = "circuit board (PACMAN-type generator)"
 	build_path = /obj/machinery/power/port_gen/pacman
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 3, TECH_POWER = 3, TECH_PHORON = 3, TECH_ENGINEERING = 3)
@@ -14,21 +14,21 @@
 		/obj/item/stock_parts/power/apc/buildable = 1
 	)
 /obj/item/stock_parts/circuitboard/pacman/super
-	name = T_BOARD("SUPERPACMAN-type generator")
+	name = "circuit board (SUPERPACMAN-type generator)"
 	build_path = /obj/machinery/power/port_gen/pacman/super
 	origin_tech = list(TECH_DATA = 3, TECH_POWER = 4, TECH_ENGINEERING = 4)
 
 /obj/item/stock_parts/circuitboard/pacman/super/potato
-	name = T_BOARD("PTTO-3 nuclear generator")
+	name = "circuit board (PTTO-3 nuclear generator)"
 	build_path = /obj/machinery/power/port_gen/pacman/super/potato
 	origin_tech = list(TECH_DATA = 3, TECH_POWER = 5, TECH_ENGINEERING = 4)
 
 /obj/item/stock_parts/circuitboard/pacman/super/potato/reactor
-	name = T_BOARD("ICRER-2 nuclear generator")
+	name = "circuit board (ICRER-2 nuclear generator)"
 	build_path = /obj/machinery/power/port_gen/pacman/super/potato/reactor
 	origin_tech = list(TECH_DATA = 3, TECH_POWER = 5, TECH_ENGINEERING = 4)
 
 /obj/item/stock_parts/circuitboard/pacman/mrs
-	name = T_BOARD("MRSPACMAN-type generator")
+	name = "circuit board (MRSPACMAN-type generator)"
 	build_path = /obj/machinery/power/port_gen/pacman/mrs
 	origin_tech = list(TECH_DATA = 3, TECH_POWER = 5, TECH_ENGINEERING = 5)

--- a/code/game/objects/items/weapons/circuitboards/machinery/portable_atmospherics.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/portable_atmospherics.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/portable_scrubber
-	name = T_BOARD("portable scrubber")
+	name = "circuit board (portable scrubber)"
 	board_type = "machine"
 	build_path = /obj/machinery/portable_atmospherics/powered/scrubber
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_POWER = 4)
@@ -16,12 +16,12 @@
 	)
 
 /obj/item/stock_parts/circuitboard/portable_scrubber/pump
-	name = T_BOARD("portable pump")
+	name = "circuit board (portable pump)"
 	board_type = "machine"
 	build_path = /obj/machinery/portable_atmospherics/powered/pump
 
 /obj/item/stock_parts/circuitboard/portable_scrubber/huge
-	name = T_BOARD("large portable scrubber")
+	name = "circuit board (large portable scrubber)"
 	board_type = "machine"
 	build_path = /obj/machinery/portable_atmospherics/powered/scrubber/huge
 	origin_tech = list(TECH_ENGINEERING = 5, TECH_POWER = 5, TECH_MATERIAL = 5)
@@ -31,12 +31,12 @@
 							/obj/item/pipe = 4)
 
 /obj/item/stock_parts/circuitboard/portable_scrubber/huge/stationary
-	name = T_BOARD("large stationary portable scrubber")
+	name = "circuit board (large stationary portable scrubber)"
 	board_type = "machine"
 	build_path = /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary
 
 /obj/item/stock_parts/circuitboard/tray
-	name = T_BOARD("hydroponics tray")
+	name = "circuit board (hydroponics tray)"
 	board_type = "machine"
 	build_path = /obj/machinery/portable_atmospherics/hydroponics
 	origin_tech = list(TECH_BIO = 3, TECH_MATERIAL = 2, TECH_DATA = 1)

--- a/code/game/objects/items/weapons/circuitboards/machinery/power.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/power.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/smes
-	name = T_BOARD("superconductive magnetic energy storage")
+	name = "circuit board (superconductive magnetic energy storage)"
 	build_path = /obj/machinery/power/smes/buildable
 	board_type = "machine"
 	origin_tech = list(TECH_POWER = 6, TECH_ENGINEERING = 4)
@@ -10,7 +10,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/batteryrack
-	name = T_BOARD("battery rack PSU")
+	name = "circuit board (battery rack PSU)"
 	build_path = /obj/machinery/power/smes/batteryrack
 	board_type = "machine"
 	origin_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 2)

--- a/code/game/objects/items/weapons/circuitboards/machinery/recharge_station.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/recharge_station.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/recharge_station
-	name = T_BOARD("cyborg recharging station")
+	name = "circuit board (cyborg recharging station)"
 	build_path = /obj/machinery/recharge_station
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 3)

--- a/code/game/objects/items/weapons/circuitboards/machinery/research.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/research.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/rdserver
-	name = T_BOARD("R&D server")
+	name = "circuit board (R&D server)"
 	build_path = /obj/machinery/r_n_d/server
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 3)
@@ -11,7 +11,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/destructive_analyzer
-	name = T_BOARD("destructive analyzer")
+	name = "circuit board (destructive analyzer)"
 	build_path = /obj/machinery/r_n_d/destructive_analyzer
 	board_type = "machine"
 	origin_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2, TECH_DATA = 2)
@@ -24,7 +24,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/autolathe
-	name = T_BOARD("autolathe")
+	name = "circuit board (autolathe)"
 	build_path = /obj/machinery/fabricator
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2)
@@ -38,7 +38,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/autolathe/micro
-	name = T_BOARD("microlathe")
+	name = "circuit board (microlathe)"
 	build_path = /obj/machinery/fabricator/micro
 	origin_tech = list(TECH_ENGINEERING = 1, TECH_DATA = 1)
 	req_components = list(
@@ -46,7 +46,7 @@
 		/obj/item/stock_parts/manipulator = 1
 	)
 /obj/item/stock_parts/circuitboard/replicator
-	name = T_BOARD("replicator")
+	name = "circuit board (replicator)"
 	build_path = /obj/machinery/fabricator/replicator
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_DATA = 2, TECH_BIO = 2)
@@ -60,7 +60,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/protolathe
-	name = T_BOARD("protolathe")
+	name = "circuit board (protolathe)"
 	build_path = /obj/machinery/r_n_d/protolathe
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2)
@@ -73,7 +73,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/circuit_imprinter
-	name = T_BOARD("circuit imprinter")
+	name = "circuit board (circuit imprinter)"
 	build_path = /obj/machinery/r_n_d/circuit_imprinter
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_DATA = 2)
@@ -86,7 +86,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/mechfab
-	name = T_BOARD("exosuit fabricator")
+	name = "circuit board (exosuit fabricator)"
 	build_path = /obj/machinery/robotics_fabricator
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 3)
@@ -101,7 +101,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/ntnet_relay
-	name = T_BOARD("\improper NTNet quantum relay")
+	name = "circuit board (NTNet quantum relay)"
 	build_path = /obj/machinery/ntnet_relay
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 4)
@@ -114,7 +114,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/suspension_gen
-	name = T_BOARD("suspension generator")
+	name = "circuit board (suspension generator)"
 	build_path = /obj/machinery/suspension_gen
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3, TECH_MAGNET = 4)
@@ -130,7 +130,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/anomaly_container
-	name = T_BOARD("anomaly container")
+	name = "circuit board (anomaly container)"
 	build_path = /obj/machinery/anomaly_container
 	board_type = "machine"
 	origin_tech = list(TECH_BLUESPACE = 3, TECH_ENGINEERING = 4, TECH_MAGNET = 4)
@@ -145,7 +145,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/cracker
-	name = T_BOARD("molecular cracking unit")
+	name = "circuit board (molecular cracking unit)"
 	build_path = /obj/machinery/portable_atmospherics/cracker
 	board_type = "machine"
 	origin_tech = list(TECH_MAGNET = 4, TECH_ENGINEERING = 3, TECH_MATERIAL = 3)
@@ -158,7 +158,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/doppler_array
-	name = T_BOARD("doppler array")
+	name = "circuit board (doppler array)"
 	build_path = /obj/machinery/doppler_array
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 7, TECH_MATERIAL = 4, TECH_DATA = 4, TECH_BLUESPACE = 3)

--- a/code/game/objects/items/weapons/circuitboards/machinery/shieldgen.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/shieldgen.dm
@@ -1,6 +1,6 @@
 // New shields
 /obj/item/stock_parts/circuitboard/shield_generator
-	name = T_BOARD("advanced shield generator")
+	name = "circuit board (advanced shield generator)"
 	board_type = "machine"
 	build_path = /obj/machinery/power/shield_generator
 	origin_tech = list(TECH_MAGNET = 3, TECH_POWER = 4)
@@ -15,7 +15,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/shield_diffuser
-	name = T_BOARD("shield diffuser")
+	name = "circuit board (shield diffuser)"
 	board_type = "machine"
 	build_path = /obj/machinery/shield_diffuser
 	origin_tech = list(TECH_MAGNET = 4, TECH_POWER = 2)
@@ -29,7 +29,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/pointdefense
-	name = T_BOARD("point defense battery")
+	name = "circuit board (point defense battery)"
 	board_type = "machine"
 	build_path = /obj/machinery/pointdefense
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_COMBAT = 2)
@@ -37,7 +37,7 @@
 		/obj/item/mech_equipment/mounted_system/taser/laser = 1,
 		/obj/item/stock_parts/manipulator = 2,
 		/obj/item/stock_parts/capacitor = 2,
-		
+
 	)
 	additional_spawn_components = list(
 		/obj/item/stock_parts/power/terminal/buildable = 1,
@@ -46,7 +46,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/pointdefense_control
-	name = T_BOARD("fire assist mainframe")
+	name = "circuit board (fire assist mainframe)"
 	board_type = "machine"
 	build_path = /obj/machinery/pointdefense_control
 	origin_tech = list(TECH_ENGINEERING = 3, TECH_COMBAT = 2)

--- a/code/game/objects/items/weapons/circuitboards/machinery/telecomms.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/telecomms.dm
@@ -7,7 +7,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/telecomms/receiver
-	name = T_BOARD("subspace receiver")
+	name = "circuit board (subspace receiver)"
 	build_path = /obj/machinery/telecomms/receiver
 	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 3, TECH_BLUESPACE = 2)
 	req_components = list(
@@ -17,7 +17,7 @@
 							/obj/item/stock_parts/micro_laser = 1)
 
 /obj/item/stock_parts/circuitboard/telecomms/hub
-	name = T_BOARD("hub mainframe")
+	name = "circuit board (hub mainframe)"
 	build_path = /obj/machinery/telecomms/hub
 	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4)
 	req_components = list(
@@ -25,7 +25,7 @@
 							/obj/item/stock_parts/subspace/filter = 2)
 
 /obj/item/stock_parts/circuitboard/telecomms/bus
-	name = T_BOARD("bus mainframe")
+	name = "circuit board (bus mainframe)"
 	build_path = /obj/machinery/telecomms/bus
 	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4)
 	req_components = list(
@@ -33,7 +33,7 @@
 							/obj/item/stock_parts/subspace/filter = 1)
 
 /obj/item/stock_parts/circuitboard/telecomms/processor
-	name = T_BOARD("processor unit")
+	name = "circuit board (processor unit)"
 	build_path = /obj/machinery/telecomms/processor
 	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4)
 	req_components = list(
@@ -44,7 +44,7 @@
 							/obj/item/stock_parts/subspace/amplifier = 1)
 
 /obj/item/stock_parts/circuitboard/telecomms/server
-	name = T_BOARD("telecommunication server")
+	name = "circuit board (telecommunication server)"
 	build_path = /obj/machinery/telecomms/server
 	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4)
 	req_components = list(
@@ -52,7 +52,7 @@
 							/obj/item/stock_parts/subspace/filter = 1)
 
 /obj/item/stock_parts/circuitboard/telecomms/broadcaster
-	name = T_BOARD("subspace broadcaster")
+	name = "circuit board (subspace broadcaster)"
 	build_path = /obj/machinery/telecomms/broadcaster
 	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4, TECH_BLUESPACE = 2)
 	req_components = list(
@@ -62,7 +62,7 @@
 							/obj/item/stock_parts/micro_laser/high = 2)
 
 /obj/item/stock_parts/circuitboard/telecomms/allinone
-	name = T_BOARD("telecommunication mainframe")
+	name = "circuit board (telecommunication mainframe)"
 	build_path = /obj/machinery/telecomms/allinone
 	origin_tech = list(TECH_DATA = 3, TECH_ENGINEERING = 3);
 	req_components = list(

--- a/code/game/objects/items/weapons/circuitboards/machinery/teleporter.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/teleporter.dm
@@ -1,5 +1,5 @@
 /obj/item/stock_parts/circuitboard/tele_beacon
-	name = T_BOARD("teleporter beacon")
+	name = "circuit board (teleporter beacon)"
 	build_path = /obj/machinery/tele_beacon
 	board_type = "machine"
 	origin_tech = list(

--- a/code/game/objects/items/weapons/circuitboards/machinery/unary_atmos.dm
+++ b/code/game/objects/items/weapons/circuitboards/machinery/unary_atmos.dm
@@ -15,7 +15,7 @@
 		U.node.build_network()
 
 /obj/item/stock_parts/circuitboard/unary_atmos/heater
-	name = T_BOARD("gas heating system")
+	name = "circuit board (gas heating system)"
 	build_path = /obj/machinery/atmospherics/unary/heater
 	origin_tech = list(TECH_POWER = 2, TECH_ENGINEERING = 1)
 	req_components = list(
@@ -24,7 +24,7 @@
 							/obj/item/stock_parts/capacitor = 2)
 
 /obj/item/stock_parts/circuitboard/unary_atmos/cooler
-	name = T_BOARD("gas cooling system")
+	name = "circuit board (gas cooling system)"
 	build_path = /obj/machinery/atmospherics/unary/freezer
 	origin_tech = list(TECH_MAGNET = 2, TECH_ENGINEERING = 2)
 	req_components = list(

--- a/code/game/objects/items/weapons/circuitboards/other.dm
+++ b/code/game/objects/items/weapons/circuitboards/other.dm
@@ -1,13 +1,13 @@
 //Stuff that doesn't fit into any category goes here
 
 /obj/item/stock_parts/circuitboard/aicore
-	name = T_BOARD("AI core")
+	name = "circuit board (AI core)"
 	origin_tech = list(TECH_DATA = 4, TECH_BIO = 2)
 	board_type = "other"
 
 
 /obj/item/stock_parts/circuitboard/drone_pad
-	name = T_BOARD("transport drone landing pad")
+	name = "circuit board (transport drone landing pad)"
 	build_path = /obj/machinery/drone_pad
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 2)

--- a/code/modules/mechs/components/software.dm
+++ b/code/modules/mechs/components/software.dm
@@ -1,5 +1,3 @@
-#define T_BOARD_MECH(name)	"exosuit software (" + (name) + ")"
-
 /obj/item/circuitboard/exosystem
 	name = "exosuit software template"
 	icon = 'icons/obj/module.dmi'
@@ -8,26 +6,24 @@
 	var/list/contains_software = list()
 
 /obj/item/circuitboard/exosystem/engineering
-	name = T_BOARD_MECH("engineering systems")
+	name = "exosuit software (engineering systems)"
 	contains_software = list(MECH_SOFTWARE_ENGINEERING)
 	origin_tech = list(TECH_DATA = 1)
 
 /obj/item/circuitboard/exosystem/utility
-	name = T_BOARD_MECH("utility systems")
+	name = "exosuit software (utility systems)"
 	contains_software = list(MECH_SOFTWARE_UTILITY)
 	icon_state = "mcontroller"
 	origin_tech = list(TECH_DATA = 1)
 
 /obj/item/circuitboard/exosystem/medical
-	name = T_BOARD_MECH("medical systems")
+	name = "exosuit software (medical systems)"
 	contains_software = list(MECH_SOFTWARE_MEDICAL)
 	icon_state = "mcontroller"
 	origin_tech = list(TECH_DATA = 3,TECH_BIO = 2)
 
 /obj/item/circuitboard/exosystem/weapons
-	name = T_BOARD_MECH("basic weapon systems")
+	name = "exosuit software (basic weapon systems)"
 	contains_software = list(MECH_SOFTWARE_WEAPONS)
 	icon_state = "mainboard"
 	origin_tech = list(TECH_DATA = 4, TECH_COMBAT = 3)
-
-#undef T_BOARD_MECH

--- a/code/modules/overmap/disperser/disperser_circuit.dm
+++ b/code/modules/overmap/disperser/disperser_circuit.dm
@@ -1,10 +1,10 @@
 /obj/item/stock_parts/circuitboard/disperser
-	name = T_BOARD("obstruction field disperser control")
+	name = "circuit board (obstruction field disperser control)"
 	build_path = /obj/machinery/computer/ship/disperser
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_COMBAT = 2, TECH_BLUESPACE = 2)
 
 /obj/item/stock_parts/circuitboard/disperserfront
-	name = T_BOARD("obstruction field disperser beam generator")
+	name = "circuit board (obstruction field disperser beam generator)"
 	build_path = /obj/machinery/disperser/front
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_COMBAT = 2, TECH_BLUESPACE = 2)
@@ -13,7 +13,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/dispersermiddle
-	name = T_BOARD("obstruction field disperser fusor")
+	name = "circuit board (obstruction field disperser fusor)"
 	build_path = /obj/machinery/disperser/middle
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_COMBAT = 2, TECH_BLUESPACE = 2)
@@ -22,7 +22,7 @@
 	)
 
 /obj/item/stock_parts/circuitboard/disperserback
-	name = T_BOARD("obstruction field disperser material deconstructor")
+	name = "circuit board (obstruction field disperser material deconstructor)"
 	build_path = /obj/machinery/disperser/back
 	board_type = "machine"
 	origin_tech = list(TECH_ENGINEERING = 2, TECH_COMBAT = 2, TECH_BLUESPACE = 2)

--- a/code/modules/overmap/ships/beacon.dm
+++ b/code/modules/overmap/ships/beacon.dm
@@ -19,7 +19,7 @@
 	var/const/activation_frequency = 1 MINUTE
 
 /obj/item/stock_parts/circuitboard/radio_beacon
-	name = T_BOARD("transmission beacon")
+	name = "circuit board (transmission beacon)"
 	board_type = "machine"
 	icon_state = "mcontroller"
 	build_path = /obj/machinery/radio_beacon

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -243,7 +243,7 @@
 	heat_reduction = round(total_component_rating_of_type(/obj/item/stock_parts/manipulator) / 3)
 
 /obj/item/stock_parts/circuitboard/shipsensors
-	name = T_BOARD("broad-band sensor suite")
+	name = "circuit board (broad-band sensor suite)"
 	board_type = "machine"
 	icon_state = "mcontroller"
 	build_path = /obj/machinery/shipsensors

--- a/code/modules/overmap/ships/engines/gas_thruster.dm
+++ b/code/modules/overmap/ships/engines/gas_thruster.dm
@@ -212,7 +212,7 @@
 		qdel(src)
 
 /obj/item/stock_parts/circuitboard/unary_atmos/engine//why don't we move this elsewhere?
-	name = T_BOARD("gas thruster")
+	name = "circuit board (gas thruster)"
 	icon_state = "mcontroller"
 	build_path = /obj/machinery/atmospherics/unary/engine
 	origin_tech = list(TECH_POWER = 1, TECH_ENGINEERING = 2)

--- a/code/modules/overmap/ships/engines/ion_thruster.dm
+++ b/code/modules/overmap/ships/engines/ion_thruster.dm
@@ -75,7 +75,7 @@
 	return thrust_limit * generated_thrust * on
 
 /obj/item/stock_parts/circuitboard/engine/ion
-	name = T_BOARD("ion propulsion device")
+	name = "circuit board (ion propulsion device)"
 	board_type = "machine"
 	icon_state = "mcontroller"
 	build_path = /obj/machinery/ion_engine

--- a/code/modules/power/fusion/fusion_circuits.dm
+++ b/code/modules/power/fusion/fusion_circuits.dm
@@ -1,10 +1,10 @@
 /obj/item/stock_parts/circuitboard/fusion/core_control
-	name = T_BOARD("fusion core controller")
+	name = "circuit board (fusion core controller)"
 	build_path = /obj/machinery/computer/fusion/core_control
 	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4)
 
 /obj/item/stock_parts/circuitboard/kinetic_harvester
-	name = T_BOARD("kinetic harvester")
+	name = "circuit board (kinetic harvester)"
 	build_path = /obj/machinery/kinetic_harvester
 	board_type = "machine"
 	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4, TECH_MATERIAL = 4)
@@ -16,7 +16,7 @@
 		)
 
 /obj/item/stock_parts/circuitboard/fusion_fuel_compressor
-	name = T_BOARD("fusion fuel compressor")
+	name = "circuit board (fusion fuel compressor)"
 	build_path = /obj/machinery/fusion_fuel_compressor
 	board_type = "machine"
 	origin_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 4, TECH_MATERIAL = 4)
@@ -28,17 +28,17 @@
 							)
 
 /obj/item/stock_parts/circuitboard/fusion_fuel_control
-	name = T_BOARD("fusion fuel controller")
+	name = "circuit board (fusion fuel controller)"
 	build_path = /obj/machinery/computer/fusion/fuel_control
 	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4)
 
 /obj/item/stock_parts/circuitboard/gyrotron_control
-	name = T_BOARD("gyrotron controller")
+	name = "circuit board (gyrotron controller)"
 	build_path = /obj/machinery/computer/fusion/gyrotron
 	origin_tech = list(TECH_DATA = 4, TECH_ENGINEERING = 4)
 
 /obj/item/stock_parts/circuitboard/fusion_core
-	name = T_BOARD("fusion core")
+	name = "circuit board (fusion core)"
 	build_path = /obj/machinery/power/fusion_core
 	board_type = "machine"
 	origin_tech = list(TECH_BLUESPACE = 2, TECH_MAGNET = 4, TECH_POWER = 4)
@@ -51,7 +51,7 @@
 							)
 
 /obj/item/stock_parts/circuitboard/fusion_injector
-	name = T_BOARD("fusion fuel injector")
+	name = "circuit board (fusion fuel injector)"
 	build_path = /obj/machinery/fusion_fuel_injector
 	board_type = "machine"
 	origin_tech = list(TECH_POWER = 3, TECH_ENGINEERING = 4, TECH_MATERIAL = 4)
@@ -64,7 +64,7 @@
 							)
 
 /obj/item/stock_parts/circuitboard/gyrotron
-	name = T_BOARD("gyrotron")
+	name = "circuit board (gyrotron)"
 	build_path = /obj/machinery/power/emitter/gyrotron
 	board_type = "machine"
 	origin_tech = list(TECH_POWER = 4, TECH_ENGINEERING = 4)


### PR DESCRIPTION
These serve no real purpose and enforcing usage of them is pointless and pedantic.

## Changelog
NUFC

## Other Changes
- Removes `T_BOARD()` and `T_BOARD_MECH()` defines.