### PR TITLE
removes union membership from uniformed services loadout options

### DIFF
--- a/maps/torch/loadout/loadout_misc.dm
+++ b/maps/torch/loadout/loadout_misc.dm
@@ -37,3 +37,7 @@
 	/datum/mil_branch/civilian,
 	/datum/mil_branch/iccgn
 )
+
+/datum/gear/union_card/allowed_branches = list(
+	/datum/mil_branch/civilian
+)


### PR DESCRIPTION
At the end of a long, self-imposed pull request hiatus, I can stand atop my hill and scream to the world...

We're So Back.

But what am I back doing? Well, Joey (bless his soul) informed me that uniformed branches could take union membership. Now, not only is this treason, but it's also heresy, and if there's two things I don't stand for, it's treason and heresy. I've, as such, gone ahead and removed their right to union membership, which they never really had in the first place. I've never seen anyone actually try to pick union membership in the services, but it is my civil duty to stop somebody from doing so in the future.