### PR TITLE
Camera Tweaks & Fixes

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -41,8 +41,10 @@
 
 /obj/machinery/camera/examine(mob/user)
 	. = ..()
-	if(MACHINE_IS_BROKEN(src))
+	if (MACHINE_IS_BROKEN(src))
 		to_chat(user, SPAN_WARNING("It is completely demolished."))
+	else if (inoperable(MACHINE_STAT_EMPED))
+		to_chat(user, SPAN_WARNING("It's unpowered."))
 
 /obj/machinery/camera/malf_upgrade(mob/living/silicon/ai/user)
 	..()
@@ -301,7 +303,7 @@
 		else if(dir == EAST)
 			pixel_x = -10
 
-	if (!status || (MACHINE_IS_BROKEN(src)))
+	if (!status || inoperable())
 		icon_state = "[initial(icon_state)]1"
 	else if (GET_FLAGS(stat, MACHINE_STAT_EMPED))
 		icon_state = "[initial(icon_state)]emp"
@@ -323,7 +325,7 @@
 /obj/machinery/camera/proc/can_use()
 	if(!status)
 		return 0
-	if(MACHINE_IS_BROKEN(src) || GET_FLAGS(stat, MACHINE_STAT_EMPED))
+	if(inoperable(MACHINE_STAT_EMPED))
 		return 0
 	return 1
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -206,10 +206,23 @@
 	else
 		..()
 
+
+/**
+ * Handles resetting the view of all clients currently viewing this camera. Does not include resetting nano modules.
+ */
+/obj/machinery/camera/proc/disconnect_viewers()
+	for (var/mob/mob as anything in SSmobs.mob_list)
+		if (!mob.client || mob.client.eye != src)
+			continue
+		mob.reset_view()
+
+
 /obj/machinery/camera/proc/deactivate(user as mob, choice = 1)
 	// The only way for AI to reactivate cameras are malf abilities, this gives them different messages.
 	if(istype(user, /mob/living/silicon/ai))
 		user = null
+
+	disconnect_viewers()
 
 	if(choice != 1)
 		return

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -250,6 +250,7 @@
 	. = ..()
 	wires.RandomCutAll()
 
+	deactivate()
 	triggerCameraAlarm()
 	queue_icon_update()
 	update_coverage()

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -105,9 +105,11 @@
 					number = max(number, C.number+1)
 			c_tag = "[A.name][number == 1 ? "" : " #[number]"]"
 		invalidateCameraCache()
+	GLOB.moved_event.register(src, src, .proc/camera_moved)
 
 
 /obj/machinery/camera/Destroy()
+	GLOB.moved_event.unregister(src, src, .proc/camera_moved)
 	deactivate(null, 0) //kick anyone viewing out
 	if(assembly)
 		qdel(assembly)
@@ -121,6 +123,13 @@
 		update_icon()
 		update_coverage()
 	return internal_process()
+
+
+/obj/machinery/camera/proc/camera_moved(atom/movable/moved_atom, atom/old_loc, atom/new_loc)
+	if (AreConnectedZLevels(get_z(old_loc), get_z(new_loc)))
+		return
+	disconnect_viewers()
+
 
 /obj/machinery/camera/emp_act(severity)
 	if (!isEmpProof())

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -128,6 +128,7 @@
 			if (!affected_by_emp_until || (world.time < affected_by_emp_until))
 				affected_by_emp_until = max(affected_by_emp_until, world.time + (90 SECONDS / severity))
 			else
+				deactivate(choice = FALSE)
 				set_stat(MACHINE_STAT_EMPED, TRUE)
 				set_light(0)
 				triggerCameraAlarm()

--- a/code/modules/mob/observer/freelook/ai/update_triggers.dm
+++ b/code/modules/mob/observer/freelook/ai/update_triggers.dm
@@ -8,10 +8,6 @@
 	if(!can_use())
 		set_light(0)
 	cameranet.update_visibility(src)
-	for (var/mob/mob as anything in SSmobs.mob_list)
-		if (!mob.client || mob.client.eye != src)
-			continue
-		mob.reset_view()
 
 /obj/machinery/camera/Initialize()
 	. = ..()

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -41,6 +41,12 @@
 	var/obj/machinery/camera/current_camera = null
 	var/current_network = null
 
+
+/datum/nano_module/camera_monitor/Destroy()
+	reset_current()
+	. = ..()
+
+
 /datum/nano_module/camera_monitor/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, state = GLOB.default_state)
 	var/list/data = host.initial_data()
 
@@ -143,12 +149,14 @@
 
 	current_camera = C
 	if(current_camera)
+		GLOB.destroyed_event.register(current_camera, src, .proc/reset_current)
 		var/mob/living/L = current_camera.loc
 		if(istype(L))
 			L.tracking_initiated()
 
 /datum/nano_module/camera_monitor/proc/reset_current()
 	if(current_camera)
+		GLOB.destroyed_event.unregister(current_camera, src, .proc/reset_current)
 		var/mob/living/L = current_camera.loc
 		if(istype(L))
 			L.tracking_cancelled()

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -150,13 +150,20 @@
 	current_camera = C
 	if(current_camera)
 		GLOB.destroyed_event.register(current_camera, src, .proc/reset_current)
+		GLOB.moved_event.register(current_camera, src, .proc/camera_moved)
 		var/mob/living/L = current_camera.loc
 		if(istype(L))
 			L.tracking_initiated()
 
+/datum/nano_module/camera_monitor/proc/camera_moved(atom/movable/moved_atom, atom/old_loc, atom/new_loc)
+	if (AreConnectedZLevels(get_z(old_loc), get_z(new_loc)))
+		return
+	reset_current()
+
 /datum/nano_module/camera_monitor/proc/reset_current()
 	if(current_camera)
 		GLOB.destroyed_event.unregister(current_camera, src, .proc/reset_current)
+		GLOB.moved_event.register(current_camera, src, .proc/camera_moved)
 		var/mob/living/L = current_camera.loc
 		if(istype(L))
 			L.tracking_cancelled()

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -108,6 +108,9 @@
 		if (!os?.get_ntnet_status() && !C.is_helmet_cam)
 			to_chat(usr, "Unable to establish a connection.")
 			return
+		if (C.inoperable(MACHINE_STAT_EMPED))
+			to_chat(usr, "Unable to establish a connection.")
+			return
 
 		switch_to_camera(usr, C)
 		return 1


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Fixes the exploit that allows people to keep camera monitors connected to cameras even after they leave camera range.
rscadd: Cameras that have been EMPed or are in areas with no power no longer function.
tweak: Cameras now kick you out of their view in the camera app on the following additional events: EMPed, destroyed through damage, movement to a non-connected z-level.
/:cl: