### PR TITLE
Ban Checking UI Updates

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1343,6 +1343,7 @@
 #include "code\modules\admin\buildmode\turret.dm"
 #include "code\modules\admin\buildmode\_datums\mob_spawner.dm"
 #include "code\modules\admin\callproc\callproc.dm"
+#include "code\modules\admin\connectioncheck\bancheck_functions.dm"
 #include "code\modules\admin\connectioncheck\connectioncheck_functions.dm"
 #include "code\modules\admin\DB ban\functions.dm"
 #include "code\modules\admin\permissionverbs\permissionedit.dm"

--- a/code/modules/admin/connectioncheck/bancheck_functions.dm
+++ b/code/modules/admin/connectioncheck/bancheck_functions.dm
@@ -1,0 +1,178 @@
+/**
+ * Checks for bans matching ckey, ip, or cid.
+ *
+ * Returns list of lists.
+ */
+/proc/_fetch_bans(ckey, ip, cid, include_inactive = FALSE)
+	RETURN_TYPE(/list)
+	. = list()
+	ckey = sql_sanitize_text(ckey)
+	ip = sql_sanitize_text(ip)
+	cid = sql_sanitize_text(cid)
+	if (!ckey && !ip && !cid)
+		return
+	establish_db_connection()
+	if (!dbcon.IsConnected())
+		crash_with("Database connection failed.")
+		return
+	var/DBQuery/query = dbcon.NewQuery("\
+		SELECT `bantime`, `bantype`, `reason`, `job`, `duration`, `expiration_time`, `ckey`, `ip`, `computerid`, `a_ckey`, `unbanned`\
+			FROM `erro_ban`\
+			WHERE `bantype` IN ('PERMABAN', 'TEMPBAN') AND \
+			(`ckey` = '[ckey]' OR `ip` = '[ip]' OR `computerid` = '[cid]')\
+	")
+	query.Execute()
+	var/now = time2text(world.realtime, "YYYY-MM-DD hh:mm:ss")
+	while (query.NextRow())
+		var/row = list(
+			"bantime" = query.item[1],
+			"bantype" = query.item[2],
+			"reason" = query.item[3],
+			"job" = query.item[4],
+			"duration" = query.item[5],
+			"expiration_time" = query.item[6],
+			"ckey" = query.item[7],
+			"ip" = query.item[8],
+			"computerid" = query.item[9],
+			"a_ckey" = query.item[10],
+			"unbanned" = query.item[11]
+		)
+		row["expired"] = ((row["bantype"] in list("TEMPBAN", "JOB_TEMPBAN")) && now > row["expiration_time"])
+		if (include_inactive || !(row["expired"] || row["unbanned"]))
+			. += list(row)
+
+
+/**
+ * Checks a list of connections for bans matching any of the list entries.
+ *
+ * **Parameters**:
+ * - `connections` (list) - List of connections. Should be the output of `_fetch_connections()`.
+ * - `include_inactive` (boolean, default `FALSE`) - If set, includes inactive/expired bans in the list.
+ *
+ * Returns list of lists.
+ */
+/proc/_find_bans_in_connections(list/connections, include_inactive = FALSE)
+	RETURN_TYPE(/list)
+	. = list()
+
+	var/list/ckeys = list()
+	var/list/ips = list()
+	var/list/cids = list()
+	var/list/final_query_components = list()
+
+	for (var/list/connection in connections)
+		ckeys |= connection["ckey"]
+		ips |= connection["ip"]
+		cids |= connection["computerid"]
+
+	var/empty_string = ""
+	var/comma_separator = "', '"
+	if (length(ckeys))
+		final_query_components += "`ckey` IN ('[english_list(ckeys, empty_string, comma_separator, comma_separator, empty_string)]')"
+
+	if (length(ips))
+		final_query_components += "`ip` IN ('[english_list(ips, empty_string, comma_separator, comma_separator, empty_string)]')"
+
+	if (length(cids))
+		final_query_components += "`computerid` IN ('[english_list(cids, empty_string, comma_separator, comma_separator, empty_string)]')"
+
+	if (!length(final_query_components))
+		return
+
+	establish_db_connection()
+	if (!dbcon.IsConnected())
+		crash_with("Database connection failed.")
+		return
+	var/DBQuery/query = dbcon.NewQuery({"
+		SELECT `bantime`, `bantype`, `reason`, `job`, `duration`, `expiration_time`, `ckey`, `ip`, `computerid`, `a_ckey`, `unbanned`
+			FROM `erro_ban`
+			WHERE `bantype` IN ('PERMABAN', 'TEMPBAN') AND
+			([english_list(final_query_components, "", "", " OR ", " OR ")])
+	"})
+	query.Execute()
+	var/now = time2text(world.realtime, "YYYY-MM-DD hh:mm:ss")
+	while (query.NextRow())
+		var/row = list(
+			"bantime" = query.item[1],
+			"bantype" = query.item[2],
+			"reason" = query.item[3],
+			"job" = query.item[4],
+			"duration" = query.item[5],
+			"expiration_time" = query.item[6],
+			"ckey" = query.item[7],
+			"ip" = query.item[8],
+			"computerid" = query.item[9],
+			"a_ckey" = query.item[10],
+			"unbanned" = query.item[11]
+		)
+		row["expired"] = ((row["bantype"] in list("TEMPBAN", "JOB_TEMPBAN")) && now > row["expiration_time"])
+		if (include_inactive || !(row["expired"] || row["unbanned"]))
+			. += list(row)
+
+
+/client/proc/fetch_bans()
+	RETURN_TYPE(/list)
+	return _find_bans_in_connections(fetch_connections())
+
+
+/mob/proc/fetch_bans()
+	RETURN_TYPE(/list)
+	return _find_bans_in_connections(fetch_connections())
+
+
+/proc/_debug_fetch_bans(ckey, ip, cid, include_inactive = FALSE)
+	var/list/result = _find_bans_in_connections(_fetch_connections(ckey, ip, cid), include_inactive)
+	var/table = {"
+		<table>
+			<thead>
+				<tr>
+					<th>BANTIME</th>
+					<th>BANTYPE</th>
+					<th>REASON</th>
+					<th>JOB</th>
+					<th>DURATION</th>
+					<th>EXPIRATION_TIME</th>
+					<th>CKEY</th>
+					<th>IP</th>
+					<th>COMPUTERID</th>
+					<th>A_CKEY</th>
+					<th>UNBANNED</th>
+					<th>EXPIRED</th>
+				</tr>
+			</thead>
+			<tbody>
+	"}
+	for (var/list/row in result)
+		table += {"
+				<tr>
+					<td>[row["bantime"]]</td>
+					<td>[row["bantype"]]</td>
+					<td>[row["reason"]]</td>
+					<td>[row["job"]]</td>
+					<td>[row["duration"]]</td>
+					<td>[row["expiration_time"]]</td>
+					<td>[row["ckey"]]</td>
+					<td>[row["ip"]]</td>
+					<td>[row["computerid"]]</td>
+					<td>[row["a_ckey"]]</td>
+					<td>[row["unbanned"]]</td>
+					<td>[row["expired"]]</td>
+				</tr>
+		"}
+	table += {"
+			</tbody>
+		</table>
+	"}
+	show_browser(usr, table, "window=debug")
+
+
+/client/proc/debug_fetch_bans()
+	RETURN_TYPE(/list)
+	return _debug_fetch_bans(ckey, address, computer_id)
+
+
+/mob/proc/debug_fetch_bans()
+	RETURN_TYPE(/list)
+	if (client)
+		return client.debug_fetch_bans()
+	return _debug_fetch_bans(ckey ? ckey : last_ckey, lastKnownIP, computer_id)

--- a/code/modules/admin/connectioncheck/bancheck_functions.dm
+++ b/code/modules/admin/connectioncheck/bancheck_functions.dm
@@ -110,11 +110,21 @@
 			. += list(row)
 
 
+/**
+ * Aliases to `_find_bans_in_connections()` with this client's `fetch_connections()` result.
+ *
+ * Returns list of lists.
+ */
 /client/proc/fetch_bans()
 	RETURN_TYPE(/list)
 	return _find_bans_in_connections(fetch_connections())
 
 
+/**
+ * Aliases to `_find_bans_in_connections()` with this mob's `fetch_connections()` result.
+ *
+ * Returns list of lists.
+ */
 /mob/proc/fetch_bans()
 	RETURN_TYPE(/list)
 	return _find_bans_in_connections(fetch_connections())

--- a/code/modules/admin/connectioncheck/connectioncheck_functions.dm
+++ b/code/modules/admin/connectioncheck/connectioncheck_functions.dm
@@ -55,6 +55,8 @@
 
 /**
  * Returns a list containing only each unique IP present in a list of connections provided by `_fetch_connections()`.
+ *
+ * Returns list of lists.
  */
 /proc/_unique_ips_from_connections(list/connections)
 	RETURN_TYPE(/list)
@@ -63,11 +65,21 @@
 		. |= connection["ip"]
 
 
+/**
+ * Aliases to `_fetch_connections()` with this client's ckey, address, and CID.
+ *
+ * Returns list of lists.
+ */
 /client/proc/fetch_connections()
 	RETURN_TYPE(/list)
 	return _fetch_connections(ckey, address, computer_id)
 
 
+/**
+ * Aliases to `_fetch_connections()` with this mob's client, if present, or this mob's ckey/last ckey, last IP, and last CID.
+ *
+ * Returns list of lists.
+ */
 /mob/proc/fetch_connections()
 	RETURN_TYPE(/list)
 	if (client)
@@ -75,6 +87,24 @@
 	return _fetch_connections(ckey ? ckey : last_ckey, lastKnownIP, computer_id)
 
 
+/**
+ * Generates and displays an HTML window, displaying data from a `_fetch_connections()` call with the provided
+ *   parameters.
+ *
+ * **WARNING: This proc makes no validation or access checks. Ensure `user` is a valid candidate to receive this
+ *   information before calling.**
+ *
+ * Used by the `Check Connections` button in the player panel.
+ *
+ * **Parameters**:
+ * - `user` - The mob requesing that the window is displayed to.
+ * - `connections` - List generated from a `_fetch_connections()` call.
+ * - `target_ckey` - If provided, highlights ckeys in the window that match this value.
+ * - `target_ip` - If provided, highlights IP addresses in the window that match this value.
+ * - `target_cid` - If provided, highlights CIDs in the window that match this value.
+ *
+ * Has no return value.
+ */
 /proc/_show_associated_connections(mob/user, list/connections, target_ckey, target_ip, target_cid)
 	// Unique Ckeys
 	var/list/unique_ckeys = _unique_ckeys_from_connections(connections)
@@ -204,12 +234,22 @@
 	show_browser(user, html_page("Associated Connections ([target_ckey ? target_ckey : "NO CKEY"])", final_body), "window=associatedconnections;size=500x480;")
 
 
+/**
+ * Aliases to `_show_associated_connections()` using this client's `fetch_connections()` result, ckey, IP address, and CID.
+ *
+ * Has no return value.
+ */
 /client/proc/show_associated_connections(mob/user, list/connections)
 	if (isnull(connections))
 		connections = fetch_connections()
 	_show_associated_connections(user, connections, ckey, address, computer_id)
 
 
+/**
+ * Aliases to `_show_associated_connections()` using this mob's `fetch_connections()` result, ckey, IP address, and CID.
+ *
+ * Has no return value.
+ */
 /mob/proc/show_associated_connections(mob/user, list/connections)
 	if (client)
 		client.show_associated_connections(user, connections)

--- a/code/modules/admin/connectioncheck/connectioncheck_functions.dm
+++ b/code/modules/admin/connectioncheck/connectioncheck_functions.dm
@@ -34,118 +34,6 @@
 
 
 /**
- * Checks for bans matching ckey, ip, or cid.
- *
- * Returns list of lists.
- */
-/proc/_fetch_bans(ckey, ip, cid, include_inactive = FALSE)
-	RETURN_TYPE(/list)
-	. = list()
-	ckey = sql_sanitize_text(ckey)
-	ip = sql_sanitize_text(ip)
-	cid = sql_sanitize_text(cid)
-	if (!ckey && !ip && !cid)
-		return
-	establish_db_connection()
-	if (!dbcon.IsConnected())
-		crash_with("Database connection failed.")
-		return
-	var/DBQuery/query = dbcon.NewQuery("\
-		SELECT `bantime`, `bantype`, `reason`, `job`, `duration`, `expiration_time`, `ckey`, `ip`, `computerid`, `a_ckey`, `unbanned`\
-			FROM `erro_ban`\
-			WHERE `bantype` IN ('PERMABAN', 'TEMPBAN') AND \
-			(`ckey` = '[ckey]' OR `ip` = '[ip]' OR `computerid` = '[cid]')\
-	")
-	query.Execute()
-	var/now = time2text(world.realtime, "YYYY-MM-DD hh:mm:ss")
-	while (query.NextRow())
-		var/row = list(
-			"bantime" = query.item[1],
-			"bantype" = query.item[2],
-			"reason" = query.item[3],
-			"job" = query.item[4],
-			"duration" = query.item[5],
-			"expiration_time" = query.item[6],
-			"ckey" = query.item[7],
-			"ip" = query.item[8],
-			"computerid" = query.item[9],
-			"a_ckey" = query.item[10],
-			"unbanned" = query.item[11]
-		)
-		row["expired"] = ((row["bantype"] in list("TEMPBAN", "JOB_TEMPBAN")) && now > row["expiration_time"])
-		if (include_inactive || !(row["expired"] || row["unbanned"]))
-			. += list(row)
-
-
-/**
- * Checks a list of connections for bans matching any of the list entries.
- *
- * **Parameters**:
- * - `connections` (list) - List of connections. Should be the output of `_fetch_connections()`.
- * - `include_inactive` (boolean, default `FALSE`) - If set, includes inactive/expired bans in the list.
- *
- * Returns list of lists.
- */
-/proc/_find_bans_in_connections(list/connections, include_inactive = FALSE)
-	RETURN_TYPE(/list)
-	. = list()
-
-	var/list/ckeys = list()
-	var/list/ips = list()
-	var/list/cids = list()
-	var/list/final_query_components = list()
-
-	for (var/list/connection in connections)
-		ckeys |= connection["ckey"]
-		ips |= connection["ip"]
-		cids |= connection["computerid"]
-
-	var/empty_string = ""
-	var/comma_separator = "', '"
-	if (length(ckeys))
-		final_query_components += "`ckey` IN ('[english_list(ckeys, empty_string, comma_separator, comma_separator, empty_string)]')"
-
-	if (length(ips))
-		final_query_components += "`ip` IN ('[english_list(ips, empty_string, comma_separator, comma_separator, empty_string)]')"
-
-	if (length(cids))
-		final_query_components += "`computerid` IN ('[english_list(cids, empty_string, comma_separator, comma_separator, empty_string)]')"
-
-	if (!length(final_query_components))
-		return
-
-	establish_db_connection()
-	if (!dbcon.IsConnected())
-		crash_with("Database connection failed.")
-		return
-	var/DBQuery/query = dbcon.NewQuery({"
-		SELECT `bantime`, `bantype`, `reason`, `job`, `duration`, `expiration_time`, `ckey`, `ip`, `computerid`, `a_ckey`, `unbanned`
-			FROM `erro_ban`
-			WHERE `bantype` IN ('PERMABAN', 'TEMPBAN') AND
-			([english_list(final_query_components, "", "", " OR ", " OR ")])
-	"})
-	query.Execute()
-	var/now = time2text(world.realtime, "YYYY-MM-DD hh:mm:ss")
-	while (query.NextRow())
-		var/row = list(
-			"bantime" = query.item[1],
-			"bantype" = query.item[2],
-			"reason" = query.item[3],
-			"job" = query.item[4],
-			"duration" = query.item[5],
-			"expiration_time" = query.item[6],
-			"ckey" = query.item[7],
-			"ip" = query.item[8],
-			"computerid" = query.item[9],
-			"a_ckey" = query.item[10],
-			"unbanned" = query.item[11]
-		)
-		row["expired"] = ((row["bantype"] in list("TEMPBAN", "JOB_TEMPBAN")) && now > row["expiration_time"])
-		if (include_inactive || !(row["expired"] || row["unbanned"]))
-			. += list(row)
-
-
-/**
  * Returns a list containing only each unique ckey present in a list of connections provided by `_fetch_connections()`.
  */
 /proc/_unique_ckeys_from_connections(list/connections)
@@ -180,21 +68,11 @@
 	return _fetch_connections(ckey, address, computer_id)
 
 
-/client/proc/fetch_bans()
-	RETURN_TYPE(/list)
-	return _find_bans_in_connections(fetch_connections())
-
-
 /mob/proc/fetch_connections()
 	RETURN_TYPE(/list)
 	if (client)
 		return client.fetch_connections()
 	return _fetch_connections(ckey ? ckey : last_ckey, lastKnownIP, computer_id)
-
-
-/mob/proc/fetch_bans()
-	RETURN_TYPE(/list)
-	return _find_bans_in_connections(fetch_connections())
 
 
 /proc/_show_associated_connections(mob/user, list/connections, target_ckey, target_ip, target_cid)
@@ -339,61 +217,3 @@
 	if (isnull(connections))
 		connections = fetch_connections()
 	_show_associated_connections(user, connections, ckey ? ckey : last_ckey, lastKnownIP, computer_id)
-
-
-/proc/_debug_fetch_bans(ckey, ip, cid, include_inactive = FALSE)
-	var/list/result = _find_bans_in_connections(_fetch_connections(ckey, ip, cid), include_inactive)
-	var/table = {"
-		<table>
-			<thead>
-				<tr>
-					<th>BANTIME</th>
-					<th>BANTYPE</th>
-					<th>REASON</th>
-					<th>JOB</th>
-					<th>DURATION</th>
-					<th>EXPIRATION_TIME</th>
-					<th>CKEY</th>
-					<th>IP</th>
-					<th>COMPUTERID</th>
-					<th>A_CKEY</th>
-					<th>UNBANNED</th>
-					<th>EXPIRED</th>
-				</tr>
-			</thead>
-			<tbody>
-	"}
-	for (var/list/row in result)
-		table += {"
-				<tr>
-					<td>[row["bantime"]]</td>
-					<td>[row["bantype"]]</td>
-					<td>[row["reason"]]</td>
-					<td>[row["job"]]</td>
-					<td>[row["duration"]]</td>
-					<td>[row["expiration_time"]]</td>
-					<td>[row["ckey"]]</td>
-					<td>[row["ip"]]</td>
-					<td>[row["computerid"]]</td>
-					<td>[row["a_ckey"]]</td>
-					<td>[row["unbanned"]]</td>
-					<td>[row["expired"]]</td>
-				</tr>
-		"}
-	table += {"
-			</tbody>
-		</table>
-	"}
-	show_browser(usr, table, "window=debug")
-
-
-/client/proc/debug_fetch_bans()
-	RETURN_TYPE(/list)
-	return _debug_fetch_bans(ckey, address, computer_id)
-
-
-/mob/proc/debug_fetch_bans()
-	RETURN_TYPE(/list)
-	if (client)
-		return client.debug_fetch_bans()
-	return _debug_fetch_bans(ckey ? ckey : last_ckey, lastKnownIP, computer_id)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1082,7 +1082,7 @@
 		if (!check_rights(R_ADMIN))
 			return
 		var/mob/target = locate(href_list["bans"])
-		target.debug_fetch_bans()
+		target.show_associated_bans(usr)
 
 	else if (href_list["cloneother"])
 		if (!check_rights(R_DEBUG))


### PR DESCRIPTION
I hate UI work.

## Changelog
:cl: SierraKomodo
admin: The `Check Bans` button in the player panel now uses a cleaned up and better organized UI.
/:cl:

## Other Changes
- Moved all of the associated ban fetching and handling logic to a separate `bancheck_functions.dm` file.
- Added documentation to all connection and ban checking procs that were missing it.

![dreamseeker_lE0H2Fpkkk](https://user-images.githubusercontent.com/11140088/235006460-93ee9aa5-4819-488b-b286-156c704edc35.png)
