### PR TITLE
Fix empty use_sanity_check calls

### DIFF
--- a/code/game/machinery/doors/firedoor_assembly.dm
+++ b/code/game/machinery/doors/firedoor_assembly.dm
@@ -98,7 +98,7 @@
 			SPAN_NOTICE("\The [user] starts cutting \the [src]'s wires with \a [tool]."),
 			SPAN_NOTICE("You start cutting \the [src]'s wires with \the [tool].")
 		)
-		if (!user.do_skilled(4 SECONDS, SKILL_ELECTRICAL, src, do_flags = DO_REPAIR_CONSTRUCT) || user.use_sanity_check(src, tool))
+		if (!user.do_skilled(4 SECONDS, SKILL_ELECTRICAL, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (!wired)
 			USE_FEEDBACK_FAILURE("\The [src] has no wires to cut.")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -524,7 +524,7 @@
 			SPAN_NOTICE("\The [user] starts repairing some of the electronics in \the [src] with [cable.get_vague_name(FALSE)]."),
 			SPAN_NOTICE("You start repairing some of the electronics in \the [src] with [cable.get_exact_name(1)]."),
 		)
-		if (!do_after(user, 1 SECOND, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check())
+		if (!do_after(user, 1 SECOND, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
 			return TRUE
 		if (!wiresexposed)
 			USE_FEEDBACK_FAILURE("\The [src]'s wires must be exposed to repair electronics damage.")

--- a/code/modules/mob/living/simple_animal/defense.dm
+++ b/code/modules/mob/living/simple_animal/defense.dm
@@ -88,7 +88,7 @@
 			SPAN_WARNING("\The [user] begins butchering \the [src]'s corpse with \a [tool]."),
 			SPAN_WARNING("You begin \the [src]'s corpse with \the [tool].")
 		)
-		if (!user.do_skilled(time_to_butcher, SKILL_COOKING, src) || !user.use_sanity_check())
+		if (!user.do_skilled(time_to_butcher, SKILL_COOKING, src) || !user.use_sanity_check(src, tool))
 			USE_FEEDBACK_FAILURE("Some of \the [src]'s meat is ruined.")
 			subtract_meat(user)
 			return TRUE

--- a/code/modules/power/cable_coil.dm
+++ b/code/modules/power/cable_coil.dm
@@ -124,7 +124,7 @@ GLOBAL_LIST_INIT(cable_default_colors, list(
 	// Multitool - Recolor cable coil
 	if (isMultitool(tool))
 		var/new_color = input(user, "Select a color to change to:", "\The [src] - Color Change", null) as null|anything in GLOB.cable_default_colors
-		if (!new_color || !user.use_sanity_check(src))
+		if (!new_color || !user.use_sanity_check(src, tool))
 			return TRUE
 		var/new_color_code = GLOB.cable_default_colors["[new_color]"]
 		if (get_color() == new_color_code)


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: The following tool interactions have been fixed and should properly work after their pauses:
bugfix: - Cable coil -> Robots (Repairing burn damage)
bugfix: - Cleaver -> Animals (Butchering)
bugfix: - Multitool -> Cable Coil (Recoloring cable)
/:cl: