### PR TITLE
Apply `use_*` to `/obj/item/gun/*`

### DIFF
--- a/code/modules/projectiles/guns/launcher/crossbow.dm
+++ b/code/modules/projectiles/guns/launcher/crossbow.dm
@@ -136,55 +136,136 @@
 		return
 
 
-/obj/item/gun/launcher/crossbow/attackby(obj/item/W, mob/user)
+/obj/item/gun/launcher/crossbow/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Arrow - Load ammo
+	if (istype(tool, /obj/item/arrow))
+		if (bolt)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [bolt] loaded.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		bolt = tool
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] slides \a [bolt] into \a [src]."),
+			SPAN_NOTICE("You slide \the [bolt] into \the [src].")
+		)
+		return TRUE
 
-	if(istype(W, /obj/item/rcd))
-		var/obj/item/rcd/rcd = W
-		if(rcd.crafting && user.unEquip(rcd) && user.unEquip(src))
-			new /obj/item/gun/launcher/crossbow/rapidcrossbowdevice(get_turf(src))
-			qdel(rcd)
-			qdel_self()
-		else
-			to_chat(user, SPAN_WARNING("\The [rcd] is not prepared for installation in \the [src]."))
-		return
+	// RCD - Created rapid crossbow device
+	if (istype(tool, /obj/item/rcd))
+		var/obj/item/rcd/rcd = tool
+		if (!rcd.crafting)
+			USE_FEEDBACK_FAILURE("\The [tool] isn't ready to be modified.")
+			return TRUE
+		if (!user.canUnEquip(tool))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		if (!user.canUnEquip(src))
+			FEEDBACK_UNEQUIP_FAILURE(user, src)
+			return TRUE
+		var/obj/item/gun/launcher/crossbow/rapidcrossbowdevice/new_crossbow = new(get_turf(src))
+		transfer_fingerprints_to(new_crossbow)
+		tool.transfer_fingerprints_to(new_crossbow)
+		new_crossbow.add_fingerprint(user)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] combines \a [tool] and \a [src] to create \a [new_crossbow]."),
+			SPAN_NOTICE("You combine \the [tool] and \the [src] to create \a [new_crossbow].")
+		)
+		qdel(tool)
+		qdel_self()
+		return TRUE
 
-	if(!bolt)
-		if (istype(W,/obj/item/arrow) && user.unEquip(W, src))
-			bolt = W
-			user.visible_message("[user] slides [bolt] into [src].","You slide [bolt] into [src].")
-			update_icon()
-			return
-		else if(istype(W,/obj/item/stack/material/rods))
-			var/obj/item/stack/material/rods/R = W
-			if (R.use(1))
-				bolt = new /obj/item/arrow/rod(src)
-				bolt.fingerprintslast = src.fingerprintslast
-				update_icon()
-				user.visible_message("[user] jams [bolt] into [src].","You jam [bolt] into [src].")
-				superheat_rod(user)
-			return
+	// Rods - Load ammo
+	if (istype(tool, /obj/item/stack/material/rods))
+		if (bolt)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [bolt] loaded.")
+			return TRUE
+		var/obj/item/stack/material/rods/rods = tool
+		if (!rods.use(1))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(rods, 1, "to load \the [src].")
+			return TRUE
+		bolt = new /obj/item/arrow/rod(src)
+		bolt.add_fingerprint(user)
+		update_icon()
+		superheat_rod(user)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] jams ")
+		)
 
-	if(istype(W, /obj/item/cell))
-		if(!cell)
-			if(!user.unEquip(W, src))
-				return
-			cell = W
-			to_chat(user, SPAN_NOTICE("You jam [cell] into [src] and wire it to the firing coil."))
-			superheat_rod(user)
-		else
-			to_chat(user, SPAN_NOTICE("[src] already has a cell installed."))
+	return ..()
 
-	else if(isScrewdriver(W))
-		if(cell)
-			var/obj/item/C = cell
-			C.dropInto(user.loc)
-			to_chat(user, SPAN_NOTICE("You jimmy [cell] out of [src] with [W]."))
-			cell = null
-		else
-			to_chat(user, SPAN_NOTICE("[src] doesn't have a cell installed."))
 
-	else
-		..()
+/obj/item/gun/launcher/crossbow/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Arrow - Load ammo
+	if (istype(tool, /obj/item/arrow))
+		if (bolt)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [bolt] loaded.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		bolt = tool
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] slides \a [tool] into \a [src]."),
+			SPAN_NOTICE("You slide \the [tool] into \the [src].")
+		)
+		return TRUE
+
+	// Cell - Attach cell
+	if (istype(tool, /obj/item/cell))
+		if (cell)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [cell] installed.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		cell = tool
+		user.visible_message(
+			SPAN_NOTICE("\The [user] jams \a [cell] into \a [src] and wires it to the firing coil."),
+			SPAN_NOTICE("You jam \the [cell] into \the [src] and wire it to the firing coil.")
+		)
+		superheat_rod(user)
+		return TRUE
+
+	// Rods - Load ammo
+	if (istype(tool, /obj/item/stack/material/rods))
+		if (bolt)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [bolt] loaded.")
+			return TRUE
+		var/obj/item/stack/material/rods/rods = tool
+		if (!rods.use(1))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(rods, 1, "to load \the [src].")
+			return TRUE
+		bolt = new /obj/item/arrow/rod(src)
+		tool.transfer_fingerprints_to(bolt)
+		bolt.add_fingerprint(user, tool = src)
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] slides [rods.get_vague_name()] into \a [src]."),
+			SPAN_NOTICE("You slide [rods.get_exact_name(1)] into \the [src].")
+		)
+		superheat_rod(user)
+		return TRUE
+
+	// Screwdriver - Remove cell
+	if (isScrewdriver(tool))
+		if (!cell)
+			USE_FEEDBACK_FAILURE("\The [src] has no cell to remove.")
+			return TRUE
+		user.put_in_hands(cell)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] jimmies \a [cell] out of \a [src] with \a [tool]."),
+			SPAN_NOTICE("You jimmy \the [cell] out of \the [src] with \the [tool].")
+		)
+		cell = null
+		update_icon()
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/launcher/crossbow/proc/superheat_rod(mob/user)
 	if(!user || !cell || !bolt) return
@@ -245,32 +326,56 @@
 		generate_bolt(user)
 		draw(user)
 
-/obj/item/gun/launcher/crossbow/rapidcrossbowdevice/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/rcd_ammo))
-		var/obj/item/rcd_ammo/cartridge = W
-		if(stored_matter >= max_stored_matter)
-			to_chat(user, SPAN_NOTICE("The RCD is at maximum capacity."))
-			return
-		var/matter_exchange = min(cartridge.remaining,max_stored_matter - stored_matter)
+
+/obj/item/gun/launcher/crossbow/rapidcrossbowdevice/use_tool(obj/item/tool, mob/user, list/click_params)
+	// RCD Ammo - Reload RCD
+	if (istype(tool, /obj/item/rcd_ammo))
+		if (stored_matter >= max_stored_matter)
+			USE_FEEDBACK_FAILURE("\The [src]'s RCD is already at maximum capacity.")
+			return TRUE
+		var/obj/item/rcd_ammo/cartridge = tool
+		var/matter_exchange = min(cartridge.remaining, max_stored_matter - stored_matter)
 		stored_matter += matter_exchange
 		cartridge.remaining -= matter_exchange
-		if(cartridge.remaining <= 0)
-			qdel(W)
-		cartridge.matter = list(MATERIAL_STEEL = 500 * cartridge.remaining,MATERIAL_GLASS = 250 * cartridge.remaining)
-		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-		to_chat(user, SPAN_NOTICE("The RCD now holds [stored_matter]/[max_stored_matter] matter-units."))
+		if (cartridge.remaining <= 0)
+			qdel(tool)
+		else
+			cartridge.matter = list(
+				MATERIAL_STEEL = 500 * cartridge.remaining,
+				MATERIAL_GLASS = 250 * cartridge.remaining
+			)
 		update_icon()
+		playsound(src, 'sound/machines/click.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] loads \a [tool] into \a [src]'s RCD."),
+			SPAN_NOTICE("You load \the [tool] into \the [src]'s RCD.")
+		)
+		if (max_stored_matter > 1)
+			to_chat(user, SPAN_INFO("\The [src]'s RCD now holds [stored_matter]/[max_stored_matter] matter unit\s."))
+		return TRUE
 
-	if(istype(W, /obj/item/arrow/rapidcrossbowdevice))
-		var/obj/item/arrow/rapidcrossbowdevice/A = W
-		if((stored_matter + 10) > max_stored_matter)
-			to_chat(user, SPAN_NOTICE("Unable to reclaim flashforged bolt. The RCD can't hold that many additional matter-units."))
-			return
+	// Bolt - Reclaim bolt
+	if (istype(tool, /obj/item/arrow/rapidcrossbowdevice))
+		if ((stored_matter + 10) > max_stored_matter)
+			USE_FEEDBACK_FAILURE("\The [src] can't reclaim \the [tool]. The RCD is too full.")
+			return TRUE
+		if (!user.canUnEquip(tool))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
 		stored_matter += 10
-		qdel(A)
-		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-		to_chat(user, SPAN_NOTICE("Flashforged bolt reclaimed. The RCD now holds [stored_matter]/[max_stored_matter] matter-units."))
+		qdel(tool)
 		update_icon()
+		playsound(src, 'sound/machines/click.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] reclaims \a [tool] with \a [src]'s RCD."),
+			SPAN_NOTICE("You reclaim \the [tool] with \the [src]'s RCD.")
+		)
+		if (max_stored_matter > 1)
+			to_chat(user, SPAN_INFO("\The [src]'s RCD now holds [stored_matter]/[max_stored_matter] matter unit\s."))
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/launcher/crossbow/rapidcrossbowdevice/on_update_icon()
 	overlays.Cut()

--- a/code/modules/projectiles/guns/launcher/foam_gun.dm
+++ b/code/modules/projectiles/guns/launcher/foam_gun.dm
@@ -19,15 +19,27 @@
 	var/max_darts = 1
 	var/list/darts = new/list()
 
-/obj/item/gun/launcher/foam/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/foam_dart))
-		if(length(darts) < max_darts)
-			if(!user.unEquip(I, src))
-				return
-			darts += I
-			to_chat(user, SPAN_NOTICE("You slot \the [I] into \the [src]."))
-		else
-			to_chat(user, SPAN_WARNING("\The [src] can hold no more darts."))
+
+/obj/item/gun/launcher/foam/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Foam Dart - Load ammo
+	if (istype(tool, /obj/item/foam_dart))
+		if (length(darts) >= max_darts)
+			USE_FEEDBACK_FAILURE("\The [src] is full.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		darts += tool
+		user.visible_message(
+			SPAN_NOTICE("\The [user] loads \the [src] with \a [tool]."),
+			SPAN_NOTICE("You load \the [src] with \the [tool].")
+		)
+		if (max_darts > 1)
+			to_chat(user, SPAN_INFO("\The [src] now has [length(darts)]/[max_darts] darts loaded."))
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/launcher/foam/consume_next_projectile()
 	if(length(darts))

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -76,11 +76,15 @@
 /obj/item/gun/launcher/grenade/attack_self(mob/user)
 	pump(user)
 
-/obj/item/gun/launcher/grenade/attackby(obj/item/I, mob/user)
-	if((istype(I, /obj/item/grenade)))
-		load(I, user)
-	else
-		..()
+
+/obj/item/gun/launcher/grenade/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Grenade - Load ammo
+	if (istype(tool, /obj/item/grenade))
+		load(tool, user)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/launcher/grenade/attack_hand(mob/user)
 	if(user.get_inactive_hand() == src)

--- a/code/modules/projectiles/guns/launcher/money_cannon.dm
+++ b/code/modules/projectiles/guns/launcher/money_cannon.dm
@@ -129,30 +129,34 @@
 	else
 		return ..()
 
-/obj/item/gun/launcher/money/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/spacecash))
-		var/obj/item/spacecash/bling = W
-		if(bling.worth < 1)
-			to_chat(user, SPAN_WARNING("You can't seem to get the bills to slide into the receptacle."))
-			return
-		if(receptacle_value >= max_capacity)
-			to_chat(user, SPAN_WARNING("There's no space in the receptacle for [bling]."))
-			return
-		else if (receptacle_value && receptacle_value + bling.worth > max_capacity) //If we have enough money to fill it to capacity
-			bling.worth -= max_capacity - receptacle_value
-			receptacle_value = max_capacity
-			to_chat(user, SPAN_NOTICE("You load [src] to capacity with [bling]."))
-			if(!bling.worth)
-				qdel(bling)
-			else
-				bling.update_icon()
-			return
-		receptacle_value += bling.worth
-		to_chat(user, SPAN_NOTICE("You slide [bling.worth] [GLOB.using_map.local_currency_name_singular] into [src]'s receptacle."))
-		qdel(bling)
 
-	else
-		to_chat(user, SPAN_WARNING("That's not going to fit in there."))
+/obj/item/gun/launcher/money/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Money - Load ammo
+	if (istype(tool, /obj/item/spacecash))
+		if (receptacle_value >= max_capacity)
+			USE_FEEDBACK_FAILURE("\The [src] is full.")
+			return TRUE
+		var/obj/item/spacecash/cash = tool
+		if (cash.worth < 1)
+			USE_FEEDBACK_FAILURE("\The [tool] won't fit into \the [src].")
+			return TRUE
+		var/amount_transferred = min(max_capacity, receptacle_value + cash.worth)
+		cash.worth -= amount_transferred
+		receptacle_value += amount_transferred
+		if (!cash.worth)
+			qdel(cash)
+		else
+			cash.update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] loads \a [src] with some [GLOB.using_map.local_currency_name_singular]s."),
+			SPAN_NOTICE("You load \the [src] with [amount_transferred] [GLOB.using_map.local_currency_name_singular]\s.")
+		)
+		if (max_capacity > 1)
+			to_chat(user, SPAN_INFO("\The [src]'s receptable now has [receptacle_value]/[max_capacity] [GLOB.using_map.local_currency_name_singular]\s loaded."))
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/launcher/money/examine(mob/user)
 	. = ..(user)

--- a/code/modules/projectiles/guns/launcher/net.dm
+++ b/code/modules/projectiles/guns/launcher/net.dm
@@ -52,11 +52,15 @@
 	else
 		to_chat(user, SPAN_WARNING("\The [src] is empty."))
 
-/obj/item/gun/launcher/net/attackby(obj/item/I, mob/user)
-	if((istype(I, /obj/item/net_shell)))
-		load(I, user)
-	else
-		..()
+
+/obj/item/gun/launcher/net/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Net Shell - Load
+	if (istype(tool, /obj/item/net_shell))
+		load(tool, user)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/launcher/net/attack_hand(mob/user)
 	if(user.get_inactive_hand() == src)

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -65,13 +65,32 @@
 	else
 		return ..()
 
-/obj/item/gun/launcher/pneumatic/attackby(obj/item/W as obj, mob/user as mob)
-	if(!tank && istype(W,/obj/item/tank) && user.unEquip(W, src))
-		tank = W
-		user.visible_message("[user] jams [W] into [src]'s valve and twists it closed.","You jam [W] into [src]'s valve and twist it closed.")
+
+/obj/item/gun/launcher/pneumatic/use_tool(obj/item/tool, mob/user, list/click_params)
+	SHOULD_CALL_PARENT(FALSE) // Everything is passed through to item insertion.
+
+	// Tank - Install tank
+	if (istype(tool, /obj/item/tank))
+		if (tank)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [tank] installed.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		tank = tool
 		update_icon()
-	else if(istype(W) && item_storage.can_be_inserted(W, user))
-		item_storage.handle_item_insertion(W)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] jams \a [tool] into \a [src]'s valve and twists it closed."),
+			SPAN_NOTICE("You jam \the [tool] into \the [src]'s valve and twist it closed.")
+		)
+		return TRUE
+
+	// Anything else - Attempt to install
+	if (!item_storage.can_be_inserted(tool, user))
+		return TRUE
+	item_storage.handle_item_insertion(tool)
+	return TRUE
+
 
 /obj/item/gun/launcher/pneumatic/attack_self(mob/user as mob)
 	eject_tank(user)

--- a/code/modules/projectiles/guns/launcher/rocket.dm
+++ b/code/modules/projectiles/guns/launcher/rocket.dm
@@ -23,16 +23,27 @@
 	if(distance <= 2)
 		to_chat(user, SPAN_NOTICE("[length(rockets)] / [max_rockets] rockets."))
 
-/obj/item/gun/launcher/rocket/attackby(obj/item/I as obj, mob/user as mob)
-	if(istype(I, /obj/item/ammo_casing/rocket))
-		if(length(rockets) < max_rockets)
-			if(!user.unEquip(I, src))
-				return
-			rockets += I
-			to_chat(user, SPAN_NOTICE("You put the rocket in [src]."))
-			to_chat(user, SPAN_NOTICE("[length(rockets)] / [max_rockets] rockets."))
-		else
-			to_chat(usr, SPAN_WARNING("\The [src] cannot hold more rockets."))
+
+/obj/item/gun/launcher/rocket/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Rocket - Load ammo
+	if (istype(tool, /obj/item/ammo_casing/rocket))
+		if (length(rockets) >= max_rockets)
+			USE_FEEDBACK_FAILURE("\The [src] is full.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		rockets += tool
+		user.visible_message(
+			SPAN_NOTICE("\The [user] loads \a [src] with \a [tool]."),
+			SPAN_NOTICE("You load \the [src] with \the [tool].")
+		)
+		if (max_rockets > 1)
+			to_chat(user, SPAN_INFO("\The [src] now has [length(rockets)]/[max_rockets] rocket\s loaded."))
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/launcher/rocket/consume_next_projectile()
 	if(length(rockets))

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -118,18 +118,27 @@
 	else
 		..()
 
-/obj/item/gun/launcher/syringe/attackby(obj/item/A as obj, mob/user as mob)
-	if(istype(A, /obj/item/syringe_cartridge))
-		var/obj/item/syringe_cartridge/C = A
-		if(length(darts) >= max_darts)
-			to_chat(user, SPAN_WARNING("[src] is full!"))
-			return
-		if(!user.unEquip(C, src))
-			return
-		darts += C //add to the end
-		user.visible_message("[user] inserts \a [C] into [src].", SPAN_NOTICE("You insert \a [C] into [src]."))
-	else
-		..()
+
+/obj/item/gun/launcher/syringe/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Syringe Cartridge - Load ammo
+	if (istype(tool, /obj/item/syringe_cartridge))
+		if (length(darts) >= max_darts)
+			USE_FEEDBACK_FAILURE("\The [src] is full.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		darts += tool
+		user.visible_message(
+			SPAN_NOTICE("\The [user] loads \a [src] with \a [tool]."),
+			SPAN_NOTICE("You load \the [src] with \the [tool].")
+		)
+		if (max_darts > 1)
+			to_chat(user, SPAN_INFO("\The [src] now has [length(darts)]/[max_darts] dart\s loaded."))
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/launcher/syringe/rapid
 	name = "syringe gun revolver"

--- a/code/modules/projectiles/guns/magnetic/magnetic.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic.dm
@@ -105,90 +105,119 @@
 		else
 			to_chat(user, SPAN_NOTICE("The capacitor charge indicator is [SPAN_COLOR("[COLOR_GREEN]", "green")]."))
 
-/obj/item/gun/magnetic/attackby(obj/item/thing, mob/user)
 
-	if(removable_components)
-		if(istype(thing, /obj/item/cell))
-			if(cell)
-				to_chat(user, SPAN_WARNING("\The [src] already has \a [cell] installed."))
-				return
-			if(!user.unEquip(thing, src))
-				return
-			cell = thing
-			playsound(loc, 'sound/machines/click.ogg', 10, 1)
-			user.visible_message(SPAN_NOTICE("\The [user] slots \the [cell] into \the [src]."))
-			update_icon()
-			return
+/obj/item/gun/magnetic/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Capacitor - Install capacitor
+	if (istype(tool, /obj/item/stock_parts/capacitor))
+		if (!removable_components)
+			USE_FEEDBACK_FAILURE("\The [src]'s components can't be swapped out.")
+			return TRUE
+		if (capacitor)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [capacitor] installed.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		capacitor = tool
+		power_per_tick = (power_cost * 0.15) * capacitor.rating
+		update_icon()
+		playsound(src, 'sound/machines/click.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] slots \a [tool] into \a [src]."),
+			SPAN_NOTICE("You slot \the [tool] into \the [src].")
+		)
+		return TRUE
 
-		if(isScrewdriver(thing))
-			if(!capacitor)
-				to_chat(user, SPAN_WARNING("\The [src] has no capacitor installed."))
-				return
-			user.put_in_hands(capacitor)
-			user.visible_message(SPAN_NOTICE("\The [user] unscrews \the [capacitor] from \the [src]."))
-			playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
-			capacitor = null
-			update_icon()
-			return
+	// Cell - Install cell
+	if (istype(tool, /obj/item/cell))
+		if (!removable_components)
+			USE_FEEDBACK_FAILURE("\The [src]'s components can't be swapped out.")
+			return TRUE
+		if (cell)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [cell] installed.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		cell = tool
+		update_icon()
+		playsound(src, 'sound/machines/click.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] slots \a [tool] into \a [src]."),
+			SPAN_NOTICE("You slot \the [tool] into \the [src].")
+		)
+		return TRUE
 
-		if(istype(thing, /obj/item/stock_parts/capacitor))
-			if(capacitor)
-				to_chat(user, SPAN_WARNING("\The [src] already has \a [capacitor] installed."))
-				return
-			if(!user.unEquip(thing, src))
-				return
-			capacitor = thing
-			playsound(loc, 'sound/machines/click.ogg', 10, 1)
-			power_per_tick = (power_cost*0.15) * capacitor.rating
-			user.visible_message(SPAN_NOTICE("\The [user] slots \the [capacitor] into \the [src]."))
-			update_icon()
-			return
+	// Screwdriver - Remove capacitor
+	if (isScrewdriver(tool))
+		if (!removable_components)
+			USE_FEEDBACK_FAILURE("\The [src]'s components can't be swapped out.")
+			return TRUE
+		if (!capacitor)
+			USE_FEEDBACK_FAILURE("\The [src] has no capacitor to remove.")
+			return TRUE
+		user.put_in_hands(capacitor)
+		playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] detaches \a [capacitor] from \a [src] with \a [tool]."),
+			SPAN_NOTICE("You detach \the [capacitor] from \the [src] with \the [tool].")
+		)
+		capacitor = null
+		power_per_tick = 0
+		update_icon()
+		return TRUE
 
-	if(istype(thing, load_type))
-
+	// Attempt to load ammo
+	if (istype(tool, load_type))
 		// This is not strictly necessary for the magnetic gun but something using
 		// specific ammo types may exist down the track.
-		var/obj/item/stack/ammo = thing
-		if(!istype(ammo))
-			if(loaded)
-				to_chat(user, SPAN_WARNING("\The [src] already has \a [loaded] loaded."))
-				return
-			var/obj/item/magnetic_ammo/mag = thing
-			if(istype(mag))
-				if(!(load_type == mag.basetype))
-					to_chat(user, SPAN_WARNING("\The [src] doesn't seem to accept \a [mag]."))
-					return
-				projectile_type = mag.projectile_type
-			if(!user.unEquip(thing, src))
-				return
-
-			loaded = thing
-		else if(load_sheet_max > 1)
-			var ammo_count = 0
+		if (isstack(tool))
+			var/obj/item/stack/ammo = tool
+			var/ammo_count = 0
 			var/obj/item/stack/loaded_ammo = loaded
-			if(!istype(loaded_ammo))
-				ammo_count = min(load_sheet_max,ammo.amount)
+			if (!istype(loaded_ammo))
+				if (loaded)
+					USE_FEEDBACK_FAILURE("\The [src] already has \a [loaded] loaded.")
+					return TRUE
+				ammo_count = min(load_sheet_max, ammo.amount)
 				loaded = new load_type(src, ammo_count)
+				loaded_ammo = loaded
 			else
-				ammo_count = min(load_sheet_max-loaded_ammo.amount,ammo.amount)
+				if (loaded_ammo.type != ammo.type)
+					USE_FEEDBACK_FAILURE("\The [src] is currently loaded with [loaded_ammo.get_stack_name()]. \The [ammo.get_stack_name()] is not cannot be mixed with this.")
+					return TRUE
+				ammo_count = min(load_sheet_max - loaded_ammo.amount, ammo.amount)
 				loaded_ammo.amount += ammo_count
-			if(ammo_count <= 0)
-				// This will also display when someone tries to insert a stack of 0, but that shouldn't ever happen anyway.
-				to_chat(user, SPAN_WARNING("\The [src] is already fully loaded."))
-				return
+			if (!ammo_count)
+				USE_FEEDBACK_FAILURE("\The [src] is already fully loaded.")
+				return TRUE
 			ammo.use(ammo_count)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] loads \a [src] with [ammo.get_vague_name(ammo_count > 1)]."),
+				SPAN_NOTICE("You load \the [src] with [ammo.get_exact_name(ammo_count)].")
+			)
+			if (load_sheet_max > 1)
+				to_chat(user, SPAN_INFO("\The [src] now has [loaded_ammo.get_exact_name()] out of [load_sheet_max] loaded."))
 		else
-			if(loaded)
-				to_chat(user, SPAN_WARNING("\The [src] already has \a [loaded] loaded."))
-				return
-			loaded = new load_type(src, 1)
-			ammo.use(1)
-
-		user.visible_message(SPAN_NOTICE("\The [user] loads \the [src] with \the [loaded]."))
-		playsound(loc, 'sound/weapons/flipblade.ogg', 50, 1)
+			if (loaded)
+				USE_FEEDBACK_FAILURE("\The [src] already has \a [loaded] loaded.")
+				return TRUE
+			if (!user.unEquip(tool, src))
+				FEEDBACK_UNEQUIP_FAILURE(user, tool)
+				return TRUE
+			if (istype(tool, /obj/item/magnetic_ammo))
+				var/obj/item/magnetic_ammo/mag = tool
+				if (load_type != mag.basetype)
+					USE_FEEDBACK_FAILURE("\The [mag] doesn't fit in \the [src].")
+					return TRUE
+				projectile_type = mag.projectile_type
+			loaded = tool
+		playsound(src, 'sound/weapons/flipblade.ogg', 50, TRUE)
 		update_icon()
-		return
-	. = ..()
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/magnetic/attack_hand(mob/user)
 	if(user.get_inactive_hand() == src)

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -267,9 +267,14 @@
 		to_chat(user, SPAN_WARNING("[src] is empty."))
 	update_icon()
 
-/obj/item/gun/projectile/attackby(obj/item/A as obj, mob/user as mob)
-	if(!load_ammo(A, user))
-		return ..()
+
+/obj/item/gun/projectile/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Anything - Attempt to load ammo
+	if (load_ammo(tool, user))
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/projectile/attack_self(mob/user as mob)
 	if(length(firemodes) > 1)

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -203,11 +203,15 @@
 	. = ..()
 	launcher = new(src)
 
-/obj/item/gun/projectile/automatic/bullpup_rifle/attackby(obj/item/I, mob/user)
-	if((istype(I, /obj/item/grenade)))
-		launcher.load(I, user)
-	else
-		..()
+
+/obj/item/gun/projectile/automatic/bullpup_rifle/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Grenade - Load launcher
+	if (istype(tool, /obj/item/grenade))
+		launcher.load(tool, user)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/projectile/automatic/bullpup_rifle/attack_hand(mob/user)
 	if(user.get_inactive_hand() == src && use_launcher)

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -104,11 +104,15 @@
 				for(var/datum/reagent/R in B.reagents.reagent_list)
 					to_chat(user, SPAN_NOTICE("[R.volume] units of [R.name]"))
 
-/obj/item/gun/projectile/dartgun/attackby(obj/item/I as obj, mob/user as mob)
-	if(istype(I, /obj/item/reagent_containers/glass))
-		add_beaker(I, user)
-		return 1
-	..()
+
+/obj/item/gun/projectile/dartgun/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Glass Reagent Container - Add beaker
+	if (istype(tool, /obj/item/reagent_containers/glass))
+		add_beaker(tool, user)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/projectile/dartgun/proc/add_beaker(obj/item/reagent_containers/glass/B, mob/user)
 	if(!istype(B, container_type))

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -137,20 +137,32 @@
 			return
 	..()
 
-/obj/item/gun/projectile/pistol/holdout/attackby(obj/item/I, mob/user)
-	if(istype(I, /obj/item/silencer))
+
+/obj/item/gun/projectile/pistol/holdout/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Silencer - Attach silencer
+	if (istype(tool, /obj/item/silencer))
 		if (silenced)
-			to_chat(user, SPAN_WARNING("\The [src] is already silenced."))
-			return
-		if(!user.unEquip(I, src))
-			return//put the silencer into the gun
-		to_chat(user, SPAN_NOTICE("You screw \the [I] onto \the [src]."))
+			if (silencer)
+				USE_FEEDBACK_FAILURE("\The [src] already has \a [silencer] attached.")
+			else
+				USE_FEEDBACK_FAILURE("\The [src] is already silenced.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_FAILURE(user, tool)
+			return TRUE
 		silenced = TRUE
-		silencer = I
+		silencer = tool
 		w_class = ITEM_SIZE_NORMAL
 		update_icon()
-		return
-	..()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] screws \a [tool] onto \a [src]."),
+			SPAN_NOTICE("You screw \a [tool] onto \a [src]."),
+			range = 2
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/gun/projectile/pistol/holdout/on_update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -76,12 +76,40 @@
 	caliber = CALIBER_CAPS
 	origin_tech = list(TECH_COMBAT = 1, TECH_MATERIAL = 1)
 	ammo_type = /obj/item/ammo_casing/cap
+	var/snipped = FALSE
 
-/obj/item/gun/projectile/revolver/capgun/attackby(obj/item/wirecutters/W, mob/user)
-	if(!istype(W) || icon_state == "revolver")
-		return ..()
-	to_chat(user, SPAN_NOTICE("You snip off the toy markings off the [src]."))
-	name = "revolver"
-	icon_state = "revolver"
-	desc += " Someone snipped off the barrel's toy mark. How dastardly, this could get someone shot."
-	return 1
+
+/obj/item/gun/projectile/revolver/capgun/on_update_icon()
+	if (snipped)
+		icon_state = "revolver"
+	else
+		icon_state = "revolver-toy"
+	..()
+
+
+/obj/item/gun/projectile/revolver/capgun/proc/set_snipped(new_snipped = TRUE)
+	snipped = new_snipped
+	if (new_snipped)
+		SetName("revolver")
+		desc += " Someone snipped off the barrel's toy mark. How dastardly, this could get someone shot."
+	else
+		SetName(initial(name))
+		desc = initial(desc)
+	update_icon()
+
+
+/obj/item/gun/projectile/revolver/capgun/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Wirecutters - Remove toy marking
+	if (isWirecutter(tool))
+		if (snipped)
+			USE_FEEDBACK_FAILURE("\The [src] has already had it's barrel snipped.")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] snips \a [src]'s toy markings with \a [tool]."),
+			SPAN_NOTICE("You snip \the [src]'s toy markings with \the [tool]."),
+			range = 3
+		)
+		set_snipped()
+		return TRUE
+
+	return ..()

--- a/code/modules/projectiles/secure.dm
+++ b/code/modules/projectiles/secure.dm
@@ -25,18 +25,27 @@ GLOBAL_LIST_INIT(secure_weapons, list())
 	if(distance <= 0 && is_secure_gun())
 		to_chat(user, "The registration screen shows, \"" + (registered_owner ? "[registered_owner]" : "unregistered") + "\"")
 
-/obj/item/gun/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/card/id) && is_secure_gun())
-		user.visible_message("[user] swipes an ID through \the [src].", range = 3)
-		if(!registered_owner)
-			var/obj/item/card/id/id = W
+
+/obj/item/gun/use_tool(obj/item/tool, mob/user, list/click_params)
+	// ID Card - Register gun
+	if (is_secure_gun())
+		var/obj/item/card/id/id = tool.GetIdCard()
+		if (istype(id))
+			if (registered_owner)
+				USE_FEEDBACK_FAILURE("\The [src] is already registered to \"[registered_owner]\".")
+				return TRUE
 			verbs += /obj/item/gun/proc/reset_registration
 			registered_owner = id.registered_name
-			to_chat(user, SPAN_NOTICE("\The [src] chimes quietly as it registers to \"[registered_owner]\"."))
-		else
-			to_chat(user, SPAN_NOTICE("\The [src] buzzes quietly, refusing to register without first being reset."))
-	else
-		..()
+			var/idname = GET_ID_NAME(id, tool)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] runs \a [tool] over \the [src]'s ID scanner."),
+				SPAN_NOTICE("You scan [idname] over \the [src]'s ID scanner, registering it to \"[registered_owner]\"."),
+				range = 3
+			)
+			return TRUE
+
+	return ..()
+
 
 /obj/item/gun/emag_act(charges, mob/user)
 	if(!charges)

--- a/maps/torch/items/explo_shotgun.dm
+++ b/maps/torch/items/explo_shotgun.dm
@@ -38,25 +38,46 @@
 		return TRUE
 	return ..()
 
-/obj/item/gun/projectile/shotgun/pump/exploration/attackby(obj/item/I, mob/user)
-	if(!reinforced && istype(I, /obj/item/pipe) && user.unEquip(I, src))
-		reinforced = I
-		to_chat(user, SPAN_WARNING("You reinforce \the [src] with \the [reinforced]."))
-		playsound(src, 'sound/effects/tape.ogg',25)
+
+/obj/item/gun/projectile/shotgun/pump/exploration/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Pipe - Reinforce gun
+	if (istype(tool, /obj/item/pipe))
+		if (reinforced)
+			USE_FEEDBACK_FAILURE("\The [src] is already reinforced with \a [reinforced].")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		reinforced = tool
 		explosion_chance = 10
-		bulk = bulk + 4
+		bulk += 4
 		update_icon()
-		return 1
-	if(reinforced && isWirecutter(I))
-		to_chat(user, SPAN_WARNING("You remove \the [reinforced] that was reinforcing \the [src]."))
-		playsound(src.loc, 'sound/items/Wirecutter.ogg', 25, 1)
+		playsound(src, 'sound/effects/tape.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] reinforces \a [src] with \a [tool]."),
+			SPAN_NOTICE("You reinforce \the [src] with \the [tool].")
+		)
+		return TRUE
+
+
+	// Wirecutter - Remove reinforcement
+	if (isWirecutter(tool))
+		if (!reinforced)
+			USE_FEEDBACK_FAILURE("\The [src] has no reinforcement to remove.")
+			return TRUE
 		reinforced.dropInto(loc)
-		reinforced = null
 		explosion_chance = initial(explosion_chance)
 		bulk = initial(bulk)
 		update_icon()
-		return 1
+		user.visible_message(
+			SPAN_NOTICE("\The [user] removes \a [reinforced] from \a [src] with \a [tool]."),
+			SPAN_NOTICE("You remove \the [reinforced] from \the [src] with \the [tool].")
+		)
+		return TRUE
+
+
 	return ..()
+
 
 /obj/item/gun/projectile/shotgun/pump/exploration/special_check()
 	if(chambered && chambered.BB && prob(explosion_chance))

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -53,7 +53,7 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 5 "uses of .len" '\.len\b' -P
-exactly 445 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 426 "attackby() override" '\/attackby\((.*)\)'  -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 num=`find ./html/changelogs -not -name "*.yml" | wc -l`


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Magnetic weapons no longer delete existing ammunition if attempting to load a stack while loaded with a non-stack projectile.
bugfix: Magnetic weapons no longer allow you to increase the size of a loaded stack by loading it with an entirely different type of stack.
refactor: Item interactions with guns have been updated. There should be no user facing changes aside from those listed in the changelog.
rscadd: Various item interactions with various guns now display helpful feedback messages on failure.
rscadd: Various item interactions with various guns now display visible messages to those around you.
rscadd: Loading weapons that hold more than 1 projectile at a time will now tell you how many projectiles are loaded out of the maximum amount. This does not occur for magazine fed weapons.
rscadd: You can now scan IDs on secure weapons without needing to remove said IDs from your wallet, PDA, etc, instead scanning the container itself directly on the gun.
/:cl:

## Other Changes
- Added `on_update_icon()` override for toy revolvers.