### PR TITLE
Cosmosharks and Carp variants no longer fight

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/space_pike.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_pike.dm
@@ -15,15 +15,12 @@
 	health = 150
 	maxHealth = 150
 	harm_intent_damage = 5
-	natural_weapon = /obj/item/natural_weapon/bite/pike
+	natural_weapon = /obj/item/natural_weapon/bite/strong
 	can_escape = TRUE
 	break_stuff_probability = 55
 	meat_amount = 10
 	bone_amount = 20
 	skin_amount = 20
-
-/obj/item/natural_weapon/bite/pike
-	force = 25
 
 /mob/living/simple_animal/hostile/carp/pike/carp_randomify()
 	return

--- a/code/modules/mob/living/simple_animal/hostile/space_shark.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_shark.dm
@@ -14,7 +14,6 @@
 	harm_intent_damage = 5
 	natural_weapon = /obj/item/natural_weapon/bite/strong
 	break_stuff_probability = 35
-	faction = "shark"
 	special_attack_min_range = 0
 	special_attack_max_range = 2
 	special_attack_cooldown = 15 SECONDS


### PR DESCRIPTION
🆑 Jux
bugfix: Cosmosharks will no longer kill carp and pikes.
/🆑

Calling this a bugfix because a 3rd of the mobs spawned by the carp event shouldn't kill off the rest or die trying, imo. We could always remove them from the event or have mob spawner events set their faction though.

The change to the pike's natural weapon is a non-change, really. The strong bite has the same force and is used by multiple other simplemobs; there was no reason for the pike to have a unique one.