### PR TITLE
Remove rotatable flag from fullsize windows

### DIFF
--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -70,6 +70,7 @@
 
 	if(is_fulltile())
 		layer = FULL_WINDOW_LAYER
+		CLEAR_FLAGS(obj_flags, OBJ_FLAG_ROTATABLE)
 
 	health_min_damage = material.hardness * 1.25
 	if (reinf_material)


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Full-size windows can be alt-clicked to show the turf tab again.
/:cl: