### PR TITLE
Call parent if closet has no lock

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -332,8 +332,7 @@
 	var/obj/item/card/id/id = tool.GetIdCard()
 	if (istype(id))
 		if (!HAS_FLAGS(setup, CLOSET_HAS_LOCK))
-			USE_FEEDBACK_FAILURE("\The [src] cannot be locked.")
-			return TRUE
+			return ..()
 		togglelock(user, id)
 		return TRUE
 


### PR DESCRIPTION
Why are these even closet subtypes anyway?

## Changelog
:cl: SierraKomodo
bugfix: Fixes a bug where PDAs that had IDs in them couldn't scan rescue or stasis bags,
/:cl:

## Bug Fixes
- Fixes #33482

## Other Changes
- `/obj/structure/closet/use_tool()` now calls the parent instead of returning with a failure message when using an ID on a closet without a lock.