### PR TITLE
Fetch Connections/Bans UI and Function Cleanup & Fixes

### DIFF
--- a/code/modules/admin/connectioncheck/bancheck_functions.dm
+++ b/code/modules/admin/connectioncheck/bancheck_functions.dm
@@ -222,10 +222,12 @@
 				</tr>
 			</tbody>
 		</table>
+		<hr />
 
 		<h2>Matching Banned Ckeys</h2>
 		<p><small>Entries matching the current query are <span class='highlight'>highlighted</span>.</small></p>
 		[unique_ckeys_table]
+		<hr />
 
 		<h2>All Matching Bans</h2>
 		<p><small>Entries matching the current query are <span class='highlight'>highlighted</span>.</small></p>

--- a/code/modules/admin/connectioncheck/bancheck_functions.dm
+++ b/code/modules/admin/connectioncheck/bancheck_functions.dm
@@ -48,13 +48,14 @@
 
 
 /**
- * Returns a list containing only each unique ckey present in a list of connections provided by `_fetch_connections()`.
+ * Returns a sorted list containing only each unique ckey present in a list of connections provided by `_fetch_connections()`.
  */
 /proc/_unique_ckeys_from_bans(list/bans)
 	RETURN_TYPE(/list)
 	. = list()
 	for (var/list/ban in bans)
 		. |= ban["ckey"]
+	return sortList(.)
 
 
 /**

--- a/code/modules/admin/connectioncheck/bancheck_functions.dm
+++ b/code/modules/admin/connectioncheck/bancheck_functions.dm
@@ -15,11 +15,19 @@
 	if (!dbcon.IsConnected())
 		crash_with("Database connection failed.")
 		return
+	var/selection = list()
+	if (ckey)
+		selection += "`ckey` = '[ckey]'"
+	if (ip)
+		selection += "`ip` = '[ip]'"
+	if (cid)
+		selection += "`computerid` = '[cid]'"
+	selection = english_list(selection, "", "", " OR ", " OR ")
 	var/DBQuery/query = dbcon.NewQuery("\
 		SELECT `bantype`, `reason`, `expiration_time`, `ckey`, `ip`, `computerid`, `a_ckey`, `unbanned`\
 			FROM `erro_ban`\
 			WHERE `bantype` IN ('PERMABAN', 'TEMPBAN') AND \
-			(`ckey` = '[ckey]' OR `ip` = '[ip]' OR `computerid` = '[cid]')\
+			([selection])\
 	")
 	query.Execute()
 	var/now = time2text(world.realtime, "YYYY-MM-DD hh:mm:ss")

--- a/code/modules/admin/connectioncheck/bancheck_functions.dm
+++ b/code/modules/admin/connectioncheck/bancheck_functions.dm
@@ -146,15 +146,17 @@
 	// Unique Ckeys
 	var/list/unique_ckeys = _unique_ckeys_from_bans(bans)
 	var/unique_ckeys_table = {"
-		<table style='width: 100%;'>
+		<table class="data hover">
 			<tbody>
 	"}
+	var/stripe = FALSE
 	for (var/ckey in unique_ckeys)
 		unique_ckeys_table += {"
-				<tr>
+				<tr[stripe ? " class='stripe'" : null]>
 					<td[ckey == target_ckey ? " class='highlight'" : null]>[ckey]</td>
 				</tr>
 		"}
+		stripe = !stripe
 	unique_ckeys_table += {"
 			</tbody>
 		</table>
@@ -162,7 +164,7 @@
 
 	// List of all bans
 	var/all_bans_table = {"
-		<table style='width: 100%;'>
+		<table class="data hover">
 			<thead>
 				<tr>
 					<th>Banned Ckey</th>
@@ -174,25 +176,74 @@
 			</thead>
 			<tbody>
 				"}
+	stripe = FALSE
 	for (var/list/row in bans)
+		// Row classes
+		var/classes_row = list()
+		if (stripe)
+			classes_row += "stripe"
+
+		// Ckey classes
+		var/classes_ckey = ""
+		var/ckey = row["ckey"]
+		if (!row["ckey"])
+			classes_ckey = "disabled"
+			ckey = "(EMPTY)"
+		else if (row["ckey"] == target_ckey)
+			classes_ckey = "highlight"
+		if (classes_ckey)
+			classes_ckey = " class='[classes_ckey]'"
+
+		// IP classes
+		var/classes_ip = ""
+		var/ip = row["ip"]
+		if (!row["ip"])
+			classes_ip = "disabled"
+			ip = "(EMPTY)"
+		else if (row["ip"] == target_ip)
+			classes_ip = "highlight"
+		if (classes_ip)
+			classes_ip = " class='[classes_ip]'"
+
+		// CID classes
+		var/classes_cid = ""
+		var/cid = row["computerid"]
+		if (!row["computerid"])
+			classes_cid = "disabled"
+			cid = "(EMPTY)"
+		else if (row["computerid"] == target_cid)
+			classes_cid = "highlight"
+		if (classes_cid)
+			classes_cid = " class='[classes_cid]'"
+
+		// Status cell
 		var/status = "ACTIVE"
 		if (row["expired"])
 			status = row["unbanned"] ? "UNBANNED" : "EXPIRED"
+			classes_row += "disabled"
 		else
 			switch (row["bantype"])
 				if ("PERMABAN")
 					status += " (PERMANENT)"
 				if ("TEMPBAN")
 					status += " (UNTIL [row["expiration_time"]])"
+
+		// Combine row classes
+		if (length(classes_row))
+			classes_row = " class='[english_list(classes_row, "", "", " ", " ")]'"
+		else
+			classes_row = null
+
+		// Build table row
 		all_bans_table += {"
-				<tr[row["expired"] ? " style='color: gray;'" : null]>
-					<td[row["ckey"] == target_ckey ? " class='highlight'" : null]>[row["ckey"] ? row["ckey"] : "<span class='color: gray;'>N/A</span>"]</td>
-					<td[row["ip"] == target_ip ? " class='highlight'" : null]>[row["ip"] ? row["ip"] : "<span class='color: gray;'>N/A</span>"]</td>
-					<td[row["computerid"] == target_cid ? " class='highlight'" : null]>[row["computerid"] ? row["computerid"] : "<span class='color: gray;'>N/A</span>"]</td>
+				<tr[classes_row]>
+					<td[classes_ckey]>[ckey]</td>
+					<td[classes_ip]>[ip]</td>
+					<td[classes_cid]>[cid]</td>
 					<td>[status]</td>
 					<td>[row["a_ckey"]]</td>
 				</tr>
-				<tr[row["expired"] ? " style='color: gray;'" : null]>
+				<tr[classes_row]>
 					<th>Reason</th>
 					<td colspan='4'>[row["reason"]]</td>
 				</tr>
@@ -206,7 +257,7 @@
 	var/final_body = {"
 		<h1>Associated Bans</h1>
 		<h2>Queried Details</h2>
-		<table stype='width: 100%;'>
+		<table class="data">
 			<thead>
 				<tr>
 					<th style='width: 33%';>Ckey</th>
@@ -216,9 +267,9 @@
 			</thead>
 			<tbody>
 				<tr>
-					<td>[target_ckey ? target_ckey : "N/A"]</td>
-					<td>[target_ip ? target_ip : "N/A"]</td>
-					<td>[target_cid ? target_cid : "N/A"]</td>
+					<td class='[target_ckey ? "highlight" : "disabled"]'>[target_ckey ? target_ckey : "(EMPTY)"]</td>
+					<td class='[target_ip ? "highlight" : "disabled"]'>[target_ip ? target_ip : "(EMPTY)"]</td>
+					<td class='[target_cid ? "highlight" : "disabled"]'>[target_cid ? target_cid : "(EMPTY)"]</td>
 				</tr>
 			</tbody>
 		</table>

--- a/code/modules/admin/connectioncheck/bancheck_functions.dm
+++ b/code/modules/admin/connectioncheck/bancheck_functions.dm
@@ -16,7 +16,7 @@
 		crash_with("Database connection failed.")
 		return
 	var/DBQuery/query = dbcon.NewQuery("\
-		SELECT `bantime`, `bantype`, `reason`, `job`, `duration`, `expiration_time`, `ckey`, `ip`, `computerid`, `a_ckey`, `unbanned`\
+		SELECT `bantype`, `reason`, `expiration_time`, `ckey`, `ip`, `computerid`, `a_ckey`, `unbanned`\
 			FROM `erro_ban`\
 			WHERE `bantype` IN ('PERMABAN', 'TEMPBAN') AND \
 			(`ckey` = '[ckey]' OR `ip` = '[ip]' OR `computerid` = '[cid]')\
@@ -25,17 +25,14 @@
 	var/now = time2text(world.realtime, "YYYY-MM-DD hh:mm:ss")
 	while (query.NextRow())
 		var/row = list(
-			"bantime" = query.item[1],
-			"bantype" = query.item[2],
-			"reason" = query.item[3],
-			"job" = query.item[4],
-			"duration" = query.item[5],
-			"expiration_time" = query.item[6],
-			"ckey" = query.item[7],
-			"ip" = query.item[8],
-			"computerid" = query.item[9],
-			"a_ckey" = query.item[10],
-			"unbanned" = query.item[11]
+			"bantype"         = query.item[1],
+			"reason"          = query.item[2],
+			"expiration_time" = query.item[3],
+			"ckey"            = query.item[4],
+			"ip"              = query.item[5],
+			"computerid"      = query.item[6],
+			"a_ckey"          = query.item[7],
+			"unbanned"        = query.item[8]
 		)
 		row["expired"] = ((row["bantype"] in list("TEMPBAN", "JOB_TEMPBAN")) && now > row["expiration_time"])
 		if (include_inactive || !(row["expired"] || row["unbanned"]))
@@ -94,7 +91,7 @@
 		crash_with("Database connection failed.")
 		return
 	var/DBQuery/query = dbcon.NewQuery({"
-		SELECT `bantime`, `bantype`, `reason`, `job`, `duration`, `expiration_time`, `ckey`, `ip`, `computerid`, `a_ckey`, `unbanned`
+		SELECT `bantype`, `reason`, `expiration_time`, `ckey`, `ip`, `computerid`, `a_ckey`, `unbanned`
 			FROM `erro_ban`
 			WHERE `bantype` IN ('PERMABAN', 'TEMPBAN') AND
 			([english_list(final_query_components, "", "", " OR ", " OR ")])
@@ -103,17 +100,14 @@
 	var/now = time2text(world.realtime, "YYYY-MM-DD hh:mm:ss")
 	while (query.NextRow())
 		var/row = list(
-			"bantime" = query.item[1],
-			"bantype" = query.item[2],
-			"reason" = query.item[3],
-			"job" = query.item[4],
-			"duration" = query.item[5],
-			"expiration_time" = query.item[6],
-			"ckey" = query.item[7],
-			"ip" = query.item[8],
-			"computerid" = query.item[9],
-			"a_ckey" = query.item[10],
-			"unbanned" = query.item[11]
+			"bantype"         = query.item[1],
+			"reason"          = query.item[2],
+			"expiration_time" = query.item[3],
+			"ckey"            = query.item[4],
+			"ip"              = query.item[5],
+			"computerid"      = query.item[6],
+			"a_ckey"          = query.item[7],
+			"unbanned"        = query.item[8]
 		)
 		row["expired"] = ((row["bantype"] in list("TEMPBAN", "JOB_TEMPBAN")) && now > row["expiration_time"])
 		if (include_inactive || !(row["expired"] || row["unbanned"]))

--- a/code/modules/admin/connectioncheck/connectioncheck_functions.dm
+++ b/code/modules/admin/connectioncheck/connectioncheck_functions.dm
@@ -212,6 +212,7 @@
 				</tr>
 			</tbody>
 		</table>
+		<hr />
 
 		<h2>Associated Ckeys, IP Addresses, and Computer IDs</h2>
 		<p><small>NOTE: Rows in this table are not necessarily associated with eachother. This is simply a list of each category's entries for ease of information.<br />
@@ -232,6 +233,7 @@
 				</tr>
 			</tbody>
 		</table>
+		<hr />
 
 		<h2>All Unique Connections</h2>
 		<p><small>NOTE: This table does not list every single connection ever made, only the first connection seen for each unique combination of ckey, IP, and CID.<br />

--- a/code/modules/admin/connectioncheck/connectioncheck_functions.dm
+++ b/code/modules/admin/connectioncheck/connectioncheck_functions.dm
@@ -42,35 +42,36 @@
 
 
 /**
- * Returns a list containing only each unique ckey present in a list of connections provided by `_fetch_connections()`.
+ * Returns a sorted list containing only each unique ckey present in a list of connections provided by `_fetch_connections()`.
  */
 /proc/_unique_ckeys_from_connections(list/connections)
 	RETURN_TYPE(/list)
 	. = list()
 	for (var/list/connection in connections)
 		. |= connection["ckey"]
+	return sortList(.)
 
 
 /**
- * Returns a list containing only each unique CID present in a list of connections provided by `_fetch_connections()`.
+ * Returns a sorted list containing only each unique CID present in a list of connections provided by `_fetch_connections()`.
  */
 /proc/_unique_cids_from_connections(list/connections)
 	RETURN_TYPE(/list)
 	. = list()
 	for (var/list/connection in connections)
 		. |= connection["computerid"]
+	return sortList(.)
 
 
 /**
- * Returns a list containing only each unique IP present in a list of connections provided by `_fetch_connections()`.
- *
- * Returns list of lists.
+ * Returns a sorted list containing only each unique IP present in a list of connections provided by `_fetch_connections()`.
  */
 /proc/_unique_ips_from_connections(list/connections)
 	RETURN_TYPE(/list)
 	. = list()
 	for (var/list/connection in connections)
 		. |= connection["ip"]
+	return sortList(.)
 
 
 /**

--- a/code/modules/admin/connectioncheck/connectioncheck_functions.dm
+++ b/code/modules/admin/connectioncheck/connectioncheck_functions.dm
@@ -117,15 +117,17 @@
 	// Unique Ckeys
 	var/list/unique_ckeys = _unique_ckeys_from_connections(connections)
 	var/unique_ckeys_table = {"
-		<table style='width: 100%;'>
+		<table class="data hover">
 			<tbody>
 	"}
+	var/stripe = FALSE
 	for (var/ckey in unique_ckeys)
 		unique_ckeys_table += {"
-				<tr>
+				<tr[stripe ? " class='stripe'" : null]>
 					<td[ckey == target_ckey ? " class='highlight'" : null]>[ckey]</td>
 				</tr>
 		"}
+		stripe = !stripe
 	unique_ckeys_table += {"
 			</tbody>
 		</table>
@@ -134,15 +136,17 @@
 	// Unique IP Addresses
 	var/list/unique_ips = _unique_ips_from_connections(connections)
 	var/unique_ips_table = {"
-		<table style='width: 100%;'>
+		<table class="data hover">
 			<tbody>
 	"}
+	stripe = FALSE
 	for (var/ip in unique_ips)
 		unique_ips_table += {"
-				<tr>
-					<td[ip == target_ip ? " class='highlight'" : null]>[ip]</td>
+				<tr[stripe ? " class='stripe'" : null]>
+					<td style='vertical-align: top;'[ip == target_ip ? " class='highlight'" : null]>[ip]</td>
 				</tr>
 		"}
+		stripe = !stripe
 	unique_ips_table += {"
 			</tbody>
 		</table>
@@ -151,15 +155,17 @@
 	// Unique CIDs
 	var/list/unique_cids = _unique_cids_from_connections(connections)
 	var/unique_cids_table = {"
-		<table style='width: 100%;'>
+		<table class="data hover">
 			<tbody>
 	"}
+	stripe = FALSE
 	for (var/cid in unique_cids)
 		unique_cids_table += {"
-				<tr>
-					<td[cid == target_cid ? " class='highlight'" : null]>[cid]</td>
+				<tr[stripe ? " class='stripe'" : null]>
+					<td style='vertical-align: top;'[cid == target_cid ? " class='highlight'" : null]>[cid]</td>
 				</tr>
 		"}
+		stripe = !stripe
 	unique_cids_table += {"
 			</tbody>
 		</table>
@@ -167,7 +173,7 @@
 
 	// List of all connections
 	var/all_connections_table = {"
-		<table style='width: 100%;'>
+		<table class="data hover">
 			<thead>
 				<tr>
 					<th>First Seen</th>
@@ -178,15 +184,17 @@
 			</thead>
 			<tbody>
 	"}
+	stripe = FALSE
 	for (var/list/row in connections)
 		all_connections_table += {"
-				<tr>
+				<tr[stripe ? " class='stripe'" : null]>
 					<td>[row["datetime"]]</td>
 					<td[row["ckey"] == target_ckey ? " class='highlight'" : null]>[row["ckey"]]</td>
 					<td[row["ip"] == target_ip ? " class='highlight'" : null]>[row["ip"]]</td>
 					<td[row["computerid"] == target_cid ? " class='highlight'" : null]>[row["computerid"]]</td>
 				</tr>
 		"}
+		stripe = !stripe
 	all_connections_table += {"
 			</tbody>
 		</table>
@@ -196,7 +204,7 @@
 	var/final_body = {"
 		<h1>Associated Connections</h1>
 		<h2>Queried Details</h2>
-		<table style='width: 100%;'>
+		<table class="data hover">
 			<thead>
 				<tr>
 					<th style='width: 33%;'>Ckey</th>
@@ -217,7 +225,7 @@
 		<h2>Associated Ckeys, IP Addresses, and Computer IDs</h2>
 		<p><small>NOTE: Rows in this table are not necessarily associated with eachother. This is simply a list of each category's entries for ease of information.<br />
 			Entries matching the current query are <span class='highlight'>highlighted</span>.</small></p>
-		<table style='width: 100%;'>
+		<table class="data"> <!-- Intentionally not set to hover. Nested tables hover instead. -->
 			<thead>
 				<tr>
 					<th style='width: 33%;'>Ckeys</th>

--- a/code/modules/admin/connectioncheck/connectioncheck_functions.dm
+++ b/code/modules/admin/connectioncheck/connectioncheck_functions.dm
@@ -15,10 +15,18 @@
 	if (!dbcon.IsConnected())
 		crash_with("Database connection failed.")
 		return
+	var/selection = list()
+	if (ckey)
+		selection += "`ckey` = '[ckey]'"
+	if (ip)
+		selection += "`ip` = '[ip]'"
+	if (cid)
+		selection += "`computerid` = '[cid]'"
+	selection = english_list(selection, "", "", " OR ", " OR ")
 	var/DBQuery/query = dbcon.NewQuery("\
 		SELECT `datetime`, `ckey`, `ip`, `computerid`\
 			FROM `erro_connection_log`\
-			WHERE `ckey` = '[ckey]' OR `ip` = '[ip]' OR `computerid` = '[cid]'\
+			WHERE [selection]\
 			GROUP BY `ckey`, `ip`, `computerid`\
 			ORDER BY `datetime`\
 	")

--- a/html/browser/common.css
+++ b/html/browser/common.css
@@ -335,3 +335,52 @@ div.notice
 	padding: 4px;
 	margin: 3px 0;
 }
+
+
+/* Data tables */
+table.data {
+	border-collapse: collapse;
+	width: 100%;
+}
+
+table.data thead th {
+	border-bottom: 2px solid #161616;
+	background: #383838;
+	color: #98B0C3;
+}
+
+table.data tbody th {
+	border-right: 2px solid #161616;
+	background: #383838;
+	color: #98B0C3;
+}
+
+table.data tbody td,
+table.data tbody th {
+	border-bottom: #40628a 1px solid;
+	vertical-align: top;
+}
+
+
+/* Hover tables */
+table.hover tr:hover,
+table tr.hover:hover,
+table tr.forcehover {
+	background: #294059;
+}
+
+
+/* Striped tables */
+table tr.stripe {
+	background: #383838;
+}
+
+
+/* Other misc table styles */
+table tr.disabled td,
+table tr.disabled th,
+table td.disabled,
+table th.disabled {
+	color: #999999;
+	font-style: italic;
+}


### PR DESCRIPTION
Some various misc updates to the panels and underlying functions.

## Changelog
:cl: SierraKomodo
admin: Made some minor tweaks to the Check Connections and Check Bans panel UI.
/:cl:

## Other Changes
- Removed references to unused table columns from select queries in `_fetch_bans()`.
- Updated `_fetch_connections()` and `_fetch_bans()` to only pass ckey, ip, and/or computerid parameters to the select query if these values are not null. This prevents showing all of the bans that are missing an IP or computer ID if you search by ckey only.
- Added CSS classes to `common.css` for various table styling (`.data`, `.hover`, `.disabled`, and `.stripe`, most notably.). I avoided modifying `table` directly, in case of uses elsewhere that aren't expecting styling changes.