### PR TITLE
Toggle gamemode requirements check verb

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -32,6 +32,8 @@ SUBSYSTEM_DEF(ticker)
 	///Set to TRUE when an admin forcefully ends the round.
 	var/forced_end = FALSE
 
+	var/skip_requirement_checks = FALSE
+
 	var/static/list/mode_tags = list()
 
 	var/static/list/mode_names = list()
@@ -332,7 +334,11 @@ Helpers
 	mode_datum.pre_setup() // Makes lists of viable candidates; performs candidate draft for job-override roles; stores the draft result both internally and on the draftee.
 	SSjobs.divide_occupations(mode_datum) // Gives out jobs to everyone who was not selected to antag.
 	var/list/lobby_players = SSticker.lobby_players()
-	var/result = mode_datum.check_startable(lobby_players)
+
+	var/result = FALSE
+	if (!skip_requirement_checks)
+		result = mode_datum.check_startable(lobby_players)
+
 	if(result)
 		mode_datum.fail_setup()
 		SSjobs.reset_occupations()

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1637,3 +1637,15 @@ GLOBAL_VAR_INIT(skip_allow_lists, FALSE)
 
 	transfer_controller.do_continue_vote = !transfer_controller.do_continue_vote
 	log_and_message_admins("toggled the continue vote [transfer_controller.do_continue_vote ? "ON" : "OFF"]")
+
+/datum/admins/proc/togglemoderequirementchecks()
+	set category = "Server"
+	set desc = "Toggle the gamemode requirement checks on/off. Toggling off will allow any gamemode to start regardless of readied players."
+	set name = "Toggle Gamemode Requirement Checks"
+
+	if (GAME_STATE > RUNLEVEL_LOBBY)
+		to_chat(usr, SPAN_WARNING("You cannot change the gamemode requirement checks after the game has started!"))
+		return
+
+	SSticker.skip_requirement_checks = !SSticker.skip_requirement_checks
+	log_and_message_admins("toggled the gamemode requirement checks [SSticker.skip_requirement_checks ? "OFF" : "ON"]")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -98,7 +98,8 @@ var/global/list/admin_verbs_admin = list(
 	/client/proc/check_fax_history,
 	/client/proc/cmd_admin_notarget,
 	/datum/admins/proc/setroundlength,
-	/datum/admins/proc/toggleroundendvote
+	/datum/admins/proc/toggleroundendvote,
+	/datum/admins/proc/togglemoderequirementchecks
 )
 var/global/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,


### PR DESCRIPTION
:cl: Mucker
admin: Added the 'Toggle Gamemode Requirements Check' verb to the Server tab, which when turned on in the lobby will allow any game mode to start even if player/role requirements aren't met. 
/:cl: