### PR TITLE
Fix runtimes when do_after has no target.

### DIFF
--- a/code/_helpers/mobs.dm
+++ b/code/_helpers/mobs.dm
@@ -155,13 +155,13 @@
 		// Autoset over-user if not in an otherwise visible location
 		// For public progress: This is if it's not on a turf.
 		// For private progress: This is if it's not on a turf or directly in the user's visible inventory HUD.
-		if (!HAS_FLAGS(do_flags, DO_BAR_OVER_USER) && !isturf(target.loc))
-			if (HAS_FLAGS(do_flags, DO_PUBLIC_PROGRESS) || target.loc != user)
-				SET_FLAGS(do_flags, DO_BAR_OVER_USER)
-
 		if (do_flags & DO_PUBLIC_PROGRESS)
+			if (!HAS_FLAGS(do_flags, DO_BAR_OVER_USER) && (!target || !isturf(target.loc)))
+				SET_FLAGS(do_flags, DO_BAR_OVER_USER)
 			bar = new /datum/progressbar/public(user, delay, target, !!(do_flags & DO_BAR_OVER_USER))
 		else
+			if (!HAS_FLAGS(do_flags, DO_BAR_OVER_USER) && (!target || (!isturf(target.loc) && target.loc != user)))
+				SET_FLAGS(do_flags, DO_BAR_OVER_USER)
 			bar = new /datum/progressbar/private(user, delay, target, !!(do_flags & DO_BAR_OVER_USER))
 
 	var/start_time = world.time


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Targetless `do_after()` calls, such as breaking handcuffs, no longer instantly succeed.
/:cl:

## Bug Fixes
- Fixes #33373
- Alternative to and closes #33403