### PR TITLE
Bug Fixes 2023-04-23

### DIFF
--- a/code/controllers/subsystems/initialization/misc_late.dm
+++ b/code/controllers/subsystems/initialization/misc_late.dm
@@ -137,5 +137,8 @@ GLOBAL_LIST(xeno_digsite_turfs)
 		var/selected = rand(1, len)
 		var/turf/simulated/mineral/T = artifact_turfs[selected]
 		artifact_turfs.Cut(selected, selected + 1)
+		// Failsafe for invalid turf types
+		if (!istype(T))
+			continue
 		GLOB.xeno_artifact_turfs += T
 		T.artifact_find = new

--- a/code/datums/trading/trade.dm
+++ b/code/datums/trading/trade.dm
@@ -64,16 +64,35 @@
 
 /datum/trader/proc/generate_pool(list/trading_pool)
 	. = list()
+	// Add types
 	for(var/type in trading_pool)
 		var/status = trading_pool[type]
 		if(status & TRADER_THIS_TYPE)
 			. += type
 		if(status & TRADER_SUBTYPES_ONLY)
 			. += subtypesof(type)
-		if(status & TRADER_BLACKLIST)
+
+	// Remove blacklisted
+	for (var/type in .)
+		var/status = trading_pool[type]
+		if (HAS_FLAGS(status, TRADER_BLACKLIST) || !validate_type_for_trade(type))
 			. -= type
-		if(status & TRADER_BLACKLIST_SUB)
+		if (HAS_FLAGS(status, TRADER_BLACKLIST_SUB))
 			. -= subtypesof(type)
+
+
+/**
+ * Validates a given type can be used for trading. Intended to prevent certain items from being attainable via merchants.
+ *
+ * Returns boolean.
+ */
+/datum/trader/proc/validate_type_for_trade(type)
+	if (isatom(type))
+		var/atom/atom = type
+		// Block abstracts
+		if (type == initial(atom.abstract_type))
+			return FALSE
+	return TRUE
 
 
 //If this hits 0 then they decide to up and leave.

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -44,6 +44,7 @@
 	if(!can_become_antag(player, ignore_role))
 		return 0
 	current_antagonists |= player
+	GLOB.destroyed_event.register(player, src, .proc/remove_antagonist)
 
 	if(faction_verb)
 		player.current.verbs |= faction_verb
@@ -71,7 +72,9 @@
 	return 1
 
 /datum/antagonist/proc/remove_antagonist(datum/mind/player, show_message, implanted)
+	GLOB.destroyed_event.unregister(player, src, .proc/remove_antagonist)
 	if(!istype(player))
+		current_antagonists -= player
 		return 0
 	if (player.current)
 		if (faction_verb)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -312,21 +312,6 @@
 
 // This function can not be undone; do not call this unless you are sure
 // Also make sure there is a valid control computer
-/obj/machinery/cryopod/robot/despawn_occupant()
-	var/mob/living/silicon/robot/R = occupant
-	if(!istype(R)) return ..()
-
-	qdel(R.mmi)
-	for(var/obj/item/I in R.module) // the tools the borg has; metal, glass, guns etc
-		for(var/obj/item/O in I) // the things inside the tools, if anything; mainly for janiborg trash bags
-			O.forceMove(R)
-		qdel(I)
-	qdel(R.module)
-
-	. = ..()
-
-// This function can not be undone; do not call this unless you are sure
-// Also make sure there is a valid control computer
 /obj/machinery/cryopod/proc/despawn_occupant()
 	SHOULD_NOT_SLEEP(TRUE) // Sleeping causes the double-despawn bug
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -319,10 +319,11 @@ var/global/const/NO_EMAG_ACT = -50
 		id_card.military_branch = char_branch
 	if(GLOB.using_map.flags & MAP_HAS_RANK)
 		id_card.military_rank = char_rank
-		var/singleton/rank_category/category = char_rank.rank_category()
-		if(category)
-			for(var/add_access in category.add_accesses)
-				id_card.access.Add(add_access)
+		if (char_rank)
+			var/singleton/rank_category/category = char_rank.rank_category()
+			if(category)
+				for(var/add_access in category.add_accesses)
+					id_card.access.Add(add_access)
 
 /obj/item/card/id/proc/dat()
 	var/list/dat = list("<table><tr><td>")

--- a/code/game/objects/structures/drain.dm
+++ b/code/game/objects/structures/drain.dm
@@ -64,6 +64,9 @@
 
 /obj/item/drain/attackby(obj/item/thing, mob/user)
 	if(isWrench(thing))
+		if (!isturf(loc))
+			USE_FEEDBACK_FAILURE("\The [src] needs to be placed on the floor before you can secure it.")
+			return TRUE
 		new constructed_type(src.loc)
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 		to_chat(user, SPAN_WARNING("[user] wrenches the [src] down."))

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -348,12 +348,14 @@
 	base_icon = "wooden_chair"
 	icon_state = "wooden_chair_preview"
 	color = WOOD_COLOR_GENERIC
+	/// String (One of `MATERIAL_*`). Base material for the chair. Only used if `New()` is not passed a material.
 	var/chair_material = MATERIAL_WOOD
 	buckle_movable = FALSE
 	bed_flags = BED_FLAG_CANNOT_BE_PADDED
 
-/obj/structure/bed/chair/wood/New(newloc)
-	..(newloc, chair_material)
+/obj/structure/bed/chair/wood/New(newloc, _material)
+	..(newloc, _material? _material : chair_material)
+	set_color(material.icon_colour)
 
 /obj/structure/bed/chair/wood/mahogany
 	color = WOOD_COLOR_RICH
@@ -398,6 +400,7 @@
 	icon_state = "pew"
 	base_icon = "pew"
 	color = WOOD_COLOR_GENERIC
+	/// String (One of `MATERIAL_*`). Base material for the chair. Only used if `New()` is not passed a material.
 	var/material/pew_material = MATERIAL_WOOD
 	obj_flags = 0
 	buckle_movable = FALSE
@@ -406,8 +409,9 @@
 	icon_state = "pew_left"
 	base_icon = "pew_left"
 
-/obj/structure/bed/chair/pew/New(newloc)
-	..(newloc, pew_material)
+/obj/structure/bed/chair/pew/New(newloc, _material)
+	..(newloc, _material? _material : pew_material)
+	set_color(material.icon_colour)
 
 /obj/structure/bed/chair/pew/mahogany
 	color = WOOD_COLOR_RICH

--- a/code/modules/admin/view_variables/view_variables.dm
+++ b/code/modules/admin/view_variables/view_variables.dm
@@ -185,7 +185,7 @@ var/global/list/view_variables_no_assoc = list("verbs", "contents","screen","ima
 			extra += "<ul>"
 			for (var/index = 1 to length(L))
 				var/entry = L[index]
-				if(!isnum(entry) && !isnull(entry) && !(varname in view_variables_no_assoc) && L[entry] != null)
+				if(!isnum(entry) && !isnull(entry) && !(varname in view_variables_no_assoc))
 					extra += "<li>[index]: [make_view_variables_value(entry)] -> [make_view_variables_value(L[entry])]</li>"
 				else
 					extra += "<li>[index]: [make_view_variables_value(entry)]</li>"

--- a/code/modules/games/boardgame.dm
+++ b/code/modules/games/boardgame.dm
@@ -9,18 +9,11 @@
 	var/board = list()
 	var/selected = -1
 
-/obj/item/board/ShiftClick(mob/user)
-	if(CanPhysicallyInteract(user))
-		user.set_machine(src)
+/obj/item/board/AltClick(mob/user)
+	if (CanPhysicallyInteract(user))
 		interact(user)
-	else
-		..()
-
-/obj/item/board/attack_hand(mob/living/carbon/human/M as mob)
-	if(M.machine == src)
-		return ..()
-	else
-		M.examinate(src)
+		return TRUE
+	return ..()
 
 /obj/item/board/attackby(obj/item/I as obj, mob/user as mob)
 	if(!addPiece(I,user))

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -80,7 +80,7 @@
 	if (QDELETED(src) || !assailant)
 		return TRUE
 	if (A.use_grab(src, user, click_params))
-		assailant.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		action_used()
 		if (current_grab.downgrade_on_action)
 			downgrade()

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -43,8 +43,7 @@ var/global/list/default_material_composition = list(MATERIAL_STEEL = 0, MATERIAL
 	for(var/material_needed in design.materials)
 		if(materials[material_needed] < design.materials[material_needed])
 			ret += "[design.materials[material_needed] - materials[material_needed]] [material_needed]"
-	for(var/chemical_needed in design.chemicals)
+	for(var/datum/reagent/chemical_needed as anything in design.chemicals)
 		if(!reagents.has_reagent(chemical_needed, design.chemicals[chemical_needed]))
-			var/datum/reagent/reagent_needed = reagents.get_reagent(chemical_needed)
-			ret += "[design.chemicals[chemical_needed] - reagents.get_reagent_amount(chemical_needed)]u [reagent_needed.name]"
+			ret += "[design.chemicals[chemical_needed] - reagents.get_reagent_amount(chemical_needed)]u [initial(chemical_needed.name)]"
 	return english_list(ret)

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -38,13 +38,13 @@ var/global/list/default_material_composition = list(MATERIAL_STEEL = 0, MATERIAL
 	for(var/f in materials)
 		. += materials[f]
 
-/obj/machinery/r_n_d/proc/getLackingMaterials(datum/design/D)
+/obj/machinery/r_n_d/proc/getLackingMaterials(datum/design/design)
 	var/list/ret = list()
-	for(var/M in D.materials)
-		if(materials[M] < D.materials[M])
-			ret += "[D.materials[M] - materials[M]] [M]"
-	for(var/C in D.chemicals)
-		if(!reagents.has_reagent(C, D.chemicals[C]))
-			var/datum/reagent/R = reagents.get_reagent(C)
-			ret += "[D.chemicals[C] - reagents.get_reagent_amount(C)]u [R.name]"
+	for(var/material_needed in design.materials)
+		if(materials[material_needed] < design.materials[material_needed])
+			ret += "[design.materials[material_needed] - materials[material_needed]] [material_needed]"
+	for(var/chemical_needed in design.chemicals)
+		if(!reagents.has_reagent(chemical_needed, design.chemicals[chemical_needed]))
+			var/datum/reagent/reagent_needed = reagents.get_reagent(chemical_needed)
+			ret += "[design.chemicals[chemical_needed] - reagents.get_reagent_amount(chemical_needed)]u [reagent_needed.name]"
 	return english_list(ret)


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Gutters can no longer be assembled inside of mobs, storage containers, or anywhere else that isn't a turf.
bugfix: Classic chairs, fancy chairs, and pews now use the correct material when crafted.
bugfix: Using cables on crates now properly creates a wire-rigged crate, instead of silently failing.
bugfix: Circuit printers and autolathes that run out of resources while printing will now properly display their 'Out of X' message if the resource amount is `0` or was never added.
tweak: Board game UI is now opened by ALT+CLICKing the board. The board can now be picked up and handled like any other item with a normal left click, and shift+click examines the board.
/:cl:

## Bug Fixes
- Fixes #33332
- Fixes #33322
- Fixes #33336
- Fixes #33331
- Fixes #33330
- Fixes #33323
- Fixes #33327
- Fixes #33324
- Fixes #33037
- Fixes #33034
- Fixes #33000

## Other Changes
- Traders no longer allow abstract types in their pools.
- Trader pools now remove blacklisted entries after adding all whitelisted entries. This ensures any blacklists provided out of order are still properly handled.
- Robotic storage units no longer double-delete robot brains and modules.
- `proc/getLackingMaterials()` now uses long form var names for readability.