### PR TITLE
Remove `use_user()`

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -53,9 +53,6 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	if ((item_flags & ITEM_FLAG_TRY_ATTACK) && attack(A, user))
 		use_call = "attack"
 		. = TRUE
-	if (!. && A == user)
-		use_call = "user"
-		. = user.use_user(src, click_params)
 	if (!. && user.a_intent == I_HURT)
 		use_call = "weapon"
 		. = A.use_weapon(src, user, click_params)
@@ -237,35 +234,6 @@ avoid code duplication. This includes items that may sometimes act as a standard
 
 
 /**
- * Interaction handler for using an item on yourself. This is called and the result checked before the other `use_*`
- * interaction procs are called, regardless of user intent.
- *
- * **Parameters**:
- * - `tool` - The item being used by the mob.
- * - `click_params` - List of click parameters.
- *
- * Returns boolean to indicate whether the attack call was handled or not. If `FALSE`, the next `use_*` proc in the
- * resolve chain will be called.
- */
-/mob/proc/use_user(obj/item/tool, list/click_params = list())
-	SHOULD_CALL_PARENT(TRUE)
-	return FALSE
-
-
-/mob/living/carbon/human/use_user(obj/item/tool, list/click_params)
-	// Devouring
-	if (zone_sel.selecting == BP_MOUTH && can_devour(tool, silent = TRUE))
-		var/obj/item/blocked = check_mouth_coverage()
-		if (blocked)
-			FEEDBACK_FAILURE(src, "\The [blocked] is in the way!")
-			return TRUE
-		devour(tool)
-		return TRUE
-
-	return ..()
-
-
-/**
  * Interaction handler for being clicked on with a grab. This is called regardless of user intent.
  *
  * **Parameters**:
@@ -335,6 +303,19 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /mob/living/use_tool(obj/item/tool, mob/user, list/click_params)
 	// Surgery is handled by the tool
 	if (can_operate(src, user) && tool.do_surgery(src, user))
+		return TRUE
+
+	return ..()
+
+
+/mob/living/carbon/human/use_tool(obj/item/tool, mob/user, list/click_params)
+	// Anything on Self - Devour
+	if (user == src && zone_sel.selecting == BP_MOUTH && can_devour(tool, silent = TRUE))
+		var/obj/item/blocked = check_mouth_coverage()
+		if (blocked)
+			USE_FEEDBACK_FAILURE("\The [blocked] is in the way!")
+			return TRUE
+		devour(tool)
 		return TRUE
 
 	return ..()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -463,15 +463,6 @@
 	return 2
 
 
-/mob/living/silicon/robot/use_user(obj/item/tool, list/click_params)
-	// Welding Tool - Block self repair
-	if (isWelder(tool))
-		FEEDBACK_FAILURE(src, "You lack the reach to be able to repair yourself.")
-		return TRUE
-
-	return ..()
-
-
 /mob/living/silicon/robot/post_use_item(obj/item/tool, mob/user, interaction_handled, use_call, click_params)
 	..()
 
@@ -800,6 +791,9 @@
 
 	// Welding Tool - Repair brute damage
 	if (isWelder(tool))
+		if (user == src)
+			USE_FEEDBACK_FAILURE("You lack the reach to be able to repair yourself.")
+			return TRUE
 		if (!getBruteLoss())
 			USE_FEEDBACK_FAILURE("\The [src] has no physical damage to repair.")
 			return TRUE


### PR DESCRIPTION
Removes the `use_user()` proc. It was primarily unused, logically redundant, and awkwardly named.

No user-facing changes.