### PR TITLE
Make `is_species()` null-safe

### DIFF
--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -42,7 +42,7 @@
 
 
 /mob/living/carbon/is_species(datum/species/S)
-	if (!S) return FALSE
+	if (!S || !species) return FALSE
 	if (istext(S)) return species.name == S
 	if (ispath(S)) return species.name == initial(S.name)
 	return species.name == S.name


### PR DESCRIPTION
Slimes lack a species, and there's probably a few other carbon mobs like that :)

## Bug Fixes
- Fixes #33387
