### PR TITLE
Bug Fixes 2023-04-26

### DIFF
--- a/code/modules/mob/living/carbon/human/human_maneuvers.dm
+++ b/code/modules/mob/living/carbon/human/human_maneuvers.dm
@@ -36,10 +36,13 @@
 	..()
 
 	var/broken_limb_fail_chance = 0
+	var/missing_limb_fail_chance = 0
 	var/list/broken_limbs = list()
 	for (var/_limb in BP_LEGS_FEET)
 		var/obj/item/organ/external/limb = get_organ(_limb)
-		if (limb.status & ORGAN_BROKEN)
+		if (!limb)
+			missing_limb_fail_chance += 33
+		else if (limb.status & ORGAN_BROKEN)
 			broken_limbs += limb
 			broken_limb_fail_chance += limb.splinted ? 25 : 50
 	if (broken_limb_fail_chance)
@@ -56,3 +59,12 @@
 			to_chat(src, SPAN_DANGER("You feel a sharp pain through your [limb.name] as you land!"))
 			apply_effect(1, EFFECT_STUN)
 			limb.add_pain(15)
+	if (missing_limb_fail_chance)
+		if (prob(missing_limb_fail_chance))
+			visible_message(
+				SPAN_WARNING("\The [src] lands unsteadily and topples over!"),
+				SPAN_DANGER("You land unsteadily, unused to jumping with your missing limb, and topple over!")
+			)
+			// Math should result in 1 missing limb = 2 seconds, 2 missing limbs = 4 seconds, etc.
+			// Note that a foot and a leg is a separate limb, and missing a leg also means you're missing a foot.
+			apply_effect(round(missing_limb_fail_chance / 16.5), EFFECT_WEAKEN)

--- a/code/modules/mob/observer/freelook/ai/update_triggers.dm
+++ b/code/modules/mob/observer/freelook/ai/update_triggers.dm
@@ -8,6 +8,10 @@
 	if(!can_use())
 		set_light(0)
 	cameranet.update_visibility(src)
+	for (var/mob/mob as anything in SSmobs.mob_list)
+		if (!mob.client || mob.client.eye != src)
+			continue
+		mob.reset_view()
 
 /obj/machinery/camera/Initialize()
 	. = ..()

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -864,6 +864,13 @@ Note that amputating the affected organ does in fact remove the infection from t
 	if(!clean)
 		victim.shock_stage += min_broken_damage
 
+	// Handle any internal organ removal before removing the limb itself
+	if (disintegrate == DROPLIMB_BLUNT || disintegrate == DROPLIMB_BURN)
+		for(var/obj/item/organ/I in internal_organs)
+			I.removed()
+			if(!QDELETED(I) && isturf(I.loc))
+				I.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)
+
 	removed(null, ignore_children)
 	if(QDELETED(src))
 		return
@@ -919,11 +926,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 					G.update_icon()
 
 			gore.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)
-
-			for(var/obj/item/organ/I in internal_organs)
-				I.removed()
-				if(!QDELETED(I) && isturf(loc))
-					I.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)
 
 			for(var/obj/item/I in src)
 				I.dropInto(loc)

--- a/maps/away/bearcat/bearcat-1.dmm
+++ b/maps/away/bearcat/bearcat-1.dmm
@@ -17,9 +17,7 @@
 	opacity = 0
 	},
 /obj/effect/paint/brown,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "ad" = (
 /obj/machinery/door/airlock/external/bolted/cycling{
@@ -33,9 +31,7 @@
 	name = "External Blast Doors";
 	opacity = 0
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "ae" = (
 /obj/machinery/door/airlock/external/bolted/cycling{
@@ -54,17 +50,13 @@
 	name = "External Blast Doors";
 	opacity = 0
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "ag" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "ah" = (
 /obj/effect/paint/brown,
@@ -88,9 +80,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "ak" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
@@ -108,16 +98,12 @@
 	id_tag = "cargo_sensor";
 	pixel_x = 25
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "al" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/brown,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "am" = (
 /obj/machinery/door/blast/regular{
@@ -130,9 +116,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/brown,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "an" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -183,15 +167,11 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "au" = (
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "av" = (
 /obj/structure/ladder/up,
@@ -267,9 +247,7 @@
 	id_tag = "cargo_in"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "aE" = (
 /obj/machinery/door/airlock/external/bolted/cycling{
@@ -281,9 +259,7 @@
 	pixel_y = -12
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "aF" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -359,9 +335,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/escape_port)
 "aN" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -410,9 +384,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/escape_star)
 "aT" = (
 /turf/simulated/wall,
@@ -423,9 +395,7 @@
 /area/ship/scrap/crew/dorms1)
 "aV" = (
 /obj/item/device/flashlight/lamp,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/gambling)
 "aW" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -435,9 +405,7 @@
 	icon_state = "bulb1"
 	},
 /obj/item/hand/missing_card,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/gambling)
 "aX" = (
 /obj/structure/cable/green{
@@ -450,9 +418,7 @@
 /obj/machinery/power/apc/derelict{
 	dir = 1
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/gambling)
 "aY" = (
 /obj/machinery/light/small{
@@ -464,9 +430,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "aZ" = (
 /obj/effect/floor_decal/corner/beige{
@@ -529,9 +493,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "bf" = (
 /obj/machinery/power/apc/derelict{
@@ -587,16 +549,12 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/brown,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/gambling)
 "bj" = (
 /obj/structure/holostool,
 /obj/item/hand/missing_card,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/gambling)
 "bk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -608,9 +566,7 @@
 /obj/structure/table/gamblingtable,
 /obj/item/deck/cards,
 /obj/item/dice,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/gambling)
 "bl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -626,9 +582,7 @@
 	},
 /obj/structure/holostool,
 /obj/item/hand/missing_card,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/gambling)
 "bm" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -643,9 +597,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/gambling)
 "bn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -664,15 +616,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "bo" = (
 /obj/machinery/door/airlock/autoname/bearcat,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "bp" = (
 /obj/effect/floor_decal/corner/beige{
@@ -759,9 +707,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "bw" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -817,14 +763,10 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/brown,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/crew/dorms1)
 "bB" = (
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/gambling)
 "bC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -833,9 +775,7 @@
 	},
 /obj/structure/holostool,
 /obj/item/hand/missing_card,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/gambling)
 "bD" = (
 /obj/machinery/alarm{
@@ -845,9 +785,7 @@
 	},
 /obj/item/hand/missing_card,
 /obj/item/hand/missing_card,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/gambling)
 "bE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -857,9 +795,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "bF" = (
 /obj/effect/decal/cleanable/dirt,
@@ -1014,24 +950,18 @@
 	icon_state = "16-0"
 	},
 /obj/structure/cable/green,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "bW" = (
 /obj/machinery/floodlight,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/broken2)
 "bX" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/machinery/light_construct/small{
 	dir = 1
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/broken2)
 "bY" = (
 /obj/structure/cable/green{
@@ -1044,9 +974,7 @@
 /obj/machinery/power/apc/derelict{
 	dir = 1
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/broken2)
 "bZ" = (
 /obj/effect/paint/brown,
@@ -1065,9 +993,7 @@
 	},
 /obj/effect/decal/cleanable/cobweb,
 /obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "cb" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1131,9 +1057,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "ci" = (
 /obj/structure/cable/green{
@@ -1192,15 +1116,11 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/brown,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/broken2)
 "cn" = (
 /obj/structure/inflatable/wall,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/broken2)
 "co" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1210,9 +1130,7 @@
 	dir = 5
 	},
 /obj/item/cell/high/empty,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/broken2)
 "cp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1226,9 +1144,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/broken2)
 "cq" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -1244,9 +1160,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/broken2)
 "cr" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -1265,9 +1179,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "cs" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1311,9 +1223,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "cy" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -1370,9 +1280,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/brown,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/crew/dorms2)
 "cD" = (
 /turf/simulated/floor{
@@ -1385,9 +1293,7 @@
 	level = 2
 	},
 /obj/structure/inflatable/wall,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/broken2)
 "cF" = (
 /obj/machinery/alarm{
@@ -1396,9 +1302,7 @@
 	req_access = newlist()
 	},
 /obj/item/stack/cable_coil/green,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/broken2)
 "cG" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1461,9 +1365,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/autoname/bearcat,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "cP" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -1546,9 +1448,7 @@
 /obj/item/device/radio/intercom/map_preset/bearcat{
 	pixel_y = 22
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/broken1)
 "cZ" = (
 /obj/machinery/light/small{
@@ -1561,9 +1461,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "da" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -1636,9 +1534,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "dg" = (
 /turf/simulated/wall,
@@ -1697,9 +1593,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/brown,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/broken1)
 "dl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1714,9 +1608,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/broken1)
 "dm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1730,9 +1622,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/broken1)
 "dn" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -1748,9 +1638,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/broken1)
 "do" = (
 /obj/effect/floor_decal/corner/beige{
@@ -1837,9 +1725,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/brown,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/crew/dorms3)
 "dx" = (
 /obj/structure/mopbucket,
@@ -1891,9 +1777,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/autoname/bearcat,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "dC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1903,9 +1787,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "dD" = (
 /obj/effect/paint/brown,
@@ -1944,9 +1826,7 @@
 /area/ship/scrap/crew/dorms3)
 "dH" = (
 /obj/machinery/floodlight,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/broken1)
 "dI" = (
 /obj/item/stool/padded,
@@ -1980,9 +1860,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "dL" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -1997,9 +1875,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "dM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2013,9 +1889,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "dN" = (
 /obj/structure/cable/green{
@@ -2034,9 +1908,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "dO" = (
 /obj/machinery/light/small{
@@ -2054,9 +1926,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "dP" = (
 /obj/structure/cable/green{
@@ -2080,9 +1950,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "dQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2096,9 +1964,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "dR" = (
 /obj/structure/cable/green{
@@ -2113,9 +1979,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "dS" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -2130,9 +1994,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "dT" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2149,9 +2011,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "dU" = (
 /obj/effect/paint/brown,
@@ -2170,9 +2030,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/airlock/autoname/bearcat,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/storage)
 "dZ" = (
 /obj/effect/paint/brown,
@@ -2261,9 +2119,7 @@
 	dir = 1;
 	icon_state = "bulb1"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/storage)
 "eh" = (
 /obj/structure/ladder/up,
@@ -2271,9 +2127,7 @@
 /obj/structure/sign/deck/second{
 	pixel_y = 32
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/storage)
 "ei" = (
 /obj/structure/cable/green{
@@ -2288,15 +2142,11 @@
 	pixel_x = 22
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/storage)
 "ej" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/eva)
 "ek" = (
 /obj/effect/decal/cleanable/dirt,
@@ -2312,9 +2162,7 @@
 	},
 /obj/item/device/suit_cooling_unit,
 /obj/item/device/suit_cooling_unit,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/eva)
 "el" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -2338,9 +2186,7 @@
 	opacity = 0
 	},
 /obj/effect/paint/brown,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/eva)
 "en" = (
 /obj/machinery/light/small{
@@ -2375,9 +2221,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/techstorage)
 "eq" = (
 /obj/machinery/door/airlock/autoname/bearcat,
@@ -2392,9 +2236,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/techstorage)
 "er" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -2515,9 +2357,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/eva)
 "ez" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -2552,9 +2392,7 @@
 	name = "External Blast Doors";
 	opacity = 0
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/eva)
 "eB" = (
 /obj/machinery/light/small{
@@ -2582,9 +2420,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/eva)
 "eC" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/airlock{
@@ -2595,9 +2431,7 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/eva)
 "eD" = (
 /obj/machinery/door/airlock/external/bolted/cycling{
@@ -2617,9 +2451,7 @@
 	name = "External Blast Doors";
 	opacity = 0
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/eva)
 "eE" = (
 /obj/item/stock_parts/capacitor,
@@ -2653,9 +2485,7 @@
 	dir = 1;
 	level = 2
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/techstorage)
 "eG" = (
 /obj/structure/table/rack,
@@ -2665,9 +2495,7 @@
 /obj/item/stock_parts/circuitboard/unary_atmos/engine,
 /obj/item/stock_parts/circuitboard/unary_atmos/engine,
 /obj/item/stock_parts/circuitboard/unary_atmos/engine,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/techstorage)
 "eH" = (
 /obj/item/storage/toolbox/mechanical{
@@ -2701,9 +2529,7 @@
 /area/ship/scrap/maintenance/storage)
 "eL" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/storage)
 "eM" = (
 /obj/item/device/radio/intercom/map_preset/bearcat{
@@ -2714,9 +2540,7 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/eva)
 "eN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -2786,15 +2610,11 @@
 /obj/item/device/radio/intercom/map_preset/bearcat{
 	pixel_y = -32
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/storage)
 "eU" = (
 /obj/machinery/vending/tool/bearcat,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/storage)
 "eV" = (
 /obj/machinery/suit_cycler/salvage/bearcat,
@@ -2825,9 +2645,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced,
 /obj/effect/paint/brown,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/storage)
 "fb" = (
 /obj/structure/curtain/open/bed,
@@ -2859,9 +2677,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/space)
 "kV" = (
 /turf/simulated/floor/reinforced{
@@ -2907,9 +2723,7 @@
 	dir = 8;
 	pixel_x = 22
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "vU" = (
 /obj/effect/floor_decal/corner/beige{
@@ -2954,9 +2768,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/cargo/lower)
 "Gr" = (
 /turf/simulated/floor/reinforced{
@@ -2988,9 +2800,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/ship/scrap/maintenance/lower)
 "Ro" = (
 /obj/effect/floor_decal/industrial/warning{

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -44,18 +44,14 @@
 /area/ship/scrap/command/bridge)
 "ag" = (
 /obj/machinery/computer/modular/preset/cardslot/command,
-/turf/simulated/floor/bluegrid{
-	map_airless = 1
-	},
+/turf/simulated/floor/bluegrid,
 /area/ship/scrap/command/bridge)
 "ah" = (
 /obj/machinery/computer/ship/helm{
 	req_access = list(list("ACCESS_BEARCAT"))
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/bluegrid{
-	map_airless = 1
-	},
+/turf/simulated/floor/bluegrid,
 /area/ship/scrap/command/bridge)
 "ai" = (
 /obj/structure/table/standard,
@@ -126,7 +122,9 @@
 /obj/machinery/door/blast/regular{
 	id_tag = "sensor"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/comms)
 "at" = (
 /obj/effect/paint/brown,
@@ -169,7 +167,9 @@
 /area/ship/scrap/command/bridge)
 "ax" = (
 /obj/machinery/shipsensors,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/comms)
 "ay" = (
 /obj/machinery/light,
@@ -2422,7 +2422,9 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/engine/port)
 "eB" = (
 /obj/machinery/light/small{
@@ -2438,7 +2440,9 @@
 	dir = 6
 	},
 /obj/machinery/meter,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/engine/port)
 "eC" = (
 /obj/structure/cable/green{
@@ -2450,7 +2454,9 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/autoname/engineering/bearcat,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/engine/port)
 "eD" = (
 /obj/item/screwdriver,
@@ -2462,7 +2468,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/engine/port)
 "eE" = (
 /obj/structure/table/standard,
@@ -2620,7 +2628,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/engine/starboard)
 "eS" = (
 /obj/structure/cable/green{
@@ -2632,7 +2642,9 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/autoname/engineering/bearcat,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/engine/starboard)
 "eT" = (
 /obj/machinery/light/small{
@@ -2650,7 +2662,9 @@
 	dir = 10
 	},
 /obj/machinery/meter,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/engine/starboard)
 "eU" = (
 /obj/machinery/power/apc/derelict{
@@ -2660,21 +2674,27 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/engine/starboard)
 "eV" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 6
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/engine/port)
 "eW" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/engine/port)
 "eX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -2800,14 +2820,18 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 8
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/engine/starboard)
 "fj" = (
 /obj/effect/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/engine/starboard)
 "fk" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -2819,11 +2843,15 @@
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/engine/port)
 "fm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/engine/starboard)
 "fo" = (
 /obj/machinery/alarm{
@@ -3008,7 +3036,9 @@
 /obj/machinery/atmospherics/unary/engine{
 	dir = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/engine/starboard)
 "fD" = (
 /obj/effect/floor_decal/industrial/warning,
@@ -5579,9 +5609,7 @@
 /turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/engineering)
 "JH" = (
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/power)
 "Kj" = (
 /turf/simulated/floor/reinforced{
@@ -5656,7 +5684,9 @@
 /area/ship/scrap/maintenance/engine/port)
 "PG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/ship/scrap/maintenance/engine/port)
 "PP" = (
 /obj/machinery/power/port_gen/pacman/super,

--- a/maps/away/casino/casino.dmm
+++ b/maps/away/casino/casino.dmm
@@ -3374,7 +3374,7 @@
 /turf/simulated/floor{
 	map_airless = 1
 	},
-/area/space)
+/area/casino/casino_crew_atmos)
 "jv" = (
 /obj/machinery/atmospherics/pipe/simple/visible/red{
 	dir = 9
@@ -4785,7 +4785,9 @@
 /turf/simulated/wall/r_titanium,
 /area/casino/casino_bow)
 "ns" = (
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/casino/casino_bow)
 "ob" = (
 /obj/structure/table/gamblingtable,

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -1383,8 +1383,10 @@
 	id = "n2_in";
 	use_power = 1
 	},
-/turf/simulated/floor,
-/area/space)
+/turf/simulated/floor{
+	map_airless = 1
+	},
+/area/errant_pisces/bow_maint)
 "dB" = (
 /obj/effect/wallframe_spawn/reinforced,
 /obj/machinery/atmospherics/pipe/simple/visible/red{
@@ -1896,7 +1898,9 @@
 	master_tag = "xyn_solar_port_airlock";
 	pixel_y = 20
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/errant_pisces/solar_port)
 "eE" = (
 /obj/structure/cable/yellow{
@@ -6223,7 +6227,9 @@
 	icon_state = "pdoor0";
 	id_tag = "xynergy_perimeter_blast"
 	},
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/errant_pisces/bridge)
 "pq" = (
 /obj/structure/lattice,
@@ -6600,7 +6606,9 @@
 /area/errant_pisces/fishing_wing)
 "qx" = (
 /obj/machinery/shipsensors,
-/turf/simulated/floor/reinforced,
+/turf/simulated/floor/reinforced{
+	map_airless = 1
+	},
 /area/errant_pisces/bridge)
 "qy" = (
 /obj/structure/closet/firecloset,
@@ -29429,7 +29437,7 @@ pK
 qa
 po
 qx
-qM
+pp
 qH
 bc
 aa
@@ -29832,7 +29840,7 @@ py
 oS
 qc
 po
-qM
+pp
 pq
 aa
 aa
@@ -30034,7 +30042,7 @@ oS
 oS
 qd
 po
-qM
+pp
 pq
 aa
 aa
@@ -30438,7 +30446,7 @@ oS
 oS
 qf
 po
-qM
+pp
 pq
 aa
 aa
@@ -31044,7 +31052,7 @@ oS
 oS
 qh
 po
-qM
+pp
 pq
 aa
 aa
@@ -31246,7 +31254,7 @@ oS
 oS
 qc
 po
-qM
+pp
 pq
 aa
 aa
@@ -31448,7 +31456,7 @@ oS
 oS
 pA
 po
-qM
+pp
 pq
 aa
 aa
@@ -31650,7 +31658,7 @@ oS
 oS
 pj
 po
-qM
+pp
 pq
 aa
 aa
@@ -31852,7 +31860,7 @@ oS
 pL
 pj
 po
-qM
+pp
 pq
 aa
 aa
@@ -32054,7 +32062,7 @@ pA
 pM
 qc
 po
-qM
+pp
 pq
 aa
 aa

--- a/maps/away/meatstation/meatstation.dmm
+++ b/maps/away/meatstation/meatstation.dmm
@@ -23,9 +23,7 @@
 /turf/simulated/wall/r_wall,
 /area/meatstation/engineering)
 "af" = (
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "ag" = (
 /turf/simulated/floor,
@@ -357,9 +355,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "aZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -373,9 +369,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "ba" = (
 /obj/machinery/light/small/red{
@@ -439,9 +433,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "bi" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -455,9 +447,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "bj" = (
 /obj/structure/cable/cyan{
@@ -509,9 +499,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "bo" = (
 /obj/item/book/manual/psionics,
@@ -539,9 +527,7 @@
 	level = 2
 	},
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "bs" = (
 /obj/effect/paint/meatstation,
@@ -561,9 +547,7 @@
 	},
 /obj/machinery/light/small/red,
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "bw" = (
 /obj/effect/floor_decal/corner/brown/border{
@@ -620,9 +604,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "bG" = (
 /obj/machinery/door/airlock{
@@ -639,9 +621,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/mess)
 "bH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -670,9 +650,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "bL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -700,9 +678,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "bN" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
@@ -739,9 +715,7 @@
 "bQ" = (
 /obj/structure/inflatable/wall,
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "bR" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -755,18 +729,14 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "bS" = (
 /obj/structure/inflatable/wall,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "bT" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -850,9 +820,7 @@
 /turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
 "cd" = (
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "ce" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -875,9 +843,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "ch" = (
 /obj/effect/floor_decal/corner/black/border{
@@ -888,9 +854,7 @@
 	name = "exterior lab bolt control";
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "ci" = (
 /obj/machinery/door/airlock{
@@ -907,9 +871,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "cj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -938,9 +900,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "cl" = (
 /obj/structure/inflatable/wall,
@@ -969,9 +929,7 @@
 	dir = 1;
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "co" = (
 /obj/machinery/door/airlock{
@@ -1024,9 +982,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/cargo)
 "ct" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -1053,9 +1009,6 @@
 /obj/structure/stasis_cage,
 /turf/simulated/floor/tiled/dark,
 /area/meatstation/cargo)
-"cv" = (
-/turf/simulated/floor/tiled/dark,
-/area/meatstation/cargo)
 "cw" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1077,9 +1030,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/engineering)
 "cy" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -1192,15 +1143,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "cJ" = (
 /obj/structure/inflatable/wall,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "cK" = (
 /turf/simulated/floor/tiled/dark,
@@ -1263,9 +1210,7 @@
 /obj/random/junk,
 /obj/machinery/light/small/red,
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "cS" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -1276,9 +1221,7 @@
 /obj/machinery/door/airlock{
 	stripe_color = "#aab1c1"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/dorm)
 "cU" = (
 /obj/structure/closet/wardrobe/pjs,
@@ -1585,9 +1528,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "dE" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -1660,9 +1601,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "dN" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -1680,18 +1619,14 @@
 /turf/simulated/floor/tiled/monotile,
 /area/meatstation/hydroponics)
 "dO" = (
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/meatstation/bathroom)
 "dP" = (
 /obj/random/single/meatstation/low/wormscientist,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "dQ" = (
 /obj/item/stack/material/rods,
@@ -1851,9 +1786,7 @@
 /obj/structure/barricade/spike{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "en" = (
 /obj/machinery/door/airlock{
@@ -1940,9 +1873,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "et" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -1954,9 +1885,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "eu" = (
 /obj/item/paper,
@@ -2007,9 +1936,7 @@
 "ez" = (
 /obj/effect/floor_decal/corner/black/border,
 /obj/item/tape_roll,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "eA" = (
 /obj/structure/table/rack/dark,
@@ -2098,9 +2025,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "eL" = (
 /obj/random/junk,
@@ -2110,9 +2035,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "eM" = (
 /obj/machinery/door/airlock{
@@ -2145,9 +2068,7 @@
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "eP" = (
 /obj/machinery/power/smes/buildable,
@@ -2191,10 +2112,6 @@
 	},
 /turf/simulated/floor,
 /area/meatstation/engineering)
-"eS" = (
-/obj/random/single/meatstation/low/wormguard,
-/turf/simulated/floor/tiled/dark,
-/area/meatstation/cargo)
 "eT" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9;
@@ -2210,9 +2127,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "eV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2302,9 +2217,7 @@
 "fb" = (
 /obj/effect/floor_decal/corner/black/border,
 /obj/random/single/meatstation/meatworm,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "fc" = (
 /obj/effect/paint/meatstation,
@@ -2460,9 +2373,7 @@
 /area/meatstation/engineering)
 "fs" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "ft" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -2481,9 +2392,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "fu" = (
 /obj/item/paper,
@@ -2543,9 +2452,7 @@
 	locked = 1;
 	stripe_color = "#aab1c1"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/hydroponics)
 "fA" = (
 /obj/structure/table/rack/dark,
@@ -2574,9 +2481,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "fC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2832,9 +2737,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "ge" = (
 /obj/structure/table/glass,
@@ -3384,9 +3287,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "hx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3803,9 +3704,7 @@
 /area/meatstation/kitchen)
 "ix" = (
 /obj/structure/girder,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/meatstation/bathroom)
 "iy" = (
 /obj/structure/girder,
@@ -4028,9 +3927,7 @@
 /area/meatstation/bathroom)
 "jf" = (
 /obj/structure/girder,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/meatstation/mess)
 "jg" = (
 /obj/item/stack/material/rods,
@@ -5266,29 +5163,10 @@
 /obj/random/junk,
 /turf/simulated/floor/tiled/dark,
 /area/meatstation/swhallway)
-"mk" = (
-/obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled/dark,
-/area/meatstation/cargo)
 "ml" = (
 /obj/structure/mine,
 /obj/random/trash,
 /obj/random/junk,
-/turf/simulated/floor/tiled/dark,
-/area/meatstation/swhallway)
-"mm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/mine,
-/turf/simulated/floor/tiled/dark,
-/area/meatstation/swhallway)
-"mn" = (
-/obj/structure/mine,
 /turf/simulated/floor/tiled/dark,
 /area/meatstation/swhallway)
 "mo" = (
@@ -5397,9 +5275,7 @@
 /area/meatstation/engineering)
 "mC" = (
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "mD" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
@@ -5535,9 +5411,7 @@
 "mW" = (
 /obj/random/single/meatstation/meatworm,
 /obj/random/junk,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "mX" = (
 /obj/structure/cable/cyan{
@@ -6033,9 +5907,7 @@
 	dir = 1
 	},
 /obj/random/single/meatstation/low/wormguard,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "ou" = (
 /obj/machinery/portable_atmospherics/powered/pump/filled,
@@ -6058,9 +5930,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "ox" = (
 /obj/machinery/door/airlock{
@@ -6078,9 +5948,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/kitchen)
 "oy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6119,9 +5987,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/inflatable/door,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "oC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6139,9 +6005,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/cargo)
 "oE" = (
 /obj/effect/overmap/visitable/sector/meatstation,
@@ -6149,9 +6013,7 @@
 /area/space)
 "oF" = (
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/meatstation/centerhallway)
 "oG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -6280,9 +6142,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "pd" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -6298,9 +6158,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "pf" = (
 /obj/structure/lattice,
@@ -6320,9 +6178,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "pi" = (
 /obj/item/extinguisher,
@@ -6742,9 +6598,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "qt" = (
 /obj/item/storage/backpack/dufflebag,
@@ -6980,14 +6834,10 @@
 	icon_state = "1-2"
 	},
 /obj/structure/barricade/spike,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "qY" = (
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/meatstation/centerhallway)
 "qZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7016,9 +6866,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/inflatable/door,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/meatstation/centerhallway)
 "rb" = (
 /obj/structure/lattice,
@@ -7062,9 +6910,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/meatstation/centerhallway)
 "rf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7074,12 +6920,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
-/area/meatstation/centerhallway)
-"rg" = (
-/obj/structure/girder,
 /turf/simulated/floor,
 /area/meatstation/centerhallway)
 "rh" = (
@@ -7122,9 +6962,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/inflatable/door,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "rl" = (
 /obj/random/single/meatstation/meatworm,
@@ -7133,9 +6971,7 @@
 /area/meatstation/mess)
 "rm" = (
 /obj/structure/inflatable/wall,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "rn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -7146,9 +6982,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/inflatable/door,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "ro" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -7204,9 +7038,7 @@
 /area/meatstation/storage)
 "rs" = (
 /obj/effect/floor_decal/corner/black/bordercorner,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "rt" = (
 /obj/random/single/meatstation/meatball,
@@ -7219,9 +7051,7 @@
 "rv" = (
 /obj/machinery/light/small/red,
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "rw" = (
 /obj/effect/decal/cleanable/blood,
@@ -7234,9 +7064,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "rx" = (
 /obj/effect/decal/cleanable/blood,
@@ -7255,9 +7083,7 @@
 	icon_state = "4-8"
 	},
 /obj/random/junk,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "rz" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -7368,9 +7194,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 6
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "rK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7400,9 +7224,7 @@
 	icon_state = "1-4"
 	},
 /obj/random/junk,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "rM" = (
 /obj/effect/decal/cleanable/liquid_fuel,
@@ -7476,9 +7298,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 9
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "rZ" = (
 /obj/effect/decal/cleanable/blood,
@@ -7498,9 +7318,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/vomit,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "sb" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -7526,9 +7344,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "sf" = (
 /obj/effect/decal/cleanable/filth,
@@ -7547,9 +7363,7 @@
 "sh" = (
 /obj/effect/floor_decal/corner/black/border,
 /obj/random/single/meatstation/low/wormguard,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "si" = (
 /obj/effect/decal/cleanable/cobweb2,
@@ -7613,9 +7427,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "ss" = (
 /obj/item/paper,
@@ -7789,9 +7601,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "sL" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -7811,9 +7621,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "sM" = (
 /obj/random/closet,
@@ -7828,9 +7636,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "sO" = (
 /obj/random/single/meatstation/low/wormscientist,
@@ -7842,9 +7648,7 @@
 	dir = 10
 	},
 /obj/random/single/meatstation/meatball,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "sQ" = (
 /obj/item/usedcryobag,
@@ -8080,9 +7884,7 @@
 	icon_state = "1-2"
 	},
 /obj/random/single/meatstation/meatworm,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "tt" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8104,17 +7906,13 @@
 /area/meatstation/swhallway)
 "tu" = (
 /obj/random/single/meatstation/meatball,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "tv" = (
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "tw" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -8125,9 +7923,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "tx" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8142,9 +7938,7 @@
 	icon_state = "4-8"
 	},
 /obj/random/single/meatstation/low/wormscientist,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "ty" = (
 /obj/structure/bed/chair/office/comfy/black,
@@ -8203,9 +7997,7 @@
 /area/meatstation/storage)
 "tE" = (
 /obj/item/remains/human,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "tF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8217,9 +8009,7 @@
 	},
 /obj/random/single/meatstation/meatworm,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "tG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8234,15 +8024,11 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "tH" = (
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "tI" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8303,9 +8089,7 @@
 	},
 /obj/random/single/meatstation/meatball,
 /obj/effect/decal/cleanable/blood,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "tP" = (
 /obj/effect/decal/cleanable/blood/drip,
@@ -8380,18 +8164,14 @@
 	icon_state = "4-8"
 	},
 /obj/random/single/meatstation/low/wormguard,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "tW" = (
 /obj/effect/decal/cleanable/filth,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "tX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8437,45 +8217,35 @@
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "uc" = (
 /obj/structure/roller_bed,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "ud" = (
 /obj/random/single/meatstation/wormscientist,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "ue" = (
 /obj/random/junk,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "uf" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "ug" = (
 /obj/random/junk,
@@ -8485,17 +8255,13 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "uh" = (
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "ui" = (
 /obj/effect/decal/cleanable/blood,
@@ -8516,9 +8282,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/closet/firecloset,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "ul" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8529,18 +8293,14 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "um" = (
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
 /obj/random/single/meatstation/meatworm,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "un" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -8549,9 +8309,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "uo" = (
 /obj/item/clothing/accessory/badge/press,
@@ -8593,9 +8351,7 @@
 	},
 /obj/effect/decal/cleanable/blood,
 /obj/random/single/meatstation/meatworm,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "uu" = (
 /obj/item/clothing/under/wetsuit,
@@ -8620,9 +8376,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "uy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -8749,9 +8503,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "uN" = (
 /obj/structure/closet/crate/trashcart,
@@ -8773,9 +8525,7 @@
 	},
 /obj/random/single/meatstation/meatball,
 /obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "uP" = (
 /obj/effect/floor_decal/corner/lightgrey/border{
@@ -8793,9 +8543,7 @@
 	},
 /obj/random/single/meatstation/meatworm,
 /obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "uR" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8834,9 +8582,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "uU" = (
 /obj/machinery/light{
@@ -8872,9 +8618,7 @@
 	},
 /obj/random/junk,
 /obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "uY" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -8887,9 +8631,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "uZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8905,9 +8647,7 @@
 	},
 /obj/random/single/meatstation/meatworm,
 /obj/effect/decal/cleanable/blood/drip,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "va" = (
 /obj/item/storage/bag/trash,
@@ -9027,9 +8767,7 @@
 /obj/machinery/light/small/red{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "vo" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -9042,9 +8780,7 @@
 /obj/machinery/light/small/red{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/nwhallway)
 "vp" = (
 /obj/structure/table/rack,
@@ -9276,9 +9012,7 @@
 	dir = 8
 	},
 /obj/random/single/meatstation/meatworm,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "vR" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -9369,9 +9103,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "wf" = (
 /obj/machinery/light/small/red,
@@ -10091,9 +9823,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 9
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "xZ" = (
 /obj/machinery/light/small/red{
@@ -10102,26 +9832,20 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "ya" = (
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yb" = (
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10135,35 +9859,27 @@
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "ye" = (
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yf" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yg" = (
 /obj/random/single/meatstation/low/wormscientist,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yh" = (
 /obj/structure/barricade/spike{
@@ -10172,27 +9888,21 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yi" = (
 /obj/random/junk,
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yj" = (
 /obj/structure/inflatable/wall,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
@@ -10200,18 +9910,14 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yl" = (
 /obj/effect/decal/cleanable/vomit,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "ym" = (
 /obj/machinery/light/small/red{
@@ -10220,9 +9926,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yn" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -10231,75 +9935,57 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yo" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yq" = (
 /obj/effect/floor_decal/corner/black/border{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yr" = (
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yt" = (
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yu" = (
 /obj/structure/barricade/spike,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yv" = (
 /obj/random/junk,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yx" = (
 /obj/structure/inflatable/wall,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yz" = (
 /obj/structure/closet/emcloset,
 /obj/machinery/light/small/red,
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10316,9 +10002,7 @@
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yB" = (
 /obj/structure/barricade/spike,
@@ -10328,36 +10012,28 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yC" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yD" = (
 /obj/random/junk,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yE" = (
 /obj/random/single/meatstation/meatworm,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yG" = (
 /obj/effect/decal/cleanable/blood,
@@ -10365,18 +10041,14 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yH" = (
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10391,59 +10063,45 @@
 	icon_state = "2-8"
 	},
 /obj/effect/floor_decal/corner/black/bordercorner,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yK" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yL" = (
 /obj/structure/barricade/spike{
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yM" = (
 /obj/random/single/meatstation/meatworm,
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yN" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/floor_decal/corner/black/border,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yO" = (
 /obj/effect/floor_decal/corner/black/bordercorner,
 /obj/effect/floor_decal/corner/black/bordercorner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yP" = (
 /obj/structure/closet/firecloset,
 /obj/effect/floor_decal/corner/black/border{
 	dir = 6
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10456,9 +10114,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yR" = (
 /obj/effect/floor_decal/corner/black/border{
@@ -10467,9 +10123,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -10483,9 +10137,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yT" = (
 /obj/machinery/light/small/red{
@@ -10497,9 +10149,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yU" = (
 /obj/structure/barricade/spike,
@@ -10509,9 +10159,7 @@
 /obj/effect/floor_decal/corner/black/border{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "yV" = (
 /obj/structure/stasis_cage,
@@ -10765,9 +10413,7 @@
 	name = "exterior lab bolt control";
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "zC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -10793,9 +10439,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "zE" = (
 /obj/structure/cable/cyan{
@@ -11010,9 +10654,7 @@
 	dir = 4
 	},
 /obj/random/single/meatstation/low/wormguard,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "zZ" = (
 /obj/random/maintenance/clean,
@@ -11033,9 +10675,7 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/random/single/meatstation/meatball,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "Ab" = (
 /obj/effect/floor_decal/corner/purple/border,
@@ -11132,9 +10772,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "Am" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11171,9 +10809,7 @@
 	},
 /obj/effect/decal/cleanable/blood/drip,
 /obj/effect/decal/cleanable/filth,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/meatstation/centerhallway)
 "Ao" = (
 /obj/machinery/door/airlock/vault/bolted{
@@ -11336,9 +10972,7 @@
 /area/meatstation/storage)
 "Ut" = (
 /obj/structure/girder,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/meatstation/centerhallway)
 
 (1,1,1) = {"
@@ -23958,7 +23592,7 @@ aa
 fm
 fm
 cK
-eS
+sI
 wf
 fm
 fm
@@ -24764,27 +24398,27 @@ fe
 fe
 fe
 hP
-cv
-cv
-cv
-cv
+cK
+cK
+cK
+cK
 px
-cv
-cv
+cK
+cK
 qt
 pC
-cv
-cv
-cv
+cK
+cK
+cK
 qw
-cv
+cK
 oH
 pW
 pR
 sy
 oH
 oH
-cv
+cK
 wV
 fm
 fm
@@ -24966,8 +24600,8 @@ mb
 aD
 fe
 pq
-cv
-cv
+cK
+cK
 qt
 pK
 qC
@@ -24985,7 +24619,7 @@ pf
 ln
 oH
 oH
-cv
+cK
 oH
 wW
 fm
@@ -25168,9 +24802,9 @@ lo
 aK
 pv
 pq
-cv
-cv
-cv
+cK
+cK
+cK
 pK
 qP
 uG
@@ -25179,7 +24813,7 @@ wL
 pK
 qK
 pE
-cv
+cK
 qC
 qD
 wL
@@ -25187,8 +24821,8 @@ oH
 xU
 xW
 pB
-cv
-mk
+cK
+tP
 wW
 fm
 fm
@@ -25370,9 +25004,9 @@ md
 cm
 co
 bY
-cv
+cK
 eD
-cv
+cK
 pL
 qR
 pK
@@ -25388,7 +25022,7 @@ oH
 sx
 qC
 oH
-cv
+cK
 qV
 ou
 wX
@@ -25572,9 +25206,9 @@ aD
 fq
 fe
 pw
-cv
+cK
 rC
-cv
+cK
 pK
 uF
 uH
@@ -25583,15 +25217,15 @@ wM
 pK
 gq
 pF
-cv
+cK
 qf
 qH
 qC
 qQ
 xV
 xX
-cv
-mk
+cK
+tP
 ou
 wX
 fm
@@ -25774,8 +25408,8 @@ fe
 fe
 fe
 pw
-cv
-cv
+cK
+cK
 cu
 pK
 qC
@@ -25785,7 +25419,7 @@ qC
 pK
 qi
 pN
-cv
+cK
 qC
 qQ
 qC
@@ -25793,7 +25427,7 @@ qC
 qC
 qC
 rc
-cv
+cK
 qi
 wY
 fm
@@ -25976,27 +25610,27 @@ cd
 cJ
 eh
 qM
-cv
+cK
 qE
-cv
-cv
+cK
+cK
 py
-cv
-cv
+cK
+cK
 qO
-cv
-cv
+cK
+cK
 qU
 qt
-cv
+cK
 qh
 qo
-cv
+cK
 eD
 qV
-cv
+cK
 At
-cv
+cK
 rj
 tT
 cl
@@ -26004,7 +25638,7 @@ pn
 jg
 mi
 ml
-mn
+sA
 mq
 sA
 jt
@@ -26205,7 +25839,7 @@ eo
 pt
 mh
 mj
-mm
+mY
 mo
 mY
 sB
@@ -26382,23 +26016,23 @@ fm
 uE
 uW
 wH
-mk
+tP
 cu
-cv
-cv
-cv
+cK
+cK
+cK
 cc
-cv
+cK
 tC
-cv
-cv
-cv
+cK
+cK
+cK
 sI
-cv
+cK
 qz
 hO
 qt
-cv
+cK
 dw
 qT
 rQ
@@ -26613,7 +26247,7 @@ aa
 aa
 aA
 sE
-mn
+sA
 aA
 aA
 aa
@@ -26815,7 +26449,7 @@ aa
 aa
 aA
 sJ
-mn
+sA
 aA
 aA
 aa
@@ -27614,7 +27248,7 @@ ah
 ah
 ah
 ah
-rg
+Ut
 ah
 ah
 ah

--- a/maps/away/miningstation/miningstation.dmm
+++ b/maps/away/miningstation/miningstation.dmm
@@ -8,9 +8,7 @@
 /area/space)
 "ad" = (
 /obj/machinery/door/blast/regular,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "ae" = (
 /obj/machinery/door/blast/regular,
@@ -56,9 +54,7 @@
 	dir = 6
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "am" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -68,9 +64,7 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "an" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -80,9 +74,7 @@
 	dir = 10
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "ao" = (
 /obj/structure/lattice,
@@ -92,9 +84,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "aq" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -108,59 +98,45 @@
 	dir = 4
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "as" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "at" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "au" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "av" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "aw" = (
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "ax" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "ay" = (
 /obj/machinery/alarm{
@@ -181,9 +157,7 @@
 	dir = 8
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "aB" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -191,9 +165,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "aC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -234,9 +206,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "aH" = (
 /obj/machinery/power/terminal{
@@ -252,9 +222,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "aI" = (
 /obj/structure/grille,
@@ -276,9 +244,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "aM" = (
 /turf/simulated/floor/reinforced{
@@ -393,15 +359,11 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "aX" = (
 /obj/machinery/atmospherics/unary/engine,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/fix)
 "aY" = (
 /obj/structure/fuel_port,
@@ -412,9 +374,7 @@
 	dir = 10;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "bc" = (
 /obj/structure/shuttle/engine/heater{
@@ -424,18 +384,14 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 8
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/fix)
 "bd" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 6;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "be" = (
 /obj/structure/window/reinforced,
@@ -443,9 +399,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/fix)
 "bf" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -460,9 +414,7 @@
 	icon_state = "warning";
 	pixel_y = 6
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "bg" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -477,9 +429,7 @@
 	icon_state = "warning";
 	pixel_y = 6
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "bh" = (
 /obj/structure/cable{
@@ -495,9 +445,7 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/light,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "bi" = (
 /obj/structure/cable{
@@ -512,9 +460,7 @@
 	dir = 9
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "bj" = (
 /obj/machinery/power/terminal{
@@ -525,9 +471,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "bk" = (
 /obj/structure/cable{
@@ -775,10 +719,6 @@
 /obj/effect/paint/black,
 /turf/simulated/wall/r_titanium,
 /area/miningstation/prep2)
-"bO" = (
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/miningstation/power)
 "bP" = (
 /obj/effect/paint/black,
 /turf/simulated/wall/r_titanium,
@@ -863,14 +803,10 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 9
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/fix)
 "ch" = (
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/fix)
 "ci" = (
 /turf/simulated/floor/tiled/white,
@@ -976,18 +912,14 @@
 /area/miningstation/power)
 "cy" = (
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "cz" = (
 /obj/structure/catwalk,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "cA" = (
 /obj/item/device/radio/intercom,
@@ -1004,9 +936,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "cD" = (
 /obj/machinery/power/solar/improved,
@@ -1029,9 +959,7 @@
 	icon_state = "warning";
 	pixel_y = 6
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "cF" = (
 /obj/structure/catwalk,
@@ -1040,9 +968,7 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "cG" = (
 /obj/machinery/power/solar_control,
@@ -1051,9 +977,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "cH" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -1112,16 +1036,12 @@
 /obj/random/tool,
 /obj/random/tool,
 /obj/random/toolbox,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "cR" = (
 /obj/structure/catwalk,
 /obj/machinery/computer/atmos_alert,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "cS" = (
 /obj/structure/cable{
@@ -1133,9 +1053,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "cT" = (
 /obj/structure/cable{
@@ -1150,16 +1068,12 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "cU" = (
 /obj/machinery/power/port_gen/pacman,
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "cV" = (
 /obj/structure/catwalk,
@@ -1176,18 +1090,14 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/smes/buildable/outpost_substation,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "cW" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "cX" = (
 /obj/machinery/alarm{
@@ -1382,34 +1292,26 @@
 "dr" = (
 /obj/structure/closet/crate/solar_assembly,
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "ds" = (
 /obj/structure/catwalk,
 /obj/structure/bed/chair/office{
 	dir = 1
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "dt" = (
 /obj/structure/catwalk,
 /obj/structure/table/steel,
 /obj/item/paper_bin,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "du" = (
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /mob/living/simple_animal/hostile/meat/strippedhuman,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "dv" = (
 /obj/structure/cable{
@@ -1666,9 +1568,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "dP" = (
 /obj/structure/cable{
@@ -1684,9 +1584,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "dQ" = (
 /obj/structure/cable{
@@ -1703,9 +1601,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "dR" = (
 /obj/structure/cable{
@@ -1720,9 +1616,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "dS" = (
 /obj/structure/cable{
@@ -1732,9 +1626,7 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "dT" = (
 /obj/machinery/power/solar/improved,
@@ -2276,9 +2168,7 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/light,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "fc" = (
 /obj/structure/cable{
@@ -2310,9 +2200,7 @@
 	icon_state = "warning";
 	pixel_y = 6
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "fg" = (
 /turf/simulated/floor/tiled/techfloor,
@@ -2603,9 +2491,7 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/fix)
 "gb" = (
 /obj/structure/bed/chair/shuttle/blue{
@@ -2660,9 +2546,7 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/canister/air/airlock,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/fix)
 "gi" = (
 /obj/effect/paint/black,
@@ -2727,9 +2611,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/operationshall2)
 "gr" = (
 /obj/effect/paint/black,
@@ -2753,9 +2635,7 @@
 	icon_state = "warning";
 	pixel_y = 6
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "gu" = (
 /obj/item/device/radio/intercom,
@@ -2839,9 +2719,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "gG" = (
 /obj/structure/filingcabinet/filingcabinet,
@@ -2876,9 +2754,7 @@
 "gL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/atmos)
 "gM" = (
 /obj/machinery/alarm,
@@ -2915,9 +2791,7 @@
 	dir = 4;
 	start_pressure = 4559.63
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/atmos)
 "gT" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -2931,9 +2805,7 @@
 	},
 /obj/structure/catwalk,
 /mob/living/simple_animal/hostile/meat/strippedhuman,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/atmos)
 "gU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3182,9 +3054,7 @@
 "hm" = (
 /obj/structure/catwalk,
 /obj/machinery/computer/atmos_alert,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/atmos)
 "hn" = (
 /obj/machinery/door/airlock/civilian,
@@ -3213,9 +3083,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/atmos)
 "hp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3237,9 +3105,7 @@
 	pixel_x = 24
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/atmos)
 "hq" = (
 /obj/machinery/cryopod{
@@ -3430,18 +3296,14 @@
 "hJ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/atmos)
 "hK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/atmos)
 "hL" = (
 /obj/structure/catwalk,
@@ -3451,9 +3313,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/atmos)
 "hM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -4913,9 +4773,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/dorms3)
 "lj" = (
 /obj/machinery/light{
@@ -5392,9 +5250,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/dorms2)
 "md" = (
 /obj/structure/cable{
@@ -5427,9 +5283,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/dorms)
 "mh" = (
 /obj/machinery/door/airlock/civilian,
@@ -5489,9 +5343,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/mess)
 "mn" = (
 /obj/item/device/radio/intercom,
@@ -5520,9 +5372,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/mess)
 "mr" = (
 /obj/effect/paint/black,
@@ -5538,9 +5388,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/kitchen)
 "mt" = (
 /obj/structure/table/steel,
@@ -5880,9 +5728,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 8
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/mess)
 "nr" = (
 /obj/effect/floor_decal/corner/blue{
@@ -6143,9 +5989,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/atmos)
 "nW" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
@@ -6200,9 +6044,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 8
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/mess)
 "oc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6504,9 +6346,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 8
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/mess)
 "oF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6575,9 +6415,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/kitchen)
 "oK" = (
 /obj/effect/floor_decal/corner/blue{
@@ -6748,9 +6586,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 8
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/mess)
 "pg" = (
 /obj/structure/table/marble,
@@ -6829,9 +6665,7 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 8
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/mess)
 "pq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7741,9 +7575,7 @@
 	icon_state = "0-8"
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "rj" = (
 /obj/structure/catwalk,
@@ -7752,9 +7584,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "rk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -7762,17 +7592,13 @@
 	dir = 1
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/atmos)
 "rl" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/atmos)
 "rm" = (
 /obj/structure/catwalk,
@@ -7785,9 +7611,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "rn" = (
 /obj/machinery/power/terminal,
@@ -7809,9 +7633,7 @@
 	name = "south bump";
 	pixel_y = -28
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "ro" = (
 /obj/structure/catwalk,
@@ -7824,9 +7646,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/power)
 "rp" = (
 /obj/structure/table/steel,
@@ -7987,9 +7807,7 @@
 	dir = 4;
 	name = "Exterior Vent"
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/atmos)
 "rL" = (
 /obj/machinery/light{
@@ -8096,9 +7914,7 @@
 	pixel_y = 6
 	},
 /obj/machinery/light,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "xO" = (
 /obj/structure/cable{
@@ -8143,9 +7959,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/atmos)
 "yI" = (
 /obj/effect/gibspawner/human,
@@ -8171,9 +7985,7 @@
 	},
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "zI" = (
 /obj/effect/paint/black,
@@ -8201,9 +8013,7 @@
 	pixel_y = 6
 	},
 /obj/machinery/light,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "AL" = (
 /obj/machinery/light{
@@ -8496,9 +8306,7 @@
 /area/miningstation/cryo)
 "JX" = (
 /obj/effect/shuttle_landmark/nav_miningstation/hangar,
-/turf/simulated/floor/plating{
-	map_airless = 1
-	},
+/turf/simulated/floor/plating,
 /area/miningstation/hangar)
 "Kd" = (
 /obj/machinery/light{
@@ -22541,7 +22349,7 @@ dT
 aO
 bx
 bE
-bO
+cy
 cf
 cB
 cT

--- a/maps/away/scavver/scavver_gantry-1.dmm
+++ b/maps/away/scavver/scavver_gantry-1.dmm
@@ -240,12 +240,11 @@
 /turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "ev" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 6
 	},
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "eB" = (
 /obj/structure/lattice,
@@ -600,10 +599,9 @@
 /turf/simulated/floor,
 /area/scavver/gantry/down2)
 "jy" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped,
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "jz" = (
 /obj/effect/floor_decal/corner/blue{
@@ -615,12 +613,11 @@
 /turf/simulated/floor/tiled,
 /area/scavver/calypso)
 "jH" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 4
 	},
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "jJ" = (
 /obj/structure/iv_stand,
@@ -773,14 +770,13 @@
 /turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "lD" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
 	},
 /obj/random/loot,
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "lV" = (
 /obj/effect/floor_decal/corner/blue{
@@ -798,23 +794,13 @@
 	},
 /turf/simulated/floor/wood/yew,
 /area/scavver/yachtdown)
-"mi" = (
-/obj/structure/railing/mapped{
-	dir = 8;
-	icon_state = "railing0-1"
-	},
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
-/turf/space,
-/area/space)
 "mo" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 1;
 	icon_state = "railing0-1"
 	},
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "mU" = (
 /obj/structure/lattice,
@@ -865,11 +851,6 @@
 /area/scavver/gantry/down1)
 "nC" = (
 /obj/effect/shuttle_landmark/scavver_gantry/six,
-/turf/space,
-/area/space)
-"nS" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /turf/space,
 /area/space)
 "nT" = (
@@ -1027,14 +1008,13 @@
 /turf/simulated/floor/wood/yew,
 /area/scavver/yachtdown)
 "qH" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
 	},
 /obj/structure/railing/mapped,
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "qK" = (
 /obj/structure/lattice,
@@ -1280,8 +1260,7 @@
 /area/scavver/calypso)
 "uR" = (
 /obj/effect/catwalk_plated/dark,
-/obj/structure/lattice,
-/turf/space,
+/turf/simulated/floor,
 /area/space)
 "uY" = (
 /turf/space,
@@ -1665,15 +1644,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/scavver/calypso)
-"BM" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
-	},
-/turf/space,
-/area/space)
 "BO" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -2093,8 +2063,6 @@
 /turf/simulated/floor/tiled,
 /area/scavver/calypso)
 "ID" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
@@ -2103,11 +2071,10 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "IF" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 4;
 	icon_state = "railing0-1"
@@ -2116,7 +2083,8 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "IJ" = (
 /obj/machinery/air_sensor{
@@ -2168,14 +2136,13 @@
 /turf/simulated/floor,
 /area/scavver/gantry/down2)
 "JP" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 1;
 	icon_state = "railing0-1"
 	},
 /obj/random/gloves,
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "Ke" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -2195,11 +2162,10 @@
 /turf/simulated/floor,
 /area/scavver/gantry/down1)
 "KL" = (
-/obj/structure/lattice,
 /obj/random/loot,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped,
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "KP" = (
 /obj/effect/catwalk_plated/dark,
@@ -2457,13 +2423,12 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/scavver/calypso)
 "QQ" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
 	},
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "QR" = (
 /obj/structure/railing/mapped{
@@ -2876,13 +2841,12 @@
 /turf/simulated/floor,
 /area/scavver/yachtdown/thrusters)
 "XA" = (
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 4;
 	icon_state = "railing0-1"
 	},
-/obj/structure/lattice,
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "XC" = (
 /obj/structure/cable{
@@ -2951,14 +2915,13 @@
 /turf/simulated/floor/tiled,
 /area/scavver/calypso)
 "YU" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 1;
 	icon_state = "railing0-1"
 	},
 /obj/random/tech_supply,
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "YV" = (
 /obj/effect/paint/black,
@@ -11611,9 +11574,9 @@ UM
 ID
 QQ
 QQ
-mi
-mi
-mi
+QQ
+QQ
+QQ
 QQ
 QQ
 lD
@@ -12673,8 +12636,8 @@ UM
 UM
 UM
 mo
-nS
-nS
+uR
+uR
 dk
 QD
 GK
@@ -13439,8 +13402,8 @@ XH
 ny
 OD
 eY
-nS
-nS
+uR
+uR
 jy
 UM
 UM
@@ -14021,12 +13984,12 @@ mo
 eB
 vM
 UM
-nS
+uR
 UM
 UM
 UM
 UM
-nS
+uR
 UM
 UM
 vM
@@ -14037,7 +14000,7 @@ UM
 UM
 rW
 UM
-nS
+uR
 UM
 UM
 UM
@@ -14173,12 +14136,12 @@ mo
 UM
 vM
 Lg
-nS
+uR
 UM
 UM
 UM
 UM
-nS
+uR
 UM
 vM
 vM
@@ -14189,7 +14152,7 @@ UM
 UM
 vU
 UM
-nS
+uR
 UM
 UM
 UM
@@ -14474,8 +14437,8 @@ UM
 UM
 UM
 mo
-nS
-nS
+uR
+uR
 rs
 SZ
 SZ
@@ -15091,7 +15054,7 @@ vM
 jt
 UM
 UM
-nS
+uR
 UM
 UM
 UM
@@ -15243,7 +15206,7 @@ UM
 vM
 rW
 UM
-nS
+uR
 UM
 UM
 UM
@@ -15386,44 +15349,44 @@ UM
 UM
 UM
 IF
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
-BM
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
+XA
 XA
 IV
-BM
-nS
-BM
-BM
+XA
+uR
+XA
+XA
 jH
 jH
 jH
 jH
-nS
-nS
+uR
+uR
 SF
 Mz
 Mz
@@ -15567,14 +15530,14 @@ UM
 UM
 ky
 UM
-nS
+uR
 UM
 vM
 UM
 UM
 vM
 UM
-nS
+uR
 KL
 mU
 mU
@@ -15719,14 +15682,14 @@ UM
 UM
 ky
 UM
-nS
+uR
 UM
 vM
 Zg
 ua
 sj
 UM
-nS
+uR
 jy
 UM
 UM

--- a/maps/away/scavver/scavver_gantry-2.dmm
+++ b/maps/away/scavver/scavver_gantry-2.dmm
@@ -108,15 +108,6 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor,
 /area/scavver/gantry/up2)
-"aM" = (
-/obj/structure/railing/mapped{
-	dir = 8;
-	icon_state = "railing0-1"
-	},
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
-/turf/space,
-/area/space)
 "aZ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/techfloor,
@@ -842,15 +833,6 @@
 /obj/effect/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor,
 /area/scavver/yachtup)
-"hw" = (
-/obj/structure/railing/mapped{
-	dir = 8;
-	icon_state = "railing0-1"
-	},
-/obj/effect/catwalk_plated/dark,
-/obj/structure/lattice,
-/turf/space,
-/area/space)
 "hB" = (
 /obj/machinery/alarm{
 	dir = 1;
@@ -862,14 +844,13 @@
 /turf/simulated/floor/tiled,
 /area/scavver/hab)
 "hD" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 4;
 	icon_state = "railing0-1"
 	},
 /obj/structure/railing/mapped,
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "hG" = (
 /obj/machinery/atmospherics/pipe/simple/visible/blue{
@@ -883,13 +864,12 @@
 	},
 /area/scavver/lifepod)
 "hH" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
 	},
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "hP" = (
 /obj/machinery/portable_atmospherics/canister/nitrogen/engine_setup,
@@ -2003,8 +1983,6 @@
 /turf/simulated/floor/plating,
 /area/scavver/escapepod)
 "qv" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 4;
 	icon_state = "railing0-1"
@@ -2013,7 +1991,8 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "qC" = (
 /obj/structure/cable{
@@ -2025,14 +2004,13 @@
 /turf/simulated/floor,
 /area/scavver/yachtup)
 "qD" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
 	},
 /obj/random/loot,
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "qF" = (
 /obj/structure/cable{
@@ -2439,10 +2417,9 @@
 /turf/space,
 /area/scavver/yachtup)
 "tf" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/effect/shuttle_landmark/scavver_gantry,
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "tl" = (
 /obj/effect/floor_decal/techfloor/orange{
@@ -2566,10 +2543,9 @@
 /turf/simulated/floor/tiled/white,
 /area/scavver/escapepod)
 "tX" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped,
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "ub" = (
 /obj/machinery/light{
@@ -2699,14 +2675,13 @@
 	},
 /area/scavver/lifepod)
 "uZ" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 4;
 	icon_state = "railing0-1"
 	},
 /obj/random/hat,
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "va" = (
 /obj/structure/cable,
@@ -2925,14 +2900,13 @@
 /turf/simulated/floor,
 /area/scavver/escapepod)
 "wz" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
 	},
 /obj/structure/railing/mapped,
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "wB" = (
 /obj/structure/sign/warning/docking_area{
@@ -3248,13 +3222,12 @@
 /turf/simulated/floor/wood/yew,
 /area/scavver/hab)
 "zU" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 1;
 	icon_state = "railing0-1"
 	},
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "zX" = (
 /obj/structure/cable{
@@ -3308,11 +3281,10 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/scavver/hab)
 "An" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped,
 /obj/random/loot,
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "Aq" = (
 /obj/structure/cable{
@@ -3770,14 +3742,13 @@
 /turf/simulated/floor,
 /area/scavver/yachtup)
 "EM" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 1;
 	icon_state = "railing0-1"
 	},
 /obj/item/caution/cone,
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "ES" = (
 /obj/random/toolbox,
@@ -3846,8 +3817,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/scavver/hab)
 "FC" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 8;
 	icon_state = "railing0-1"
@@ -3857,7 +3826,8 @@
 	icon_state = "railing0-1"
 	},
 /obj/item/caution/cone,
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "FF" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -4157,11 +4127,6 @@
 "In" = (
 /turf/simulated/floor,
 /area/scavver/gantry/up2)
-"Iy" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
-/turf/space,
-/area/space)
 "IF" = (
 /obj/effect/floor_decal/techfloor/orange{
 	dir = 1
@@ -5240,8 +5205,7 @@
 /area/scavver/gantry/up1)
 "UT" = (
 /obj/effect/catwalk_plated/dark,
-/obj/structure/lattice,
-/turf/space,
+/turf/simulated/floor,
 /area/space)
 "UU" = (
 /obj/structure/cable{
@@ -5615,13 +5579,12 @@
 /turf/simulated/floor/plating,
 /area/scavver/hab)
 "XR" = (
-/obj/structure/lattice,
-/obj/effect/catwalk_plated/dark,
 /obj/structure/railing/mapped{
 	dir = 4;
 	icon_state = "railing0-1"
 	},
-/turf/space,
+/obj/effect/catwalk_plated/dark,
+/turf/simulated/floor,
 /area/space)
 "XX" = (
 /obj/structure/cable{
@@ -14395,9 +14358,9 @@ eN
 zU
 hH
 hH
-aM
-aM
-aM
+hH
+hH
+hH
 hH
 hH
 hH
@@ -15457,8 +15420,8 @@ wh
 eN
 eN
 zU
-Iy
-Iy
+UT
+UT
 oo
 rX
 rX
@@ -16223,8 +16186,8 @@ gp
 ML
 mq
 WG
-Iy
-Iy
+UT
+UT
 tX
 Im
 Im
@@ -16511,8 +16474,8 @@ eN
 eN
 eN
 eN
-Iy
-Iy
+UT
+UT
 eN
 eN
 aa
@@ -16648,7 +16611,6 @@ hH
 hH
 qD
 hH
-hw
 hH
 hH
 hH
@@ -16658,13 +16620,14 @@ hH
 hH
 hH
 hH
-Iy
+hH
+UT
 hH
 hH
 hH
 hH
-Iy
-Iy
+UT
+UT
 hH
 hH
 xR
@@ -16672,7 +16635,7 @@ Oa
 PX
 hH
 hH
-Iy
+UT
 eN
 eN
 fr
@@ -16790,7 +16753,7 @@ zU
 xC
 hX
 eN
-Iy
+UT
 eN
 eN
 eN
@@ -16810,7 +16773,7 @@ eN
 hX
 xC
 eN
-Iy
+UT
 eN
 eN
 eN
@@ -16942,7 +16905,7 @@ zU
 eN
 hX
 wB
-Iy
+UT
 eN
 eN
 eN
@@ -16962,7 +16925,7 @@ eN
 eN
 VB
 eN
-Iy
+UT
 eN
 eN
 eN
@@ -17243,8 +17206,8 @@ eN
 eN
 eN
 zU
-Iy
-Iy
+UT
+UT
 dD
 SX
 Uf
@@ -17860,7 +17823,7 @@ hX
 Ds
 eN
 eN
-Iy
+UT
 eN
 eN
 eN
@@ -17869,7 +17832,7 @@ Id
 Og
 df
 eN
-Iy
+UT
 eN
 eN
 eN
@@ -17880,7 +17843,7 @@ eN
 Ds
 eN
 eN
-Iy
+UT
 eN
 eN
 eN
@@ -18012,7 +17975,7 @@ eN
 hX
 xC
 eN
-Iy
+UT
 eN
 eN
 eN
@@ -18021,7 +17984,7 @@ eN
 eN
 bc
 eN
-Iy
+UT
 eN
 eN
 eN
@@ -18032,7 +17995,7 @@ hX
 xC
 eN
 eN
-Iy
+UT
 eN
 eN
 eN
@@ -18173,7 +18136,7 @@ XR
 XR
 iI
 XR
-Iy
+UT
 XR
 XR
 XR
@@ -18325,7 +18288,7 @@ hX
 eN
 bc
 eN
-Iy
+UT
 eN
 eN
 eN

--- a/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
@@ -1700,9 +1700,7 @@
 /obj/machinery/ion_engine{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/ship/skrellscoutship/maintenance/atmos)
 "fH" = (
 /obj/structure/table/rack,
@@ -1942,9 +1940,7 @@
 /obj/machinery/ion_engine{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/ship/skrellscoutship/hangar)
 "gp" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3516,9 +3512,7 @@
 /obj/machinery/ion_engine{
 	dir = 8
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/ship/skrellscoutship/command/armory)
 "kG" = (
 /obj/effect/landmark/map_data,

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -23,9 +23,7 @@
 /turf/simulated/wall/r_wall/hull,
 /area/vacant/brig)
 "ae" = (
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/brig)
 "af" = (
 /obj/machinery/computer/arcade,
@@ -48,15 +46,11 @@
 /area/crew_quarters/gym)
 "ak" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/brig)
 "al" = (
 /obj/random/trash,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/brig)
 "am" = (
 /obj/machinery/shieldwallgen{
@@ -86,24 +80,18 @@
 /obj/structure/bed/chair/comfy/black{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/brig)
 "aq" = (
 /obj/effect/landmark{
 	name = "xeno_spawn";
 	pixel_x = -1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/brig)
 "ar" = (
 /obj/effect/decal/cleanable/vomit,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/brig)
 "as" = (
 /obj/structure/hygiene/toilet{
@@ -133,30 +121,22 @@
 	dir = 1
 	},
 /obj/machinery/constructable_frame/computerframe,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/brig)
 "ay" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 1
 	},
 /obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/brig)
 "az" = (
 /obj/structure/door_assembly,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/brig)
 "aA" = (
 /obj/structure/table/steel_reinforced,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/brig)
 "aB" = (
 /obj/structure/closet{
@@ -178,9 +158,7 @@
 /obj/machinery/door/airlock/security{
 	name = "Old Brig"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/brig)
 "aF" = (
 /obj/random/obstruction,
@@ -191,18 +169,14 @@
 	dir = 9
 	},
 /obj/structure/closet/secure_closet/brig,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/brig)
 "aH" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 5
 	},
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/brig)
 "aI" = (
 /turf/simulated/floor/reinforced,
@@ -211,9 +185,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/brig)
 "aK" = (
 /obj/structure/cable/green{
@@ -221,9 +193,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/brig)
 "aL" = (
 /obj/machinery/power/apc{
@@ -262,9 +232,7 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/green,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "aQ" = (
 /turf/simulated/wall/r_wall/hull,
@@ -280,9 +248,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "aS" = (
 /obj/structure/cable/green{
@@ -293,9 +259,7 @@
 /obj/machinery/door/airlock/security{
 	name = "Old Brig"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/brig)
 "aT" = (
 /turf/simulated/wall/r_wall/hull,
@@ -343,9 +307,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "bd" = (
 /turf/simulated/wall/r_wall/hull,
@@ -392,9 +354,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "bn" = (
 /obj/effect/decal/cleanable/dirt,
@@ -461,9 +421,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "by" = (
 /obj/machinery/alarm{
@@ -473,9 +431,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "bz" = (
 /obj/structure/closet/crate,
@@ -515,18 +471,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "bC" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
 /obj/machinery/smartfridge/drying_rack,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "bD" = (
 /obj/machinery/alarm{
@@ -740,9 +692,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/janitor/storage)
 "bS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -756,9 +706,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/chief_steward)
 "bT" = (
 /obj/structure/table/standard,
@@ -820,9 +768,7 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/green,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "cd" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -842,9 +788,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "ce" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -869,9 +813,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "cf" = (
 /obj/structure/cable/green{
@@ -897,23 +839,17 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "cg" = (
 /obj/effect/floor_decal/corner/yellow/half{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "ch" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "ci" = (
 /obj/machinery/button/blast_door{
@@ -1038,9 +974,7 @@
 /obj/effect/floor_decal/corner/green/half{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "cz" = (
 /obj/machinery/photocopier,
@@ -1166,9 +1100,7 @@
 "cN" = (
 /obj/machinery/smartfridge,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/galley)
 "cO" = (
 /obj/machinery/door/firedoor,
@@ -1217,9 +1149,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 9
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "cS" = (
 /obj/structure/cable/green{
@@ -1288,9 +1218,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "cY" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -1310,9 +1238,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 6
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "cZ" = (
 /obj/machinery/door/firedoor,
@@ -1401,9 +1327,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/starboard)
 "dd" = (
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/maintenance/thirddeck/starboard)
 "de" = (
 /obj/item/beach_ball,
@@ -1575,17 +1499,13 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "dC" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "dD" = (
 /turf/simulated/floor/tiled/techfloor,
@@ -1652,9 +1572,7 @@
 	dir = 9
 	},
 /obj/effect/floor_decal/corner/green,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "dI" = (
 /obj/structure/catwalk,
@@ -1698,9 +1616,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "dM" = (
 /obj/machinery/suit_storage_unit/atmos/alt/sol,
@@ -1720,9 +1636,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "dO" = (
 /obj/machinery/field_generator,
@@ -1738,9 +1652,7 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/green,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "dQ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -1773,9 +1685,7 @@
 /area/maintenance/thirddeck/starboard)
 "dS" = (
 /obj/machinery/washing_machine,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/maintenance/thirddeck/starboard)
 "dT" = (
 /obj/machinery/alarm{
@@ -2109,9 +2019,7 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "eM" = (
 /obj/machinery/door/firedoor,
@@ -2222,9 +2130,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/chief_steward)
 "fb" = (
 /turf/simulated/wall/r_wall/hull,
@@ -2250,9 +2156,7 @@
 /obj/structure/table/rack{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/maintenance/thirddeck/starboard)
 "ff" = (
 /obj/machinery/door/firedoor,
@@ -2268,9 +2172,7 @@
 	id_tag = "cs_door";
 	name = "Chief Steward's Office"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/chief_steward)
 "fg" = (
 /obj/structure/railing/mapped{
@@ -2396,9 +2298,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "ft" = (
 /obj/machinery/firealarm{
@@ -2453,9 +2353,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "fy" = (
 /obj/structure/closet/secure_closet/freezer/meat,
@@ -2691,9 +2589,7 @@
 /obj/structure/table/steel,
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/maintenance/thirddeck/starboard)
 "fV" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -2914,9 +2810,7 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "gv" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
@@ -3610,9 +3504,7 @@
 /area/crew_quarters/head/sauna)
 "hM" = (
 /obj/effect/floor_decal/industrial/warning/corner,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/command/disperser)
 "hN" = (
 /obj/random/junk,
@@ -3656,9 +3548,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "hY" = (
 /obj/machinery/door/firedoor,
@@ -3844,9 +3734,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "iq" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -3913,9 +3801,7 @@
 /area/command/disperser)
 "ix" = (
 /obj/machinery/light,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/command/disperser)
 "iy" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -4053,9 +3939,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "iN" = (
 /obj/structure/table/standard,
@@ -4223,9 +4107,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "jc" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
@@ -4244,9 +4126,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "jf" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
@@ -4337,9 +4217,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "jn" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
@@ -4456,9 +4334,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/yellow,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "jG" = (
 /obj/structure/ore_box,
@@ -4535,9 +4411,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "jO" = (
 /obj/machinery/light/small{
@@ -4872,9 +4746,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "kC" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -5127,9 +4999,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "ld" = (
 /turf/simulated/open,
@@ -5316,9 +5186,7 @@
 /obj/item/material/hatchet,
 /obj/item/material/minihoe,
 /obj/item/screwdriver,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "lB" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
@@ -5377,9 +5245,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "lK" = (
 /obj/machinery/light{
@@ -5728,9 +5594,7 @@
 "mw" = (
 /obj/machinery/computer/arcade,
 /obj/machinery/light,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "mx" = (
 /obj/machinery/light{
@@ -5769,9 +5633,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "mF" = (
 /obj/structure/table/rack,
@@ -5844,17 +5706,13 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/yellow,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "mV" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "mW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -6001,9 +5859,7 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/holocontrol)
 "nm" = (
 /obj/structure/table/steel,
@@ -6039,9 +5895,7 @@
 /obj/structure/bed/chair/office/comfy/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "nt" = (
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -6050,9 +5904,7 @@
 	linkedholodeck_area = /area/holodeck/alphadeck;
 	programs_list_id = "TorchMainPrograms"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/holocontrol)
 "nu" = (
 /obj/structure/disposalpipe/segment{
@@ -6149,9 +6001,7 @@
 	icon_state = "4-8"
 	},
 /obj/structure/hygiene/drain,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "nP" = (
 /obj/item/device/radio/intercom{
@@ -6162,9 +6012,7 @@
 	c_tag = "Third Deck Hallway - Fore Starboard";
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "nQ" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -6205,9 +6053,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "nS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -6328,9 +6174,7 @@
 /area/hydroponics)
 "oa" = (
 /obj/structure/stairs/west,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "ob" = (
 /obj/effect/floor_decal/corner/green/half{
@@ -6376,9 +6220,7 @@
 	dir = 8;
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "og" = (
 /obj/structure/cable/green{
@@ -6421,9 +6263,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/holocontrol)
 "ol" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -6432,9 +6272,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/holocontrol)
 "om" = (
 /obj/machinery/door/firedoor,
@@ -6506,9 +6344,7 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "ow" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -6520,9 +6356,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "oy" = (
 /obj/effect/floor_decal/corner/red{
@@ -6531,9 +6365,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "oz" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -6543,9 +6375,7 @@
 /obj/structure/sign/warning/moving_parts{
 	pixel_y = 32
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/command/disperser)
 "oA" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -6577,9 +6407,7 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "oJ" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -6604,9 +6432,7 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "oL" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -6688,9 +6514,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 6
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "oX" = (
 /obj/structure/bed/chair/wood{
@@ -6907,9 +6731,7 @@
 	dir = 4;
 	pixel_x = -21
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/holocontrol)
 "pk" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -6918,9 +6740,7 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/holocontrol)
 "pl" = (
 /obj/random/obstruction,
@@ -6949,9 +6769,7 @@
 /area/hallway/primary/thirddeck/center)
 "pp" = (
 /obj/structure/fitness/weightlifter,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "pq" = (
 /obj/structure/cable/green{
@@ -6968,9 +6786,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "pr" = (
 /obj/structure/cable/green{
@@ -7097,9 +6913,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "pI" = (
 /turf/simulated/wall/r_wall/hull,
@@ -7123,9 +6937,7 @@
 	pixel_x = 24
 	},
 /obj/effect/floor_decal/corner/paleblue,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "pO" = (
 /turf/simulated/open,
@@ -7284,9 +7096,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/galleybackroom)
 "qo" = (
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/crew_quarters/service_break_room)
 "qp" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -7320,9 +7130,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 6
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "qs" = (
 /obj/structure/table/woodentable,
@@ -7333,9 +7141,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 9
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "qt" = (
 /obj/effect/floor_decal/corner/lime/three_quarters{
@@ -7344,9 +7150,7 @@
 /obj/machinery/vending/cola{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "qu" = (
 /turf/simulated/floor/carpet,
@@ -7393,9 +7197,7 @@
 	dir = 4;
 	pixel_x = -25
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "qB" = (
 /obj/effect/decal/cleanable/dirt,
@@ -7441,15 +7243,11 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "qL" = (
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "qM" = (
 /obj/structure/catwalk,
@@ -7482,18 +7280,14 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "qS" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "qT" = (
 /obj/structure/flora/ausbushes/lavendergrass,
@@ -7509,9 +7303,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "qV" = (
 /obj/machinery/atm{
@@ -7520,9 +7312,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "qW" = (
 /obj/machinery/atmospherics/valve/digital{
@@ -7571,9 +7361,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "rc" = (
 /obj/effect/floor_decal/corner/green{
@@ -7581,20 +7369,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "re" = (
 /obj/effect/floor_decal/corner/green/half,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "rf" = (
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "rh" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -7604,9 +7386,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "ri" = (
 /obj/machinery/light{
@@ -7624,9 +7404,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "rl" = (
 /obj/machinery/alarm{
@@ -7635,9 +7413,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "rm" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -7676,9 +7452,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "rt" = (
 /obj/machinery/camera/network/third_deck{
@@ -7699,9 +7473,7 @@
 /obj/machinery/atm{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "rv" = (
 /obj/machinery/hologram/holopad,
@@ -7722,9 +7494,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "rx" = (
 /obj/machinery/newscaster{
@@ -7733,9 +7503,7 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "rz" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7775,9 +7543,7 @@
 /obj/effect/floor_decal/corner/lime/three_quarters{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "rC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -7897,9 +7663,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "rS" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8032,9 +7796,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "sh" = (
 /obj/structure/cable/green{
@@ -8279,9 +8041,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "sB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8434,9 +8194,7 @@
 /area/crew_quarters/recreation)
 "sM" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/cryolocker)
 "sN" = (
 /obj/structure/disposalpipe/segment{
@@ -8453,9 +8211,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "sP" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -8503,14 +8259,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/tele_beacon,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "sW" = (
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "sX" = (
 /obj/effect/floor_decal/corner/lime{
@@ -8521,9 +8273,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "sZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -8572,9 +8322,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "th" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -8594,9 +8342,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "ti" = (
 /obj/random/junk,
@@ -8645,18 +8391,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "ts" = (
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Hallway - Fore Central";
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "tt" = (
 /obj/machinery/door/firedoor,
@@ -8674,9 +8416,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "tw" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -8685,9 +8425,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "tx" = (
 /obj/machinery/camera/network/third_deck{
@@ -8701,9 +8439,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "ty" = (
 /obj/effect/floor_decal/corner/blue{
@@ -8726,18 +8462,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "tC" = (
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "tD" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -8750,9 +8482,7 @@
 	dir = 1;
 	pixel_y = -28
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "tE" = (
 /obj/machinery/firealarm{
@@ -8769,9 +8499,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "tG" = (
 /obj/effect/floor_decal/techfloor{
@@ -8797,9 +8525,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "tJ" = (
 /obj/machinery/atm{
@@ -8808,9 +8534,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "tK" = (
 /obj/structure/lattice,
@@ -8824,9 +8548,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "tN" = (
 /obj/structure/bed/chair/pew/left/mahogany,
@@ -8849,9 +8571,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "tS" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -8863,9 +8583,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "tT" = (
 /obj/structure/cable/green{
@@ -8873,9 +8591,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "tU" = (
 /obj/structure/cable/green{
@@ -8897,9 +8613,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "tX" = (
 /obj/effect/decal/cleanable/dirt,
@@ -8932,9 +8646,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "ub" = (
 /turf/simulated/wall/walnut,
@@ -9005,9 +8717,7 @@
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "ul" = (
 /obj/effect/floor_decal/corner/lime{
@@ -9017,18 +8727,14 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "um" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "un" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -9042,9 +8748,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "up" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -9106,18 +8810,14 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "uz" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "uA" = (
 /obj/effect/floor_decal/industrial/warning/corner{
@@ -9127,9 +8827,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/command/disperser)
 "uB" = (
 /obj/machinery/computer/arcade,
@@ -9156,9 +8854,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "uG" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -9459,9 +9155,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "vw" = (
 /obj/structure/bed/chair/padded/green{
@@ -9493,9 +9187,7 @@
 /turf/simulated/floor/grass,
 /area/crew_quarters/observation)
 "vF" = (
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "vG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9628,9 +9320,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "wa" = (
 /obj/effect/floor_decal/techfloor{
@@ -9682,17 +9372,13 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "wk" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "wl" = (
 /turf/simulated/wall/prepainted,
@@ -9707,9 +9393,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "wp" = (
 /turf/simulated/floor/lino,
@@ -9819,9 +9503,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "wC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -9863,9 +9545,7 @@
 /obj/machinery/vending/fitness{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "wK" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -9879,9 +9559,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "wM" = (
 /obj/structure/bed/chair/comfy/black,
@@ -9894,9 +9572,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "wO" = (
 /obj/machinery/atm{
@@ -9905,9 +9581,7 @@
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Hallway - Teleporter"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "wP" = (
 /obj/structure/extinguisher_cabinet{
@@ -9922,9 +9596,7 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "wR" = (
 /obj/effect/floor_decal/industrial/warning/fulltile,
@@ -9952,9 +9624,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "wU" = (
 /obj/structure/sign/warning/vent_port{
@@ -9970,9 +9640,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "wW" = (
 /turf/simulated/wall/walnut,
@@ -10018,9 +9686,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/green,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "xg" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -10032,9 +9698,7 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "xi" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -10085,9 +9749,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "xo" = (
 /obj/structure/table/standard,
@@ -10179,9 +9841,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "xF" = (
 /turf/simulated/floor/tiled/steel_grid,
@@ -10191,9 +9851,7 @@
 	dir = 10
 	},
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "xI" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -10202,9 +9860,7 @@
 /obj/structure/sign/directions/janitor{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "xJ" = (
 /obj/structure/cable/green{
@@ -10250,9 +9906,7 @@
 "xN" = (
 /obj/structure/table/marble,
 /obj/machinery/recharger,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "xO" = (
 /obj/structure/cable/green{
@@ -10283,9 +9937,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 9
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/chief_steward)
 "xQ" = (
 /obj/structure/cable/green{
@@ -10335,9 +9987,7 @@
 	dir = 8;
 	icon_state = "railing0-1"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "xT" = (
 /obj/structure/cable/green{
@@ -10358,9 +10008,7 @@
 	dir = 4;
 	icon_state = "pipe-j2"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "xU" = (
 /obj/effect/wallframe_spawn/reinforced,
@@ -10410,9 +10058,7 @@
 /obj/effect/floor_decal/corner/red/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/emcloset,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "xY" = (
 /obj/structure/bed/padded,
@@ -10544,9 +10190,7 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "yq" = (
 /obj/machinery/computer/modular/preset/civilian{
@@ -10594,9 +10238,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "yz" = (
 /obj/effect/floor_decal/spline/fancy/black{
@@ -10847,9 +10489,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "zl" = (
 /obj/structure/cable/green{
@@ -10862,9 +10502,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "zn" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -11005,9 +10643,7 @@
 /obj/structure/reagent_dispensers/water_cooler{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "zL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -11023,9 +10659,7 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "zQ" = (
 /obj/structure/railing/mapped{
@@ -11140,9 +10774,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 9
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Aq" = (
 /obj/machinery/firealarm{
@@ -11271,9 +10903,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/storage/tools)
 "AJ" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -11282,9 +10912,7 @@
 /obj/machinery/air_sensor{
 	id_tag = "cChamber3s"
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d3starboard)
 "AK" = (
 /obj/structure/table/rack{
@@ -11371,9 +10999,7 @@
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "AV" = (
 /obj/effect/floor_decal/spline/fancy/black{
@@ -11428,9 +11054,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "Bi" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -11579,9 +11203,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/storage/tools)
 "BD" = (
 /obj/effect/floor_decal/corner/green/half{
@@ -11605,9 +11227,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "BH" = (
 /obj/machinery/firealarm{
@@ -11622,25 +11242,19 @@
 /obj/effect/floor_decal/corner/yellow{
 	dir = 6
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "BK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/storage/tools)
 "BL" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/storage/tools)
 "BM" = (
 /obj/random/junk,
@@ -11784,9 +11398,7 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Cj" = (
 /obj/machinery/light/spot{
@@ -12049,9 +11661,7 @@
 "CP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/largecrate,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/maintenance/thirddeck/starboard)
 "CQ" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -12279,9 +11889,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "Du" = (
 /obj/machinery/door/firedoor,
@@ -12313,9 +11921,7 @@
 	dir = 4;
 	pixel_x = 26
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "Dx" = (
 /obj/structure/disposalpipe/segment{
@@ -12333,9 +11939,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/light,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Dy" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -12560,16 +12164,12 @@
 	},
 /obj/structure/bed/chair/comfy/lime,
 /obj/random/junk,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/cabin)
 "DW" = (
 /obj/effect/floor_decal/corner/lime,
 /obj/effect/decal/cleanable/cobweb2,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/cabin)
 "DX" = (
 /obj/machinery/atmospherics/valve/digital{
@@ -12834,9 +12434,7 @@
 /obj/effect/floor_decal/corner/lime{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/cabin)
 "ED" = (
 /turf/simulated/floor/plating,
@@ -13060,9 +12658,7 @@
 	dir = 8
 	},
 /obj/structure/catwalk,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/maintenance/thirddeck/port)
 "Ff" = (
 /obj/machinery/door/airlock/maintenance{
@@ -13080,9 +12676,7 @@
 "Fh" = (
 /obj/effect/floor_decal/corner/lime,
 /obj/random/trash,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/cabin)
 "Fi" = (
 /obj/structure/bed/chair/office/light{
@@ -13238,9 +12832,7 @@
 	c_tag = "Third Deck Hallway - Fore Port";
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "FC" = (
 /obj/machinery/door/firedoor,
@@ -13308,9 +12900,7 @@
 /area/vacant/cabin)
 "FL" = (
 /obj/effect/floor_decal/corner/lime,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/cabin)
 "FM" = (
 /obj/structure/table/steel,
@@ -13489,9 +13079,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Gt" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -13645,9 +13233,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "GD" = (
 /obj/structure/catwalk,
@@ -13766,17 +13352,13 @@
 /area/maintenance/thirddeck/foreport)
 "GY" = (
 /obj/structure/hygiene/drain,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "GZ" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/cryolocker)
 "Ha" = (
 /obj/structure/disposalpipe/segment,
@@ -13815,9 +13397,7 @@
 /obj/machinery/light_switch{
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "Hh" = (
 /obj/structure/cable/green{
@@ -13916,9 +13496,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/storage/tools)
 "Hv" = (
 /obj/effect/floor_decal/techfloor{
@@ -14121,9 +13699,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/command/disperser)
 "HU" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
@@ -14150,9 +13726,7 @@
 /area/command/disperser)
 "HZ" = (
 /obj/effect/floor_decal/industrial/loading,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/command/disperser)
 "Ia" = (
 /obj/effect/wallframe_spawn/reinforced/hull,
@@ -14183,17 +13757,13 @@
 	dir = 1;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/command/disperser)
 "Id" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/command/disperser)
 "Ie" = (
 /obj/structure/table/steel,
@@ -14235,9 +13805,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "Il" = (
 /obj/structure/flora/ausbushes/brflowers,
@@ -14250,41 +13818,31 @@
 	id_tag = "bsa-core";
 	name = "OFD Blast Door"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/command/disperser)
 "In" = (
 /obj/machinery/disperser/front{
 	dir = 8
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/command/disperser)
 "Io" = (
 /obj/machinery/disperser/middle{
 	dir = 8
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/command/disperser)
 "Ip" = (
 /obj/machinery/disperser/back{
 	dir = 8
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/command/disperser)
 "Iq" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 6
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Ir" = (
 /obj/machinery/camera/network/command{
@@ -14376,9 +13934,7 @@
 /area/hallway/primary/thirddeck/fore)
 "ID" = (
 /obj/random_multi/single_item/punitelly,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/brig)
 "IE" = (
 /obj/random_multi/single_item/punitelly,
@@ -14635,9 +14191,7 @@
 /area/hallway/primary/thirddeck/center)
 "Jc" = (
 /obj/effect/floor_decal/corner/green,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "Je" = (
 /obj/structure/disposalpipe/segment,
@@ -14648,18 +14202,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "Jg" = (
 /obj/effect/floor_decal/corner/green{
 	dir = 8
 	},
 /obj/structure/flora/pottedplant/dead,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "Jh" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -15045,9 +14595,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "JR" = (
 /obj/structure/cable/green{
@@ -15290,9 +14838,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "Ku" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -15549,9 +15095,7 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d3starboard)
 "KW" = (
 /obj/structure/railing/mapped{
@@ -15605,9 +15149,7 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d3port)
 "Lh" = (
 /obj/structure/closet/emcloset,
@@ -15619,17 +15161,13 @@
 	id_tag = "cChamber3pV";
 	name = "Chamber Vent"
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d3port)
 "Lj" = (
 /obj/effect/landmark{
 	name = "lightsout"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "Lk" = (
 /obj/structure/catwalk,
@@ -15766,9 +15304,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/floor_decal/corner/green/half,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "Lz" = (
 /obj/machinery/door/firedoor,
@@ -15835,9 +15371,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "LE" = (
 /obj/machinery/computer/air_control{
@@ -15863,9 +15397,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "LG" = (
 /turf/simulated/wall/prepainted,
@@ -15942,9 +15474,7 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d3port)
 "LP" = (
 /obj/structure/cable/green{
@@ -16054,9 +15584,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Ma" = (
 /obj/machinery/atmospherics/valve/shutoff/supply,
@@ -16142,9 +15670,7 @@
 /area/engineering/hardstorage)
 "Mi" = (
 /obj/effect/floor_decal/corner/green,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "Mj" = (
 /obj/structure/cable/green{
@@ -16160,9 +15686,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 32
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Mn" = (
 /obj/structure/disposalpipe/segment{
@@ -16232,9 +15756,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/galleybackroom)
 "Mx" = (
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "My" = (
 /obj/machinery/jukebox/old,
@@ -16249,9 +15771,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "MB" = (
 /obj/structure/disposalpipe/segment,
@@ -16311,9 +15831,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "MI" = (
 /obj/structure/cable/green{
@@ -16385,9 +15903,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "MU" = (
 /obj/effect/floor_decal/corner/yellow/half,
@@ -16482,9 +15998,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "Ni" = (
 /obj/structure/table/rack,
@@ -16616,9 +16130,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "NF" = (
 /obj/machinery/door/firedoor,
@@ -16636,9 +16148,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "NH" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -16710,9 +16220,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "NO" = (
 /obj/random_multi/single_item/punitelly,
@@ -16759,9 +16267,7 @@
 	dir = 5
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "NV" = (
 /obj/structure/cable/green{
@@ -16805,9 +16311,7 @@
 	volume_rate = 4000
 	},
 /obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d3port)
 "Ob" = (
 /obj/effect/shuttle_landmark/torch/deck4/aquila{
@@ -16819,9 +16323,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "Od" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -16870,9 +16372,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "Oj" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -16918,9 +16418,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "Oq" = (
 /obj/effect/floor_decal/corner/green{
@@ -16933,9 +16431,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "Or" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
@@ -16987,9 +16483,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "Oz" = (
 /obj/machinery/light/small{
@@ -17029,9 +16523,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "OE" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -17151,9 +16643,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -32
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "OW" = (
 /obj/structure/sign/directions/engineering{
@@ -17206,9 +16696,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "Pc" = (
 /obj/structure/table/rack,
@@ -17243,9 +16731,7 @@
 	dir = 1;
 	icon_state = "warningcorner"
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/command/disperser)
 "Pn" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -17266,9 +16752,7 @@
 	dir = 10
 	},
 /obj/machinery/beehive,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "Po" = (
 /obj/structure/disposalpipe/segment{
@@ -17338,9 +16822,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "PA" = (
 /obj/structure/sign/directions/science{
@@ -17400,9 +16882,7 @@
 	dir = 8;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "PH" = (
 /obj/effect/floor_decal/corner/green/half,
@@ -17439,9 +16919,7 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d3starboard)
 "PN" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -17505,9 +16983,7 @@
 /obj/machinery/vending/coffee{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "PV" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -17542,9 +17018,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d3starboard)
 "Qd" = (
 /obj/structure/table/rack,
@@ -17627,9 +17101,7 @@
 /obj/structure/hygiene/sink/kitchen{
 	pixel_y = -32
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "Qq" = (
 /turf/simulated/wall/r_wall/hull,
@@ -17725,9 +17197,7 @@
 	dir = 5
 	},
 /obj/machinery/ship_map,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "QE" = (
 /obj/structure/table/rack,
@@ -17757,9 +17227,7 @@
 /area/crew_quarters/office)
 "QJ" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "QK" = (
 /obj/machinery/firealarm{
@@ -17787,9 +17255,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "QQ" = (
 /obj/effect/wallframe_spawn/no_grille,
@@ -17884,9 +17350,7 @@
 /obj/structure/bed/chair{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Re" = (
 /obj/structure/cable/green{
@@ -17908,9 +17372,7 @@
 /obj/machinery/camera/network/third_deck{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "Rh" = (
 /obj/structure/bed/chair/padded/green{
@@ -17933,9 +17395,7 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Rl" = (
 /obj/effect/floor_decal/industrial/hatch,
@@ -17989,9 +17449,7 @@
 /obj/item/reagent_containers/glass/beaker{
 	pixel_x = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "Ro" = (
 /obj/effect/floor_decal/corner/green/half,
@@ -18057,9 +17515,7 @@
 /obj/structure/table/rack,
 /obj/item/towel/random,
 /obj/item/towel/random,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "RB" = (
 /obj/structure/catwalk,
@@ -18075,9 +17531,7 @@
 	dir = 2;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "RE" = (
 /obj/machinery/alarm{
@@ -18090,9 +17544,7 @@
 /area/crew_quarters/head)
 "RF" = (
 /obj/random/junk,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/maintenance/thirddeck/starboard)
 "RG" = (
 /turf/simulated/wall/prepainted,
@@ -18203,17 +17655,13 @@
 	id_tag = "shop_shutters";
 	name = "Commissary Shutters"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "Sb" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d3port)
 "Sc" = (
 /obj/effect/floor_decal/corner/green{
@@ -18233,17 +17681,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Sd" = (
 /obj/structure/closet/hydrant{
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Sf" = (
 /obj/machinery/light{
@@ -18252,18 +17696,14 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "Sg" = (
 /obj/machinery/door/blast/regular{
 	id_tag = "cChamber3sV";
 	name = "Chamber Vent"
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d3starboard)
 "Sh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -18346,9 +17786,7 @@
 	pixel_y = -26
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "So" = (
 /obj/structure/cable/green{
@@ -18449,9 +17887,7 @@
 	dir = 1
 	},
 /obj/random/vendor,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "SA" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -18714,17 +18150,13 @@
 /obj/machinery/chem_master/condimaster{
 	name = "CondiMaster Neo"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "Tn" = (
 /obj/effect/floor_decal/corner/lime{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "To" = (
 /obj/structure/lattice,
@@ -18739,9 +18171,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Tr" = (
 /obj/effect/floor_decal/corner/red/diagonal,
@@ -18832,9 +18262,7 @@
 /area/maintenance/thirddeck/port)
 "TC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "TE" = (
 /turf/simulated/wall/prepainted,
@@ -19028,9 +18456,7 @@
 /area/crew_quarters/observation)
 "Ui" = (
 /obj/machinery/meter/turf,
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/command/disperser)
 "Um" = (
 /obj/machinery/light{
@@ -19047,9 +18473,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "Un" = (
 /obj/machinery/status_display,
@@ -19214,9 +18638,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "UD" = (
 /obj/structure/grille,
@@ -19329,9 +18751,7 @@
 	name = "Sanitation Supplies"
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/janitor/storage)
 "UP" = (
 /obj/structure/fitness/weightlifter,
@@ -19339,9 +18759,7 @@
 	dir = 8;
 	pixel_x = 25
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "UQ" = (
 /obj/item/device/radio/intercom{
@@ -19352,9 +18770,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "UR" = (
 /obj/machinery/sparker{
@@ -19367,9 +18783,7 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d3starboard)
 "UU" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -19383,9 +18797,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 8
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "UX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -19441,9 +18853,7 @@
 /obj/machinery/vending/fitness{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "Vd" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -19513,9 +18923,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 9
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Vm" = (
 /obj/structure/cable/green{
@@ -19523,9 +18931,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "Vn" = (
 /obj/effect/floor_decal/corner/lime{
@@ -19539,9 +18945,7 @@
 	pixel_y = 26
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "Vo" = (
 /obj/effect/wallframe_spawn/reinforced/hull,
@@ -19640,9 +19044,7 @@
 /obj/effect/floor_decal/corner/green/half{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "VD" = (
 /obj/structure/catwalk,
@@ -19695,9 +19097,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "VI" = (
 /obj/structure/ladder,
@@ -19809,9 +19209,7 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "VU" = (
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "VV" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -19884,15 +19282,11 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "We" = (
 /obj/random_multi/single_item/poppy,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/vacant/brig)
 "Wg" = (
 /obj/random/trash,
@@ -19927,9 +19321,7 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Wo" = (
 /obj/machinery/meter,
@@ -19989,9 +19381,7 @@
 /obj/structure/closet/hydrant{
 	pixel_y = 32
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "Wy" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -20000,9 +19390,7 @@
 /obj/machinery/air_sensor{
 	id_tag = "cChamber3p"
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d3port)
 "Wz" = (
 /obj/effect/floor_decal/spline/fancy/wood{
@@ -20028,9 +19416,7 @@
 	dir = 4;
 	pixel_x = 24
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "WC" = (
 /turf/simulated/floor/reinforced/hydrogen,
@@ -20054,9 +19440,7 @@
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "WF" = (
 /obj/effect/wallframe_spawn/reinforced_phoron,
@@ -20276,9 +19660,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Xj" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -20315,9 +19697,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "Xo" = (
 /obj/effect/floor_decal/corner/grey/diagonal{
@@ -20398,9 +19778,7 @@
 	pixel_x = -20;
 	pixel_y = -20
 	},
-/turf/simulated/floor{
-	map_airless = 1
-	},
+/turf/simulated/floor,
 /area/command/disperser)
 "Xz" = (
 /obj/structure/closet/crate/solar,
@@ -20535,9 +19913,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/thirddeck/center)
 "XR" = (
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/cryolocker)
 "XS" = (
 /obj/random/torchcloset,
@@ -20647,9 +20023,7 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Ye" = (
 /obj/machinery/light/small,
@@ -20664,9 +20038,7 @@
 /obj/structure/reagent_dispensers/water_cooler{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Yj" = (
 /obj/structure/railing/mapped{
@@ -20728,9 +20100,7 @@
 	},
 /obj/structure/closet/crate/hydroponics/beekeeping,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hydroponics)
 "Yp" = (
 /obj/random/junk,
@@ -20756,17 +20126,13 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Yu" = (
 /obj/machinery/camera/network/third_deck{
 	c_tag = "Third Deck Hallway - Commissary"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Yv" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -20822,9 +20188,7 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/gym)
 "YG" = (
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "YH" = (
 /obj/structure/railing/mapped{
@@ -20839,9 +20203,7 @@
 /area/maintenance/thirddeck/port)
 "YJ" = (
 /obj/effect/floor_decal/corner/red,
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "YK" = (
 /turf/simulated/floor/tiled/freezer,
@@ -20899,9 +20261,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "YT" = (
 /obj/machinery/atmospherics/binary/passive_gate/on{
@@ -20918,9 +20278,7 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "YV" = (
 /obj/item/stool,
@@ -20947,9 +20305,7 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
 "YZ" = (
 /obj/machinery/door/airlock/maintenance{
@@ -20968,17 +20324,13 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "Zb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "Zc" = (
 /obj/machinery/atmospherics/binary/pump/on{
@@ -21030,9 +20382,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/storage/tools)
 "Zl" = (
 /obj/structure/cable/green{
@@ -21093,9 +20443,7 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/crew_quarters/commissary)
 "Zt" = (
 /obj/machinery/computer/modular/preset/civilian{
@@ -21216,9 +20564,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/simulated/floor/tiled{
-	map_airless = 1
-	},
+/turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/aft)
 "ZF" = (
 /obj/machinery/atmospherics/portables_connector{
@@ -21252,9 +20598,7 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d3port)
 "ZJ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -21320,9 +20664,7 @@
 	volume_rate = 4000
 	},
 /obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d3starboard)
 "ZV" = (
 /obj/structure/railing/mapped,

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -37,9 +37,7 @@
 /obj/machinery/fusion_fuel_injector/mapped{
 	initial_id_tag = "aux_fusion_plant"
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/vacant/prototype/engine)
 "ae" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -684,9 +682,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/engine_room)
 "bq" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2284,9 +2280,7 @@
 	dir = 8;
 	initial_id_tag = "aux_fusion_plant"
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/vacant/prototype/engine)
 "eu" = (
 /obj/structure/cable{
@@ -2316,9 +2310,7 @@
 /obj/machinery/power/port_gen/pacman/mrs{
 	anchored = 1
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/vacant/prototype/engine)
 "ex" = (
 /obj/random/torchcloset,
@@ -2421,9 +2413,7 @@
 	dir = 1;
 	initial_id_tag = "aux_fusion_plant"
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/vacant/prototype/engine)
 "eI" = (
 /obj/structure/cable/green{
@@ -4797,11 +4787,10 @@
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/seconddeck)
 "ky" = (
-/obj/machinery/shield_diffuser,
 /turf/simulated/floor/reinforced{
 	map_airless = 1
 	},
-/area/torchexterior)
+/area/vacant/prototype/engine)
 "kz" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -6907,9 +6896,7 @@
 	name = "Reactor Blast Door"
 	},
 /obj/effect/wallframe_spawn/reinforced_phoron,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/engine_room)
 "qe" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -7407,9 +7394,7 @@
 	id_tag = "EngineAccess";
 	name = "Engine Access Hatch"
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/engine_room)
 "ri" = (
 /obj/structure/cable{
@@ -8720,9 +8705,7 @@
 	id_tag = "WasteGate";
 	name = "Waste Gate"
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/wastetank)
 "uY" = (
 /obj/effect/floor_decal/corner/yellow/half,
@@ -8734,7 +8717,7 @@
 /turf/simulated/floor/reinforced{
 	map_airless = 1
 	},
-/area/space)
+/area/torchexterior)
 "vc" = (
 /obj/effect/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -9525,9 +9508,7 @@
 	icon_state = "pdoor0";
 	id_tag = "prototype_chamber_blast"
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/vacant/prototype/engine)
 "xy" = (
 /obj/machinery/light,
@@ -11156,9 +11137,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/engine_room)
 "Cl" = (
 /obj/structure/table/rack,
@@ -11750,9 +11729,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "DF" = (
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/wastetank)
 "DG" = (
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -11980,17 +11957,13 @@
 	id_tag = "prototype_chamber_blast"
 	},
 /obj/effect/wingrille_spawn/reinforced_phoron/full,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/vacant/prototype/engine)
 "Ek" = (
 /obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/wastetank)
 "El" = (
 /obj/machinery/door/blast/regular{
@@ -11999,9 +11972,7 @@
 	name = "Reactor Blast Door"
 	},
 /obj/effect/wallframe_spawn/reinforced_phoron,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/engine_room)
 "Eo" = (
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -12044,9 +12015,7 @@
 	dir = 4
 	},
 /obj/machinery/meter,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/wastetank)
 "Eu" = (
 /obj/machinery/atmospherics/unary/vent_pump/tank{
@@ -12062,9 +12031,7 @@
 	pressure_checks_default = 2;
 	pump_direction = 0
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/wastetank)
 "Ev" = (
 /obj/structure/cable/green{
@@ -12381,9 +12348,7 @@
 /obj/machinery/air_sensor{
 	id_tag = "waste_sensor"
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/wastetank)
 "Fg" = (
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -12828,9 +12793,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Gr" = (
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/torchexterior)
 "Gs" = (
 /obj/structure/cable{
@@ -13149,9 +13112,7 @@
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /obj/machinery/atmospherics/pipe/simple/visible/yellow,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/wastetank)
 "Hu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -13602,12 +13563,6 @@
 /obj/structure/ladder/up,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/central)
-"IR" = (
-/obj/structure/grille,
-/turf/simulated/floor{
-	map_airless = 1
-	},
-/area/space)
 "IU" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -13927,9 +13882,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/disposal)
-"JO" = (
-/turf/simulated/floor/reinforced,
-/area/space)
 "JQ" = (
 /obj/structure/table/steel,
 /obj/machinery/recharger,
@@ -14235,9 +14187,7 @@
 	},
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /obj/machinery/atmospherics/pipe/simple/visible/fuel,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/engine_room)
 "Lf" = (
 /obj/structure/disposalpipe/segment{
@@ -14271,9 +14221,7 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/seconddeck/fore)
 "Li" = (
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/vacant/prototype/engine)
 "Lj" = (
 /obj/structure/cable/yellow,
@@ -14322,9 +14270,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "Ls" = (
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/space)
 "Lt" = (
 /obj/machinery/portable_atmospherics/powered/scrubber,
@@ -14918,9 +14864,7 @@
 	id = "waste_in";
 	use_power = 1
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/wastetank)
 "ND" = (
 /obj/structure/sign/warning/airlock{
@@ -15313,9 +15257,7 @@
 /area/engineering/bluespace)
 "OG" = (
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/wastetank)
 "OI" = (
 /obj/machinery/computer/modular/preset/engineering{
@@ -15998,9 +15940,7 @@
 "QN" = (
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/wastetank)
 "QQ" = (
 /obj/structure/cable/green{
@@ -16079,9 +16019,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/engine_room)
 "Re" = (
 /obj/effect/floor_decal/corner/yellow{
@@ -16452,9 +16390,7 @@
 /obj/machinery/camera/network/engine{
 	c_tag = "Engine - Prototype Chamber One"
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/vacant/prototype/engine)
 "Sh" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
@@ -16500,9 +16436,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/engine_room)
 "Sl" = (
 /obj/machinery/cryopod{
@@ -16776,9 +16710,7 @@
 	icon_state = "pdoor0";
 	id_tag = "prototype_chamber_blast"
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/vacant/prototype/engine)
 "Tl" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow,
@@ -16805,9 +16737,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/engine_room)
 "Tp" = (
 /obj/structure/sign/warning/vacuum,
@@ -17081,9 +17011,7 @@
 /obj/machinery/power/supermatter,
 /obj/effect/engine_setup/core,
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/greengrid{
-	map_airless = 1
-	},
+/turf/simulated/floor/greengrid,
 /area/engineering/engine_room)
 "Up" = (
 /obj/machinery/atmospherics/pipe/simple/hidden{
@@ -17201,9 +17129,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/vacant/prototype/engine)
 "Vf" = (
 /obj/machinery/computer/air_control{
@@ -17222,9 +17148,7 @@
 	locked = 1
 	},
 /obj/machinery/door/firedoor,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/vacant/prototype/engine)
 "Vh" = (
 /obj/structure/cable{
@@ -17287,9 +17211,7 @@
 /area/engineering/engine_room)
 "Vo" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging,
-/turf/simulated/floor/greengrid{
-	map_airless = 1
-	},
+/turf/simulated/floor/greengrid,
 /area/engineering/engine_room)
 "Vq" = (
 /turf/simulated/wall/r_wall/hull,
@@ -17546,9 +17468,7 @@
 	name = "Reactor Vent"
 	},
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/engine_room)
 "Wp" = (
 /turf/simulated/wall/r_wall/hull,
@@ -17878,9 +17798,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/vacant/prototype/engine)
 "Xf" = (
 /obj/machinery/shield_diffuser,
@@ -17961,9 +17879,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/engine_room)
 "Xp" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
@@ -18074,9 +17990,7 @@
 /area/assembly/robotics)
 "XT" = (
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/torchexterior)
 "XU" = (
 /obj/effect/floor_decal/industrial/warning/corner,
@@ -18424,9 +18338,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 6
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/engine_room)
 "Zi" = (
 /obj/structure/cable/yellow{
@@ -18510,9 +18422,7 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 5
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/engineering/engine_room)
 "Zp" = (
 /obj/item/ammo_magazine/pistol/small/empty,
@@ -27221,11 +27131,11 @@ qw
 mc
 ue
 Se
-Li
+ky
 mg
 mg
 mg
-Li
+ky
 Se
 ue
 dj
@@ -27423,11 +27333,11 @@ qw
 Lc
 ad
 Ej
-Li
+ky
 Fg
 Xg
 Oh
-Li
+ky
 Ej
 eH
 qj
@@ -27625,11 +27535,11 @@ qw
 md
 ad
 Ej
-Li
+ky
 Gg
 eh
 Ph
-Li
+ky
 Ej
 eH
 rj
@@ -27827,11 +27737,11 @@ qw
 Lc
 ad
 Ej
-Li
+ky
 Hg
 mh
 Qh
-Li
+ky
 Ej
 eH
 qj
@@ -28030,7 +27940,7 @@ ud
 Pe
 Se
 IV
-Li
+ky
 qh
 Rh
 Na
@@ -32657,8 +32567,8 @@ aa
 aa
 aa
 aa
-Ls
-Ls
+Gr
+Gr
 Ib
 cd
 cI
@@ -32697,7 +32607,7 @@ Cn
 CP
 Xk
 lk
-XT
+uZ
 aa
 aa
 aa
@@ -32899,7 +32809,7 @@ Co
 CQ
 EV
 lk
-XT
+uZ
 aa
 aa
 aa
@@ -33060,9 +32970,9 @@ aa
 aa
 aa
 wb
-uZ
-lk
-lk
+XT
+Gr
+Gr
 bF
 cf
 cJ
@@ -33101,7 +33011,7 @@ Cn
 CR
 Xk
 lk
-XT
+uZ
 aa
 aa
 aa
@@ -45602,13 +45512,13 @@ ij
 ij
 jh
 YL
-JO
+Ls
 aa
 aa
 Gr
 aa
 aa
-JO
+Ls
 YL
 jh
 ij
@@ -45804,13 +45714,13 @@ ik
 ik
 ji
 ik
-JO
+Ls
 ag
 ag
 Gr
 ag
 ag
-JO
+Ls
 ik
 ji
 ik
@@ -46009,7 +45919,7 @@ ik
 aa
 aa
 aa
-ky
+XT
 aa
 aa
 aa
@@ -46615,7 +46525,7 @@ ik
 aa
 aa
 aa
-ky
+XT
 aa
 aa
 aa
@@ -47221,7 +47131,7 @@ ik
 aa
 aa
 aa
-ky
+XT
 aa
 aa
 aa
@@ -47435,7 +47345,7 @@ il
 jj
 fT
 ox
-IR
+TK
 aa
 aa
 aa
@@ -47827,7 +47737,7 @@ fT
 gE
 ag
 aa
-ky
+XT
 aa
 ag
 FW
@@ -48433,7 +48343,7 @@ ag
 af
 af
 oH
-ky
+XT
 oH
 af
 af

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -1037,9 +1037,7 @@
 	name = "Engineering External Access"
 	},
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/maintenance/firstdeck/forestarboard)
 "acd" = (
 /turf/simulated/floor/reinforced,
@@ -1248,9 +1246,7 @@
 	volume_rate = 4000
 	},
 /obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d1starboard)
 "acw" = (
 /turf/simulated/wall/r_titanium,
@@ -1264,9 +1260,7 @@
 	volume_rate = 4000
 	},
 /obj/effect/floor_decal/industrial/outline/red,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d1port)
 "acy" = (
 /obj/effect/floor_decal/corner/pink{
@@ -3176,9 +3170,7 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d1starboard)
 "afx" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -3218,9 +3210,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d1starboard)
 "afB" = (
 /obj/structure/roller_bed,
@@ -3727,9 +3717,7 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d1starboard)
 "agx" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -4271,9 +4259,7 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d1starboard)
 "ahz" = (
 /obj/effect/floor_decal/spline/plain/beige{
@@ -5082,7 +5068,9 @@
 	injecting = 1;
 	use_power = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/thruster/d1starboard)
 "ajO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -11842,9 +11830,7 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d1port)
 "aQm" = (
 /obj/machinery/light/small{
@@ -12141,17 +12127,13 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d1port)
 "aRh" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 4
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d1port)
 "aRj" = (
 /obj/machinery/atmospherics/binary/passive_gate/on{
@@ -12591,9 +12573,7 @@
 	internal_pressure_bound_default = 35000
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d1port)
 "aSk" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -13211,9 +13191,7 @@
 	name = "Engineering External Access"
 	},
 /obj/machinery/shield_diffuser,
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/maintenance/firstdeck/foreport)
 "aUb" = (
 /obj/machinery/door/firedoor,
@@ -14178,9 +14156,7 @@
 	id_tag = "cChamber1sV";
 	name = "Chamber Vent"
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d1starboard)
 "bhy" = (
 /obj/effect/floor_decal/corner/paleblue{
@@ -14430,9 +14406,7 @@
 	id_tag = "cChamber1pV";
 	name = "Chamber Vent"
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d1port)
 "btE" = (
 /turf/simulated/floor/tiled/dark,
@@ -23879,9 +23853,7 @@
 /obj/machinery/air_sensor{
 	id_tag = "cChamber1s"
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d1starboard)
 "otb" = (
 /obj/machinery/light{
@@ -24811,9 +24783,7 @@
 /obj/machinery/air_sensor{
 	id_tag = "cChamber1p"
 	},
-/turf/simulated/floor/reinforced{
-	map_airless = 1
-	},
+/turf/simulated/floor/reinforced,
 /area/thruster/d1port)
 "pBb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -3647,7 +3647,9 @@
 	lethal = 1
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/aquila/cockpit)
 "ha" = (
 /obj/machinery/camera/network/aquila{
@@ -3680,7 +3682,9 @@
 	enabled = 0;
 	lethal = 1
 	},
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/aquila/cockpit)
 "hi" = (
 /obj/effect/floor_decal/industrial/outline/grey,
@@ -13449,7 +13453,9 @@
 "OX" = (
 /obj/machinery/shipsensors,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/turf/simulated/floor,
+/turf/simulated/floor{
+	map_airless = 1
+	},
 /area/aquila/air)
 "Pb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: SEV Torch Deck 3 no longer loses pressure during round start.
bugfix: Organs within limbs now probably drop onto the ground when the limb is destroyed/dropped.
bugfix: Cameras now kick you out of their view in the camera app when they are deleted, instead of locking you in a black screen.
tweak: Leaping with a missing limb now has a chance of toppling you over.
/:cl:

## Bug Fixes
- Fixes #33353
- Fixes #33355
- Fixes #33017
- Fixes #19813