### PR TITLE
MMIs inside FBPs are no longer immortal

### DIFF
--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -134,6 +134,8 @@
 		return
 	if(damage < 0.1*max_damage)
 		heal_damage(0.1)
+		if(stored_mmi.brainobj)
+			stored_mmi.brainobj.heal_damage(0.1)
 
 /obj/item/organ/internal/mmi_holder/proc/update_from_mmi()
 
@@ -183,3 +185,13 @@
 			if(response == "Yes")
 				persistantMind.transfer_to(stored_mmi.brainmob)
 	qdel(src)
+
+/obj/item/organ/internal/mmi_holder/take_internal_damage(amount, silent=FALSE)
+	..()
+	if(stored_mmi.brainobj)
+		stored_mmi.brainobj.take_internal_damage(amount)
+
+/obj/item/organ/internal/mmi_holder/die()
+	..()
+	if(stored_mmi.brainobj)
+		stored_mmi.brainobj.die()


### PR DESCRIPTION
MMIs inside FBPs didn't actually transfer damage from the mmi organ to the brain or the MMI itself, meaning that no matter how damaged an MMI is inside an FBP it can be extracted in perfect condition. This meant that an FBP'd player was effectively unkillable, provided new bodies could be made for them. Now, whenever an MMI organ takes damage, heals minor amounts of damage, or dies, the brain inside does the same.

🆑 Jux
bugfix: MMI organs now transfer damage to the brain they contain.
bugfix: MMI organs now kill the brain they contain if they themselves die.
/🆑 