### PR TITLE
records aren't deleted on cryo

### DIFF
--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -319,6 +319,14 @@
 		log_and_message_admins("A mob was deleted while in a cryopod, or the cryopod double-processed. This may cause errors!")
 		return
 
+	if (istype(occupant, /mob/living/carbon/human))
+		var/mob/living/carbon/human/human = occupant
+		var/record_name = human.get_id_name("")
+		if (record_name)
+			var/datum/computer_file/report/crew_record/record = get_crewmember_record(record_name)
+			if (record)
+				record.set_status("Stored")
+
 	//Drop all items into the pod.
 	for(var/obj/item/W in occupant)
 		occupant.drop_from_inventory(W)
@@ -378,13 +386,6 @@
 		if(LAZYLEN(occupant.mind.objectives))
 			occupant.mind.objectives = null
 			occupant.mind.special_role = null
-
-	// Delete them from datacore.
-	var/sanitized_name = occupant.real_name
-	sanitized_name = sanitize(sanitized_name)
-	var/datum/computer_file/report/crew_record/R = get_crewmember_record(sanitized_name)
-	if(R)
-		qdel(R)
 
 	icon_state = base_icon_state
 

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -1,6 +1,6 @@
 GLOBAL_LIST_EMPTY(all_crew_records)
 GLOBAL_LIST_INIT(blood_types, list("A-", "A+", "B-", "B+", "AB-", "AB+", "O-", "O+"))
-GLOBAL_LIST_INIT(physical_statuses, list("Active", "Disabled", "SSD", "Deceased", "MIA"))
+GLOBAL_LIST_INIT(physical_statuses, list("Active", "Disabled", "SSD", "Deceased", "MIA", "Stored"))
 GLOBAL_VAR_INIT(default_physical_status, "Active")
 GLOBAL_LIST_INIT(security_statuses, list("None", "Released", "Parolled", "Incarcerated", "Arrest"))
 GLOBAL_VAR_INIT(default_security_status, "None")


### PR DESCRIPTION
:cl:
tweak: Records aren't deleted when people exit a round through cryopods.
tweak: If wearing an ID card while being stored by a cryopod, the record associated with the name on that ID has its status updated to "Stored".
/:cl:
