### PR TITLE
Remove topic checks from default sanity checks

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -332,9 +332,9 @@
 #define SANITY_CHECK_BOTH_ADJACENT FLAG(3)
 /// Verify the tool is in the user's active hand. Ignored if the tool is not an item.
 #define SANITY_CHECK_TOOL_IN_HAND FLAG(4)
-/// Check `CanInteractWith(target, user)`. Functionally exclusive with `SANITY_CHECK_PHYSICALLY_INTERACT`.
-#define SANITY_CHECK_INTERACT FLAG(5)
-/// Check `CanPhysicallyInteractWith(target, user)`. Functionally exclusive with `SANITY_CHECK_INTERACT`.
-#define SANITY_CHECK_PHYSICALLY_INTERACT FLAG(6)
+/// Check `CanInteractWith(target, user)`. Only use this for Topic() revalidation. Functionally exclusive with `SANITY_CHECK_TOPIC_PHYSICALLY_INTERACT`.
+#define SANITY_CHECK_TOPIC_INTERACT FLAG(5)
+/// Check `CanPhysicallyInteractWith(target, user)`. Only use this for Topic() revalidation. Functionally exclusive with `SANITY_CHECK_TOPIC_INTERACT`.
+#define SANITY_CHECK_TOPIC_PHYSICALLY_INTERACT FLAG(6)
 
-#define SANITY_CHECK_DEFAULT (SANITY_CHECK_TOOL_IN_HAND | SANITY_CHECK_BOTH_ADJACENT | SANITY_CHECK_PHYSICALLY_INTERACT)
+#define SANITY_CHECK_DEFAULT (SANITY_CHECK_TOOL_IN_HAND | SANITY_CHECK_BOTH_ADJACENT)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -204,11 +204,11 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		if (!silent)
 			FEEDBACK_UNEQUIP_FAILURE(src, target)
 		return FALSE
-	if (HAS_FLAGS(flags, SANITY_CHECK_INTERACT) && !CanInteractWith(src, target, target.DefaultTopicState()))
+	if (HAS_FLAGS(flags, SANITY_CHECK_TOPIC_INTERACT) && !CanInteractWith(src, target, target.DefaultTopicState()))
 		if (!silent)
 			FEEDBACK_FAILURE(src, "You can't interact with \the [src].")
 		return FALSE
-	if (HAS_FLAGS(flags, SANITY_CHECK_PHYSICALLY_INTERACT) && !CanPhysicallyInteractWith(src, target))
+	if (HAS_FLAGS(flags, SANITY_CHECK_TOPIC_PHYSICALLY_INTERACT) && !CanPhysicallyInteractWith(src, target))
 		if (!silent)
 			FEEDBACK_FAILURE(src, "You can't physically interact with \the [src].")
 		return FALSE


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Incorrect physical interaction checks have been removed from general interactions; Various things that weren't working when clicked on should be working again now.
/:cl:

## Other Changes
- Renamed `SANITY_CHECK_TOPIC_INTERACT` and `SANITY_CHECK_TOPIC_PHYSICALLY_INTERACT` to make it more apparent they're specifically for `Topic()` checks.
- Removed `SANITY_CHECK_TOPIC_PHYSICALLY_INTERACT` from `SANITY_CHECK_DEFAULT`.