### PR TITLE
Revert "Moves the damage and surgery layers above clothes."

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -121,10 +121,10 @@ Please contact me on #coderbus IRC. ~Carn x
 //Human Overlays Indexes/////////
 #define HO_MUTATIONS_LAYER  1
 #define HO_SKIN_LAYER       2
-#define HO_UNDERWEAR_LAYER  3
-#define HO_UNIFORM_LAYER    4
-#define HO_DAMAGE_LAYER     5
-#define HO_SURGERY_LAYER    6 //bs12 specific.
+#define HO_DAMAGE_LAYER     3
+#define HO_SURGERY_LAYER    4 //bs12 specific.
+#define HO_UNDERWEAR_LAYER  5
+#define HO_UNIFORM_LAYER    6
 #define HO_ID_LAYER         7
 #define HO_SHOES_LAYER      8
 #define HO_GLOVES_LAYER     9


### PR DESCRIPTION
Reverts Baystation12/Baystation12#33543

Resulted in layering problems for character setup and other computed images. Implementation needs reconsidering.