### PR TITLE
Bug Fixes 2023-04-24

### DIFF
--- a/code/game/objects/structures/railing.dm
+++ b/code/game/objects/structures/railing.dm
@@ -261,6 +261,7 @@
 		if (anchored)
 			playsound(src, 'sound/items/Ratchet.ogg', 50, TRUE)
 			set_density(!density)
+			update_icon()
 			user.visible_message(
 				SPAN_NOTICE("\The [user] [density ? "closes" : "opens"] \the [src] with \a [tool]."),
 				SPAN_NOTICE("You [density ? "close" : "open"] \the [src] with \the [tool].")

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -381,8 +381,8 @@
 				set_anchored(!anchored)
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
 				user.visible_message(
-					SPAN_NOTICE("\The [user] fastens \the [src]'s frame to the floor with \a [tool]."),
-					SPAN_NOTICE("You fasten \the [src]'s frame to the floor with \the [tool].")
+					SPAN_NOTICE("\The [user] [!anchored ? "un" : null]fastens \the [src] [!anchored ? "from" : "to"] the floor with \a [tool]."),
+					SPAN_NOTICE("You [!anchored ? "un" : null]fasten \the [src] [!anchored ? "from" : "to"] the floor with \the [tool].")
 				)
 				return TRUE
 			construction_state = 3 - construction_state
@@ -399,8 +399,8 @@
 		set_anchored(!anchored)
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
 		user.visible_message(
-			SPAN_NOTICE("\The [user] fastens \the [src] to the floor with \a [tool]."),
-			SPAN_NOTICE("You fasten \the [src] to the floor with \the [tool].")
+			SPAN_NOTICE("\The [user] [!anchored ? "un" : null]fastens \the [src] [!anchored ? "from" : "to"] the floor with \a [tool]."),
+			SPAN_NOTICE("You [!anchored ? "un" : null]fasten \the [src] [!anchored ? "from" : "to"] the floor with \the [tool].")
 		)
 		return TRUE
 

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -181,7 +181,7 @@
 	wielded_item_state = "semistrip-wielded"
 
 /obj/item/gun/projectile/sniper/semistrip/on_update_icon()
-	if(length(ammo_magazine.stored_ammo))
+	if(ammo_magazine && length(ammo_magazine.stored_ammo))
 		icon_state = initial(icon_state)
 		wielded_item_state = initial(wielded_item_state)
 	else


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Railings now update their icons when wrenched open and closed.
bugfix: Windows now correctly show 'unfastens' when using a screwdriver on them to detach them from the floor.
bugfix: M1 Garand sprites now properly update when they lack a magazine.
/:cl:

## Bug Fixes
- Fixes #33346