### PR TITLE
Adds some additional sensor scan functionality

### DIFF
--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -224,6 +224,23 @@
 	/// Health state tracker to prevent redundant var updates in `process_core_health()
 	var/core_health_state = null
 
+
+/obj/effect/blob/core/Initialize()
+	. = ..()
+	var/obj/effect/overmap/visitable/visitable = map_sectors["[get_z(src)]"]
+	if (!visitable)
+		return
+	if (++visitable.blob_count == 1)
+		visitable.add_scan_data("blob", SPAN_COLOR(COLOR_RED, "Level-7 biohazard outbreak detected."))
+
+
+/obj/effect/blob/core/Destroy()
+	var/obj/effect/overmap/visitable/visitable = map_sectors["[get_z(src)]"]
+	if (visitable && --visitable.blob_count == 0)
+		visitable.remove_scan_data("blob")
+	return ..()
+
+
 /*
 the master core becomes more vulnereable to damage as it weakens,
 but it also becomes more aggressive, and channels more of its energy into regenerating rather than spreading

--- a/code/modules/events/exo_awakening/exo_awaken.dm
+++ b/code/modules/events/exo_awakening/exo_awaken.dm
@@ -136,6 +136,8 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 	for (var/obj/effect/overmap/visitable/ship/S in range(chosen_planet,2)) //announce the event to ships in range of the planet
 		command_announcement.Announce(announcement, "[S.name] Biological Sensor Array", zlevels = S.map_z)
 
+	chosen_planet.add_scan_data("exo_awaken", SPAN_COLOR(COLOR_RED, announcement), null, SKILL_SCIENCE, SKILL_TRAINED)
+
 /datum/event/exo_awakening/tick()
 	count_mobs()
 	if (!spawning || (stop_spawning && prob(99)))
@@ -213,6 +215,9 @@ GLOBAL_LIST_INIT(exo_event_mob_count,list())// a list of all mobs currently spaw
 /datum/event/exo_awakening/end()
 	if (!chosen_area)
 		return
+
+	chosen_planet.remove_scan_data("exo_awaken")
+	chosen_planet.add_scan_data("exo_awaken_aftermath", SPAN_COLOR(COLOR_GREEN, "Biological and geological activity within tolerance, trace unknown lifeforms detected."), null, SKILL_SCIENCE, SKILL_TRAINED)
 
 	QDEL_NULL(chosen_mob_list)
 	log_debug("Exoplanet Awakening event spawned [spawned_mobs] mobs. It was a level [severity] out of 3 severity.")

--- a/code/modules/events/spider_infestation.dm
+++ b/code/modules/events/spider_infestation.dm
@@ -19,6 +19,13 @@ var/global/sent_spiders_to_station = 0
 
 /datum/event/spider_infestation/announce()
 	GLOB.using_map.unidentified_lifesigns_announcement()
+	var/obj/effect/overmap/visitable/O = map_sectors["[pick(affecting_z)]"]
+	if (!O)
+		return
+
+	O.add_scan_data("spider_infestation", SPAN_COLOR(COLOR_RED, "Unidentified hostile lifeforms detected."))
+
+	addtimer(new Callback(O, /obj/effect/overmap/proc/remove_scan_data, "spider_infestation"), 10 MINUTES)
 
 /datum/event/spider_infestation/start()
 	var/list/vents = list()

--- a/code/modules/overmap/overmap_object.dm
+++ b/code/modules/overmap/overmap_object.dm
@@ -6,16 +6,30 @@
 
 	var/known = TRUE		//shows up on nav computers automatically
 	var/scannable       //if set to TRUE will show up on ship sensors for detailed scans
+	/// The list of scans that can be performed on this overmap effect. See /datum/sector_scan for more info.
+	var/list/scans = list()
+	///Used for generating unique keys for the associated list 'scans'
+	var/next_id = 0
 
 //Overlay of how this object should look on other skyboxes
 /obj/effect/overmap/proc/get_skybox_representation()
 	return
 
 /obj/effect/overmap/proc/get_scan_data(mob/user)
-	return desc
+	var/temp_data = list()
+	for(var/id in scans)
+		var/datum/sector_scan/scan = scans[id]
+		if (!scan.required_skill || user.skill_check(scan.required_skill, scan.required_skill_level))
+			temp_data += scan.description
+		else if (scan.low_skill_description)
+			temp_data += scan.low_skill_description
+
+	return temp_data
 
 /obj/effect/overmap/Initialize()
 	. = ..()
+	add_scan_data("base_scan", desc)
+
 	if(!GLOB.using_map.use_overmap)
 		return INITIALIZE_HINT_QDEL
 
@@ -54,3 +68,46 @@
  */
 /obj/effect/overmap/proc/update_known_connections(notify = FALSE)
 	return
+
+/obj/effect/overmap/proc/add_scan_data(id, description, low_skill_description, required_skill, required_skill_level)
+
+	var/datum/sector_scan/new_scan = new()
+	//If id isn't specified, generate unique-ish one
+	if(!id)
+		id = "scan_data_[next_id++]"
+
+	if (scans[id])
+		log_debug("Tried to add a scan with an id that already exists: [id]")
+		return FALSE
+
+	new_scan.id = id
+	new_scan.description = description
+	new_scan.low_skill_description = low_skill_description
+	new_scan.required_skill = required_skill
+	new_scan.required_skill_level = required_skill_level
+
+	scans[id] = new_scan
+
+	return TRUE
+
+/obj/effect/overmap/proc/remove_scan_data(id)
+	if(!scans[id])
+		return FALSE
+
+	var/datum/scan = scans[id]
+	scans -= id
+	qdel(scan)
+
+	return TRUE
+
+/datum/sector_scan
+	/// The id of the scan. Used for referencing the scan in the linked overmap effect's 'scans' list.
+	var/id = "Sector Scan"
+	/// The description of the scan. This is what will be shown to the player when they scan the sector.
+	var/description = "A scan of the sector."
+	/// The description of the scan if the player doesn't have the required skill to see the normal description.
+	var/low_skill_description = "A scan of the sector. You can't make out much."
+	/// The skill required to see the normal description.
+	var/required_skill = SKILL_SCIENCE
+	/// The level of the skill required to see the normal description.
+	var/required_skill_level = SKILL_TRAINED

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -25,6 +25,8 @@
 	/// null | num | list. If a num or a (num, num) list, the radius or random bounds for placing this sector near the main map's overmap icon.
 	var/list/place_near_main
 
+	var/blob_count = 0
+
 /obj/effect/overmap/visitable/Initialize()
 	. = ..()
 	if(. == INITIALIZE_HINT_QDEL)

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -124,7 +124,11 @@
 
 	if (href_list["print"])
 		playsound(loc, "sound/machines/dotprinter.ogg", 30, 1)
-		new/obj/item/paper/(get_turf(src), last_scan["data"], "paper (Sensor Scan - [last_scan["name"]])", L = print_language)
+		var/scan_data = ""
+		for(var/scan in last_scan["data"])
+			scan_data += scan + "\n"
+
+		new/obj/item/paper/(get_turf(src), scan_data, "paper (Sensor Scan - [last_scan["name"]])", L = print_language)
 		return TOPIC_HANDLED
 
 /obj/machinery/computer/ship/sensors/Process()

--- a/nano/templates/shipsensors.tmpl
+++ b/nano/templates/shipsensors.tmpl
@@ -1,6 +1,6 @@
 
 <fieldset style="background-color: #202020;border-color: rgb(117, 117, 117);">
-	<legend style="text-align:center">Controls</legend> 
+	<legend style="text-align:center">Controls</legend>
 	<div class='item'>
 		<div class="itemLabel">
 			Power
@@ -27,7 +27,7 @@
 	</div>
 </fieldset>
 <fieldset style="background-color: #202020;border-color: rgb(117, 117, 117);">
-	<legend style="text-align:center">Status</legend> 
+	<legend style="text-align:center">Status</legend>
 	<div class='item'>
 		<div class="itemLabel">
 			Status:
@@ -61,7 +61,7 @@
 	</div>
 </fieldset>
 <fieldset style="background-color: #202020;border-color: rgb(117, 117, 117);">
-	<legend style="text-align:center">Contacts</legend> 
+	<legend style="text-align:center">Contacts</legend>
 {{if data.contacts}}
 	<table>
 	{{for data.contacts}}
@@ -78,12 +78,14 @@
 {{/if}}
 </fieldset>
 <fieldset style="background-color: #202020;border-color: rgb(117, 117, 117);">
-	<legend style="text-align:center">Scan data</legend> 
+	<legend style="text-align:center">Scan data</legend>
 	{{if data.last_scan}}
 		<b>{{:data.last_scan.name}}</b> at {{:data.last_scan.location}}
 		{{:helper.link('Print', 'print' ,{ 'print' : 1 }, null, null)}}
 		<div class='block'>
-			{{:data.last_scan.data}}
+			{{for data.last_scan.data}}
+				{{:value}}<br><br>
+			{{/for}}
 		</div>
 	{{else}}
 		N/A


### PR DESCRIPTION
:cl: Mucker
rscadd: Ships that scan the Torch will now show if the ship is currently dealing with a spider infestation or a Blob.
rscadd: Exoplanets undergoing the 'Exoplanet Awakening' will now display as such on scans.
/:cl:

nufc:
Adds a 'scan' datum to overmap objects, allowing for more dynamic additions to the scans done on them. Does not replace how planets and some special away sites use get_scan_data() for now.