### PR TITLE
Moves the damage layers above clothes (Now with less naked)

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -121,10 +121,10 @@ Please contact me on #coderbus IRC. ~Carn x
 //Human Overlays Indexes/////////
 #define HO_MUTATIONS_LAYER  1
 #define HO_SKIN_LAYER       2
-#define HO_DAMAGE_LAYER     3
-#define HO_SURGERY_LAYER    4 //bs12 specific.
-#define HO_UNDERWEAR_LAYER  5
-#define HO_UNIFORM_LAYER    6
+#define HO_SURGERY_LAYER    3 //bs12 specific.
+#define HO_UNDERWEAR_LAYER  4
+#define HO_UNIFORM_LAYER    5
+#define HO_DAMAGE_LAYER     6
 #define HO_ID_LAYER         7
 #define HO_SHOES_LAYER      8
 #define HO_GLOVES_LAYER     9
@@ -894,10 +894,10 @@ var/global/list/damage_icon_parts = list()
 //Human Overlays Indexes/////////
 #undef HO_MUTATIONS_LAYER
 #undef HO_SKIN_LAYER
-#undef HO_DAMAGE_LAYER
 #undef HO_SURGERY_LAYER
 #undef HO_UNDERWEAR_LAYER
 #undef HO_UNIFORM_LAYER
+#undef HO_DAMAGE_LAYER
 #undef HO_ID_LAYER
 #undef HO_SHOES_LAYER
 #undef HO_GLOVES_LAYER


### PR DESCRIPTION
:cl:PurplePineapple
tweak: Damage layers such as wounds, gauze, and splints are applied above your clothes. Armor and voidsuits still go over them.
/:cl:

Damage to a person is now visible through their clothes (not armor). More visible feedback as to how ouched someone is.

Surgery layers removed from the PR because I could not wrestle with the confusion.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->