### PR TITLE
add /singleton/shared_list

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -424,6 +424,7 @@
 #include "code\datums\repositories\crew\tracking.dm"
 #include "code\datums\repositories\crew\vital.dm"
 #include "code\datums\repositories\crew\~defines.dm"
+#include "code\datums\singletons\shared_list.dm"
 #include "code\datums\singletons\pools\instance_configurator.dm"
 #include "code\datums\singletons\pools\instance_configurator_auto.dm"
 #include "code\datums\singletons\pools\instance_pool.dm"

--- a/code/datums/singletons/shared_list.dm
+++ b/code/datums/singletons/shared_list.dm
@@ -1,0 +1,167 @@
+/singleton/shared_list
+	abstract_type = /singleton/shared_list
+	var/max_pick = 8
+	var/list/list
+	var/mutable
+
+#if DM_VERSION >= 515
+/singleton/shared_list/proc/operator""()
+	return {"{"type":"[type]","mutable":"[mutable]","list":[json_encode(list)]}"}
+#endif
+
+
+/singleton/shared_list/proc/operator[](index)
+	return list[index]
+
+
+/singleton/shared_list/proc/operator[]=(index, value)
+	if (!mutable)
+		throw EXCEPTION("[type] is not mutable.")
+		return
+	list[index] = value
+
+
+/singleton/shared_list/proc/operator+(value)
+	return list + value
+
+
+/singleton/shared_list/proc/operator+=(value)
+	if (!mutable)
+		throw EXCEPTION("[type] is not mutable.")
+		return
+	list += value
+
+
+/singleton/shared_list/proc/operator-(value)
+	return list - value
+
+
+/singleton/shared_list/proc/operator-=(value)
+	if (!mutable)
+		throw EXCEPTION("[type] is not mutable.")
+		return
+	list -= value
+
+
+/singleton/shared_list/proc/operator|(value)
+	return list | value
+
+
+/singleton/shared_list/proc/operator|=(value)
+	if (!mutable)
+		throw EXCEPTION("[type] is not mutable.")
+		return
+	list |= value
+
+
+/singleton/shared_list/proc/operator&(value)
+	return list & value
+
+
+/singleton/shared_list/proc/operator&=(value)
+	if (!mutable)
+		throw EXCEPTION("[type] is not mutable.")
+		return
+	list &= value
+
+
+/singleton/shared_list/proc/operator^(value)
+	return list ^ value
+
+
+/singleton/shared_list/proc/operator^=(value)
+	if (!mutable)
+		throw EXCEPTION("[type] is not mutable.")
+		return
+	list ^= value
+
+
+/singleton/shared_list/proc/Add(/*Item1, Item2, ...*/)
+	if (!mutable)
+		throw EXCEPTION("[type] is not mutable.")
+		return
+	return list.Add(arglist(args))
+
+
+/singleton/shared_list/proc/Copy(Start = 1, End = 0)
+	return list.Copy(Start, End)
+
+
+/singleton/shared_list/proc/Cut(Start = 1, End = 0)
+	if (!mutable)
+		throw EXCEPTION("[type] is not mutable.")
+		return
+	return list.Cut(Start, End)
+
+
+/singleton/shared_list/proc/Find(Elem, Start = 1, End = 0)
+	return list.Find(Elem, Start, End)
+
+
+/singleton/shared_list/proc/Insert(/*Index, Item1, Item2, ...*/)
+	if (!mutable)
+		throw EXCEPTION("[type] is not mutable.")
+		return
+	return list.Insert(arglist(args))
+
+
+/singleton/shared_list/proc/Join(Glue, Start = 1, End = 0)
+	return list.Join(Glue, Start, End)
+
+
+/singleton/shared_list/proc/Remove(/*Item1, Item2, ...*/)
+	if (!mutable)
+		throw EXCEPTION("[type] is not mutable.")
+		return
+	return list.Remove(arglist(args))
+
+
+#if DM_VERSION >= 515
+/singleton/shared_list/proc/RemoveAll(/*Item1, Item2, ...*/)
+	if (!mutable)
+		throw EXCEPTION("[type] is not mutable.")
+		return
+	return list.RemoveAll(arglist(args))
+#endif
+
+
+/singleton/shared_list/proc/Splice(/*Start = 1, End = 0, Item1, Item2, ...*/)
+	if (!mutable)
+		throw EXCEPTION("[type] is not mutable.")
+		return
+	return list.Splice(arglist(args))
+
+
+/singleton/shared_list/proc/Swap(Index1, Index2)
+	if (!mutable)
+		throw EXCEPTION("[type] is not mutable.")
+		return
+	return list.Swap(Index1, Index2)
+
+
+/singleton/shared_list/proc/Len()
+	return length(list)
+
+
+/singleton/shared_list/proc/Ref()
+	return list
+
+
+/singleton/shared_list/proc/Pick(count = 1)
+	count = clamp(floor(count), 1, max_pick)
+	if (count == 1)
+		return pick(list)
+	var/list/result[count]
+	for (var/i = 1 to count)
+		result[i] = pick(list)
+	return result
+
+
+/singleton/shared_list/proc/PickWeight(count = 1)
+	count = clamp(floor(count), 1, max_pick)
+	if (count == 1)
+		return pickweight(list)
+	var/list/result[count]
+	for (var/i = 1 to count)
+		result[i] = pickweight(list)
+	return result


### PR DESCRIPTION
nufc


shared_list provides the option to supply a /singleton/shared_list/... path in datum configurations where otherwise duplicate lists would be instanced, such as on storage items that only permit specific contents.

shared_list implements (nearly) all of the /list API through overloads and mirror procs. Because they cannot implement .len or use of their own reference as a list, they implement `.Len()` and `.Ref()` instead.

shared_list may also implement conveniences. In this initial version, it is able to treat the underlying list as immutable when `.mutable` is falsy and throws exceptions where it would be changed through the shared_list. `.Pick` and `.PickWeight` are also implemented, and may return a single result or a set limited by `.max_pick`.
\---

using this in a bit for a thing