### PR TITLE
Fix Integrated Cameras

### DIFF
--- a/code/game/machinery/_machines_base/machinery_stat.dm
+++ b/code/game/machinery/_machines_base/machinery_stat.dm
@@ -45,6 +45,25 @@
 
 
 /**
+ * Updates the machine's stat immunity. This also updates the stat flag itself, if it's set and you're turning on immunity.
+ *
+ * **Parameters**:
+ * - `statflag` (bitfield, One of `MACHINE_STAT_*`) - The stat flag to set immunity of.
+ * - `new_state` (boolean, default `TRUE`) - The new state of the stat immunity flag.
+ *
+ * Returns boolean. Whether or not `stat` was updated during the operation.
+ */
+/obj/machinery/proc/set_stat_immunity(statflag, new_state = TRUE)
+	if (new_state == !!HAS_FLAGS(stat_immune, statflag))
+		return FALSE
+	if (new_state)
+		SET_FLAGS(stat, FALSE)
+		return set_stat(statflag, FALSE)
+	CLEAR_FLAGS(stat_immune, statflag)
+	return FALSE
+
+
+/**
  * Toggles a stat flag.
  *
  * **Parameters**:

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -58,6 +58,7 @@
 
 	if(ispath(camera))
 		camera = new camera(src)
+		camera.set_stat_immunity(MACHINE_STAT_NOPOWER)
 		camera.set_status(0)
 		camera.is_helmet_cam = TRUE
 

--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -265,6 +265,7 @@
 /obj/item/integrated_circuit/output/video_camera/Initialize()
 	. = ..()
 	camera = new(src)
+	camera.set_stat_immunity(MACHINE_STAT_NOPOWER, TRUE)
 	camera.replace_networks(list())
 	on_data_written()
 


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Fixes void suit helmet cameras and integrated circuit cameras being unselectable in the camera monitor.
/:cl:

## Bug Fixes
- Fixes #33371
