### PR TITLE
Fix reinforced material wall and table icons

### DIFF
--- a/code/game/turfs/simulated/wall_icon.dm
+++ b/code/game/turfs/simulated/wall_icon.dm
@@ -72,14 +72,14 @@
 			I.color = reinf_color
 			overlays += I
 		else
-			if("[reinf_material.wall_icon_reinf]0" in icon_states('icons/turf/wall_masks.dmi'))
+			if("[material.wall_icon_reinf]0" in icon_states('icons/turf/wall_masks.dmi'))
 				// Directional icon
 				for(var/i = 1 to 4)
-					I = image('icons/turf/wall_masks.dmi', "[reinf_material.wall_icon_reinf][wall_connections[i]]", dir = SHIFTL(1, i - 1))
+					I = image('icons/turf/wall_masks.dmi', "[material.wall_icon_reinf][wall_connections[i]]", dir = SHIFTL(1, i - 1))
 					I.color = reinf_color
 					overlays += I
 			else
-				I = image('icons/turf/wall_masks.dmi', reinf_material.wall_icon_reinf)
+				I = image('icons/turf/wall_masks.dmi', material.wall_icon_reinf)
 				I.color = reinf_color
 				overlays += I
 	var/image/texture = material.get_wall_texture()

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -387,7 +387,7 @@
 		// Reinforcements
 		if(reinforced)
 			for(var/i = 1 to 4)
-				I = image(icon, "[reinforced.table_icon_reinf]_[connections[i]]", dir = SHIFTL(1, i - 1))
+				I = image(icon, "[material.table_icon_reinf]_[connections[i]]", dir = SHIFTL(1, i - 1))
 				I.color = reinforced.icon_colour
 				I.alpha = 255 * reinforced.opacity
 				overlays += I
@@ -425,7 +425,7 @@
 			name = "table frame"
 
 		if(reinforced)
-			var/image/I = image(icon, "[reinforced.table_icon_reinf]_flip[type]")
+			var/image/I = image(icon, "[material.table_icon_reinf]_flip[type]")
 			I.color = reinforced.icon_colour
 			I.alpha = 255 * reinforced.opacity
 			overlays += I


### PR DESCRIPTION
Walls and tables were using the reinf icon sprite from their reinforced material instead of their main material, resulting in some combinations that clashed and didn't line up properly.

## Changelog
:cl: SierraKomodo
bugfix: Reinforced walls and tables with a combination of two different materials now use the current reinforced material icon.
/:cl: