### PR TITLE
Moves the science janitor alt title to janitor, fixes a uniform spawn

### DIFF
--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -102,8 +102,7 @@
 	minimum_character_age = list(SPECIES_HUMAN = 18)
 	ideal_character_age = 30
 	alt_titles = list(
-		"Custodian" = /singleton/hierarchy/outfit/job/torch/passenger/research/assist/janitor,
-		"Testing Assistant" = /singleton/hierarchy/outfit/job/torch/passenger/research/assist/testsubject,
+		"Testing Assistant",
 		"Intern",
 		"Clerk",
 		"Field Assistant")

--- a/maps/torch/job/service_jobs.dm
+++ b/maps/torch/job/service_jobs.dm
@@ -79,6 +79,7 @@
 	minimum_character_age = list(SPECIES_HUMAN = 20)
 	ideal_character_age = 20
 	alt_titles = list(
+		"Custodian",
 		"Janitor")
 	outfit_type = /singleton/hierarchy/outfit/job/torch/crew/service/janitor
 	allowed_branches = list(


### PR DESCRIPTION
This janitor job in science is a relic of NT science and the alt title probably should have been moved back to janitor years ago.

The test subject define here doesn't actually work correctly, so I snipped it. I'm not sure this alt title should even exist either, to be honest.
🆑 
tweak: The janitor alt-title from science has been moved to the janitor role.
tweak: Test Assistants no longer spawn with a uniform, this uniform has not been removed and is still accessible. 
/🆑 