### PR TITLE
Gendered Objects Fixes

### DIFF
--- a/code/modules/clothing/underwear/base.dm
+++ b/code/modules/clothing/underwear/base.dm
@@ -40,7 +40,7 @@
 	var/list/covering_items = H.get_covering_equipped_items(required_free_body_parts)
 	if(length(covering_items))
 		var/obj/item/I = covering_items[1]
-		var/datum/gender/G = gender_datums[I.gender]
+		var/datum/gender/G = GLOB.gender_datums[I.gender]
 		if(adjustment_verb)
 			to_chat(user, SPAN_WARNING("Cannot [adjustment_verb] \the [src]. [english_list(covering_items)] [length(covering_items) == 1 ? G.is : "are"] in the way."))
 		return FALSE

--- a/code/modules/mob/gender.dm
+++ b/code/modules/mob/gender.dm
@@ -1,5 +1,7 @@
 
 GLOBAL_LIST_EMPTY(gender_datums)
+/// List (`string`|`/datum/gender` => `/datum/pronouns`). Map of genders to pronouns. Derived from each gender datum's `default_pronouns`. Accepts both string or a gender datum as a key.
+GLOBAL_LIST_EMPTY(pronouns_from_gender)
 
 /hook/startup/proc/populate_gender_datum_list()
 	for(var/type in subtypesof(/datum/gender))
@@ -7,11 +9,18 @@ GLOBAL_LIST_EMPTY(gender_datums)
 		GLOB.gender_datums[G.key] = G
 		if(!G.formal_term)
 			G.formal_term = G.key
+
+		var/datum/pronouns/P = GLOB.pronouns.by_key[G.default_pronouns]
+		GLOB.pronouns_from_gender[G.key] = P
+		GLOB.pronouns_from_gender[G] = P
+
 	return 1
 
 /datum/gender
 	var/key
 	var/formal_term
+	/// String (One of `PRONOUNS_*`). Associated default pronouns used by this gender.
+	var/default_pronouns = PRONOUNS_THEY_THEM
 
 	var/He   = "They"
 	var/he   = "they"
@@ -29,6 +38,7 @@ GLOBAL_LIST_EMPTY(gender_datums)
 
 /datum/gender/male
 	key  = MALE
+	default_pronouns = PRONOUNS_HE_HIM
 
 	He   = "He"
 	he   = "he"
@@ -42,6 +52,7 @@ GLOBAL_LIST_EMPTY(gender_datums)
 
 /datum/gender/female
 	key  = FEMALE
+	default_pronouns = PRONOUNS_SHE_HER
 
 	He   = "She"
 	he   = "she"
@@ -56,6 +67,7 @@ GLOBAL_LIST_EMPTY(gender_datums)
 /datum/gender/neuter
 	key = NEUTER
 	formal_term = "other"
+	default_pronouns = PRONOUNS_IT_ITS
 
 	He   = "It"
 	he   = "it"

--- a/code/modules/mob/gender.dm
+++ b/code/modules/mob/gender.dm
@@ -1,10 +1,10 @@
 
-var/global/list/gender_datums = list()
+GLOBAL_LIST_EMPTY(gender_datums)
 
 /hook/startup/proc/populate_gender_datum_list()
 	for(var/type in subtypesof(/datum/gender))
 		var/datum/gender/G = new type
-		gender_datums[G.key] = G
+		GLOB.gender_datums[G.key] = G
 		if(!G.formal_term)
 			G.formal_term = G.key
 	return 1

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -904,12 +904,13 @@
 		reset_view(0)
 
 /**
- * Retrieves the atom's visible gender. Generally this is just `gender` but some factors may mask or change this.
+ * Retrieves the atom's pronouns. Generally this is just based on `gender` but some factors may mask or change this.
  *
- * Returns a valid gender value. See DM documentation for `/mob/var/gender`.
+ * Returns instance of `/datum/pronouns`.
  */
 /atom/proc/choose_from_pronouns()
-	return GLOB.gender_datums[gender]
+	RETURN_TYPE(/datum/pronouns)
+	return GLOB.pronouns_from_gender[gender]
 
 /mob/living/carbon/human/choose_from_pronouns()
 	if(wear_suit && wear_suit.flags_inv & HIDEJUMPSUIT && ((head && head.flags_inv & HIDEMASK) || wear_mask))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -913,9 +913,8 @@
 	return GLOB.pronouns_from_gender[gender]
 
 /mob/living/carbon/human/choose_from_pronouns()
-	if(wear_suit && wear_suit.flags_inv & HIDEJUMPSUIT && ((head && head.flags_inv & HIDEMASK) || wear_mask))
-		var/datum/pronouns/P = GLOB.pronouns.by_key[PRONOUNS_THEY_THEM]
-		return P
+	if (wear_suit && HAS_FLAGS(wear_suit.flags_inv, HIDEJUMPSUIT) && ((head && HAS_FLAGS(head.flags_inv, HIDEMASK)) || wear_mask))
+		return GLOB.pronouns.by_key[PRONOUNS_THEY_THEM]
 	return ..()
 
 /mob/living/carbon/human/proc/increase_germ_level(n)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -909,7 +909,7 @@
  * Returns a valid gender value. See DM documentation for `/mob/var/gender`.
  */
 /atom/proc/choose_from_pronouns()
-	return gender
+	return gender_datums[gender]
 
 /mob/living/carbon/human/choose_from_pronouns()
 	if(wear_suit && wear_suit.flags_inv & HIDEJUMPSUIT && ((head && head.flags_inv & HIDEMASK) || wear_mask))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -909,7 +909,7 @@
  * Returns a valid gender value. See DM documentation for `/mob/var/gender`.
  */
 /atom/proc/choose_from_pronouns()
-	return gender_datums[gender]
+	return GLOB.gender_datums[gender]
 
 /mob/living/carbon/human/choose_from_pronouns()
 	if(wear_suit && wear_suit.flags_inv & HIDEJUMPSUIT && ((head && head.flags_inv & HIDEMASK) || wear_mask))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -687,7 +687,7 @@
 
 /mob/choose_from_pronouns()
 	if(!pronouns)
-		var/datum/gender/G = gender_datums[gender]
+		var/datum/gender/G = GLOB.gender_datums[gender]
 		return G
 	else
 		var/datum/pronouns/P = GLOB.pronouns.by_key[pronouns]

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -687,8 +687,7 @@
 
 /mob/choose_from_pronouns()
 	if(!pronouns)
-		var/datum/gender/G = GLOB.gender_datums[gender]
-		return G
+		return GLOB.pronouns.from_gender(gender)
 	else
 		var/datum/pronouns/P = GLOB.pronouns.by_key[pronouns]
 		if(P.types)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -686,13 +686,13 @@
 
 
 /mob/choose_from_pronouns()
-	if(!pronouns)
-		return GLOB.pronouns.from_gender(gender)
-	else
-		var/datum/pronouns/P = GLOB.pronouns.by_key[pronouns]
-		if(P.types)
-			P = GLOB.pronouns.by_key[pick(P.types)]
-		return P
+	if (!pronouns)
+		return ..()
+
+	var/datum/pronouns/P = GLOB.pronouns.by_key[pronouns]
+	if(P.types)
+		P = GLOB.pronouns.by_key[pick(P.types)]
+	return P
 
 
 /mob/proc/see(message)

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -452,7 +452,7 @@
 	return chosen_species.name
 
 /mob/new_player/choose_from_pronouns()
-	if(!client || !client.prefs)
+	if (!client?.prefs)
 		return ..()
 	return client.prefs.pronouns
 

--- a/code/modules/psionics/mob/mob_assay.dm
+++ b/code/modules/psionics/mob/mob_assay.dm
@@ -5,7 +5,7 @@
 	var/use_He_is =  "You are"
 	var/use_He_has = "You have"
 	if(istype(machine) || viewer != src)
-		var/datum/gender/G = gender_datums[gender]
+		var/datum/gender/G = GLOB.gender_datums[gender]
 		use_He_is =  "[G.He] [G.is]"
 		use_He_has = "[G.He] [G.has]"
 

--- a/code/modules/species/station/prometheans.dm
+++ b/code/modules/species/station/prometheans.dm
@@ -78,7 +78,7 @@ var/global/datum/species/shapeshifter/promethean/prometheans
 	prometheans = src
 
 /datum/species/shapeshifter/promethean/hug(mob/living/carbon/human/H,mob/living/target)
-	var/datum/gender/G = gender_datums[target.gender]
+	var/datum/gender/G = GLOB.gender_datums[target.gender]
 	H.visible_message(SPAN_NOTICE("\The [H] glomps [target] to make [G.him] feel better!"), \
 					SPAN_NOTICE("You glomps [target] to make [G.him] feel better!"))
 	H.apply_stored_shock_to(target)
@@ -146,7 +146,7 @@ var/global/datum/species/shapeshifter/promethean/prometheans
 
 	if(!stored_shock_by_ref["\ref[H]"])
 		return
-	var/datum/gender/G = gender_datums[H.gender]
+	var/datum/gender/G = GLOB.gender_datums[H.gender]
 
 	switch(stored_shock_by_ref["\ref[H]"])
 		if(1 to 10)


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Fixes a bug that caused preset emotes (I.e., `/stare`) targeting objects to not work.
/:cl:

## Bug Fixes
- Fixes #33337

## Other Changes
- `choose_from_pronouns()` is now guaranteed to return an instance of `/datum/pronouns`.
- Moves `gender_datums` to `GLOB`.
- Added `pronouns_from_gender` global list.
- Cleans up code in `choose_from_pronouns()` and its overrides.