### PR TITLE
Add Conn Officer and Operations Officer jobs

### DIFF
--- a/maps/torch/items/encryption_keys.dm
+++ b/maps/torch/items/encryption_keys.dm
@@ -38,6 +38,16 @@
 	icon_state = "com_cypherkey"
 	channels = list("Command" = 1, "Engineering" = 1, "Exploration" = 1, "Supply" = 1, "Service" = 1, "Science" = 1, "Hailing" = 1)
 
+/obj/item/device/encryptionkey/connofficer
+	name = "conn officer's encryption key"
+	icon_state = "com_cypherkey"
+	channels = list("Command" = 1, "Engineering" = 1, "Exploration" = 1, "Supply" = 1, "Service" = 1, "Security" = 1, "Hailing" = 1)
+
+/obj/item/device/encryptionkey/safetyofficer
+	name = "safety officer's encryption key"
+	icon_state = "com_cypherkey"
+	channels = list("Command" = 1, "Engineering" = 1, "Exploration" = 1, "Supply" = 1, "Service" = 1, "Medical" = 1, "Hailing" = 1)
+
 /obj/item/device/encryptionkey/heads/ai_integrated
 	name = "ai integrated encryption key"
 	desc = "Integrated encryption key."

--- a/maps/torch/items/headsets.dm
+++ b/maps/torch/items/headsets.dm
@@ -116,10 +116,18 @@
 
 /obj/item/device/radio/headset/bridgeofficer
 	name = "bridge officer's headset"
-	desc = "A headset with access to the command, engineering and exploration channels."
+	desc = "A headset with access to the command and various department channels."
 	icon_state = "com_headset"
 	item_state = "headset"
 	ks1type = /obj/item/device/encryptionkey/bridgeofficer
+
+/obj/item/device/radio/headset/bridgeofficer/conn
+	name = "conn officer's headset"
+	ks1type = /obj/item/device/encryptionkey/connofficer
+
+/obj/item/device/radio/headset/bridgeofficer/safety
+	name = "safety officer's headset"
+	ks1type = /obj/item/device/encryptionkey/safetyofficer
 
 /obj/item/device/radio/headset/bridgeofficer/alt
 	name = "bridge officer's bowman headset"

--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -357,8 +357,8 @@
 	title = "Bridge Officer"
 	department = "Support"
 	department_flag = SPT
-	total_positions = 3
-	spawn_positions = 3
+	total_positions = 2
+	spawn_positions = 2
 	supervisors = "the Commanding Officer and heads of staff"
 	selection_color = "#2f2f7f"
 	minimal_player_age = 0
@@ -366,6 +366,13 @@
 	minimum_character_age = list(SPECIES_HUMAN = 22)
 	ideal_character_age = 24
 	outfit_type = /singleton/hierarchy/outfit/job/torch/crew/command/bridgeofficer
+
+	alt_titles = list(
+		"Watch Officer",
+		"Officer Cadet",
+		"Helmsman"
+	)
+
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps,
 		/datum/mil_branch/fleet = /singleton/hierarchy/outfit/job/torch/crew/command/bridgeofficer/fleet
@@ -401,3 +408,123 @@
 
 /datum/job/bridgeofficer/get_description_blurb()
 	return "You are a Bridge Officer. You are a very junior officer. You do not give orders of your own. You are subordinate to all of command. You handle matters on the bridge and report directly to the CO and XO. You take the Torch's helm and pilot the Aquila if needed. You monitor bridge computer programs and communications and report relevant information to command."
+
+
+/datum/job/connofficer
+	title = "Conn Officer"
+	department = "Support"
+	department_flag = SPT
+	total_positions = 2
+	spawn_positions = 2
+	supervisors = "the Commanding Officer and heads of staff"
+	selection_color = "#2f2f7f"
+	minimal_player_age = 14
+	economic_power = 9
+	minimum_character_age = list(SPECIES_HUMAN = 23)
+	ideal_character_age = 26
+	outfit_type = /singleton/hierarchy/outfit/job/torch/crew/command/bridgeofficer/fleet/conn
+
+	alt_titles = list(
+		"Navigator",
+		"Safety Officer" = /singleton/hierarchy/outfit/job/torch/crew/command/bridgeofficer/fleet/safety,
+		"Gunnery Officer"
+	)
+
+	allowed_branches = list(
+		/datum/mil_branch/fleet
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/fleet/o1,
+		/datum/mil_rank/fleet/o2
+	)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_PILOT       = SKILL_ADEPT,
+	                    SKILL_ATMOS       = SKILL_BASIC)
+
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
+	skill_points = 22
+
+
+	access = list(
+		access_security, access_medical, access_engine, access_maint_tunnels, access_emergency_storage,
+		access_bridge, access_janitor, access_kitchen, access_cargo, access_mailsorting, access_RC_announce, access_keycard_auth,
+		access_solgov_crew, access_aquila, access_aquila_helm, access_guppy, access_guppy_helm, access_external_airlocks,
+		access_eva, access_hangar, access_cent_creed, access_explorer, access_expedition_shuttle, access_expedition_shuttle_helm, access_teleporter,
+		access_torch_fax, access_torch_helm, access_radio_comm, access_radio_eng, access_radio_exp, access_radio_serv, access_radio_sup, access_radio_sec
+	)
+
+	software_on_spawn = list(/datum/computer_file/program/comm,
+							 /datum/computer_file/program/suit_sensors,
+							 /datum/computer_file/program/power_monitor,
+							 /datum/computer_file/program/supermatter_monitor,
+							 /datum/computer_file/program/alarm_monitor,
+							 /datum/computer_file/program/camera_monitor,
+							 /datum/computer_file/program/shields_monitor,
+							 /datum/computer_file/program/reports,
+							 /datum/computer_file/program/deck_management)
+
+/datum/job/connofficer/get_description_blurb()
+	return "You are a Conn Officer. You take initiative to ensure safe navigation of the ship, within the directives of your Commanding Officer and Executive Officer. You may issue orders to lower-ranking personnel when neccessary, but so far as possible prefer to bring matters to the attention of relevant department heads to be handled through the normal chain of command. You may be called on to pilot [GLOB.using_map.full_name] in the absence of a junior bridge officer or dedicated helmsman."
+
+/datum/job/connofficer/equip(mob/living/carbon/human/H)
+	if(H.mind?.role_alt_title == "Safety Officer")
+		access -= access_radio_sec
+		access += access_radio_med
+	return ..()
+
+
+/datum/job/ops
+	title = "Operations Officer"
+	department = "Support"
+	department_flag = SPT
+	total_positions = 2
+	spawn_positions = 2
+	supervisors = "the Commanding Officer and heads of staff"
+	selection_color = "#2f2f7f"
+	minimal_player_age = 14
+	economic_power = 9
+	minimum_character_age = list(SPECIES_HUMAN = 23)
+	ideal_character_age = 29
+	outfit_type = /singleton/hierarchy/outfit/job/torch/crew/command/bridgeofficer
+
+	alt_titles = list(
+		"Signal Officer",
+		"Cosmography Officer"
+	)
+
+	allowed_branches = list(
+		/datum/mil_branch/expeditionary_corps,
+	)
+	allowed_ranks = list(
+		/datum/mil_rank/ec/o1,
+		/datum/mil_rank/ec/o3,
+	)
+	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
+	                    SKILL_PILOT       = SKILL_ADEPT,
+	                    SKILL_COMPUTER    = SKILL_BASIC,
+	                    SKILL_SCIENCE     = SKILL_BASIC)
+
+	max_skill = list(   SKILL_PILOT       = SKILL_MAX)
+	skill_points = 22
+
+
+	access = list(
+		access_security, access_medical, access_engine, access_maint_tunnels, access_emergency_storage,
+		access_bridge, access_janitor, access_kitchen, access_cargo, access_mailsorting, access_RC_announce, access_keycard_auth,
+		access_solgov_crew, access_aquila, access_aquila_helm, access_guppy, access_guppy_helm, access_external_airlocks,
+		access_eva, access_hangar, access_cent_creed, access_explorer, access_expedition_shuttle, access_expedition_shuttle_helm, access_teleporter,
+		access_torch_fax, access_torch_helm, access_radio_comm, access_radio_eng, access_radio_exp, access_radio_serv, access_radio_sci, access_radio_sup
+	)
+
+	software_on_spawn = list(/datum/computer_file/program/comm,
+							 /datum/computer_file/program/suit_sensors,
+							 /datum/computer_file/program/power_monitor,
+							 /datum/computer_file/program/supermatter_monitor,
+							 /datum/computer_file/program/alarm_monitor,
+							 /datum/computer_file/program/camera_monitor,
+							 /datum/computer_file/program/shields_monitor,
+							 /datum/computer_file/program/reports,
+							 /datum/computer_file/program/deck_management)
+
+/datum/job/ops/get_description_blurb()
+	return "You are an Operations Officer. You monitor sensors and communications channels to coordinate the activity of all departments in support of the exploration mission. You answer to your Commanding Officer and Executive Officer. You may issue orders to lower-ranking personnel when neccessary, but so far as possible, prefer to bring matters to the attention of relevant department heads to be handled through the normal chain of command. You may be called on to pilot [GLOB.using_map.full_name] in the absence of a junior bridge officer or dedicated helmsman."

--- a/maps/torch/job/outfits/command_outfits.dm
+++ b/maps/torch/job/outfits/command_outfits.dm
@@ -134,3 +134,11 @@
 	name = OUTFIT_JOB_NAME("Bridge Officer - Fleet")
 	uniform = /obj/item/clothing/under/solgov/utility/fleet/command
 	shoes = /obj/item/clothing/shoes/dutyboots
+
+/singleton/hierarchy/outfit/job/torch/crew/command/bridgeofficer/fleet/conn
+	name = OUTFIT_JOB_NAME("Conn Officer")
+	l_ear = /obj/item/device/radio/headset/bridgeofficer/conn
+
+/singleton/hierarchy/outfit/job/torch/crew/command/bridgeofficer/fleet/safety
+	name = OUTFIT_JOB_NAME("Safety Officer")
+	l_ear = /obj/item/device/radio/headset/bridgeofficer/safety

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -22,7 +22,8 @@
 	allowed_jobs = list(
 		/datum/job/captain, /datum/job/hop, /datum/job/rd, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos,
 		/datum/job/liaison, /datum/job/representative, /datum/job/sea,
-		/datum/job/bridgeofficer, /datum/job/pathfinder, /datum/job/nt_pilot, /datum/job/explorer,
+		/datum/job/ops, /datum/job/connofficer, /datum/job/bridgeofficer,
+		/datum/job/pathfinder, /datum/job/nt_pilot, /datum/job/explorer,
 		/datum/job/senior_engineer, /datum/job/engineer, /datum/job/roboticist, /datum/job/engineer_trainee,
 		/datum/job/officer, /datum/job/warden, /datum/job/detective,
 		/datum/job/senior_doctor, /datum/job/doctor, /datum/job/junior_doctor, /datum/job/chemist, /datum/job/medical_trainee,


### PR DESCRIPTION
This adds mid-career roles to bridge the gap from Bridge Officer to XO.

**Why this makes sense lore-wise**
The Bridge Officer role is specified to be a very junior person, typically starting around 22 years old and not remaining in the position more than a year. Meanwhile an Executive Officer is minimally 35, generally older. There's an missing segment of age and rank. It can't be accounted for by SLT ranks in security or medical, since those would not be a natural progression for someone who excels at being a bridge officer. Progression is allegedly not meant to happen while deployed on the Torch, but people can presumably be assigned somehow while an O-2 or between the ages of 25-35. Some discussion in the fluff channel led to the conclusion that there would be mid-career officer roles on the Torch that are currently invisible off-screen. Some suggestions were made for titles, and I gathered some more with Google-fu about what some real-world ship positions might be 3rd, 4th, or 5th in line of command.

**Why this makes sense for gameplay**
The main motivation for this PR is lowpop round dynamics. Often there is no CO or XO, and all departments are understaffed. Nominally a department head might be ROIC, but if anything is actually happening, they are likely fully occupied with the departmental role. In terms of comms, access and (lack of) responsibilities, a bridge officer is the natural choice to take command in the absence of CO/XO - except it is explicitly written into the description that they do not give orders of their own. The solution is someone who is mechanically a bridge officer, but with a different fluff mandate that lets them be more proactive.

**The actual roles**
The mission statement  is to make a BO, but with just enough authority that in the absence of other officers they can spur the rest of the crew towards doing something that resembles the Torch's standing orders to explore and render aid. As I see it, the minimal viable solution is to give BO's some alt titles, an O-2 option, and remove the line about not issuing orders. However, as I understand it, powers that be strongly prefer to preserve BO as explicitly junior. The reasons I've heard are:
- so the role is new-player friendly
- sometime or other there may have been bad RP with O-2 bridge officers pulling rank? (I dunno if that happened or if it was hypothetical)
So in light of that, I propose leaving Bridge Officer as it is and adding new occupations - two of them to be exact, Conn Officer (for fleet) and Operations Officer (for EC). In terms of gameplay, their repertoire is the same as a BO, but flavor and emphasis distinguish them from BO and each other.

While the BO should be first choice for hands-on control of the helm, the Conn Officer has more abstract responsibility for the ship's maneuvering, intended destination, and avoidance of hazards. BO's science channel is exchanged for security. The Conn Officer's alternate titles can include:
- Navigator, putting an even greater emphasis on manuevering the exterior environment, but also ceremonial and color guard duties
- Safety Officer in contrast looks more inward, ensuring shipboard equipment and procedures are in order. They would be expected to take point in organizing evacuations and responding to man-overboard situations. Instead of security they have the medical channel.
- Gunnery Officers may not be the most natural fit for the Torch, but fleet officers who do come from that background would be the most qualified to operate the OFD.

Operations Officers are more about inter-departmental communication and accomplishing the broader exploration mission. They should stay aware of the urgent needs and challenges of each department, as well as the comings and goings of auxiliary craft. From the OOC perspective, combining the BO's broad access with a little independent initiative has potential to impart some momentum to a slow round. Alternate titles are:
- Signal Officer, which emphasizes the communication aspect of the role, responding to holocalls, distress signals, and missed away checkins
- Cosmography Officer is a sort of exploration-inflected navigator, maintaining awareness of space hazards, but also planetside conditions

To reiterate, all of these things - navigation, communication, flight plans, OFD, etc - are existing parts of the bridge officer portfolio. They can just be a little more proactive with it by having a different rank and/or title. Ops and conn could flex up-rank or down-rank as needed in lowpop situations. When CO and XO are online, the O-2 would step back from command decisions, and when a BO is online, the O-2 should delegate. The different specialized alt titles carve out contained niches, so it shouldn't be too hard to self-organize a division of labor.

Okay, I've said a lot, so I look forward to Spookerton closing this with a one-word "nope"

:cl: Sennalen
rscadd: Add mid-career officer jobs, Conn Officer (Fleet) and Operations Officer (EC), with various alt titles
/:cl: