### PR TITLE
Fix light replacer replacing bag

### DIFF
--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -52,7 +52,7 @@
 		if (!user.unEquip(tool, src))
 			FEEDBACK_UNEQUIP_FAILURE(tool, src)
 			return TRUE
-		mybag = tool
+		myreplacer = tool
 		update_icon()
 		updateUsrDialog()
 		user.visible_message(


### PR DESCRIPTION
## Changelogs
:cl: SierraKomodo
bugfix: Light replacers no longer replace trash bags or become stuck in janitorial carts.
/:cl:

## Bug Fixes
- Fixes #33372
