### PR TITLE
Moves the damage and surgery layers above clothes.

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -121,10 +121,10 @@ Please contact me on #coderbus IRC. ~Carn x
 //Human Overlays Indexes/////////
 #define HO_MUTATIONS_LAYER  1
 #define HO_SKIN_LAYER       2
-#define HO_DAMAGE_LAYER     3
-#define HO_SURGERY_LAYER    4 //bs12 specific.
-#define HO_UNDERWEAR_LAYER  5
-#define HO_UNIFORM_LAYER    6
+#define HO_UNDERWEAR_LAYER  3
+#define HO_UNIFORM_LAYER    4
+#define HO_DAMAGE_LAYER     5
+#define HO_SURGERY_LAYER    6 //bs12 specific.
 #define HO_ID_LAYER         7
 #define HO_SHOES_LAYER      8
 #define HO_GLOVES_LAYER     9


### PR DESCRIPTION
:cl:
tweak: Damage and Surgery steps show through underclothes. Armor/Voidsuits is still over this layer.
/:cl:

Damage to a person is now visible through their clothes (not armor). More visible feedback as to how ouched someone is. Surgery steps also show through clothes, because assumedly you're cutting through their clothes.

Damage Example
![image](https://github.com/Baystation12/Baystation12/assets/67706292/57f47e70-dbaf-429c-acfe-77cce46709e1)
![image](https://github.com/Baystation12/Baystation12/assets/67706292/0c58a38a-2a5a-42e9-8909-6275524f701c)

Surgery Example
![image](https://github.com/Baystation12/Baystation12/assets/67706292/d01a4849-2548-4203-bfcf-1663013dabc8)
![image](https://github.com/Baystation12/Baystation12/assets/67706292/539df564-87b9-421e-9d59-60c5711f3c09)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->