### PR TITLE
Fixes the Protolathe material cost display

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -787,7 +787,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 				var/temp_dat
 				for(var/M in D.materials)
-					temp_dat += ", [D.materials[M]] [CallMaterialName(M)]"
+					temp_dat += ", [D.materials[M]*(linked_lathe ? linked_lathe.mat_efficiency : 1)] [CallMaterialName(M)]"
 				for(var/T in D.chemicals)
 					temp_dat += ", [D.chemicals[T]*(linked_imprinter ? linked_imprinter.mat_efficiency : 1)] [CallReagentName(T)]"
 				if(temp_dat)


### PR DESCRIPTION
Makes the protolathe display the correct material cost when upgraded.

![image](https://user-images.githubusercontent.com/8376059/233834386-03416772-a923-4f97-acca-e6d805865f32.png)
![image](https://user-images.githubusercontent.com/8376059/233834491-1ab21c18-b339-4dde-a836-01dbce5c07e3.png)

:cl: Fenodyree
bugfix: Protolathe now displays correct material costs after upgrades.
/:cl: