### PR TITLE
Bug Fixes 2023-04-25

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -152,6 +152,13 @@
 
 	var/datum/progressbar/bar
 	if (do_flags & DO_SHOW_PROGRESS)
+		// Autoset over-user if not in an otherwise visible location
+		// For public progress: This is if it's not on a turf.
+		// For private progress: This is if it's not on a turf or directly in the user's visible inventory HUD.
+		if (!HAS_FLAGS(do_flags, DO_BAR_OVER_USER) && !isturf(target.loc))
+			if (HAS_FLAGS(do_flags, DO_PUBLIC_PROGRESS) || target.loc != user)
+				SET_FLAGS(do_flags, DO_BAR_OVER_USER)
+
 		if (do_flags & DO_PUBLIC_PROGRESS)
 			bar = new /datum/progressbar/public(user, delay, target, !!(do_flags & DO_BAR_OVER_USER))
 		else

--- a/code/game/objects/items/weapons/material/bell.dm
+++ b/code/game/objects/items/weapons/material/bell.dm
@@ -32,11 +32,6 @@
 	flick("bell_dingeth", src)
 
 
-/obj/item/material/bell/apply_hit_effect()
-	. = ..()
-	shatter()
-
-
 /obj/item/material/bell/glass
 	default_material = MATERIAL_GLASS
 	normal_sound = 'sound/items/tinkly_bell.ogg'

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1711,7 +1711,7 @@
 	bitesize = 2
 
 /obj/item/reagent_containers/food/snacks/boiledrice/use_tool(obj/item/reagent_containers/food/snacks/W as obj, mob/user as mob)
-	if(W.sushi_overlay)
+	if(istype(W) && W.sushi_overlay)
 		new /obj/item/reagent_containers/food/snacks/sushi(get_turf(src), src, W)
 		return TRUE
 	return ..()


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Do after timer bars should now automatically appear over the user if the target item isn't on a turf, to help ensure visibility as applicable.
/:cl:

## Bug Fixes
- Fixes #33347
- Fixes #33350

## Other Changes
- Removes a redundant call to `shatter()` in `apply_hit_effect()` for bells.
- `do_after_detailed()` now automatically adds `DO_BAR_OVER_USER` if `loc` is not a turf. For private bars, this is also only set if `loc` is not `user`.