### PR TITLE
spike throwers can't be fumbled

### DIFF
--- a/code/modules/projectiles/guns/launcher/alien.dm
+++ b/code/modules/projectiles/guns/launcher/alien.dm
@@ -53,3 +53,7 @@
 
 /obj/item/gun/launcher/alien/spikethrower/on_update_icon()
 	icon_state = "spikethrower[ammo]"
+
+
+/obj/item/gun/launcher/alien/spikethrower/check_accidents()
+	return


### PR DESCRIPTION
:cl:
tweak: Spike throwers can't be fumbled.
/:cl:

fixes #30083