### PR TITLE
Fix psionics UI element not being clickable

### DIFF
--- a/code/modules/psionics/interface/ui_hub.dm
+++ b/code/modules/psionics/interface/ui_hub.dm
@@ -51,7 +51,8 @@
 	update_icon()
 
 /obj/screen/psi/hub/Click(location, control, click_params)
-	if(click_params["shift"])
+	var/list/params = params2list(click_params)
+	if(params["shift"])
 		owner.show_psi_assay(owner)
 		return
 


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed psionics not being toggleable. 
/:cl:

Fixes a bug introduced in #33383