### PR TITLE
Gun Fixes / Magazine Blacklists

### DIFF
--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -25,6 +25,7 @@
 	var/magazine_type = null	//the type of magazine that the gun comes preloaded with
 	var/obj/item/ammo_magazine/ammo_magazine = null //stored magazine
 	var/allowed_magazines		//magazine types that may be loaded. Can be a list or single path
+	var/banned_magazines 		//magazine types that may NOT be loaded. Can be a list or single path
 	var/auto_eject = 0			//if the magazine should automatically eject itself when empty.
 	var/auto_eject_sound = null
 	var/mag_insert_sound = 'sound/weapons/guns/interaction/pistol_magin.ogg'
@@ -134,7 +135,7 @@
 
 		switch(AM.mag_type)
 			if(MAGAZINE)
-				if((ispath(allowed_magazines) && !istype(A, allowed_magazines)) || (islist(allowed_magazines) && !is_type_in_list(A, allowed_magazines)))
+				if((ispath(allowed_magazines) && !istype(A, allowed_magazines)) || (islist(allowed_magazines) && !is_type_in_list(A, allowed_magazines)) || (ispath(banned_magazines) && istype(A, banned_magazines)) || (islist(banned_magazines) && is_type_in_list(A, banned_magazines)))
 					to_chat(user, SPAN_WARNING("\The [A] won't fit into [src]."))
 					return
 				if(ammo_magazine)

--- a/maps/torch/items/weapons.dm
+++ b/maps/torch/items/weapons.dm
@@ -17,6 +17,10 @@
 	desc = "A Hephaestus Industries M19. A light pistol issued as an SCGDF service weapon."
 	magazine_type = /obj/item/ammo_magazine/pistol
 	allowed_magazines = /obj/item/ammo_magazine/pistol
+	banned_magazines = list(
+		/obj/item/ammo_magazine/pistol/double,
+		/obj/item/ammo_magazine/pistol/small
+	)
 	icon = 'maps/torch/icons/obj/weapons.dmi'
 	icon_state = "m19"
 	item_state = "secgundark"

--- a/packs/faction_iccgn/weapons.dm
+++ b/packs/faction_iccgn/weapons.dm
@@ -22,5 +22,9 @@
 	safety_icon = "bobcat-safety"
 	magazine_type = /obj/item/ammo_magazine/pistol
 	allowed_magazines = /obj/item/ammo_magazine/pistol
+	banned_magazines = list(
+		/obj/item/ammo_magazine/pistol/double,
+		/obj/item/ammo_magazine/pistol/small
+	)
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_ESOTERIC = 4)
 	fire_delay = 4


### PR DESCRIPTION
:cl: PurplePineapple
rscadd: Specific magazines can be blacklisted from a gun using the banned_magazines variable.
bugfix: The small military pistols (Bobcat, M19) now only take single stack 10mm as intended.
/:cl:

Specific magazines can now be blacklisted with banned_magazines. This can allow guns to only take specific types of magazines even if other guns can take multiple magazine types.

The small military pistols now only take the single stack 10mm magazines. Previously, they could take doublestack magazines and 7mm. Both unintentional.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->