### PR TITLE
Click Modifier Refactor

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -27,24 +27,24 @@
 		return
 
 	var/list/modifiers = params2list(params)
-	if(modifiers["ctrl"] && modifiers["alt"])
-		CtrlAltClickOn(A)
-		return
-	if(modifiers["shift"] && modifiers["ctrl"])
-		CtrlShiftClickOn(A)
-		return
-	if(modifiers["middle"])
-		MiddleClickOn(A)
-		return
-	if(modifiers["shift"])
-		ShiftClickOn(A)
-		return
-	if(modifiers["alt"]) // alt and alt-gr (rightalt)
-		AltClickOn(A)
-		return
-	if(modifiers["ctrl"])
-		CtrlClickOn(A)
-		return
+	if (modifiers["ctrl"] && modifiers["alt"])
+		if (CtrlAltClickOn(A))
+			return TRUE
+	if (modifiers["shift"] && modifiers["ctrl"])
+		if (CtrlShiftClickOn(A))
+			return TRUE
+	if (modifiers["middle"])
+		if (MiddleClickOn(A))
+			return TRUE
+	if (modifiers["shift"])
+		if (ShiftClickOn(A))
+			return TRUE
+	if (modifiers["alt"])
+		if (AltClickOn(A))
+			return TRUE
+	if (modifiers["ctrl"])
+		if (CtrlClickOn(A))
+			return TRUE
 
 	face_atom(A) // change direction to face what you clicked on
 

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -30,25 +30,25 @@
 	if (modifiers["ctrl"] && modifiers["alt"] && modifiers["shift"])
 		if (CtrlAltShiftClickOn(A))
 			return TRUE
-	if (modifiers["ctrl"] && modifiers["alt"])
+	else if (modifiers["ctrl"] && modifiers["alt"])
 		if (CtrlAltClickOn(A))
 			return TRUE
-	if (modifiers["shift"] && modifiers["ctrl"])
+	else if (modifiers["shift"] && modifiers["ctrl"])
 		if (CtrlShiftClickOn(A))
 			return TRUE
-	if (modifiers["shift"] && modifiers["alt"])
+	else if (modifiers["shift"] && modifiers["alt"])
 		if (AltShiftClickOn(A))
 			return TRUE
-	if (modifiers["middle"])
+	else if (modifiers["middle"])
 		if (MiddleClickOn(A))
 			return TRUE
-	if (modifiers["shift"])
+	else if (modifiers["shift"])
 		if (ShiftClickOn(A))
 			return TRUE
-	if (modifiers["alt"])
+	else if (modifiers["alt"])
 		if (AltClickOn(A))
 			return TRUE
-	if (modifiers["ctrl"])
+	else if (modifiers["ctrl"])
 		if (CtrlClickOn(A))
 			return TRUE
 

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -109,28 +109,28 @@
 
 /mob/living/silicon/ai/CtrlShiftClickOn(atom/A)
 	if(!control_disabled && A.AICtrlShiftClick(src))
-		return
-	..()
+		return TRUE
+	return ..()
 
 /mob/living/silicon/ai/ShiftClickOn(atom/A)
 	if(!control_disabled && A.AIShiftClick(src))
-		return
-	..()
+		return TRUE
+	return ..()
 
 /mob/living/silicon/ai/CtrlClickOn(atom/A)
 	if(!control_disabled && A.AICtrlClick(src))
 		return TRUE
-	. = ..()
+	return ..()
 
 /mob/living/silicon/ai/AltClickOn(atom/A)
 	if(!control_disabled && A.AIAltClick(src))
-		return
-	..()
+		return TRUE
+	return ..()
 
 /mob/living/silicon/ai/MiddleClickOn(atom/A)
 	if(!control_disabled && A.AIMiddleClick(src))
-		return
-	..()
+		return TRUE
+	return ..()
 
 /mob/living/silicon/ai/AltShiftClickOn(atom/A)
 	if (!control_disabled && A.AIAltShiftClick(src))
@@ -148,32 +148,33 @@
 */
 
 /atom/proc/AICtrlShiftClick()
+	return FALSE
 
 /obj/machinery/door/airlock/AICtrlShiftClick() // Electrifies doors.
 	if(usr.incapacitated())
-		return
+		return FALSE
 	if(!electrified_until)
 		// permanent shock
 		Topic(src, list("command"="electrify_permanently", "activate" = "1"))
 	else
 		// disable/6 is not in Topic; disable/5 disables both temporary and permanent shock
 		Topic(src, list("command"="electrify_permanently", "activate" = "0"))
-	return 1
+	return TRUE
 
 /atom/proc/AICtrlAltClick()
-	return
+	return FALSE
 
 /atom/proc/AIShiftClick()
-	return
+	return FALSE
 
 /obj/machinery/door/airlock/AIShiftClick()  // Opens and closes doors!
 	if(usr.incapacitated())
-		return
+		return FALSE
 	if(density)
 		Topic(src, list("command"="open", "activate" = "1"))
 	else
 		Topic(src, list("command"="open", "activate" = "0"))
-	return 1
+	return TRUE
 
 /atom/proc/AICtrlClick()
 	return FALSE
@@ -204,27 +205,27 @@
 
 /obj/machinery/turretid/AIAltClick() //toggles lethal on turrets
 	if(usr.incapacitated())
-		return
+		return FALSE
 	Topic(src, list("command"="lethal", "value"="[!lethal]"))
-	return 1
+	return TRUE
 
 /obj/machinery/atmospherics/binary/pump/AIAltClick()
 	return AltClick()
 
 /atom/proc/AIMiddleClick(mob/living/silicon/user)
-	return 0
+	return FALSE
 
 /obj/machinery/door/airlock/AIMiddleClick() // Toggles door bolt lights.
 	if(usr.incapacitated())
-		return
+		return FALSE
 	if(..())
-		return
+		return TRUE
 
 	if(!src.lights)
 		Topic(src, list("command"="lights", "activate" = "1"))
 	else
 		Topic(src, list("command"="lights", "activate" = "0"))
-	return 1
+	return TRUE
 
 
 /atom/proc/AIAltShiftClick(atom/A)

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -28,27 +28,43 @@
 
 	var/list/modifiers = params2list(params)
 	if (modifiers["ctrl"] && modifiers["alt"] && modifiers["shift"])
+		if (!control_disabled && A.AICtrlAltShiftClick(src))
+			return TRUE
 		if (CtrlAltShiftClickOn(A))
 			return TRUE
 	else if (modifiers["ctrl"] && modifiers["alt"])
+		if (!control_disabled && A.AICtrlAltClick(src))
+			return TRUE
 		if (CtrlAltClickOn(A))
 			return TRUE
 	else if (modifiers["shift"] && modifiers["ctrl"])
+		if (!control_disabled && A.AICtrlShiftClick(src))
+			return TRUE
 		if (CtrlShiftClickOn(A))
 			return TRUE
 	else if (modifiers["shift"] && modifiers["alt"])
+		if (!control_disabled && A.AIAltShiftClick(src))
+			return TRUE
 		if (AltShiftClickOn(A))
 			return TRUE
 	else if (modifiers["middle"])
+		if (!control_disabled && A.AIMiddleClick(src))
+			return TRUE
 		if (MiddleClickOn(A))
 			return TRUE
 	else if (modifiers["shift"])
+		if (!control_disabled && A.AIShiftClick(src))
+			return TRUE
 		if (ShiftClickOn(A))
 			return TRUE
 	else if (modifiers["alt"])
+		if (!control_disabled && A.AIAltClick(src))
+			return TRUE
 		if (AltClickOn(A))
 			return TRUE
 	else if (modifiers["ctrl"])
+		if (!control_disabled && A.AICtrlClick(src))
+			return TRUE
 		if (CtrlClickOn(A))
 			return TRUE
 
@@ -100,47 +116,6 @@
  */
 /atom/proc/attack_ai(mob/user as mob)
 	return
-
-/*
-	Since the AI handles shift, ctrl, and alt-click differently
-	than anything else in the game, atoms have separate procs
-	for AI shift, ctrl, and alt clicking.
-*/
-
-/mob/living/silicon/ai/CtrlShiftClickOn(atom/A)
-	if(!control_disabled && A.AICtrlShiftClick(src))
-		return TRUE
-	return ..()
-
-/mob/living/silicon/ai/ShiftClickOn(atom/A)
-	if(!control_disabled && A.AIShiftClick(src))
-		return TRUE
-	return ..()
-
-/mob/living/silicon/ai/CtrlClickOn(atom/A)
-	if(!control_disabled && A.AICtrlClick(src))
-		return TRUE
-	return ..()
-
-/mob/living/silicon/ai/AltClickOn(atom/A)
-	if(!control_disabled && A.AIAltClick(src))
-		return TRUE
-	return ..()
-
-/mob/living/silicon/ai/MiddleClickOn(atom/A)
-	if(!control_disabled && A.AIMiddleClick(src))
-		return TRUE
-	return ..()
-
-/mob/living/silicon/ai/AltShiftClickOn(atom/A)
-	if (!control_disabled && A.AIAltShiftClick(src))
-		return TRUE
-	return ..()
-
-/mob/living/silicon/ai/CtrlAltShiftClickOn(atom/A)
-	if (!control_disabled && A.AICtrlAltShiftClick(src))
-		return TRUE
-	return ..()
 
 /*
 	The following criminally helpful code is just the previous code cleaned up;
@@ -201,16 +176,13 @@
 	return TRUE
 
 /atom/proc/AIAltClick(atom/A)
-	return AltClick(A)
+	return FALSE
 
 /obj/machinery/turretid/AIAltClick() //toggles lethal on turrets
 	if(usr.incapacitated())
 		return FALSE
 	Topic(src, list("command"="lethal", "value"="[!lethal]"))
 	return TRUE
-
-/obj/machinery/atmospherics/binary/pump/AIAltClick()
-	return AltClick()
 
 /atom/proc/AIMiddleClick(mob/living/silicon/user)
 	return FALSE
@@ -229,11 +201,11 @@
 
 
 /atom/proc/AIAltShiftClick(atom/A)
-	return AltShiftClick(A)
+	return FALSE
 
 
 /atom/proc/AICtrlAltShiftClick(atom/A)
-	return CtrlAltShiftClick(A)
+	return FALSE
 
 
 //

--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -27,11 +27,17 @@
 		return
 
 	var/list/modifiers = params2list(params)
+	if (modifiers["ctrl"] && modifiers["alt"] && modifiers["shift"])
+		if (CtrlAltShiftClickOn(A))
+			return TRUE
 	if (modifiers["ctrl"] && modifiers["alt"])
 		if (CtrlAltClickOn(A))
 			return TRUE
 	if (modifiers["shift"] && modifiers["ctrl"])
 		if (CtrlShiftClickOn(A))
+			return TRUE
+	if (modifiers["shift"] && modifiers["alt"])
+		if (AltShiftClickOn(A))
 			return TRUE
 	if (modifiers["middle"])
 		if (MiddleClickOn(A))
@@ -126,6 +132,16 @@
 		return
 	..()
 
+/mob/living/silicon/ai/AltShiftClickOn(atom/A)
+	if (!control_disabled && A.AIAltShiftClick(src))
+		return TRUE
+	return ..()
+
+/mob/living/silicon/ai/CtrlAltShiftClickOn(atom/A)
+	if (!control_disabled && A.AICtrlAltShiftClick(src))
+		return TRUE
+	return ..()
+
 /*
 	The following criminally helpful code is just the previous code cleaned up;
 	I have no idea why it was in atoms.dm instead of respective files.
@@ -209,6 +225,15 @@
 	else
 		Topic(src, list("command"="lights", "activate" = "0"))
 	return 1
+
+
+/atom/proc/AIAltShiftClick(atom/A)
+	return AltShiftClick(A)
+
+
+/atom/proc/AICtrlAltShiftClick(atom/A)
+	return CtrlAltShiftClick(A)
+
 
 //
 // Override AdjacentQuick for AltClicking

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -67,24 +67,24 @@
 	next_click = world.time + 1
 
 	var/list/modifiers = params2list(params)
-	if(modifiers["shift"] && modifiers["ctrl"])
-		CtrlShiftClickOn(A)
-		return 1
-	if(modifiers["ctrl"] && modifiers["alt"])
-		CtrlAltClickOn(A)
-		return 1
-	if(modifiers["middle"])
-		MiddleClickOn(A)
-		return 1
-	if(modifiers["shift"])
-		ShiftClickOn(A)
-		return 0
-	if(modifiers["alt"]) // alt and alt-gr (rightalt)
-		AltClickOn(A)
-		return 1
-	if(modifiers["ctrl"])
-		CtrlClickOn(A)
-		return 1
+	if (modifiers["shift"] && modifiers["ctrl"])
+		if (CtrlShiftClickOn(A))
+			return TRUE
+	if (modifiers["ctrl"] && modifiers["alt"])
+		if (CtrlAltClickOn(A))
+			return TRUE
+	if (modifiers["middle"])
+		if (MiddleClickOn(A))
+			return TRUE
+	if (modifiers["shift"])
+		if (ShiftClickOn(A))
+			return TRUE
+	if (modifiers["alt"])
+		if (AltClickOn(A))
+			return TRUE
+	if (modifiers["ctrl"])
+		if (CtrlClickOn(A))
+			return TRUE
 
 	if(stat || paralysis || stunned || weakened || sleeping)
 		return

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -67,11 +67,17 @@
 	next_click = world.time + 1
 
 	var/list/modifiers = params2list(params)
+	if (modifiers["ctrl"] && modifiers["alt"] && modifiers["shift"])
+		if (CtrlAltShiftClickOn(A))
+			return TRUE
 	if (modifiers["shift"] && modifiers["ctrl"])
 		if (CtrlShiftClickOn(A))
 			return TRUE
 	if (modifiers["ctrl"] && modifiers["alt"])
 		if (CtrlAltClickOn(A))
+			return TRUE
+	if (modifiers["shift"] && modifiers["alt"])
+		if (AltShiftClickOn(A))
 			return TRUE
 	if (modifiers["middle"])
 		if (MiddleClickOn(A))
@@ -381,6 +387,55 @@
  */
 /atom/proc/CtrlAltClick(mob/user)
 	return
+
+
+/**
+ * Called when the mob alt+shift+clicks on an atom. By default, this calls the atom's `AltShiftClick()` proc.
+ *
+ * **Parameters**:
+ * - `A` - The atom that was clicked on.
+ *
+ * Returns boolean - Whether or not the interaction was handled.
+ */
+/mob/proc/AltShiftClickOn(atom/A)
+	return A.AltShiftClick(src)
+
+
+/**
+ * Called when a mob alt+shift+clicks on the atom.
+ *
+ * **Parameters**:
+ * - `user` - The mob that clicked on the atom.
+ *
+ * Returns boolean - Whether or not the interaction was handled.
+ */
+/atom/proc/AltShiftClick(mob/user)
+	return FALSE
+
+
+/**
+ * Called when the mob ctrl+alt+shift+clicks on an atom. By default, this calls the atom's `CtrlAltShiftClick()` proc.
+ *
+ * **Parameters**:
+ * - `A` - The atom that was clicked on.
+ *
+ * Returns boolean - Whether or not the interaction was handled.
+ */
+/mob/proc/CtrlAltShiftClickOn(atom/A)
+	return A.CtrlAltShiftClick(src)
+
+
+/**
+ * Called when a mob ctrl+alt+shift+clicks on the atom.
+ *
+ * **Parameters**:
+ * - `user` - The mob that clicked on the atom.
+ *
+ * Returns boolean - Whether or not the interaction was handled.
+ */
+/atom/proc/CtrlAltShiftClick(mob/user)
+	return FALSE
+
 
 /*
 	Misc helpers

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -249,10 +249,12 @@
  *
  * **Parameters**:
  * - `A` - The atom that was clicked on.
+ *
+ * Returns boolean. Whether or not the interaction was handled.
  */
 /mob/proc/MiddleClickOn(atom/A)
 	swap_hand()
-	return
+	return TRUE
 
 // In case of use break glass
 /*
@@ -265,21 +267,25 @@
  *
  * **Parameters**:
  * - `A` - The atom that was clicked on.
+ *
+ * Returns boolean. Whether or not the interaction was handled.
  */
 /mob/proc/ShiftClickOn(atom/A)
-	A.ShiftClick(src)
-	return
+	return A.ShiftClick(src)
 
 /**
  * Called when a mob shift+clicks on the atom. By default, this calls the examine proc chain.
  *
  * **Parameters**:
  * - `user` - The mob that clicked on the atom.
+ *
+ * Returns boolean. Whether or not the interaction was handled.
  */
 /atom/proc/ShiftClick(mob/user)
-	if(user.client && user.client.eye == user)
+	if (user.client && user.client.eye == user)
 		user.examinate(src)
-	return
+		return TRUE
+	return FALSE
 
 /**
  * Called when the mob ctrl+clicks on an atom. By default, this calls the targeted atom's `CtrlClick()` proc.
@@ -307,19 +313,19 @@
 	if(Adjacent(user))
 		user.start_pulling(src)
 		return TRUE
-	. = ..()
+	return ..()
 
 /**
  * Called when the mob alt+clicks on an atom. By default, this calls the targeted atom's `on_click/alt` extension's `on_click()` proc, or the atom's `AltClick()` proc.
  *
  * **Parameters**:
  * - `A` - The atom that was clicked on.
+ *
+ * Returns boolean. Whether or not the interaction was handled.
  */
 /mob/proc/AltClickOn(atom/A)
 	var/datum/extension/on_click/alt = get_extension(A, /datum/extension/on_click/alt)
-	if(alt && alt.on_click(src))
-		return
-	A.AltClick(src)
+	return alt?.on_click(src) || A.AltClick(src)
 
 /**
  * Called when a mob alt+clicks the atom. By default, this creates and populates the Turf panel, displaying all objects on the atom's turf.
@@ -337,7 +343,8 @@
 		else
 			user.listed_turf = T
 			user.client.statpanel = "Turf"
-	return 1
+		return TRUE
+	return FALSE
 
 /mob/proc/TurfAdjacent(turf/T)
 	return T.AdjacentQuick(src)
@@ -352,30 +359,33 @@
  *
  * **Parameters**:
  * - `A` - The atom that was clicked on.
+ *
+ * Returns boolean. Whether or not the interaction was handled.
  */
 /mob/proc/CtrlShiftClickOn(atom/A)
-	A.CtrlShiftClick(src)
-	return
+	return A.CtrlShiftClick(src)
 
 /**
  * Called when a mob ctrl+shift+clicks on the atom.
  *
  * **Parameters**:
  * - `user` - The mob that clicked on the atom.
+ *
+ * Returns boolean. Whether or not the interaction was handled.
  */
 /atom/proc/CtrlShiftClick(mob/user)
-	return
+	return FALSE
 
 /**
  * Called when the mob ctrl+alt+clicks on an atom. By default, this calls the atom's `CtrlAltClick()` proc or calls the mob's `pointed()` proc.
  *
  * **Parameters**:
  * - `A` - The atom that was clicked on.
+ *
+ * Returns boolean. Whether or not the interaction was handled.
  */
 /mob/proc/CtrlAltClickOn(atom/A)
-	if(A.CtrlAltClick(src))
-		return
-	pointed(A)
+	return A.CtrlAltClick(src) || pointed(A)
 
 /**
  * Called when a mob ctrl+alt+clicks on the atom.
@@ -386,7 +396,7 @@
  * Returns boolean - Whather or not the interaction was handled.
  */
 /atom/proc/CtrlAltClick(mob/user)
-	return
+	return FALSE
 
 
 /**

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -70,25 +70,25 @@
 	if (modifiers["ctrl"] && modifiers["alt"] && modifiers["shift"])
 		if (CtrlAltShiftClickOn(A))
 			return TRUE
-	if (modifiers["shift"] && modifiers["ctrl"])
+	else if (modifiers["shift"] && modifiers["ctrl"])
 		if (CtrlShiftClickOn(A))
 			return TRUE
-	if (modifiers["ctrl"] && modifiers["alt"])
+	else if (modifiers["ctrl"] && modifiers["alt"])
 		if (CtrlAltClickOn(A))
 			return TRUE
-	if (modifiers["shift"] && modifiers["alt"])
+	else if (modifiers["shift"] && modifiers["alt"])
 		if (AltShiftClickOn(A))
 			return TRUE
-	if (modifiers["middle"])
+	else if (modifiers["middle"])
 		if (MiddleClickOn(A))
 			return TRUE
-	if (modifiers["shift"])
+	else if (modifiers["shift"])
 		if (ShiftClickOn(A))
 			return TRUE
-	if (modifiers["alt"])
+	else if (modifiers["alt"])
 		if (AltClickOn(A))
 			return TRUE
-	if (modifiers["ctrl"])
+	else if (modifiers["ctrl"])
 		if (CtrlClickOn(A))
 			return TRUE
 

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -130,9 +130,9 @@
 	var/sdepth = A.storage_depth(src)
 	if((!isturf(A) && A == loc) || (sdepth != -1 && sdepth <= 1))
 		if(W)
-			var/resolved = W.resolve_attackby(A, src, params)
+			var/resolved = W.resolve_attackby(A, src, modifiers)
 			if(!resolved && A && W)
-				W.afterattack(A, src, 1, params) // 1 indicates adjacency
+				W.afterattack(A, src, 1, modifiers) // 1 indicates adjacency
 		else
 			if(ismob(A)) // No instant mob attacking
 				setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
@@ -141,7 +141,7 @@
 		trigger_aiming(TARGET_CAN_CLICK)
 		return 1
 
-	if(!loc.allow_click_through(A, params, src)) // This is going to stop you from telekinesing from inside a closet, but I don't shed many tears for that
+	if(!loc.allow_click_through(A, modifiers, src)) // This is going to stop you from telekinesing from inside a closet, but I don't shed many tears for that
 		return
 
 	//Atoms on turfs (not on your person)
@@ -151,9 +151,9 @@
 		if(A.Adjacent(src)) // see adjacent.dm
 			if(W)
 				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
-				var/resolved = W.resolve_attackby(A,src, params)
+				var/resolved = W.resolve_attackby(A,src, modifiers)
 				if(!resolved && A && W)
-					W.afterattack(A, src, 1, params) // 1: clicking something Adjacent
+					W.afterattack(A, src, 1, modifiers) // 1: clicking something Adjacent
 			else
 				if(ismob(A)) // No instant mob attacking
 					setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
@@ -163,9 +163,9 @@
 			return
 		else // non-adjacent click
 			if(W)
-				W.afterattack(A, src, 0, params) // 0: not Adjacent
+				W.afterattack(A, src, 0, modifiers) // 0: not Adjacent
 			else
-				RangedAttack(A, params)
+				RangedAttack(A, modifiers)
 
 			trigger_aiming(TARGET_CAN_CLICK)
 	return 1

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -253,14 +253,13 @@
  * Returns boolean. Whether or not the interaction was handled.
  */
 /mob/proc/MiddleClickOn(atom/A)
+	if (A.MiddleClick(src))
+		return TRUE
 	swap_hand()
 	return TRUE
 
-// In case of use break glass
-/*
 /atom/proc/MiddleClick(mob/M as mob)
-	return
-*/
+	return FALSE
 
 /**
  * Called when the mob shift+clicks on an atom. By default, this calls the targeted atom's `ShiftClick()` proc.

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -12,11 +12,17 @@
 	next_click = world.time + 1
 
 	var/list/modifiers = params2list(params)
+	if (modifiers["ctrl"] && modifiers["alt"] && modifiers["shift"])
+		if (CtrlAltShiftClickOn(A))
+			return TRUE
 	if (modifiers["ctrl"] && modifiers["alt"])
 		if (CtrlAltClickOn(A))
 			return TRUE
 	if (modifiers["shift"] && modifiers["ctrl"])
 		if (CtrlShiftClickOn(A))
+			return TRUE
+	if (modifiers["shift"] && modifiers["alt"])
+		if (AltShiftClickOn(A))
 			return TRUE
 	if (modifiers["middle"])
 		if (MiddleClickOn(A))
@@ -120,6 +126,12 @@
 /mob/living/silicon/robot/CtrlShiftClickOn(atom/A)
 	A.BorgCtrlShiftClick(src)
 
+/mob/living/silicon/robot/AltShiftClickOn(atom/A)
+	return A.BorgAltShiftClick(src)
+
+/mob/living/silicon/robot/CtrlAltShiftClickOn(atom/A)
+	return A.BorgCtrlAltShiftClick(src)
+
 /atom/proc/BorgCtrlAltClick(mob/living/silicon/robot/user) //forward to human click if not overriden
 	CtrlAltClick(user)
 
@@ -162,6 +174,12 @@
 
 /atom/proc/BorgCtrlShiftClick(mob/living/silicon/robot/user)
 	CtrlShiftClick(user)
+
+/atom/proc/BorgAltShiftClick(mob/living/silicon/robot/user)
+	return AIAltShiftClick(user)
+
+/atom/proc/BorgCtrlAltShiftClick(mob/living/silicon/robot/user)
+	return AICtrlAltShiftClick(user)
 
 /*
 	As with AI, these are not used in click code,

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -13,23 +13,23 @@
 
 	var/list/modifiers = params2list(params)
 	if (modifiers["ctrl"] && modifiers["alt"])
-		CtrlAltClickOn(A)
-		return
-	if(modifiers["shift"] && modifiers["ctrl"])
-		CtrlShiftClickOn(A)
-		return
-	if(modifiers["middle"])
-		MiddleClickOn(A)
-		return
-	if(modifiers["shift"])
-		ShiftClickOn(A)
-		return
-	if(modifiers["alt"]) // alt and alt-gr (rightalt)
-		AltClickOn(A)
-		return
-	if(modifiers["ctrl"])
-		CtrlClickOn(A)
-		return
+		if (CtrlAltClickOn(A))
+			return TRUE
+	if (modifiers["shift"] && modifiers["ctrl"])
+		if (CtrlShiftClickOn(A))
+			return TRUE
+	if (modifiers["middle"])
+		if (MiddleClickOn(A))
+			return TRUE
+	if (modifiers["shift"])
+		if (ShiftClickOn(A))
+			return TRUE
+	if (modifiers["alt"])
+		if (AltClickOn(A))
+			return TRUE
+	if (modifiers["ctrl"])
+		if (CtrlClickOn(A))
+			return TRUE
 
 	if(incapacitated())
 		return

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -15,25 +15,25 @@
 	if (modifiers["ctrl"] && modifiers["alt"] && modifiers["shift"])
 		if (CtrlAltShiftClickOn(A))
 			return TRUE
-	if (modifiers["ctrl"] && modifiers["alt"])
+	else if (modifiers["ctrl"] && modifiers["alt"])
 		if (CtrlAltClickOn(A))
 			return TRUE
-	if (modifiers["shift"] && modifiers["ctrl"])
+	else if (modifiers["shift"] && modifiers["ctrl"])
 		if (CtrlShiftClickOn(A))
 			return TRUE
-	if (modifiers["shift"] && modifiers["alt"])
+	else if (modifiers["shift"] && modifiers["alt"])
 		if (AltShiftClickOn(A))
 			return TRUE
-	if (modifiers["middle"])
+	else if (modifiers["middle"])
 		if (MiddleClickOn(A))
 			return TRUE
-	if (modifiers["shift"])
+	else if (modifiers["shift"])
 		if (ShiftClickOn(A))
 			return TRUE
-	if (modifiers["alt"])
+	else if (modifiers["alt"])
 		if (AltClickOn(A))
 			return TRUE
-	if (modifiers["ctrl"])
+	else if (modifiers["ctrl"])
 		if (CtrlClickOn(A))
 			return TRUE
 

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -13,28 +13,28 @@
 
 	var/list/modifiers = params2list(params)
 	if (modifiers["ctrl"] && modifiers["alt"] && modifiers["shift"])
-		if (CtrlAltShiftClickOn(A))
+		if (A.BorgCtrlAltShiftClick(src) || A.AICtrlAltShiftClick(src) || CtrlAltShiftClickOn(A))
 			return TRUE
 	else if (modifiers["ctrl"] && modifiers["alt"])
-		if (CtrlAltClickOn(A))
+		if (A.BorgCtrlAltClick(src) || A.AICtrlAltClick(src) || CtrlAltClickOn(A))
 			return TRUE
 	else if (modifiers["shift"] && modifiers["ctrl"])
-		if (CtrlShiftClickOn(A))
+		if (A.BorgCtrlShiftClick(src) || A.AICtrlShiftClick(src) || CtrlShiftClickOn(A))
 			return TRUE
 	else if (modifiers["shift"] && modifiers["alt"])
-		if (AltShiftClickOn(A))
+		if (A.BorgAltShiftClick(src) || A.AIAltShiftClick(src) || AltShiftClickOn(A))
 			return TRUE
 	else if (modifiers["middle"])
-		if (MiddleClickOn(A))
+		if (A.BorgMiddleClick(src) || A.AIMiddleClick(src) || MiddleClickOn(A))
 			return TRUE
 	else if (modifiers["shift"])
-		if (ShiftClickOn(A))
+		if (A.BorgShiftClick(src) || A.AIShiftClick(src) || ShiftClickOn(A))
 			return TRUE
 	else if (modifiers["alt"])
-		if (AltClickOn(A))
+		if (A.BorgAltClick(src) || A.AIAltClick(src) || AltClickOn(A))
 			return TRUE
 	else if (modifiers["ctrl"])
-		if (CtrlClickOn(A))
+		if (A.BorgCtrlClick(src) || A.AICtrlClick(src) || CtrlClickOn(A))
 			return TRUE
 
 	if(incapacitated())
@@ -107,72 +107,32 @@
 	cycle_modules()
 	return TRUE
 
-//Give cyborgs hotkey clicks without breaking existing uses of hotkey clicks
-// for non-doors/apcs
 /mob/living/silicon/robot/CtrlAltClickOn(atom/A)
-	return A.BorgCtrlAltClick(src) || pointed(A)
+	return pointed(A)
 
-/mob/living/silicon/robot/ShiftClickOn(atom/A)
-	return A.BorgShiftClick(src)
+/atom/proc/BorgMiddleClick(mob/living/silicon/robot/user)
+	return FALSE
 
-/mob/living/silicon/robot/CtrlClickOn(atom/A)
-	return A.BorgCtrlClick(src)
+/atom/proc/BorgCtrlAltClick(mob/living/silicon/robot/user)
+	return FALSE
 
-/mob/living/silicon/robot/AltClickOn(atom/A)
-	return A.BorgAltClick(src)
+/atom/proc/BorgShiftClick(mob/living/silicon/robot/user)
+	return FALSE
 
-/mob/living/silicon/robot/CtrlShiftClickOn(atom/A)
-	return A.BorgCtrlShiftClick(src)
-
-/mob/living/silicon/robot/AltShiftClickOn(atom/A)
-	return A.BorgAltShiftClick(src)
-
-/mob/living/silicon/robot/CtrlAltShiftClickOn(atom/A)
-	return A.BorgCtrlAltShiftClick(src)
-
-/atom/proc/BorgCtrlAltClick(mob/living/silicon/robot/user) //forward to human click if not overriden
-	return CtrlAltClick(user)
-
-/atom/proc/BorgShiftClick(mob/living/silicon/robot/user) //forward to human click if not overriden
-	return ShiftClick(user)
-
-/obj/machinery/door/airlock/BorgShiftClick()  // Opens and closes doors! Forwards to AI code.
-	return AIShiftClick()
-
-/atom/proc/BorgCtrlClick(mob/living/silicon/robot/user) //forward to human click if not overriden
-	return CtrlClick(user)
-
-/obj/machinery/door/airlock/BorgCtrlClick() // Bolts doors. Forwards to AI code.
-	return AICtrlClick()
-
-/obj/machinery/power/apc/BorgCtrlClick() // turns off/on APCs. Forwards to AI code.
-	return AICtrlClick()
-
-/obj/machinery/turretid/BorgCtrlClick() //turret control on/off. Forwards to AI code.
-	return AICtrlClick()
+/atom/proc/BorgCtrlClick(mob/living/silicon/robot/user)
+	return FALSE
 
 /atom/proc/BorgAltClick(mob/living/silicon/robot/user)
-	return AltClick(user)
-
-/obj/machinery/door/airlock/BorgCtrlShiftClick() // Eletrifies doors. Forwards to AI code.
-	if (usr.a_intent != I_HELP)
-		return AICtrlShiftClick()
-	return ..()
-
-/obj/machinery/turretid/BorgAltClick() //turret lethal on/off. Forwards to AI code.
-	return AIAltClick()
-
-/obj/machinery/atmospherics/binary/pump/BorgAltClick()
-	return AltClick()
+	return FALSE
 
 /atom/proc/BorgCtrlShiftClick(mob/living/silicon/robot/user)
-	return CtrlShiftClick(user)
+	return FALSE
 
 /atom/proc/BorgAltShiftClick(mob/living/silicon/robot/user)
-	return AIAltShiftClick(user)
+	return FALSE
 
 /atom/proc/BorgCtrlAltShiftClick(mob/living/silicon/robot/user)
-	return AICtrlAltShiftClick(user)
+	return FALSE
 
 /*
 	As with AI, these are not used in click code,

--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -105,26 +105,24 @@
 //Middle click cycles through selected modules.
 /mob/living/silicon/robot/MiddleClickOn(atom/A)
 	cycle_modules()
-	return
+	return TRUE
 
 //Give cyborgs hotkey clicks without breaking existing uses of hotkey clicks
 // for non-doors/apcs
 /mob/living/silicon/robot/CtrlAltClickOn(atom/A)
-	if(A.BorgCtrlAltClick(src))
-		return
-	pointed(A)
+	return A.BorgCtrlAltClick(src) || pointed(A)
 
 /mob/living/silicon/robot/ShiftClickOn(atom/A)
-	A.BorgShiftClick(src)
+	return A.BorgShiftClick(src)
 
 /mob/living/silicon/robot/CtrlClickOn(atom/A)
 	return A.BorgCtrlClick(src)
 
 /mob/living/silicon/robot/AltClickOn(atom/A)
-	A.BorgAltClick(src)
+	return A.BorgAltClick(src)
 
 /mob/living/silicon/robot/CtrlShiftClickOn(atom/A)
-	A.BorgCtrlShiftClick(src)
+	return A.BorgCtrlShiftClick(src)
 
 /mob/living/silicon/robot/AltShiftClickOn(atom/A)
 	return A.BorgAltShiftClick(src)
@@ -133,16 +131,13 @@
 	return A.BorgCtrlAltShiftClick(src)
 
 /atom/proc/BorgCtrlAltClick(mob/living/silicon/robot/user) //forward to human click if not overriden
-	CtrlAltClick(user)
-
-///obj/machinery/door/airlock/BorgCtrlAltClick()
-//	AICtrlAltClick()
+	return CtrlAltClick(user)
 
 /atom/proc/BorgShiftClick(mob/living/silicon/robot/user) //forward to human click if not overriden
-	ShiftClick(user)
+	return ShiftClick(user)
 
 /obj/machinery/door/airlock/BorgShiftClick()  // Opens and closes doors! Forwards to AI code.
-	AIShiftClick()
+	return AIShiftClick()
 
 /atom/proc/BorgCtrlClick(mob/living/silicon/robot/user) //forward to human click if not overriden
 	return CtrlClick(user)
@@ -157,23 +152,21 @@
 	return AICtrlClick()
 
 /atom/proc/BorgAltClick(mob/living/silicon/robot/user)
-	AltClick(user)
-	return
+	return AltClick(user)
 
 /obj/machinery/door/airlock/BorgCtrlShiftClick() // Eletrifies doors. Forwards to AI code.
 	if (usr.a_intent != I_HELP)
-		AICtrlShiftClick()
-	else
-		..()
+		return AICtrlShiftClick()
+	return ..()
 
 /obj/machinery/turretid/BorgAltClick() //turret lethal on/off. Forwards to AI code.
-	AIAltClick()
+	return AIAltClick()
 
 /obj/machinery/atmospherics/binary/pump/BorgAltClick()
 	return AltClick()
 
 /atom/proc/BorgCtrlShiftClick(mob/living/silicon/robot/user)
-	CtrlShiftClick(user)
+	return CtrlShiftClick(user)
 
 /atom/proc/BorgAltShiftClick(mob/living/silicon/robot/user)
 	return AIAltShiftClick(user)

--- a/code/_onclick/rig.dm
+++ b/code/_onclick/rig.dm
@@ -1,26 +1,26 @@
 /mob/living/MiddleClickOn(atom/A)
 	if(get_preference_value(/datum/client_preference/hardsuit_activation) == GLOB.PREF_MIDDLE_CLICK)
 		if(HardsuitClickOn(A))
-			return
-	..()
+			return TRUE
+	return ..()
 
 /mob/living/AltClickOn(atom/A)
 	if(get_preference_value(/datum/client_preference/hardsuit_activation) == GLOB.PREF_ALT_CLICK)
 		if(HardsuitClickOn(A))
-			return
-	..()
+			return TRUE
+	return ..()
 
 /mob/living/CtrlClickOn(atom/A)
 	if(get_preference_value(/datum/client_preference/hardsuit_activation) == GLOB.PREF_CTRL_CLICK)
 		if(HardsuitClickOn(A))
-			return FALSE
-	. = ..()
+			return TRUE
+	return  ..()
 
 /mob/living/CtrlShiftClickOn(atom/A)
 	if(get_preference_value(/datum/client_preference/hardsuit_activation) == GLOB.PREF_CTRL_SHIFT_CLICK)
 		if(HardsuitClickOn(A))
-			return
-	..()
+			return TRUE
+	return ..()
 
 /mob/living/proc/can_use_rig()
 	return 0

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -263,8 +263,8 @@
 /obj/machinery/sleeper/AltClick(mob/user)
 	if(CanDefaultInteract(user))
 		go_out()
-	else
-		..()
+		return TRUE
+	return ..()
 
 /obj/machinery/sleeper/proc/set_occupant(mob/living/carbon/occupant)
 	src.occupant = occupant

--- a/code/game/machinery/bodyscanner.dm
+++ b/code/game/machinery/bodyscanner.dm
@@ -48,8 +48,8 @@
 /obj/machinery/bodyscanner/AltClick(mob/user)
 	if(CanPhysicallyInteract(user))
 		eject()
-	else
-		..()
+		return TRUE
+	return ..()
 
 /obj/machinery/bodyscanner/verb/move_inside()
 	set src in oview(1)

--- a/code/game/machinery/constructable_frame.dm
+++ b/code/game/machinery/constructable_frame.dm
@@ -38,10 +38,11 @@
 			icon_state = "box_0"
 
 /obj/machinery/constructable_frame/machine_frame/AltClick(mob/user)
-	. = ..()
-	if(!anchored)
+	if (!anchored)
 		set_dir(turn(dir, -90))
 		to_chat(user, SPAN_NOTICE("You turn \the [src] around."))
+		return TRUE
+	return ..()
 
 /obj/machinery/constructable_frame/machine_frame/deconstruct
 	anchored = TRUE

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -289,13 +289,15 @@
 /obj/machinery/atmospherics/unary/cryo_cell/AltClick(mob/user)
 	if(CanDefaultInteract(user))
 		go_out()
-	else
-		..()
+		return TRUE
+	return ..()
 
 /obj/machinery/atmospherics/unary/cryo_cell/CtrlClick(mob/user)
 	if(CanDefaultInteract(user))
 		on = !on
 		update_icon()
+		return TRUE
+	return FALSE
 
 /obj/machinery/atmospherics/unary/cryo_cell/proc/put_mob(mob/living/carbon/M as mob)
 	if (inoperable())

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -345,3 +345,4 @@ var/global/list/all_gps_units = list()
 
 /obj/item/device/gps/AltClick(mob/user)
 	toggle_tracking(user)
+	return TRUE

--- a/code/game/objects/items/devices/paint_sprayer.dm
+++ b/code/game/objects/items/devices/paint_sprayer.dm
@@ -306,14 +306,14 @@
 /obj/item/device/paint_sprayer/AltClick()
 	if (!isturf(loc))
 		choose_preset_color()
-	else
-		. = ..()
+		return TRUE
+	return ..()
 
 /obj/item/device/paint_sprayer/CtrlClick()
 	if (!isturf(loc))
 		choose_color()
-	else
-		. = ..()
+		return TRUE
+	return ..()
 
 /obj/item/device/paint_sprayer/verb/choose_color()
 	set name = "Choose color"

--- a/code/game/objects/items/devices/personal_shield.dm
+++ b/code/game/objects/items/devices/personal_shield.dm
@@ -138,8 +138,8 @@
 /obj/item/device/personal_shield/AltClick(mob/user)
 	if (loc == user)
 		toggle(user)
-	else
-		. = ..()
+		return TRUE
+	return ..()
 
 /obj/item/device/personal_shield/proc/take_charge()
 	if(!actual_take_charge())

--- a/code/game/objects/items/weapons/cane.dm
+++ b/code/game/objects/items/weapons/cane.dm
@@ -100,7 +100,8 @@
 /obj/item/gun/projectile/shotgun/cane/CtrlClick(mob/user)
 	if (src == user.get_active_hand() || src == user.get_inactive_hand())
 		to_chat(user, SPAN_NOTICE("You [safety_state ? "flick out a hidden trigger on \the [src] and shift your grip" : "flick back the hidden trigger and relax your grip"]."))
-		..()
+		return ..()
+	return FALSE
 
 /obj/item/gun/projectile/shotgun/cane/get_antag_info()
 	. = ..()

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -179,5 +179,5 @@
 
 /obj/item/storage/secure/AltClick(/mob/user)
 	if (locked)
-		return
-	..()
+		return FALSE
+	return ..()

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -64,14 +64,14 @@
 					usr.put_in_l_hand(src)
 
 /obj/item/storage/AltClick(mob/usr)
-
 	if(!canremove)
-		return
+		return FALSE
 
 	if ((ishuman(usr) || isrobot(usr) || issmall(usr)) && !usr.incapacitated() && Adjacent(usr))
 		src.add_fingerprint(usr)
 		src.open(usr)
 		return TRUE
+	return FALSE
 
 /obj/item/storage/proc/return_inv()
 

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -96,7 +96,7 @@
 	if (istype(id))
 		remove_from_storage(id, get_turf(user))
 		user.put_in_hands(id)
-		return
+		return TRUE
 	return ..()
 
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -252,7 +252,8 @@
 /obj/AltClick(mob/user)
 	if(obj_flags & OBJ_FLAG_ROTATABLE)
 		rotate(user)
-	..()
+		return TRUE
+	return ..()
 
 /obj/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -550,12 +550,12 @@
 /obj/structure/closet/AltClick(mob/user)
 	if(!src.opened)
 		togglelock(user)
-	else
-		return ..()
+		return TRUE
+	return ..()
 
 /obj/structure/closet/CtrlAltClick(mob/user)
 	verb_toggleopen()
-	return 1
+	return TRUE
 
 /obj/structure/closet/emp_act(severity)
 	for (var/atom/A as anything in src)

--- a/code/game/objects/structures/extinguisher.dm
+++ b/code/game/objects/structures/extinguisher.dm
@@ -73,6 +73,8 @@
 	if(CanPhysicallyInteract(user))
 		opened = !opened
 		update_icon()
+		return TRUE
+	return FALSE
 
 /obj/structure/extinguisher_cabinet/do_simple_ranged_interaction(mob/user)
 	if(has_extinguisher)

--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -111,10 +111,11 @@
 
 /obj/structure/bed/chair/wheelchair/CtrlClick(mob/user)
 	if(in_range(src, user))
-		if(!ishuman(user))	return
+		if(!ishuman(user))
+			return FALSE
 		if(user == buckled_mob)
 			to_chat(user, SPAN_WARNING("You realize you are unable to push the wheelchair you sit in."))
-			return
+			return TRUE
 		if(!pulling)
 			pulling = user
 			user.pulledby = src

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -63,6 +63,7 @@ Thus, the two variables affect pump operation are set in New():
 
 /obj/machinery/atmospherics/binary/pump/AltClick()
 	Topic(src, list("power" = "1"))
+	return TRUE
 
 /obj/machinery/atmospherics/binary/pump/on
 	icon_state = "map_on"

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -1072,6 +1072,8 @@ BLIND     // can't see anything
 /obj/item/clothing/under/AltClick(mob/user)
 	if(CanPhysicallyInteract(user))
 		set_sensors(user)
+		return TRUE
+	return FALSE
 
 ///////////////////////////////////////////////////////////////////////
 //Rings

--- a/code/modules/clothing/masks/monitor.dm
+++ b/code/modules/clothing/masks/monitor.dm
@@ -98,3 +98,4 @@
 
 /obj/item/clothing/mask/monitor/AltClick(mob/user)
 	set_monitor_state(user)
+	return TRUE

--- a/code/modules/detectivework/microscope/microscope.dm
+++ b/code/modules/detectivework/microscope/microscope.dm
@@ -129,6 +129,7 @@
 
 /obj/machinery/microscope/AltClick()
 	remove_sample(usr)
+	return TRUE
 
 /obj/machinery/microscope/MouseDrop(atom/other)
 	if(usr == other)

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -137,7 +137,7 @@
 /obj/machinery/portable_atmospherics/hydroponics/AltClick()
 	if(mechanical && !usr.incapacitated() && Adjacent(usr))
 		close_lid(usr)
-		return 1
+		return TRUE
 	return ..()
 
 /obj/machinery/portable_atmospherics/hydroponics/attack_ghost(mob/observer/ghost/user)

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -34,11 +34,11 @@ a creative player the means to solve many problems.  Circuits are held inside an
 	. = ..()
 	external_examine(user)
 
-/obj/item/integrated_circuit/ShiftClick(mob/living/user)
-	if(istype(user))
+/obj/item/integrated_circuit/ShiftClick(mob/user)
+	if (isliving(user))
 		interact(user)
-	else
-		..()
+		return TRUE
+	return ..()
 
 // This should be used when someone is examining while the case is opened.
 /obj/item/integrated_circuit/proc/internal_examine(mob/user)

--- a/code/modules/mechs/equipment/engineering.dm
+++ b/code/modules/mechs/equipment/engineering.dm
@@ -55,8 +55,8 @@
 		else
 			current_mode = !current_mode
 			to_chat(user, SPAN_NOTICE("You set the shields to [current_mode ? "bubble" : "barrier"] mode."))
-	else
-		..()
+		return TRUE
+	return ..()
 
 /obj/effect/mech_shield
 	name = "energy shield"

--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -191,8 +191,8 @@
 /obj/item/mech_equipment/clamp/CtrlClick(mob/user)
 	if(owner)
 		drop_carrying(user, FALSE)
-	else
-		..()
+		return TRUE
+	return ..()
 
 /obj/item/mech_equipment/clamp/proc/drop_carrying(mob/user, choose_object)
 	if(!length(carrying))
@@ -774,8 +774,8 @@
 		if (active)
 			stabilizers = !stabilizers
 			to_chat(user, SPAN_NOTICE("You toggle the stabilizers [stabilizers ? "on" : "off"]"))
-	else
-		..()
+		return TRUE
+	return ..()
 
 /obj/item/mech_equipment/ionjets/proc/activate()
 	passive_power_use = activated_passive_power

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -231,11 +231,12 @@
 
 /obj/item/modular_computer/CtrlAltClick(mob/user)
 	if(!CanPhysicallyInteract(user))
-		return 0
+		return FALSE
 	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
 	if(os)
 		os.open_terminal(user)
-		return 1
+		return TRUE
+	return FALSE
 
 /obj/item/modular_computer/CouldUseTopic(mob/user)
 	..()

--- a/code/modules/modular_computers/computers/subtypes/dev_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_console.dm
@@ -121,11 +121,12 @@
 
 /obj/machinery/computer/modular/CtrlAltClick(mob/user)
 	if(!CanPhysicallyInteract(user))
-		return 0
+		return FALSE
 	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
 	if(os)
 		os.open_terminal(user)
-		return 1
+		return TRUE
+	return FALSE
 
 /obj/machinery/computer/modular/verb/emergency_shutdown()
 	set name = "Forced Shutdown"

--- a/code/modules/modular_computers/computers/subtypes/dev_laptop.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_laptop.dm
@@ -26,13 +26,14 @@
 // Prevents carrying of open laptops inhand.
 // While they work inhand, i feel it'd make tablets lose some of their high-mobility advantage they have over laptops now.
 	if(!CanPhysicallyInteract(user))
-		return
+		return FALSE
 	if(!isturf(loc))
 		to_chat(usr, "\The [src] has to be on a stable surface first!")
-		return
+		return TRUE
 	anchored = !anchored
 	screen_on = anchored
 	update_icon()
+	return TRUE
 
 /obj/item/modular_computer/laptop/on_update_icon()
 	if(anchored)

--- a/code/modules/modular_computers/computers/subtypes/dev_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_pda.dm
@@ -21,16 +21,14 @@
 /obj/item/modular_computer/pda/CtrlClick(mob/user)
 	if(!isturf(loc)) ///If we are dragging the PDA across the ground we don't want to remove the pen
 		remove_pen(user)
-	else
-		. = ..()
+		return TRUE
+	return ..()
 
 /obj/item/modular_computer/pda/AltClick(mob/user)
-	if(!CanPhysicallyInteract(user))
-		return
-	if(card_slot && istype(card_slot.stored_card))
+	if (CanPhysicallyInteract(user) && card_slot && istype(card_slot.stored_card))
 		card_slot.eject_id(user)
-	else
-		..()
+		return TRUE
+	return ..()
 
 /obj/item/modular_computer/pda/proc/receive_notification(message = null)
 	if (!enabled || bsod)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -615,7 +615,7 @@
 	if(loc == user)
 		toggle_safety(user)
 		return TRUE
-	. = ..()
+	return ..()
 
 /obj/item/gun/proc/safety()
 	return has_safety && safety_state

--- a/code/modules/projectiles/guns/launcher/foam_gun.dm
+++ b/code/modules/projectiles/guns/launcher/foam_gun.dm
@@ -43,8 +43,8 @@
 			darts -= D
 			D.dropInto(user.loc)
 			D.mix_up()
-		return 1
-	return 0
+		return TRUE
+	return FALSE
 
 /obj/item/gun/launcher/foam/burst
 	name = "foam machine pistol"

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -21,6 +21,8 @@
 /obj/item/gun/projectile/revolver/AltClick()
 	if(CanPhysicallyInteract(usr))
 		spin_cylinder()
+		return TRUE
+	return ..()
 
 /obj/item/gun/projectile/revolver/verb/spin_cylinder()
 	set name = "Spin cylinder"

--- a/code/modules/psionics/interface/ui_hub.dm
+++ b/code/modules/psionics/interface/ui_hub.dm
@@ -50,8 +50,7 @@
 	maptext = "[round((owner.psi.stamina/owner.psi.max_stamina)*100)]%"
 	update_icon()
 
-/obj/screen/psi/hub/Click(location, control, params)
-	var/list/click_params = params2list(params)
+/obj/screen/psi/hub/Click(location, control, click_params)
 	if(click_params["shift"])
 		owner.show_psi_assay(owner)
 		return

--- a/code/modules/reagents/Chemistry-Grinder.dm
+++ b/code/modules/reagents/Chemistry-Grinder.dm
@@ -232,22 +232,22 @@
 /obj/machinery/reagentgrinder/AltClick(mob/user)
 	if(CanDefaultInteract(user))
 		detach(user)
-	else
-		..()
+		return TRUE
+	return ..()
 
 
 /obj/machinery/reagentgrinder/CtrlClick(mob/user)
 	if(anchored && CanDefaultInteract(user))
 		grind(user)
-	else
-		..()
+		return TRUE
+	return ..()
 
 
 /obj/machinery/reagentgrinder/CtrlAltClick(mob/user)
 	if(CanDefaultInteract(user))
 		eject(user)
-	else
-		..()
+		return TRUE
+	return ..()
 
 
 /obj/machinery/reagentgrinder/RefreshParts()

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -96,8 +96,8 @@
 /obj/machinery/chem_master/AltClick(mob/user)
 	if(CanDefaultInteract(user))
 		eject_beaker(user)
-	else
-		..()
+		return TRUE
+	return ..()
 
 /obj/machinery/chem_master/Topic(href, href_list, state)
 	if(..())

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -182,8 +182,8 @@
 /obj/machinery/chemical_dispenser/AltClick(mob/user)
 	if(CanDefaultInteract(user))
 		eject_beaker(user)
-	else
-		..()
+		return TRUE
+	return ..()
 
 /obj/machinery/chemical_dispenser/interface_interact(mob/user)
 	ui_interact(user)

--- a/code/modules/reagents/heat_sources/_heat_source.dm
+++ b/code/modules/reagents/heat_sources/_heat_source.dm
@@ -68,8 +68,8 @@
 /obj/machinery/reagent_temperature/AltClick(mob/user)
 	if(CanDefaultInteract(user))
 		eject_beaker(user)
-	else
-		..()
+		return TRUE
+	return ..()
 
 /obj/machinery/reagent_temperature/interface_interact(mob/user)
 	interact(user)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -204,8 +204,8 @@
 /obj/item/reagent_containers/AltClick(mob/user)
 	if(possible_transfer_amounts)
 		set_amount_per_transfer_from_this()
-	else
-		return ..()
+		return TRUE
+	return ..()
 
 /obj/item/reagent_containers/examine(mob/user)
 	. = ..()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -71,8 +71,8 @@
 /obj/structure/reagent_dispensers/AltClick(mob/user)
 	if(possible_transfer_amounts)
 		set_amount_per_transfer_from_this()
-	else
-		return ..()
+		return TRUE
+	return ..()
 
 
 //Dispensers

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -86,16 +86,12 @@ Note: This proc can be overwritten to allow for different types of auto-alignmen
 		W.pixel_z = 0
 		return
 
-	if (!click_params)
-		return
-
-	var/list/click_data = params2list(click_params)
-	if (!click_data["icon-x"] || !click_data["icon-y"])
+	if (!length(click_params) || !click_params["icon-x"] || !click_params["icon-y"])
 		return
 
 	// Calculation to apply new pixelshift.
-	var/mouse_x = text2num(click_data["icon-x"])-1 // Ranging from 0 to 31
-	var/mouse_y = text2num(click_data["icon-y"])-1
+	var/mouse_x = text2num(click_params["icon-x"])-1 // Ranging from 0 to 31
+	var/mouse_y = text2num(click_params["icon-y"])-1
 
 	var/cell_x = clamp(round(mouse_x/CELLSIZE), 0, CELLS-1) // Ranging from 0 to CELLS-1
 	var/cell_y = clamp(round(mouse_y/CELLSIZE), 0, CELLS-1)


### PR DESCRIPTION
In working on updating table interactions to be a bit less painful, I've come to realise the intended result I'm aiming for needs some tweaking to how click modifiers currently work.

And then it turned into this. I fell for the refactor trap again.

## Changelog
:cl: SierraKomodo
bugfix: Clicking atoms while holding any combination of alt, shift, or control, or middle-clicking them should no longer perform multiple actions (I.e., rotating an object and toggling the turf tab).
refactor: Underlying code for handling modified clicks (ALT/SHIFT/CTRL + Click or Middle click) has been refactored. There should be no user facing changes other than those listed in the changelog.
/:cl:

## Other Changes
- **NOTE**: The following `ClickOn()` changes were not made to `/mob/observer/ghost` or `/mob/living/mech` due to their existing code using a differing framework.
- Added `AltShiftClickOn()` and `CtrlAltShiftClickOn()` handlers.
- Uncommencted and re-implemented `MiddleClick()`.
- Updated `ClickOn()` to only return during the modifier check phase if the relevant click-modifier proc returned true. This allows `use_*()` to handle modified click interactions with the passed-through `click_params` parameter.
- Updated all `ClickOn()` and `Click()` handlers to enforce boolean return values.
- Updated `ClickOn()` handlers for AI subtypes to passthrough to main handlers if the AI overrides return `FALSE`.
- Updated `ClickOn()` handlers for Robot subtypes to passthrough to AI then main handlers if the Borg overrides return `FALSE`.
- Updated the attack proc chain to pass the listified version of click_params to `resolve_attackby()`, `ranged_attack()`, `afterattack()`, etc.

## Planned for future PRs
- Enforce click handlers calling parent.
- Move click handler overrides to respective type defining files.
- Examine and update ghost `ClickOn()`.
- Examine and update mech `ClickOn()`.
- Consider adding `ClickExtension` subtypes for all modifiers.
- Consider adding Middle+Modifier handlers.

## Pseudo-code Mapping of Click Proc-Chain
 - `[Modifier]` = Any combination of:
	 - Alt
	 - Shift
	 - Ctrl
	 - Middle
 - `[AltClickExtension]` = Instance of `/datum/extension/on_click/alt`

`[AltClickExtension]` = Instance of `/datum/extension/on_click/alt`

```dm
Mob.ClickOn(Atom)
    (`next_click` check)

    AltClickOn(Atom)
        Atom.[AltClickExtension].on_click(Mob)
            FALSE
        Atom.AltClick(Mob)
            FALSE

    [Modifier]ClickOn(Atom)
        Atom.[Modifier]Click(Mob)
            FALSE

    (Other Click Handlers)
```

```dm
AI.ClickOn(Atom)
    (`next_click` check)
    (`incapacitated()` check)

    !control_disabled && Atom.AI[Modifier]Click(AI)
        FALSE

    [Modifier]ClickOn(Atom)
        ..()
    
    (Other Click Handlers)
```

```dm
Robot.ClickOn(Atom)
    (`next_click` check)
    
    Atom.Borg[Modifier]Click(Robot)
        FALSE
    
    Atom.AI[Modifier]Click(Robot)
        ..()
    
    [Modifier]ClickOn(Atom)
        ..()
    
    (Other Click Handlers)
```