### PR TITLE
Removes (likely untended) healing effects

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -554,7 +554,6 @@
 
 /datum/reagent/arithrazine/affect_blood(mob/living/carbon/M, alien, removed)
 	M.radiation = max(M.radiation - 70 * removed, 0)
-	M.adjustToxLoss(-10 * removed)
 	if(prob(60))
 		M.take_organ_damage(4 * removed, 0, ORGAN_DAMAGE_FLESH_ONLY)
 
@@ -842,10 +841,7 @@
 	value = 5
 
 /datum/reagent/rezadone/affect_blood(mob/living/carbon/M, alien, removed)
-	M.adjustCloneLoss(-20 * removed)
-	M.adjustOxyLoss(-2 * removed)
 	M.heal_organ_damage(20 * removed, 20 * removed)
-	M.adjustToxLoss(-20 * removed)
 	if(M.chem_doses[type] > 3 && ishuman(M))
 		var/mob/living/carbon/human/H = M
 		for(var/obj/item/organ/external/E in H.organs)
@@ -920,7 +916,7 @@
 		remove_self(5)
 		if(M.resuscitate())
 			var/obj/item/organ/internal/heart = M.internal_organs_by_name[BP_HEART]
-			heart.take_internal_damage(heart.max_damage * 0.075)
+			heart.take_internal_damage(heart.max_damage * 0.025)
 
 /datum/reagent/lactate
 	name = "Lactic acid"


### PR DESCRIPTION
I also nerfed the damage adrenaline does to the heart because this was effectively put into nerf something only I did and it doesn't really matter anymore.

🆑 
tweak: Arithrazine no longer heals organ damage, as god intended
tweak: Rezadone also doesn't heal a bunch of random stuff it shouldn't
tweak: Adrenaline hurts hearts slightly less when injected into a patient undergoing cardiopulmonary arrest
/🆑 

Also skrellsocks on discord made me make this PR