### PR TITLE
Devices attached to bombs can be activated

### DIFF
--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -5,7 +5,7 @@
 	icon_state = "valve_1"
 	var/obj/item/tank/tank_one
 	var/obj/item/tank/tank_two
-	var/obj/item/device/attached_device
+	var/obj/item/device/assembly/attached_device
 	var/mob/attacher = null
 	var/valve_open = 0
 	var/toggle = 1
@@ -120,6 +120,8 @@
 			update_icon()
 		if(href_list["device"])
 			attached_device.attack_self(usr)
+		if(href_list["activate"])
+			attached_device.activate()
 	return 1 // Returning 1 sends an update to attached UIs
 
 /obj/item/device/transfer_valve/process_activation(obj/item/device/D)

--- a/nano/templates/transfer_valve.tmpl
+++ b/nano/templates/transfer_valve.tmpl
@@ -35,11 +35,14 @@
 			{{:data.valveAttachment}}
 		{{else}}
 			<i>None</i>
-		{{/if}}		
+		{{/if}}
 		{{:helper.link('Remove', 'eject', {'rem_device' : 1}, data.valveAttachment ? null : 'disabled')}}
 		{{if data.valveAttachment}}
 			{{:helper.link('View', 'wrench', {'device' : 1})}}
-		{{/if}}		
+		{{/if}}
+		{{if data.valveAttachment}}
+			{{:helper.link('Trigger', 'activate', {'activate' : 1})}}
+		{{/if}}
 	</div>
 </div>
 
@@ -53,4 +56,3 @@
 		{{:helper.link('Open', 'unlocked', {'open' : 1}, (!data.attachmentOne || !data.attachmentTwo) ? 'disabled' : (data.valveOpen ? 'selected' : null))}}{{:helper.link('Close', 'locked', {'open' : 1}, (!data.attachmentOne || !data.attachmentTwo) ? 'disabled' : (data.valveOpen ? null : 'selected'))}}
 	</div>
 </div>
-


### PR DESCRIPTION
🆑 Jux
bugfix: TTV bombs now have a UI button to activate attached devices directly. While this is nonfunctional for signalers, it allows proximity sensors and timers to work.
/🆑 