### PR TITLE
`/obj/item/device/attackby()` to `use_*()`

### DIFF
--- a/code/game/objects/items/devices/hacktool.dm
+++ b/code/game/objects/items/devices/hacktool.dm
@@ -23,12 +23,20 @@
 	hack_state = null
 	return ..()
 
-/obj/item/device/multitool/hacktool/attackby(obj/W, mob/user)
-	if(isScrewdriver(W))
+
+/obj/item/device/multitool/hacktool/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Screwdriver - Toggle hack mode
+	if (isScrewdriver(tool))
 		in_hack_mode = !in_hack_mode
-		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
-	else
-		..()
+		playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] adjusts \a [src] with \a [tool]."),
+			SPAN_NOTICE("You adjust \the [src] with \the [tool]. It is now in [in_hack_mode ? "hacking" : "normal"] mode.")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/device/multitool/hacktool/resolve_attackby(atom/A, mob/user)
 	sanity_check()

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -64,30 +64,37 @@
 		STOP_PROCESSING_POWER_OBJECT(src)
 	. = ..()
 
-/obj/item/device/powersink/attackby(obj/item/I, mob/user)
-	if(isScrewdriver(I))
-		if(mode == DISCONNECTED)
-			var/turf/T = loc
-			if(isturf(T) && !!T.is_plating())
-				attached = locate() in T
-				if(!attached)
-					to_chat(user, SPAN_WARNING("This device must be placed over an exposed, powered cable node!"))
-				else
-					set_mode(CLAMPED_OFF)
-					user.visible_message( \
-						"[user] attaches \the [src] to the cable.", \
-						SPAN_NOTICE("You attach \the [src] to the cable."),
-						SPAN_CLASS("italics", "You hear some wires being connected to something."))
-			else
-				to_chat(user, SPAN_WARNING("This device must be placed over an exposed, powered cable node!"))
-		else
+
+/obj/item/device/powersink/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Screwdriver - Toggle connection to cable
+	if (isScrewdriver(tool))
+		if (mode != DISCONNECTED)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] detaches \a [src] from \the [attached] with \a [tool]."),
+				SPAN_NOTICE("You detach \the [src] from \the [attached] with \the [tool].")
+			)
 			set_mode(DISCONNECTED)
-			user.visible_message( \
-				"[user] detaches \the [src] from the cable.", \
-				SPAN_NOTICE("You detach \the [src] from the cable."),
-				SPAN_CLASS("italics", "You hear some wires being disconnected from something."))
-	else
-		return ..()
+			return TRUE
+		if (!isturf(loc))
+			USE_FEEDBACK_FAILURE("\The [src] must be placed on the ground before you can connect it.")
+			return TRUE
+		var/turf/turf = loc
+		if (!turf.is_plating())
+			USE_FEEDBACK_FAILURE("\The [turf]'s plating must be removed before you can connect \the [src].")
+			return TRUE
+		attached = locate() in turf
+		if (!attached)
+			USE_FEEDBACK_FAILURE("\The [src] must be placed over an exposed, powered cable node before it can be connected.")
+			return TRUE
+		set_mode(CLAMPED_OFF)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] attaches \a [src] to \the [attached] with \a [tool]."),
+			SPAN_NOTICE("You attach \the [src] to \the [attached] with \the [tool].")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/device/powersink/attack_ai()
 	return

--- a/code/game/objects/items/devices/radio/electropack.dm
+++ b/code/game/objects/items/devices/radio/electropack.dm
@@ -18,26 +18,38 @@
 		return
 	..()
 
-/obj/item/device/radio/electropack/attackby(obj/item/W as obj, mob/user as mob)
-	..()
-	if(istype(W, /obj/item/clothing/head/helmet))
-		if(!b_stat)
-			to_chat(user, SPAN_NOTICE("[src] is not ready to be attached!"))
-			return
-		if(!user.unEquip(W) || !user.unEquip(src))
-			return
-		var/obj/item/assembly/shock_kit/A = new /obj/item/assembly/shock_kit( user )
-		A.icon = 'icons/obj/assemblies.dmi'
 
-		W.forceMove(A)
-		W.master = A
-		A.part1 = W
+/obj/item/device/radio/electropack/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Helmet - Attach helmet
+	if (istype(tool, /obj/item/clothing/head/helmet))
+		if (!b_stat)
+			USE_FEEDBACK_FAILURE("\The [src] is not ready to be attached.")
+			return TRUE
+		if (!user.unEquip(tool))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		if (!user.unEquip(src))
+			FEEDBACK_UNEQUIP_FAILURE(user, src)
+			return TRUE
+		var/obj/item/assembly/shock_kit/shock_kit = new(user)
+		user.put_in_hands(shock_kit)
+		tool.forceMove(shock_kit)
+		tool.master = shock_kit
+		tool.transfer_fingerprints_to(shock_kit)
+		shock_kit.part1 = tool
+		forceMove(shock_kit)
+		master = shock_kit
+		shock_kit.part2 = src
+		transfer_fingerprints_to(shock_kit)
+		shock_kit.add_fingerprint(user)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] attaches \a [src] to \a [tool] to create \a [shock_kit]."),
+			SPAN_NOTICE("You attach \the [src] to \the [tool] to create \the [shock_kit].")
+		)
+		return TRUE
 
-		forceMove(A)
-		master = A
-		A.part2 = src
+	return ..()
 
-		user.put_in_hands(A)
 
 /obj/item/device/radio/electropack/Topic(href, href_list)
 	//..()

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -12,8 +12,6 @@
 	var/syndie = 0
 	var/list/channels = list()
 
-/obj/item/device/encryptionkey/attackby(obj/item/W as obj, mob/user as mob)
-
 /obj/item/device/encryptionkey/map_preset
 	var/preset_name
 	var/use_common = FALSE

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -334,35 +334,46 @@
 	item_state = "headset"
 	ks1type = /obj/item/device/encryptionkey/specops
 
-/obj/item/device/radio/headset/attackby(obj/item/W as obj, mob/user as mob)
-//	..()
-	user.set_machine(src)
-	if (!( isScrewdriver(W) || (istype(W, /obj/item/device/encryptionkey/ ))))
-		return
 
-	if(isScrewdriver(W))
-		if(length(encryption_keys))
-			for(var/ch_name in channels)
-				radio_controller.remove_object(src, radiochannels[ch_name])
-				secure_radio_connections[ch_name] = null
-			for(var/obj/ekey in encryption_keys)
-				ekey.dropInto(user.loc)
-				encryption_keys -= ekey
+/obj/item/device/radio/headset/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Encryption Key - Install key
+	if (istype(tool, /obj/item/device/encryptionkey))
+		if (length(encryption_keys) >= max_keys)
+			USE_FEEDBACK_FAILURE("\The [src] can't hold any more encryption keys.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		encryption_keys += tool
+		recalculateChannels(TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] inserts \a [tool] into \a [src]."),
+			SPAN_NOTICE("You insert \the [tool] into \the [src]."),
+			range = 2
+		)
+		return TRUE
 
-			recalculateChannels(1)
-			to_chat(user, "You pop out the encryption keys in the headset!")
+	// Screwdriver - Remove encryption keys
+	if (isScrewdriver(tool))
+		if (!length(encryption_keys))
+			USE_FEEDBACK_FAILURE("\The [src] has no encryption keys to remove.")
+			return TRUE
+		for (var/channel_name in channels)
+			radio_controller.remove_object(src, radiochannels[channel_name])
+			secure_radio_connections[channel_name] = null
+		for (var/obj/key as anything in encryption_keys)
+			key.dropInto(get_turf(user))
+		encryption_keys.Cut()
+		recalculateChannels(TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] pops \a [src]'s encryption keys out with \a [tool]."),
+			SPAN_NOTICE("You pop \the [src]'s encryption keys out with \the [tool]."),
+			range = 2
+		)
+		return TRUE
 
-		else
-			to_chat(user, "This headset doesn't have any encryption keys!  How useless...")
+	return ..()
 
-	if(istype(W, /obj/item/device/encryptionkey))
-		if(length(encryption_keys) >= max_keys)
-			to_chat(user, "The headset can't hold another key!")
-			return
-		if(user.unEquip(W, target = src))
-			to_chat(user, SPAN_NOTICE("You put \the [W] into \the [src]."))
-			encryption_keys += W
-			recalculateChannels(1)
 
 /obj/item/device/radio/headset/MouseDrop(obj/over_object)
 	var/mob/M = usr

--- a/code/game/objects/items/devices/spy_bug.dm
+++ b/code/game/objects/items/devices/spy_bug.dm
@@ -40,12 +40,16 @@
 /obj/item/device/spy_bug/attack_self(mob/user)
 	radio.attack_self(user)
 
-/obj/item/device/spy_bug/attackby(obj/W as obj, mob/living/user as mob)
-	if(istype(W, /obj/item/device/spy_monitor))
-		var/obj/item/device/spy_monitor/SM = W
-		SM.pair(src, user)
-	else
-		..()
+
+/obj/item/device/spy_bug/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Spy Monitor - Pair device
+	if (istype(tool, /obj/item/device/spy_monitor))
+		var/obj/item/device/spy_monitor/spy_monitor = tool
+		spy_monitor.pair(src, user)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/device/spy_bug/hear_talk(mob/M, msg, verb, datum/language/speaking)
 	radio.hear_talk(M, msg, speaking)
@@ -87,11 +91,15 @@
 	radio.attack_self(user)
 	view_cameras(user)
 
-/obj/item/device/spy_monitor/attackby(obj/W as obj, mob/living/user as mob)
-	if(istype(W, /obj/item/device/spy_bug))
-		pair(W, user)
-	else
-		return ..()
+
+/obj/item/device/spy_monitor/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Spy Bug - Pair device
+	if (istype(tool, /obj/item/device/spy_bug))
+		pair(tool, user)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/device/spy_monitor/proc/pair(obj/item/device/spy_bug/SB, mob/living/user)
 	if(SB.camera in cameras)

--- a/code/game/objects/items/devices/suit_cooling.dm
+++ b/code/game/objects/items/devices/suit_cooling.dm
@@ -109,31 +109,39 @@
 		turn_on()
 	to_chat(user, SPAN_NOTICE("You switch \the [src] [on ? "on" : "off"]."))
 
-/obj/item/device/suit_cooling_unit/attackby(obj/item/W as obj, mob/user as mob)
-	if(isScrewdriver(W))
-		if(cover_open)
-			cover_open = 0
-			to_chat(user, "You screw the panel into place.")
-		else
-			cover_open = 1
-			to_chat(user, "You unscrew the panel.")
-		playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
-		update_icon()
-		return
 
-	if (istype(W, /obj/item/cell))
-		if(cover_open)
-			if(cell)
-				to_chat(user, "There is a [cell] already installed here.")
-			else
-				if(!user.unEquip(W, src))
-					return
-				cell = W
-				to_chat(user, "You insert the [cell].")
+/obj/item/device/suit_cooling_unit/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Screwdriver - Toggle cover
+	if (isScrewdriver(tool))
+		cover_open = !cover_open
+		playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
 		update_icon()
-		return
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [cover_open ? "opens" : "closes"] \a [src]'s panel with \a [tool]."),
+			SPAN_NOTICE("You [cover_open ? "open" : "close"] \the [src]'s panel with \the [tool].")
+		)
+		return TRUE
+
+	// Power Cell - Install cell
+	if (istype(tool, /obj/item/cell))
+		if (!cover_open)
+			USE_FEEDBACK_FAILURE("\The [src]'s panel is closed.")
+			return TRUE
+		if (cell)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [cell] installed.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		cell = tool
+		update_icon()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs \a [tool] into \a [src]."),
+			SPAN_NOTICE("You install \the [tool] into \the [src].")
+		)
 
 	return ..()
+
 
 /obj/item/device/suit_cooling_unit/on_update_icon()
 	overlays.Cut()

--- a/code/game/objects/items/devices/suit_sensor_jammer.dm
+++ b/code/game/objects/items/devices/suit_sensor_jammer.dm
@@ -44,24 +44,39 @@
 /obj/item/device/suit_sensor_jammer/get_cell()
 	return bcell
 
-/obj/item/device/suit_sensor_jammer/attackby(obj/item/I as obj, mob/user as mob)
-	if(isCrowbar(I))
-		if(bcell)
-			to_chat(user, SPAN_NOTICE("You remove \the [bcell]."))
-			disable()
-			bcell.dropInto(loc)
-			bcell = null
-		else
-			to_chat(user, SPAN_WARNING("There is no cell to remove."))
-	else if(istype(I, /obj/item/cell))
-		if(bcell)
-			to_chat(user, SPAN_WARNING("There's already a cell in \the [src]."))
-		else if(user.unEquip(I))
-			I.forceMove(src)
-			bcell = I
-			to_chat(user, SPAN_NOTICE("You insert \the [bcell] into \the [src].."))
-		else
-			to_chat(user, SPAN_WARNING("You're unable to insert the battery."))
+
+/obj/item/device/suit_sensor_jammer/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Crowbar - Remove cell
+	if (isCrowbar(tool))
+		if (!bcell)
+			USE_FEEDBACK_FAILURE("\The [src] has no cell to remove.")
+			return TRUE
+		disable()
+		user.put_in_hands(bcell)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] removes \a [bcell] from \a [src] with \a [tool]."),
+			SPAN_NOTICE("You remove \the [bcell] from \the [src] with \the [tool].")
+		)
+		bcell = null
+		return TRUE
+
+	// Power Cell - Install cell
+	if (istype(tool, /obj/item/cell))
+		if (bcell)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [bcell] installed.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		bcell = tool
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs \a [tool] into \a [src]."),
+			SPAN_NOTICE("you install \the [tool] into \the [src].")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/device/suit_sensor_jammer/on_update_icon()
 	overlays.Cut()

--- a/code/modules/assembly/assembly.dm
+++ b/code/modules/assembly/assembly.dm
@@ -96,20 +96,29 @@
 	return 0
 
 
-/obj/item/device/assembly/attackby(obj/item/W as obj, mob/user as mob)
-	if(isassembly(W))
-		var/obj/item/device/assembly/A = W
-		if((!A.secured) && (!secured))
-			attach_assembly(A,user)
-			return
-	if(isScrewdriver(W))
-		if(toggle_secure())
-			to_chat(user, SPAN_NOTICE("\The [src] is ready!"))
-		else
-			to_chat(user, SPAN_NOTICE("\The [src] can now be attached!"))
-		return
-	..()
-	return
+/obj/item/device/assembly/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Assembly - Attach assembly
+	if (isassembly(tool))
+		if (secured)
+			USE_FEEDBACK_FAILURE("\The [src] is not ready to be modified or attached.")
+			return TRUE
+		var/obj/item/device/assembly/assembly = tool
+		if (!assembly.secured)
+			USE_FEEDBACK_FAILURE("\The [tool] is not ready to be modified or attached.")
+			return TRUE
+		attach_assembly(tool, user)
+		return TRUE
+
+	// Screwdriver - Toggle secured
+	if (isScrewdriver(tool))
+		toggle_secure()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] adjusts \a [src] with \a [tool]."),
+			SPAN_NOTICE("You adjust \the [src] with \the [tool]. It [secured ? "is now ready to use" : "can now be taken apart"].")
+		)
+		return TRUE
+
+	return ..()
 
 
 /obj/item/device/assembly/Process()

--- a/code/modules/assembly/holder.dm
+++ b/code/modules/assembly/holder.dm
@@ -112,21 +112,20 @@
 	return
 
 
-/obj/item/device/assembly_holder/attackby(obj/item/W as obj, mob/user as mob)
-	if(isScrewdriver(W))
-		if(!a_left || !a_right)
-			to_chat(user, SPAN_WARNING("BUG:Assembly part missing, please report this!"))
-			return
+/obj/item/device/assembly_holder/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Screwdriver - Toggle secured
+	if (isScrewdriver(tool))
 		a_left.toggle_secure()
 		a_right.toggle_secure()
 		secured = !secured
-		if(secured)
-			to_chat(user, SPAN_NOTICE("\The [src] is ready!"))
-		else
-			to_chat(user, SPAN_NOTICE("\The [src] can now be taken apart!"))
 		update_icon()
-		return
-	..()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] adjusts \a [src] with \a [tool]."),
+			SPAN_NOTICE("You adjust \the [src] with \the [tool]. It [secured ? "is now ready to use" : "can now be taken apart"].")
+		)
+		return TRUE
+
+	return ..()
 
 
 /obj/item/device/assembly_holder/attack_self(mob/user as mob)

--- a/code/modules/augment/implanter.dm
+++ b/code/modules/augment/implanter.dm
@@ -31,26 +31,32 @@
 	augment.examine(user)
 
 
-/obj/item/device/augment_implanter/attackby(obj/item/I, mob/living/user)
-	if (isCrowbar(I) && augment)
+/obj/item/device/augment_implanter/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Crowbar - Remove augment
+	if (isCrowbar(tool))
+		if (!augment)
+			USE_FEEDBACK_FAILURE("\The [src] has no augment to remove.")
+			return TRUE
+		playsound(src, 'sound/items/Crowbar.ogg', 50, TRUE)
 		user.visible_message(
-			SPAN_ITALIC("\The [user] starts to remove \the [augment] from \the [src]."),
-			SPAN_WARNING("You start to remove \the [augment] from \the [src]."),
-			SPAN_ITALIC("You hear metal creaking.")
+			SPAN_NOTICE("\The [user] starts to remove \a [augment] from \a [src] with \a [tool]."),
+			SPAN_NOTICE("You start to remove \a [augment] from \the [src] with \the [tool].")
 		)
-		playsound(user, 'sound/items/Crowbar.ogg', 50, TRUE)
-		if (!do_after(user, (I.toolspeed * 10) SECONDS, src, DO_PUBLIC_UNIQUE) || !augment)
-			return
-		user.visible_message(
-			SPAN_ITALIC("\The [user] removes \the [augment] from \the [src]."),
-			SPAN_WARNING("You remove \the [augment] from \the [src]."),
-			SPAN_ITALIC("You hear a clunk.")
-		)
-		playsound(user, 'sound/items/Deconstruct.ogg', 50, TRUE)
+		if (!do_after(user, (tool.toolspeed * 10) SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (!augment)
+			USE_FEEDBACK_FAILURE("\The [src] has no augment to remove.")
+			return TRUE
 		user.put_in_hands(augment)
+		playsound(src, 'sound/items/Crowbar.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] removes \a [augment] from \a [src] with \a [tool]."),
+			SPAN_NOTICE("You remove \a [augment] from \the [src] with \the [tool].")
+		)
 		augment = null
-		return
-	..()
+		return TRUE
+
+	return ..()
 
 
 /obj/item/device/augment_implanter/attack_self(mob/living/carbon/human/user)

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -432,94 +432,135 @@
 				visible_message(SPAN_NOTICE("\The [user] points \the [src] towards \the [target]."))
 
 
-/obj/item/device/electronic_assembly/attackby(obj/item/I, mob/living/user)
-	if (user.a_intent == I_HURT)
-		..()
-		return
-
-	if(isWrench(I))
-		if(istype(loc, /turf) && (IC_FLAG_ANCHORABLE & circuit_flags))
-			user.visible_message(SPAN_NOTICE("\The [user] wrenches \the [src]'s anchoring bolts [anchored ? "back" : "into position"]."))
-			playsound(get_turf(user), 'sound/items/Ratchet.ogg',50)
-			if(user.do_skilled((I.toolspeed * 5) SECONDS, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT))
-				anchored = !anchored
-		return
-
-	if(istype(I, /obj/item/integrated_circuit))
-		if(!user.canUnEquip(I))
-			return FALSE
-		if(try_add_component(I, user))
-			return TRUE
-		else
-			for(var/obj/item/integrated_circuit/input/S in assembly_components)
-				S.attackby_react(I,user,user.a_intent)
-			return ..()
-
-	if(istype(I, /obj/item/device/multitool) || istype(I, /obj/item/device/integrated_electronics/wirer) || istype(I, /obj/item/device/integrated_electronics/debugger))
-		if(opened)
-			interact(user)
-			return TRUE
-		else
-			to_chat(user, SPAN_DANGER("\The [src]'s hatch is closed, so you can't fiddle with the internal components."))
-			for(var/obj/item/integrated_circuit/input/S in assembly_components)
-				S.attackby_react(I,user,user.a_intent)
-			return ..()
-
-	if(istype(I, /obj/item/cell))
-		if(!opened)
-			to_chat(user, SPAN_DANGER("\The [src]'s hatch is closed, so you can't access \the [src]'s power supply."))
-			for(var/obj/item/integrated_circuit/input/S in assembly_components)
-				S.attackby_react(I,user,user.a_intent)
-			return ..()
-		if(battery)
-			to_chat(user, SPAN_DANGER("\The [src] already has \a [battery] installed. Remove it first if you want to replace it."))
-			for(var/obj/item/integrated_circuit/input/S in assembly_components)
-				S.attackby_react(I,user,user.a_intent)
-			return ..()
-		var/obj/item/cell/cell = I
-		if(user.unEquip(I,loc))
-			user.drop_from_inventory(I, loc)
-			cell.forceMove(src)
-			battery = cell
-			playsound(get_turf(src), 'sound/items/Deconstruct.ogg', 50, 1)
-			to_chat(user, SPAN_NOTICE("You slot \the [cell] inside \the [src]."))
-			return TRUE
-		return FALSE
-
-	if(istype(I, /obj/item/device/integrated_electronics/detailer))
-		var/obj/item/device/integrated_electronics/detailer/D = I
-		detail_color = D.detail_color
+/obj/item/device/electronic_assembly/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Assembly Detailer - Set color
+	if (istype(tool, /obj/item/device/integrated_electronics/detailer))
+		var/obj/item/device/integrated_electronics/detailer/detailer = tool
+		detail_color = detailer.detail_color
 		update_icon()
-		return
+		user.visible_message(
+			SPAN_NOTICE("\The [user] re-colors \a [src] with \a [tool]."),
+			SPAN_NOTICE("You re-color \the [src] with \the [tool].")
+		)
+		return TRUE
 
-	if(istype(I, /obj/item/screwdriver))
-		var/hatch_locked = FALSE
-		for(var/obj/item/integrated_circuit/manipulation/hatchlock/H in assembly_components)
-			// If there's more than one hatch lock, only one needs to be enabled for the assembly to be locked
-			if(H.lock_enabled)
-				hatch_locked = TRUE
-				break
+	// Integrated Circuit - Install circuit
+	if (istype(tool, /obj/item/integrated_circuit))
+		if (!user.canUnEquip(tool))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		if (try_add_component(tool, user))
+			return TRUE
+		return ..()
 
-		if(hatch_locked)
-			to_chat(user, SPAN_NOTICE("The screws are covered by a locking mechanism!"))
-			return FALSE
+	// Multitool, wirer, debugger - Interact
+	if (isMultitool(tool) || istype(tool, /obj/item/device/integrated_electronics/wirer) || istype(tool, /obj/item/device/integrated_electronics/debugger))
+		if (!opened)
+			USE_FEEDBACK_FAILURE("\The [src]'s hatch needs to be opened before you can access the internal components.")
+			return TRUE
+		interact(user)
+		return TRUE
 
-		playsound(src, 'sound/items/Screwdriver.ogg', 25)
+	// Power Cell - Install battery
+	if (istype(tool, /obj/item/cell))
+		if (!opened)
+			USE_FEEDBACK_FAILURE("\The [src]'s hatch needs to be opened before you can install \the [tool].")
+			return TRUE
+		if (battery)
+			USE_FEEDBACK_FAILURE("\The [src] already has \a [battery] installed.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		battery = tool
+		playsound(src, 'sound/items/Deconstruct.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] installs \a [tool] into \a [src]."),
+			SPAN_NOTICE("You install \the [tool] into \the [src].")
+		)
+		return TRUE
+
+	// Screwdriver - Toggle panel
+	if (isScrewdriver(tool))
+		for (var/obj/item/integrated_circuit/manipulation/hatchlock/hatchlock in assembly_components)
+			if (hatchlock.lock_enabled)
+				USE_FEEDBACK_FAILURE("\The [src]'s [hatchlock.name] is locked and prevents you from opening the panel.")
+				return TRUE
+		playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
 		opened = !opened
-		to_chat(user, SPAN_NOTICE("You [opened ? "open" : "close"] the maintenance hatch of \the [src]."))
 		update_icon()
-		return
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [opened ? "opens" : "closes"] \a [src]'s panel with \a [tool]."),
+			SPAN_NOTICE("You [opened ? "open" : "close"] \the [src]'s panel with \the [tool].")
+		)
+		return TRUE
 
-	if(isCoil(I))
-		var/obj/item/stack/cable_coil/C = I
-		if(health_damaged() && do_after(user, 1 SECOND, src, DO_PUBLIC_UNIQUE) && C.use(1))
-			user.visible_message(SPAN_NOTICE("\The [user] patches up \the [src]."))
-			restore_health(5)
-		return
+	// Wrench - Toggle anchoring bolts
+	if (isWrench(tool))
+		if (!HAS_FLAGS(circuit_flags, IC_FLAG_ANCHORABLE))
+			USE_FEEDBACK_FAILURE("\The [src] can't be anchored.")
+			return TRUE
+		if (!isturf(loc))
+			USE_FEEDBACK_FAILURE("\The [src] needs to be on the floor to be anchored.")
+			return TRUE
+		playsound(src, 'sound/items/Ratchet.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts wrenching \a [src] [anchored ? "from" : "to"] the floor with \a [tool]."),
+			SPAN_NOTICE("You start wrenching \the [src] [anchored ? "from" : "to"] the floor with \the [tool].")
+		)
+		if (!user.do_skilled(tool.toolspeed, SKILL_CONSTRUCTION, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (!HAS_FLAGS(circuit_flags, IC_FLAG_ANCHORABLE))
+			USE_FEEDBACK_FAILURE("\The [src] can't be anchored.")
+			return TRUE
+		if (!isturf(loc))
+			USE_FEEDBACK_FAILURE("\The [src] needs to be on the floor to be anchored.")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] wrenches \a [src] [anchored ? "from" : "to"] the floor with \a [tool]."),
+			SPAN_NOTICE("You wrenches \the [src] [anchored ? "from" : "to"] the floor with \the [tool].")
+		)
+		anchored = !anchored
+		return TRUE
 
-	for(var/obj/item/integrated_circuit/input/S in assembly_components)
-		S.attackby_react(I,user,user.a_intent)
-	..()
+	// Cable Coil - Repair damage
+	if (isCoil(tool))
+		if (!health_damaged())
+			USE_FEEDBACK_FAILURE("\The [src] doesn't need repair.")
+			return TRUE
+		var/obj/item/stack/cable_coil/cable = tool
+		if (!cable.can_use(5))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(cable, 5, "to repair \the [src].")
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts repairing some of \a [src]'s damage with [cable.get_vague_name(TRUE)]."),
+			SPAN_NOTICE("You start repairing some of \the [src]'s damage with [cable.get_exact_name(5)].")
+		)
+		if (!user.do_skilled(1 SECOND, SKILL_DEVICES, src) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (!health_damaged())
+			USE_FEEDBACK_FAILURE("\The [src] doesn't need repair.")
+			return TRUE
+		if (!cable.use(5))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(cable, 5, "to repair \the [src].")
+			return TRUE
+		restore_health(5)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] repairs some of \a [src]'s damage with [cable.get_vague_name(TRUE)]."),
+			SPAN_NOTICE("You repair some of \the [src]'s damage with [cable.get_exact_name(5)].")
+		)
+		return TRUE
+
+	// Everything else - Handle component reactions
+	var/result = FALSE
+	for (var/obj/item/integrated_circuit/component in assembly_components)
+		if (component.attackby_react(tool, user, user.a_intent))
+			result = TRUE
+	if (result)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/device/electronic_assembly/attack_self(mob/user)
 	interact(user)

--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -64,24 +64,46 @@
 		icon_state = "soulstone"//TODO: cracked sprite
 		SetName("cracked soulstone")
 
-/obj/item/device/soulstone/attackby(obj/item/I, mob/user)
-	..()
-	if (owner_flag != SOULSTONE_OWNER_PURE && istype(I, /obj/item/nullrod))
-		to_chat(user, SPAN_NOTICE("You cleanse \the [src] of taint, purging its shackles to its creator.."))
+
+/obj/item/device/soulstone/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	if (weapon.force < 5)
+		return ..()
+
+	if (full == SOULSTONE_CRACKED)
+		user.visible_message(
+			SPAN_WARNING("\The [user] shatters \a [src] with \a [weapon]!"),
+			SPAN_DANGER("You shatter \the [src] with \the [weapon]!")
+		)
+		shatter()
+		return TRUE
+
+	playsound(src, 'sound/effects/Glasshit.ogg', 75, TRUE)
+	set_full(SOULSTONE_CRACKED)
+	var/scream = ""
+	if (shade?.client)
+		scream = "You hear a terrible scream!"
+	user.visible_message(
+		SPAN_WARNING("\The [user] hits \a [src] with \a [weapon], and it cracks. [scream]"),
+		SPAN_WARNING("You hit \the [src] with \the [weapon], and it cracks. [scream]")
+	)
+	return TRUE
+
+
+/obj/item/device/soulstone/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Null Rod - Purify stone
+	if (istype(tool, /obj/item/nullrod))
+		if (owner_flag == SOULSTONE_OWNER_PURE)
+			USE_FEEDBACK_FAILURE("\The [src] is already pure.")
+			return TRUE
 		owner_flag = SOULSTONE_OWNER_PURE
-		return
-	if(I.force >= 5)
-		if(full != SOULSTONE_CRACKED)
-			user.visible_message(
-				SPAN_WARNING("\The [user] hits \the [src] with \the [I], and it breaks.[shade.client ? " You hear a terrible scream!" : ""]"),
-				SPAN_WARNING("You hit \the [src] with \the [I], and it cracks.[shade.client ? " You hear a terrible scream!" : ""]"),
-				shade.client ? "You hear a scream." : null
-			)
-			playsound(loc, 'sound/effects/Glasshit.ogg', 75)
-			set_full(SOULSTONE_CRACKED)
-		else
-			user.visible_message(SPAN_DANGER("\The [user] shatters \the [src] with \the [I]!"))
-			shatter()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] waves \a [tool] over \a [src]."),
+			SPAN_NOTICE("You cleanse \the [src] of taint with \the [tool], purging its shackles to its creator...")
+		)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/device/soulstone/attack(mob/living/simple_animal/M, mob/user)
 	if(M == shade)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -183,16 +183,23 @@ var/global/photo_count = 0
 	to_chat(user, "You switch the camera [on ? "on" : "off"].")
 	return
 
-/obj/item/device/camera/attackby(obj/item/I as obj, mob/user as mob)
-	if(istype(I, /obj/item/device/camera_film))
-		if(pictures_left)
-			to_chat(user, SPAN_NOTICE("[src] still has some film in it!"))
-			return
-		to_chat(user, SPAN_NOTICE("You insert [I] into [src]."))
-		qdel(I)
+
+/obj/item/device/camera/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Camera Film - Add film
+	if (istype(tool, /obj/item/device/camera_film))
+		if (pictures_left)
+			USE_FEEDBACK_FAILURE("\The [src] already has film in it.")
+			return TRUE
 		pictures_left = pictures_max
-		return
-	..()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] adds \a [tool] to \a [src]."),
+			SPAN_NOTICE("You add \the [tool] to \the [src]."),
+			range = 2
+		)
+		qdel(tool)
+		return TRUE
+
+	return ..()
 
 
 /obj/item/device/camera/proc/get_mobs(turf/the_turf as turf)

--- a/code/modules/xenoarcheaology/sampling.dm
+++ b/code/modules/xenoarcheaology/sampling.dm
@@ -96,19 +96,29 @@
 	if(distance <= 2)
 		to_chat(user, SPAN_NOTICE("Used to extract geological core samples - this one is [sampled_turf ? "full" : "empty"], and has [num_stored_bags] bag[num_stored_bags != 1 ? "s" : ""] remaining."))
 
-/obj/item/device/core_sampler/attackby(obj/item/I, mob/living/user)
-	if(istype(I, /obj/item/evidencebag))
-		if(length(I.contents))
-			to_chat(user, SPAN_WARNING("\The [I] is full."))
-			return
-		if(num_stored_bags < 10)
-			qdel(I)
-			num_stored_bags += 1
-			to_chat(user, SPAN_NOTICE("You insert \the [I] into \the [src]."))
-		else
-			to_chat(user, SPAN_WARNING("\The [src] can not fit any more bags."))
-	else
-		return ..()
+
+/obj/item/device/core_sampler/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Evidence Bag - Insert bag
+	if (istype(tool, /obj/item/evidencebag))
+		if (length(tool.contents))
+			USE_FEEDBACK_FAILURE("\The [tool] needs to be empty to add it to \the [src].")
+			return TRUE
+		if (num_stored_bags >= 10)
+			USE_FEEDBACK_FAILURE("\The [src] can't hold any more bags.")
+			return TRUE
+		if (!user.unEquip(tool, src))
+			FEEDBACK_UNEQUIP_FAILURE(user, tool)
+			return TRUE
+		num_stored_bags++
+		user.visible_message(
+			SPAN_NOTICE("\The [user] adds \a [tool] to \a [src]."),
+			SPAN_NOTICE("You add \the [tool] to \the [src]. It now holds [num_stored_bags].")
+		)
+		qdel(tool)
+		return TRUE
+
+	return ..()
+
 
 /obj/item/device/core_sampler/proc/sample_item(item_to_sample, mob/user)
 	var/datum/geosample/geo_data

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -57,7 +57,7 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 6 "uses of .len" '\.len\b' -P
-exactly 426 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 398 "attackby() override" '\/attackby\((.*)\)'  -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 num=`find ./html/changelogs -not -name "*.yml" | wc -l`


### PR DESCRIPTION
Replaces `attackby()` overrides for devices and their subtypes with `use_*()` overrides.

NUFC