### PR TITLE
Disposals Anchoring Fixes

### DIFF
--- a/code/game/machinery/pipe/pipe_datums/disposal_pipe_datums.dm
+++ b/code/game/machinery/pipe/pipe_datums/disposal_pipe_datums.dm
@@ -97,7 +97,7 @@
 	desc = "A chute to put things into a disposal network."
 	build_icon = 'icons/obj/pipes/disposal.dmi'
 	build_icon_state = "intake"
-	build_path = /obj/structure/disposalconstruct
+	build_path = /obj/structure/disposalconstruct/machine
 	constructed_path = /obj/machinery/disposal/deliveryChute
 
 /datum/pipe/disposal_dispenser/device/sorting

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -231,9 +231,6 @@
 
 // Subtypes
 
-/obj/structure/disposalconstruct/machine
-	obj_flags = OBJ_FLAG_ANCHORABLE
-
 /obj/structure/disposalconstruct/machine/update_verbs()
 	return // No flipping
 

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -240,7 +240,7 @@
 	update_icon()
 
 /obj/structure/disposalconstruct/machine/build(obj/structure/disposalpipe/CP)
-	var/obj/machinery/disposal/P = new /obj/machinery/disposal(src.loc)
+	var/obj/machinery/disposal/P = new constructed_path(src.loc)
 	transfer_fingerprints_to(P)
 	P.set_dir(dir)
 	P.mode = 0 // start with pump off

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -213,7 +213,7 @@
 // Subtypes
 
 /obj/structure/disposalconstruct/machine
-	obj_flags = 0 // No rotating
+	obj_flags = OBJ_FLAG_ANCHORABLE
 
 /obj/structure/disposalconstruct/machine/update_verbs()
 	return // No flipping

--- a/code/modules/recycling/disposal-construction.dm
+++ b/code/modules/recycling/disposal-construction.dm
@@ -123,6 +123,25 @@
 	if (!.)
 		return
 	if (!anchored)
+		// Plating
+		var/turf/turf = get_turf(src)
+		if (!turf.is_plating())
+			if (!silent)
+				USE_FEEDBACK_FAILURE("You must remove the plating before you can secure \the [src].")
+			return FALSE
+
+		// Catwalks
+		var/obj/structure/catwalk/catwalk = locate() in get_turf(src)
+		if (catwalk)
+			if (catwalk.plated_tile && !catwalk.hatch_open)
+				if (!silent)
+					USE_FEEDBACK_FAILURE("\The [catwalk]'s hatch needs to be opened before you can secure \the [src].")
+				return FALSE
+			else if (!catwalk.plated_tile)
+				if (!silent)
+					USE_FEEDBACK_FAILURE("\The [catwalk] is blocking access to the floor.")
+				return FALSE
+
 		var/obj/structure/disposalpipe/connected_pipe = locate() in get_turf(src)
 		if (!check_buildability(connected_pipe, user))
 			return FALSE

--- a/code/modules/recycling/disposalpipe.dm
+++ b/code/modules/recycling/disposalpipe.dm
@@ -198,6 +198,32 @@
 	broken(prob(0.5))
 
 
+/obj/structure/disposalpipe/can_anchor(obj/item/tool, mob/user, silent)
+	. = ..()
+	if (!.)
+		return
+
+	if (!anchored)
+		// Plating
+		var/turf/turf = get_turf(src)
+		if (!turf.is_plating())
+			if (!silent)
+				USE_FEEDBACK_FAILURE("You must remove the plating before you can secure \the [src].")
+			return FALSE
+
+		// Catwalks
+		var/obj/structure/catwalk/catwalk = locate() in get_turf(src)
+		if (catwalk)
+			if (catwalk.plated_tile && !catwalk.hatch_open)
+				if (!silent)
+					USE_FEEDBACK_FAILURE("\The [catwalk]'s hatch needs to be opened before you can secure \the [src].")
+				return FALSE
+			else if (!catwalk.plated_tile)
+				if (!silent)
+					USE_FEEDBACK_FAILURE("\The [catwalk] is blocking access to the floor.")
+				return FALSE
+
+
 /obj/structure/disposalpipe/use_tool(obj/item/tool, mob/user, list/click_params)
 	// Welding Tool - Cut pipe
 	if (isWelder(tool))


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Fixes disposal chute constructs being unanchorable and unrotatable.
bugfix: Fixes disposal pipes and constructs being anchorable on invalid turfs.
bugfix: Fix disposal chutes not remembering direction when built.
/:cl:

## Bug Fixes
- Fixes #33364
- Fixes #33366

## Other Changes
- Updates `/datum/pipe/disposal_dispenser/device/chute` to use `/obj/structure/disposalconstruct/machine` as the `build_path`, which fixes a runtime caused by `disposalconstruct` expecting a pipe result instead of a machine.
- Fixes `/obj/structure/disposalconstruct/machine/build()` not using `constructed_path`.
