### PR TITLE
Fixes a Uranium typo

### DIFF
--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -215,7 +215,7 @@
 	amount = 10
 
 /obj/item/stack/material/uranium
-	name = "nuranium"
+	name = "uranium"
 	default_type = MATERIAL_URANIUM
 
 /obj/item/stack/material/uranium/ten


### PR DESCRIPTION
:cl:
bugfix: Fixes uranium being spelled "nuranium" as a stack. Caused incorrect displays on the merchant console, etc.
/:cl:

For some reason it was nuranium. Who knows.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->