### PR TITLE
Fix `SANITY_CHECK_BOTH_ADJACENT` check

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -328,5 +328,5 @@
 #define SANITY_CHECK_TOOL_UNEQUIP FLAG(1)
 /// Verify the target can be unequipped from user. Includes `target.loc == src` check to allow items the user isn't holding.
 #define SANITY_CHECK_TARGET_UNEQUIP FLAG(2)
-/// Verify the target and tool are adjacent to eachother.
+/// Verify the target and tool are adjacent to eachother. Ignored if tool is held by user.
 #define SANITY_CHECK_BOTH_ADJACENT FLAG(3)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -205,7 +205,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		if (!silent)
 			FEEDBACK_UNEQUIP_FAILURE(src, target)
 		return FALSE
-	if (HAS_FLAGS(flags, SANITY_CHECK_BOTH_ADJACENT) && !Adjacent(tool))
+	if (HAS_FLAGS(flags, SANITY_CHECK_BOTH_ADJACENT) && tool.loc != src && !tool.Adjacent(target))
 		if (!silent)
 			FEEDBACK_FAILURE(src, "\The [tool] must stay next to \the [target].")
 		return FALSE


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Interaction checks that needed the items to be adjacent after a timer or input now properly check for adjacency.
/:cl: