### PR TITLE
Some research colors fixes

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -158,6 +158,10 @@
 
 /obj/machinery/door/airlock/research
 	door_color = COLOR_WHITE
+	stripe_color = COLOR_RESEARCH
+
+/obj/machinery/door/airlock/corporate
+	door_color = COLOR_WHITE
 	stripe_color = COLOR_BOTTLE_GREEN
 
 /obj/machinery/door/airlock/science

--- a/maps/torch/structures/closets/research.dm
+++ b/maps/torch/structures/closets/research.dm
@@ -9,15 +9,11 @@
 	)
 
 /singleton/closet_appearance/secure_closet/torch/science/cso
-	color = COLOR_BOTTLE_GREEN
-	decals = list(
-		"lower_holes"
-	)
 	extra_decals = list(
-		"stripe_vertical_mid_full" = COLOR_GOLD,
-		"stripe_vertical_left_full" = COLOR_PURPLE,
-		"stripe_vertical_right_full" = COLOR_PURPLE,
-		"research" = COLOR_GOLD
+		"stripe_vertical_mid_full" = COLOR_CLOSET_GOLD,
+		"stripe_vertical_left_full" = COLOR_PURPLE_GRAY,
+		"stripe_vertical_right_full" = COLOR_PURPLE_GRAY,
+		"research" = COLOR_CLOSET_GOLD
 	)
 
 /obj/structure/closet/secure_closet/RD_torch

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -251,13 +251,13 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/research{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/door/airlock/corporate{
 	id_tag = "liaisondoor2";
 	name = "Corporate Liaison";
 	secured_wires = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
@@ -664,7 +664,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/research{
+/obj/machinery/door/airlock/corporate{
 	id_tag = "liaisondoor3";
 	name = "Corporate Liaison";
 	secured_wires = 1
@@ -839,11 +839,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "bL" = (
-/obj/machinery/door/airlock/research{
-	id_tag = "liaisondoor";
-	name = "Corporate Liaison";
-	secured_wires = 1
-	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
 	d1 = 4;
@@ -852,6 +847,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/corporate{
+	id_tag = "liaisondoor";
+	name = "Corporate Liaison";
+	secured_wires = 1
+	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/cl)
 "bM" = (
@@ -1632,7 +1632,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/simulated/floor/tiled/white,
+/turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
 "cT" = (
 /obj/structure/table/standard{
@@ -10102,9 +10102,6 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/co)
 "Ao" = (
-/obj/structure/bed/chair/padded/green{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -10112,6 +10109,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/bed/chair/padded/purple{
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
 "Ap" = (
@@ -10214,7 +10214,7 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/airlock)
 "AE" = (
-/obj/structure/bed/chair/comfy/green,
+/obj/structure/bed/chair/comfy/purple,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
 "AH" = (
@@ -11809,7 +11809,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/door/airlock/research{
+/obj/machinery/door/airlock/corporate{
 	id_tag = "liaisondoor3";
 	name = "Corporate Liaison";
 	secured_wires = 1
@@ -12294,7 +12294,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/foreport)
 "Jj" = (
-/obj/structure/bed/chair/padded/green{
+/obj/structure/bed/chair/padded/purple{
 	dir = 1
 	},
 /turf/simulated/floor/tiled,


### PR DESCRIPTION
1. CSO office now looks less EXO, with fewer green objects.
2. Research doors are now properly colored.

:cl: Sbotkin
maptweak: CSO office is less green and more purple now.
maptweak: Research doors are now of correct color.
/:cl:

## Before
![dreamseeker_kYx3SxgKkG](https://github.com/Baystation12/Baystation12/assets/11140088/95e5079c-a395-41c1-87ef-6b577e9feb02)

## After
![dreamseeker_1xy1WXhz9M](https://github.com/Baystation12/Baystation12/assets/11140088/32fed284-6a61-4db8-8a83-1d2b8478918a)
