### PR TITLE
Changes zipgun trigger to be a lightswitch

### DIFF
--- a/code/modules/crafting/crafting_weapons_ranged.dm
+++ b/code/modules/crafting/crafting_weapons_ranged.dm
@@ -73,7 +73,7 @@
 	next_stages = list(/singleton/crafting_stage/zipgun_trigger)
 
 /singleton/crafting_stage/zipgun_trigger
-	completion_trigger_type = /obj/item/device/assembly/mousetrap
+	completion_trigger_type = /obj/item/frame/light_switch
 	item_desc = "A half-built zipgun with a trigger and firing pin assembly loosely fitted into place."
 	item_icon_state = "zipgun3"
 	progress_message = "You take the mousetrap apart and construct a crude trigger for the zipgun."


### PR DESCRIPTION
🆑 Jux
tweak: Zipguns now use a light switch for a trigger, like crossbows.
/🆑 

Not every offship that might want to make zipguns has access to mousetraps. Since light switches can be made with just steel, they're a better trigger option that still requires some effort. 