### PR TITLE
Add `use_sanity_check()` to grabs

### DIFF
--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -118,7 +118,7 @@
 		if (occupied)
 			USE_FEEDBACK_GRAB_FAILURE("There's \a [occupied] blocking \the [src].")
 			return TRUE
-		if (!do_after(grab.assailant, 3 SECONDS, grab.affecting, DO_PUBLIC_UNIQUE) || !grab.assailant.use_sanity_check(src, grab))
+		if (!do_after(grab.assailant, 3 SECONDS, grab.affecting, DO_PUBLIC_UNIQUE) || !grab.use_sanity_check(src))
 			return TRUE
 		occupied = turf_is_crowded()
 		if (occupied)

--- a/code/game/objects/structures/ironing_board.dm
+++ b/code/game/objects/structures/ironing_board.dm
@@ -184,7 +184,7 @@
 	grab.affecting.show_message(
 		SPAN_NOTICE("\The [grab.assailant] starts buckling you to \the [src]!")
 	)
-	if (!do_after(grab.assailant, 3 SECONDS, src, DO_PUBLIC_UNIQUE) || QDELETED(grab) || !grab.assailant.use_sanity_check(src, grab.affecting))
+	if (!do_after(grab.assailant, 3 SECONDS, src, DO_PUBLIC_UNIQUE) || QDELETED(grab) || !grab.use_sanity_check(src))
 		return TRUE
 	if (!user_buckle_mob(grab.affecting, grab.assailant))
 		return TRUE

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -156,7 +156,7 @@
 		VISIBLE_MESSAGE,
 		SPAN_DANGER("You feel someone trying to force you into a bed or chair!")
 	)
-	if (!do_after(grab.assailant, 2 SECONDS, src, DO_PUBLIC_UNIQUE) || QDELETED(grab) || !grab.assailant.use_sanity_check(src, grab.affecting))
+	if (!do_after(grab.assailant, 2 SECONDS, src, DO_PUBLIC_UNIQUE) || !grab.use_sanity_check(src))
 		return TRUE
 	grab.assailant.visible_message(
 		SPAN_WARNING("\The [grab.assailant] buckles \the [grab.affecting] to \the [src]."),

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -185,7 +185,7 @@
 		VISIBLE_MESSAGE,
 		SPAN_DANGER("You feel your head being dunked in cold water!")
 	)
-	if (!do_after(grab.assailant, 3 SECONDS, src, DO_PUBLIC_UNIQUE) || !grab?.assailant.use_sanity_check(src, grab.affecting))
+	if (!do_after(grab.assailant, 3 SECONDS, src, DO_PUBLIC_UNIQUE) || !grab.use_sanity_check(src))
 		return TRUE
 	grab.assailant.visible_message(
 		SPAN_WARNING("\The [grab.assailant] gives \the [grab.affecting] a swirlie in \the [src]!"),

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -333,3 +333,25 @@
 
 /obj/item/grab/proc/resolve_openhand_attack()
 		return current_grab.resolve_openhand_attack(src)
+
+
+/**
+ * Validates that `assailant` can still perform an action with `affecting` and `target`. Performs some grab-specific
+ *   checks, then passes through to `assailant.use_sanity_check()` with both `src` and `affecting`.
+ *
+ * **Parameters**:
+ * - `target` - The atom being interacted with.
+ * - `flags` (Bitflag, any of `SANITY_CHECK_*`, default `SANITY_CHECK_DEFAULT`) - Bitflags of additional settings. See `code\__defines\misc.dm`.
+ *
+ * Returns boolean.
+ */
+/obj/item/grab/proc/use_sanity_check(atom/target, flags = SANITY_CHECK_DEFAULT)
+	if (QDELETED(src) || QDELETED(assailant))
+		return FALSE
+	// Sanity check the grab itself
+	if (!assailant.use_sanity_check(target, src, flags))
+		return FALSE
+	// Sanity check the victim
+	if (!assailant.use_sanity_check(target, affecting, flags))
+		return FALSE
+	return TRUE


### PR DESCRIPTION
Adds a variant of `use_sanity_check()` to `/obj/item/grab`, intended for use in `use_grab()`, that performs some grab specific checks and passthroughs to `grab.assailant.use_sanity_check()`.

Should be no user facing changes, aside from maybe some undocumented bugs and oversights that this probably corrects.

## Dependencies
- #33423