### PR TITLE
Fix runtime when adding robot parts to robots

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -491,7 +491,7 @@
 			if (component.installed)
 				USE_FEEDBACK_FAILURE("\The [src] already has \a [component.wrapped] installed in \the [component] slot.")
 				return TRUE
-			if (!user.unEquip(tool, component))
+			if (!user.unEquip(tool, src))
 				FEEDBACK_UNEQUIP_FAILURE(user, tool)
 				return TRUE
 			component.installed = TRUE


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Robot parts now probably attach and install into robots when used.
/:cl:

## Bug Fixes
- Fixes #33389