### PR TITLE
Add: SpaceDrift subsystem

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -211,6 +211,7 @@
 #include "code\controllers\subsystems\radiation.dm"
 #include "code\controllers\subsystems\shuttle.dm"
 #include "code\controllers\subsystems\skybox.dm"
+#include "code\controllers\subsystems\spacedrift.dm"
 #include "code\controllers\subsystems\supply.dm"
 #include "code\controllers\subsystems\throwing.dm"
 #include "code\controllers\subsystems\ticker.dm"

--- a/code/__defines/subsystem-priority.dm
+++ b/code/__defines/subsystem-priority.dm
@@ -14,7 +14,9 @@
 #define SS_PRIORITY_MOB            95  // Mob Life().
 #define SS_PRIORITY_MACHINERY      95  // Machinery + powernet ticks.
 #define SS_PRIORITY_AIR            80  // ZAS processing.
+#define SS_PRIORITY_THROWING       75  // Throwing calculation and constant checks
 #define SS_PRIORITY_CHEMISTRY      60  // Multi-tick chemical reactions.
+#define SS_PRIORITY_SPACEDRIFT     45  // Drifting things
 #define SS_PRIORITY_CHAT           40  // Chat
 #define SS_PRIORITY_ALARM          20  // Alarm processing.
 #define SS_PRIORITY_EVENT          20  // Event processing and queue handling.

--- a/code/controllers/subsystems/spacedrift.dm
+++ b/code/controllers/subsystems/spacedrift.dm
@@ -1,0 +1,63 @@
+//ported from TG 30/03/2020
+SUBSYSTEM_DEF(spacedrift)
+	name = "Space Drift"
+	priority = SS_PRIORITY_SPACEDRIFT
+	wait = 5
+	flags = SS_NO_INIT|SS_KEEP_TIMING
+	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
+
+	var/list/currentrun = list()
+	var/list/processing = list()
+
+/datum/controller/subsystem/spacedrift/UpdateStat(time)
+	if (PreventUpdateStat(time))
+		return ..()
+	..("P:[length(processing)]")
+
+
+/datum/controller/subsystem/spacedrift/fire(resumed = 0)
+	if (!resumed)
+		src.currentrun = processing.Copy()
+
+	//cache for sanic speed (lists are references anyways)
+	var/list/currentrun = src.currentrun
+
+	while (length(currentrun))
+		var/atom/movable/AM = currentrun[length(currentrun)]
+		LIST_DEC(currentrun)
+		if (!AM)
+			processing -= AM
+			if (MC_TICK_CHECK)
+				return
+			continue
+
+		if (AM.inertia_next_move > world.time)
+			if (MC_TICK_CHECK)
+				return
+			continue
+
+		if (!AM.loc || AM.loc != AM.inertia_last_loc || AM.Process_Spacemove(0))
+			AM.inertia_dir = 0
+
+		AM.inertia_ignore = null
+
+		if (!AM.inertia_dir)
+			AM.inertia_last_loc = null
+			processing -= AM
+			if (MC_TICK_CHECK)
+				return
+			continue
+
+		var/old_dir = AM.dir
+		var/old_loc = AM.loc
+		AM.inertia_moving = TRUE
+		step(AM, AM.inertia_dir)
+		AM.inertia_moving = FALSE
+		AM.inertia_next_move = world.time + AM.inertia_move_delay
+		if (AM.loc == old_loc)
+			AM.inertia_dir = 0
+
+		AM.set_dir(old_dir)
+		AM.inertia_last_loc = AM.loc
+		if (MC_TICK_CHECK)
+			return

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -78,24 +78,26 @@
 		return MOVEMENT_PROCEED
 	return (MOVEMENT_PROCEED|MOVEMENT_HANDLED)
 
+/datum/movement_handler/mob/space
+	var/allow_move
+
 // Space movement
 /datum/movement_handler/mob/space/DoMove(direction, mob/mover)
-	if(!mob.check_solid_ground())
-		var/allowmove = mob.Allow_Spacemove(0)
-		if(!allowmove)
+	if(!mob.has_gravity())
+		if(!allow_move)
 			return MOVEMENT_HANDLED
-		else if(allowmove == -1 && mob.handle_spaceslipping()) //Check to see if we slipped
+		if(!mob.space_do_move(allow_move, direction))
 			return MOVEMENT_HANDLED
-		else
-			mob.inertia_dir = 0 //If not then we can reset inertia and move
 
 /datum/movement_handler/mob/space/MayMove(mob/mover, is_external)
 	if(IS_NOT_SELF(mover) && is_external)
 		return MOVEMENT_PROCEED
 
-	if(!mob.check_solid_ground())
-		if(!mob.Allow_Spacemove(0))
+	if(!mob.has_gravity())
+		allow_move = mob.Process_Spacemove(1)
+		if(!allow_move)
 			return MOVEMENT_STOP
+
 	return MOVEMENT_PROCEED
 
 // Buckle movement
@@ -270,7 +272,7 @@
 /mob/living/carbon/human/get_stamina_used_per_step()
 	var/mod = (1-((get_skill_value(SKILL_HAULING) - SKILL_MIN)/(SKILL_MAX - SKILL_MIN)))
 	if(species && (species.species_flags & SPECIES_FLAG_LOW_GRAV_ADAPTED))
-		if(has_gravity(src))
+		if(has_gravity())
 			mod *= 1.2
 		else
 			mod *= 0.8

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -345,16 +345,27 @@
 			temp_windoor.open()
 
 /// Returns boolean. Whether or not the area is considered to have gravity.
-/area/proc/has_gravity()
+/area/has_gravity()
 	return has_gravity
 
 /area/space/has_gravity()
 	return 0
 
-/proc/has_gravity(atom/AT, turf/T)
-	if(!T)
-		T = get_turf(AT)
-	var/area/A = get_area(T)
+/atom/proc/has_gravity()
+	var/area/A = get_area(src)
+	if(A && A.has_gravity())
+		return 1
+	return 0
+
+/mob/has_gravity()
+	if(!lastarea)
+		lastarea = get_area(src)
+	if(!lastarea || !lastarea.has_gravity())
+		return 0
+	return 1
+
+/turf/has_gravity()
+	var/area/A = loc
 	if(A && A.has_gravity())
 		return 1
 	return 0

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -11,6 +11,8 @@
 	w_class = ITEM_SIZE_NO_CONTAINER
 	layer = STRUCTURE_LAYER // Layer under items
 	init_flags = INIT_MACHINERY_PROCESS_SELF
+	throw_speed = 1
+	throw_range = 5
 
 	health_resistances = DAMAGE_RESIST_ELECTRICAL
 

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -147,8 +147,8 @@
 	master.disrupt()
 
 /obj/effect/dummy/chameleon/relaymove(mob/user, direction)
-	var/area/A = get_area(src)
-	if(!A || !A.has_gravity()) return //No magical space movement!
+	if(!has_gravity())
+		return //No magical space movement!
 
 	if(can_move)
 		can_move = 0

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -140,16 +140,16 @@
 
 		playsound(src.loc, 'sound/effects/extinguish.ogg', 75, 1, -3)
 
-		var/direction = get_dir(src,target)
+		var/direction = get_dir(target, src)
 
 		if(user.buckled && isobj(user.buckled))
-			addtimer(new Callback(src, .proc/propel_object, user.buckled, user, turn(direction,180)), 0)
+			addtimer(new Callback(src, .proc/propel_object, user.buckled, user, direction), 0)
 
 		addtimer(new Callback(src, .proc/do_spray, target), 0)
 
-		if((istype(usr.loc, /turf/space)) || (usr.lastarea.has_gravity == 0))
-			user.inertia_dir = get_dir(target, user)
-			step(user, user.inertia_dir)
+		if(!user.check_space_footing())
+			step(user, direction)
+
 	else
 		return ..()
 	return

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -281,3 +281,6 @@
  */
 /obj/proc/is_safe_to_step(mob/living/L)
 	return TRUE
+
+/obj/get_mass()
+	return min(2**(w_class-1), 100)

--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -125,10 +125,7 @@
 
 			if(M.slip("the [floor_type] floor", slip_stun))
 				addtimer(new Callback(M, /mob/proc/slip_handler, M.dir, slip_dist - 1, 1), 1)
-			else
-				M.inertia_dir = 0
-		else
-			M.inertia_dir = 0
+
 
 /mob/proc/slip_handler(dir, dist, delay)
 	if (dist > 0)

--- a/code/game/turfs/simulated/footsteps.dm
+++ b/code/game/turfs/simulated/footsteps.dm
@@ -53,7 +53,7 @@
 		return
 
 	// don't need to step as often when you hop around
-	if((step_count % 3) && !has_gravity(src))
+	if((step_count % 3) && !has_gravity())
 		return
 
 	if(istype(move_intent, /singleton/move_intent/creep)) //We don't make sounds if we're tiptoeing

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -189,14 +189,7 @@ var/global/const/enterloopsanity = 100
 
 	if(ismob(A))
 		var/mob/M = A
-		if(!M.check_solid_ground())
-			inertial_drift(M)
-			//we'll end up checking solid ground again but we still need to check the other things.
-			//Ususally most people aren't in space anyways so hopefully this is acceptable.
-			M.update_floating()
-		else
-			M.inertia_dir = 0
-			M.make_floating(0) //we know we're not on solid ground so skip the checks to save a bit of processing
+		M.make_floating(0) //we know we're not on solid ground so skip the checks to save a bit of processing
 
 	var/objects = 0
 	if(A && (A.movable_flags & MOVABLE_FLAG_PROXMOVE))
@@ -218,20 +211,6 @@ var/global/const/enterloopsanity = 100
 
 /turf/proc/protects_atom(atom/A)
 	return FALSE
-
-/turf/proc/inertial_drift(atom/movable/A)
-	if(!(A.last_move))	return
-	if((ismob(A) && src.x > 2 && src.x < (world.maxx - 1) && src.y > 2 && src.y < (world.maxy-1)))
-		var/mob/M = A
-		if(M.Allow_Spacemove(1)) //if this mob can control their own movement in space then they shouldn't be drifting
-			M.inertia_dir  = 0
-			return
-		spawn(5)
-			if(M && !(M.anchored) && !(M.pulledby) && (M.loc == src))
-				if(!M.inertia_dir)
-					M.inertia_dir = M.last_move
-				step(M, M.inertia_dir)
-	return
 
 /turf/proc/levelupdate()
 	for(var/obj/O in src)
@@ -313,11 +292,14 @@ var/global/const/enterloopsanity = 100
 			if(length(M.pinned))
 				return
 
-		var/intial_dir = TT.init_dir
-		spawn(2)
-			step(AM, turn(intial_dir, 180))
+			if(M.pinned)
+				return
+		addtimer(new Callback(src, /turf/proc/bounce_off, AM, TT.init_dir), 2)
 
 	..()
+
+/turf/proc/bounce_off(atom/movable/AM, direction)
+	step(AM, turn(direction, 180))
 
 /turf/proc/can_engrave()
 	return FALSE

--- a/code/modules/ai/interfaces.dm
+++ b/code/modules/ai/interfaces.dm
@@ -84,7 +84,7 @@
 		if (safety && !newloc.is_safe_to_enter(src))
 			return MOVEMENT_FAILED
 
-	if (!check_solid_ground() && !Allow_Spacemove())
+	if (!Process_Spacemove())
 		return MOVEMENT_FAILED
 
 	// Move()ing to another tile successfully returns 32 because BYOND. Would rather deal with TRUE/FALSE-esque terms.

--- a/code/modules/mechs/mech_movement.dm
+++ b/code/modules/mechs/mech_movement.dm
@@ -12,10 +12,10 @@
 		playsound(src.loc, legs.mech_step_sound, 40, 1)
 
 /mob/living/exosuit/can_ztravel()
-	if(Allow_Spacemove()) //Handle here
+	if(Process_Spacemove()) //Handle here
 		return TRUE
 
-/mob/living/exosuit/Allow_Spacemove(check_drift)
+/mob/living/exosuit/Process_Spacemove()
 	. = ..()
 	if(.)
 		return
@@ -26,8 +26,7 @@
 
 	var/obj/item/mech_equipment/ionjets/J = hardpoints[HARDPOINT_BACK]
 	if(istype(J))
-		if(((!check_drift) || (check_drift && J.stabilizers)) && J.allowSpaceMove())
-			inertia_dir = 0
+		if(J.allowSpaceMove())
 			return TRUE
 
 //Inertia drift making us face direction makes exosuit flight a bit difficult, plus newtonian flight model yo
@@ -128,30 +127,37 @@
 /datum/movement_handler/mob/space/exosuit
 	expected_host_type = /mob/living/exosuit
 
-// Space movement
-/datum/movement_handler/mob/space/exosuit/DoMove(direction, mob/mover)
-
-	if(!mob.check_solid_ground())
-		mob.anchored = FALSE
-		var/allowmove = mob.Allow_Spacemove(0)
-		if(!allowmove)
-			return MOVEMENT_HANDLED
-		else if(allowmove == -1 && mob.handle_spaceslipping()) //Check to see if we slipped
-			return MOVEMENT_HANDLED
-		else
-			mob.inertia_dir = 0 //If not then we can reset inertia and move
-	else
-		mob.anchored = TRUE
-		mob.inertia_dir = 0 //Reset inertia values as we are not going to be treated as floating
-
 /datum/movement_handler/mob/space/exosuit/MayMove(mob/mover, is_external)
 	if((mover != host) && is_external)
 		return MOVEMENT_PROCEED
 
-	if(!mob.check_solid_ground())
-		if(!mob.Allow_Spacemove(0))
+	if(!mob.has_gravity())
+		allow_move = mob.Process_Spacemove(1)
+		if(!allow_move)
 			return MOVEMENT_STOP
+
 	return MOVEMENT_PROCEED
+
+/mob/living/exosuit/Check_Shoegrip()//mechs are always magbooting
+	return TRUE
+
+/mob/living/exosuit/Process_Spacemove()
+	if(has_gravity() || throwing || !isturf(loc) || length(grabbed_by) || check_space_footing() || locate(/obj/structure/lattice) in range(1, get_turf(src)))
+		anchored = TRUE
+		return 1
+
+	anchored = FALSE
+	return 0
+
+/mob/living/exosuit/check_space_footing()//mechs can't push off things to move around in space, they stick to hull or float away
+	for(var/thing in trange(1,src))
+		var/turf/T = thing
+		if(T.density || T.is_wall() || T.is_floor())
+			return T
+
+/mob/living/exosuit/space_do_move()
+	return 1
+
 
 /mob/living/exosuit/lost_in_space()
 	for(var/atom/movable/AM in contents)

--- a/code/modules/mob/animations.dm
+++ b/code/modules/mob/animations.dm
@@ -81,11 +81,11 @@ note dizziness decrements automatically in the mob's Life() proc.
 
 /mob/proc/update_floating()
 
-	if(anchored || buckled || check_solid_ground())
+	if(anchored || buckled || has_gravity())
 		make_floating(0)
 		return
 
-	if(Check_Shoegrip() && Check_Dense_Object())
+	if(check_space_footing())
 		make_floating(0)
 		return
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -324,10 +324,11 @@
 
 	if(!src.lastarea)
 		src.lastarea = get_area(src.loc)
-	if((istype(src.loc, /turf/space)) || (src.lastarea.has_gravity == 0))
+	if(!check_space_footing())
 		if(prob((itemsize * itemsize * 10) * MOB_MEDIUM/src.mob_size))
-			src.inertia_dir = get_dir(target, src)
-			step(src, inertia_dir)
+			var/direction = get_dir(target, src)
+			step(src,direction)
+			space_drift(direction)
 
 	item.throw_at(target, throw_range, item.throw_speed * skill_mod, src)
 
@@ -376,11 +377,12 @@
 	..()
 
 /mob/living/carbon/slip(slipped_on, stun_duration = 8)
-	var/area/A = get_area(src)
-	if(!A.has_gravity())
+	if(!has_gravity())
 		return FALSE
+
 	if(buckled)
 		return FALSE
+
 	stop_pulling()
 	to_chat(src, SPAN_WARNING("You slipped on [slipped_on]!"))
 	playsound(loc, 'sound/misc/slip.ogg', 50, 1, -3)

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -383,31 +383,8 @@ meteor_act
 					affecting.embed(I, supplied_wound = created_wound)
 					I.has_embedded()
 
-		// Begin BS12 momentum-transfer code.
-		var/mass = 1.5
-		if(istype(O, /obj/item))
-			var/obj/item/I = O
-			mass = I.w_class/THROWNOBJ_KNOCKBACK_DIVISOR
-		var/momentum = TT.speed*mass
+		process_momentum(AM, TT)
 
-		if(momentum >= THROWNOBJ_KNOCKBACK_SPEED)
-			var/dir = TT.init_dir
-
-			visible_message(SPAN_WARNING("\The [src] staggers under the impact!"),SPAN_WARNING("You stagger under the impact!"))
-
-			if(!src.isinspace())
-				src.throw_at(get_edge_target_turf(src,dir),1,momentum - THROWNOBJ_KNOCKBACK_SPEED)
-
-			if(!O || !src) return
-
-			if(O.loc == src && O.sharp && !(mob_flags & MOB_FLAG_UNPINNABLE)) //Projectile is embedded and suitable for pinning.
-				var/turf/T = near_wall(dir,2)
-
-				if(T)
-					src.forceMove(T)
-					visible_message(SPAN_WARNING("[src] is pinned to the wall by [O]!"),SPAN_WARNING("You are pinned to the wall by [O]!"))
-					src.anchored = TRUE
-					src.pinned += O
 	else
 		..()
 

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -10,8 +10,7 @@
 
 	tally += species.handle_movement_delay_special(src)
 
-	var/area/a = get_area(src)
-	if(a && !a.has_gravity())
+	if(!has_gravity())
 		if(skill_check(SKILL_EVA, SKILL_MASTER))
 			tally -= 2
 		tally -= 1
@@ -78,39 +77,41 @@
 	. = ..()
 	. += species.strength
 
-/mob/living/carbon/human/Allow_Spacemove(check_drift = 0)
-	. = ..()
-	if(.)
-		return
-
-	// This is horrible but short of spawning a jetpack inside the organ than locating
-	// it, I don't really see another viable approach short of a total jetpack refactor.
+/mob/living/carbon/human/Process_Spacemove(allow_movement)
+	var/obj/item/tank/jetpack/thrust = get_jetpack()
+	var/implant_jet = FALSE // Certified shitcode
 	for(var/obj/item/organ/internal/powered/jets/jet in internal_organs)
 		if(!jet.is_broken() && jet.active)
-			inertia_dir = 0
-			return 1
-	// End 'eugh'
+			implant_jet = TRUE
 
-	//Do we have a working jetpack?
-	var/obj/item/tank/jetpack/thrust
+	if(implant_jet || (thrust && thrust.on && (allow_movement || thrust.stabilization_on) && thrust.allow_thrust(0.01, src)))
+		return 1
+
+	. = ..()
+
+/mob/living/carbon/human/space_do_move(allow_move, direction)
+	if(allow_move == 1)
+		var/obj/item/tank/jetpack/thrust = get_jetpack()
+		if(thrust && thrust.on && skill_fail_prob(SKILL_EVA, 10, SKILL_TRAINED))
+			to_chat(src, SPAN_WARNING("You fumble with [thrust] controls!"))
+			if(prob(50))
+				thrust.toggle()
+			if(prob(50))
+				thrust.stabilization_on = 0
+			SetMoveCooldown(15)	//2 seconds of random rando panic drifting
+			step(src, pick(GLOB.alldirs))
+			return 0
+	. = ..()
+
+/mob/living/carbon/human/proc/get_jetpack()
 	if(back)
 		if(istype(back,/obj/item/tank/jetpack))
-			thrust = back
+			return back
 		else if(istype(back,/obj/item/rig))
 			var/obj/item/rig/rig = back
 			for(var/obj/item/rig_module/maneuvering_jets/module in rig.installed_modules)
-				thrust = module.jets
-				break
+				return module.jets
 
-	if(thrust && thrust.on)
-		if(prob(skill_fail_chance(SKILL_EVA, 10, SKILL_TRAINED)))
-			to_chat(src, SPAN_WARNING("You fumble with [thrust] controls!"))
-			inertia_dir = pick(GLOB.cardinal)
-			return 0
-
-		if(((!check_drift) || (check_drift && thrust.stabilization_on)) && (!lying) && (thrust.allow_thrust(0.01, src)))
-			inertia_dir = 0
-			return 1
 
 /mob/living/carbon/human/slip_chance(prob_slip = 5)
 	if(!..())

--- a/code/modules/mob/living/carbon/human/human_organs.dm
+++ b/code/modules/mob/living/carbon/human/human_organs.dm
@@ -82,8 +82,7 @@
 		return
 
 	// Can't fall if nothing pulls you down
-	var/area/area = get_area(src)
-	if (!area || !area.has_gravity())
+	if(!has_gravity())
 		return
 
 	var/limb_pain

--- a/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
+++ b/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
@@ -154,9 +154,6 @@
 
 	..()
 
-/mob/living/carbon/slime/Allow_Spacemove()
-	return 1
-
 /mob/living/carbon/slime/Stat()
 	. = ..()
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -601,8 +601,7 @@ default behaviour is:
 				return set_dir(get_dir(src, pulling))
 
 /mob/living/proc/handle_pull_damage(mob/living/puller)
-	var/area/A = get_area(src)
-	if(!A.has_gravity)
+	if(!has_gravity())
 		return
 	var/turf/location = get_turf(src)
 	if(lying && prob(getBruteLoss() / 6))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -194,32 +194,39 @@
 			if (ai_holder)
 				ai_holder.react_to_attack(TT.thrower)
 
-		// Begin BS12 momentum-transfer code.
-		var/mass = 1.5
-		if(istype(O, /obj/item))
-			var/obj/item/I = O
-			mass = I.w_class/THROWNOBJ_KNOCKBACK_DIVISOR
-		var/momentum = TT.speed*mass
+		if(O.can_embed() && (throw_damage > 5*O.w_class)) //Handles embedding for non-humans and simple_animals.
+			embed(O)
 
-		if(momentum >= THROWNOBJ_KNOCKBACK_SPEED)
-			var/dir = TT.init_dir
+	process_momentum(AM, TT)
 
-			visible_message(SPAN_WARNING("\The [src] staggers under the impact!"),SPAN_WARNING("You stagger under the impact!"))
-			throw_at(get_edge_target_turf(src,dir),1,momentum)
+/mob/living/momentum_power(atom/movable/AM, datum/thrownthing/TT)
+	if(anchored || buckled)
+		return 0
 
-			if(!O || !src) return
+	. = (AM.get_mass()*TT.speed)/(get_mass()*min(AM.throw_speed,2))
+	if(has_gravity() || check_space_footing())
+		. *= 0.5
 
-			if(O.can_embed() && !(mob_flags & MOB_FLAG_UNPINNABLE)) //Projectile is suitable for pinning.
-				//Handles embedding for non-humans and simple_animals.
-				embed(O)
+/mob/living/momentum_do(power, datum/thrownthing/TT, atom/movable/AM)
+	if(power >= 0.75)		//snowflake to enable being pinned to walls
+		var/direction = TT.init_dir
+		throw_at(get_edge_target_turf(src, direction), min((TT.maxrange - TT.dist_travelled) * power, 10), throw_speed * min(power, 1.5), callback = new Callback(src,/mob/living/proc/pin_to_wall,AM,direction))
+		visible_message(SPAN_DANGER("\The [src] staggers under the impact!"),SPAN_DANGER("You stagger under the impact!"))
+		return
 
-				var/turf/T = near_wall(dir,2)
+	. = ..()
 
-				if(T)
-					forceMove(T)
-					visible_message(SPAN_WARNING("[src] is pinned to the wall by [O]!"),SPAN_WARNING("You are pinned to the wall by [O]!"))
-					anchored = TRUE
-					pinned += O
+/mob/living/proc/pin_to_wall(obj/O, direction)
+	if(!istype(O) || O.loc != src || !O.can_embed())//Projectile is suitable for pinning.
+		return
+
+	var/turf/T = near_wall(direction,2)
+
+	if(T)
+		forceMove(T)
+		visible_message(SPAN_DANGER("[src] is pinned to the wall by [O]!"),SPAN_DANGER("You are pinned to the wall by [O]!"))
+		src.anchored = TRUE
+		src.pinned += O
 
 /mob/living/proc/embed(obj/O, def_zone=null, datum/wound/supplied_wound)
 	O.forceMove(src)

--- a/code/modules/mob/living/maneuvers/_maneuver.dm
+++ b/code/modules/mob/living/maneuvers/_maneuver.dm
@@ -12,7 +12,7 @@
 		if(!silent)
 			to_chat(user, SPAN_WARNING("You are buckled down and cannot maneuver!"))
 		return FALSE
-	if(!has_gravity(user))
+	if(!user.has_gravity())
 		if(!silent)
 			to_chat(user, SPAN_WARNING("You cannot maneuver in zero gravity!"))
 		return FALSE

--- a/code/modules/mob/living/silicon/robot/flying/flying.dm
+++ b/code/modules/mob/living/silicon/robot/flying/flying.dm
@@ -42,11 +42,11 @@
 	if(!QDELETED(src) && stat == DEAD)
 		stop_flying()
 
-/mob/living/silicon/robot/flying/Allow_Spacemove()
+/mob/living/silicon/robot/flying/Process_Spacemove()
 	return (pass_flags & PASS_FLAG_TABLE) || ..()
 
 /mob/living/silicon/robot/flying/can_fall(anchor_bypass = FALSE, turf/location_override = loc)
-	return !Allow_Spacemove()
+	return !Process_Spacemove()
 
 /mob/living/silicon/robot/flying/can_overcome_gravity()
-	return Allow_Spacemove()
+	return Process_Spacemove()

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -8,7 +8,7 @@
 		return 1
 	return 0
 
-/mob/living/silicon/robot/Allow_Spacemove()
+/mob/living/silicon/robot/Process_Spacemove()
 	if(module)
 		for(var/obj/item/tank/jetpack/J in module.equipment)
 			if(J && J.allow_thrust(0.01))

--- a/code/modules/mob/living/simple_animal/familiars/familiars.dm
+++ b/code/modules/mob/living/simple_animal/familiars/familiars.dm
@@ -69,7 +69,7 @@
 
 	wizardy_spells = list(/spell/aoe_turf/conjure/forcewall)
 
-/mob/living/simple_animal/familiar/pike/Allow_Spacemove(check_drift = 0)
+/mob/living/simple_animal/familiar/pike/Process_Spacemove()
 	return 1	//No drifting in space for space carp!	//original comments do not steal
 
 /mob/living/simple_animal/familiar/horror

--- a/code/modules/mob/living/simple_animal/friendly/juvenile_space_whale.dm
+++ b/code/modules/mob/living/simple_animal/friendly/juvenile_space_whale.dm
@@ -71,7 +71,7 @@
 			bound_height = 32
 			bound_width = 64
 
-/mob/living/simple_animal/passive/juvenile_space_whale/Allow_Spacemove()
+/mob/living/simple_animal/passive/juvenile_space_whale/Process_Spacemove()
 	return TRUE
 
 /datum/say_list/juvenile_space_whale

--- a/code/modules/mob/living/simple_animal/hostile/bluespace.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bluespace.dm
@@ -20,7 +20,7 @@
 	light_max_bright = 1
 	bleed_colour = "#0000ff"
 
-/mob/living/simple_animal/hostile/bluespace/Allow_Spacemove(check_drift = 0)
+/mob/living/simple_animal/hostile/bluespace/Process_Spacemove()
 	return 1
 
 /obj/item/natural_weapon/bluespace

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -34,7 +34,7 @@
 	damtype = DAMAGE_BURN
 	force = 15
 
-/mob/living/simple_animal/hostile/faithless/Allow_Spacemove(check_drift = 0)
+/mob/living/simple_animal/hostile/faithless/Process_Spacemove()
 	return 1
 
 /mob/living/simple_animal/hostile/faithless/apply_melee_effects(atom/A)

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -58,7 +58,7 @@
 		trail.start()
 
 
-/mob/living/simple_animal/hostile/retaliate/malf_drone/Allow_Spacemove(check_drift)
+/mob/living/simple_animal/hostile/retaliate/malf_drone/Process_Spacemove()
 	return TRUE
 
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
@@ -254,7 +254,7 @@
 	QDEL_NULL(boss_theme)
 	. = ..()
 
-/mob/living/simple_animal/hostile/retaliate/goat/king/Allow_Spacemove(check_drift = 0)
+/mob/living/simple_animal/hostile/retaliate/goat/king/Process_Spacemove()
 	return 1
 
 /datum/say_list/goat/king

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/space_whale.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/space_whale.dm
@@ -74,7 +74,7 @@
 // 	if(istype(M, /mob/living/simple_animal/passive/juvenile_space_whale))
 // 		return FALSE
 
-/mob/living/simple_animal/hostile/retaliate/space_whale/Allow_Spacemove()
+/mob/living/simple_animal/hostile/retaliate/space_whale/Process_Spacemove()
 	return TRUE
 
 /datum/say_list/space_whale

--- a/code/modules/mob/living/simple_animal/hostile/space_carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_carp.dm
@@ -62,5 +62,5 @@
 	icon_dead = "[carp_color]_dead"
 
 
-/mob/living/simple_animal/hostile/carp/Allow_Spacemove(check_drift)
+/mob/living/simple_animal/hostile/carp/Process_Spacemove()
 	return TRUE

--- a/code/modules/mob/living/simple_animal/hostile/vagrant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vagrant.dm
@@ -54,7 +54,7 @@
 			H.visible_message(SPAN_DANGER("\the [holder] latches onto \the [H], pulsating!"))
 			V.forceMove(V.gripping.loc)
 
-/mob/living/simple_animal/hostile/vagrant/Allow_Spacemove(check_drift = 0)
+/mob/living/simple_animal/hostile/vagrant/Process_Spacemove()
 	return 1
 
 /mob/living/simple_animal/hostile/vagrant/bullet_act(obj/item/projectile/Proj)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -668,10 +668,6 @@
 		if(istype(C))
 			C.leave_evidence(src)
 
-	//Attempted fix for people flying away through space when cuffed and dragged.
-	if(ismob(AM))
-		var/mob/pulled = AM
-		pulled.inertia_dir = 0
 
 /mob/proc/can_use_hands()
 	return
@@ -1273,3 +1269,6 @@
 			return FALSE
 	else
 		return FALSE
+
+/mob/get_mass()
+	return mob_size

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -136,8 +136,6 @@
 
 	var/in_throw_mode = 0
 
-	var/inertia_dir = 0
-
 //	var/job = null//Living
 
 	var/can_pull_size = ITEM_SIZE_NO_CONTAINER // Maximum w_class the mob can pull.

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -162,6 +162,10 @@
 		if ((A != src.loc && A && A.z == src.z))
 			src.last_move = get_dir(A, src.loc)
 
+	if(!inertia_moving)
+		inertia_next_move = world.time + inertia_move_delay
+		space_drift(direct ? direct : last_move)
+
 /client/Move(n, direction)
 	if(!user_acted(src))
 		return
@@ -169,51 +173,76 @@
 		return // Moved here to avoid nullrefs below
 	return mob.SelfMove(direction)
 
-// Checks whether this mob is allowed to move in space
-// Return 1 for movement, 0 for none,
-// -1 to allow movement but with a chance of slipping
-/mob/proc/Allow_Spacemove(check_drift = 0)
-	if(!Check_Dense_Object()) //Nothing to push off of so end here
-		return 0
 
-	if(restrained()) //Check to see if we can do things
-		return 0
+/mob/Process_Spacemove(allow_movement)
+	. = ..()
+	if(.)
+		return
 
-	return -1
+	var/atom/movable/backup = get_spacemove_backup()
+	if(backup)
+		if(istype(backup) && allow_movement)
+			return backup
+		return -1
 
-//Checks if a mob has solid ground to stand on
-//If there's no gravity then there's no up or down so naturally you can't stand on anything.
-//For the same reason lattices in space don't count - those are things you grip, presumably.
-/mob/proc/check_solid_ground()
-	if(istype(loc, /turf/space))
-		return 0
+/mob/proc/space_do_move(allow_move, direction)
+	if(ismovable(allow_move))//push off things in space
+		handle_space_pushoff(allow_move, direction)
+		allow_move = -1
 
-	if(!lastarea)
-		lastarea = get_area(src)
-	if(!lastarea || !lastarea.has_gravity)
+	if(allow_move == -1 && handle_spaceslipping())
 		return 0
 
 	return 1
 
-/mob/proc/Check_Dense_Object() //checks for anything to push off or grip in the vicinity. also handles magboots on gravity-less floors tiles
+/mob/proc/handle_space_pushoff(atom/movable/AM, direction)
+	if(AM.anchored)
+		return
 
+	if(ismob(AM))
+		var/mob/M = AM
+		if(M.check_space_footing())
+			return
+
+	AM.inertia_ignore = src
+	if(step(AM, turn(direction, 180)))
+		to_chat(src, "<span class='info'>You push off of [AM] to propel yourself.</span>")
+		inertia_ignore = AM
+
+/mob/proc/get_spacemove_backup()
 	var/shoegrip = Check_Shoegrip()
 
-	for(var/turf/simulated/T in trange(1,src)) //we only care for non-space turfs
-		if(T.density)	//walls work
-			return 1
-		else
-			var/area/A = T.loc
-			if(A.has_gravity || (shoegrip && !isopenspace(T)))
-				return 1
+	for(var/thing in trange(1,src))//checks for walls or grav turf first
+		var/turf/T = thing
+		if(T.density || T.is_wall() || (T.is_floor() && (shoegrip || T.has_gravity())))
+			return T
 
-	for(var/obj/O in orange(1, src))
-		if(istype(O, /obj/structure/lattice))
-			return 1
-		if(istype(O, /obj/structure/catwalk))
-			return 1
-		if(O && O.density && O.anchored)
-			return 1
+	var/obj/item/grab/G = locate() in src
+	for(var/A in range(1, get_turf(src)))
+		if(istype(A,/atom/movable))
+			var/atom/movable/AM = A
+			if(AM == src || AM == inertia_ignore || !AM.simulated || !AM.mouse_opacity || AM == buckled)	//mouse_opacity is hacky as hell, need better solution
+				continue
+			if(ismob(AM))
+				var/mob/M = AM
+				if(M.buckled)
+					continue
+			if(AM.density || !AM.CanPass(src))
+				if(AM.anchored)
+					return AM
+				if(G && AM == G.affecting)
+					continue
+				. = AM
+
+/mob/proc/check_space_footing()	//checks for gravity or maglockable turfs to prevent space related movement
+	if(has_gravity() || anchored || buckled)
+		return 1
+
+	if(Check_Shoegrip())
+		for(var/thing in trange(1,src))	//checks for turfs that one can maglock to
+			var/turf/T = thing
+			if(T.density || T.is_wall() || T.is_floor())
+				return 1
 
 	return 0
 
@@ -224,8 +253,7 @@
 /mob/proc/handle_spaceslipping()
 	if(prob(skill_fail_chance(SKILL_EVA, slip_chance(10), SKILL_EXPERIENCED)))
 		to_chat(src, SPAN_WARNING("You slipped!"))
-		src.inertia_dir = src.last_move
-		step(src, src.inertia_dir)
+		step(src,turn(last_move, pick(45,-45)))
 		return 1
 	return 0
 

--- a/code/modules/mob/observer/observer.dm
+++ b/code/modules/mob/observer/observer.dm
@@ -78,7 +78,6 @@ var/global/const/GHOST_IMAGE_ALL = ~GHOST_IMAGE_NONE
 	var/turf/T = locate(new_x, new_y, z)
 	if(T)
 		forceMove(T)
-		inertia_dir = 0
 		throwing = null
 		to_chat(src, SPAN_NOTICE("You cannot move further in this direction."))
 

--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -110,7 +110,7 @@
 	return 0
 
 /mob/living/carbon/human/can_ztravel()
-	if(Allow_Spacemove())
+	if(Process_Spacemove())
 		return 1
 
 	if(Check_Shoegrip())	//scaling hull with magboots
@@ -119,7 +119,7 @@
 				return 1
 
 /mob/living/silicon/robot/can_ztravel()
-	if(Allow_Spacemove()) //Checks for active jetpack
+	if(Process_Spacemove()) //Checks for active jetpack
 		return 1
 
 	for(var/turf/simulated/T in trange(1,src)) //Robots get "magboots"
@@ -142,8 +142,7 @@
 		return
 
 	// No gravity in space, apparently.
-	var/area/area = get_area(src)
-	if(!area.has_gravity())
+	if(!has_gravity())
 		return
 
 	if(throwing)
@@ -289,8 +288,7 @@
 	var/turf/T = get_turf(A)
 	var/turf/above = GetAbove(src)
 	if(above && T.Adjacent(bound_overlay) && above.CanZPass(src, UP)) //Certain structures will block passage from below, others not
-		var/area/location = get_area(loc)
-		if(location.has_gravity && !can_overcome_gravity())
+		if(loc.has_gravity() && !can_overcome_gravity())
 			return FALSE
 
 		visible_message(SPAN_NOTICE("[src] starts climbing onto \the [A]!"), SPAN_NOTICE("You start climbing onto \the [A]!"))

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -62,9 +62,10 @@
 /obj/structure/ladder/hitby(obj/item/I)
 	if (istype(src, /obj/structure/ladder/up))
 		return
-	var/area/room = get_area(src)
-	if(!room.has_gravity())
+
+	if(!has_gravity())
 		return
+
 	var/atom/blocker
 	var/turf/landing = get_turf(target_down)
 	for(var/atom/A in landing)

--- a/code/modules/overmap/spacetravel.dm
+++ b/code/modules/overmap/spacetravel.dm
@@ -67,7 +67,7 @@ var/global/list/cached_space = list()
 	return isnull(client)
 
 /mob/living/carbon/human/lost_in_space()
-	return isnull(client) && !last_ckey && stat == DEAD
+	return isnull(client) && (!last_ckey || stat == DEAD)
 
 /proc/overmap_spacetravel(turf/space/T, atom/movable/A)
 	if (!T || !A)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -70,6 +70,7 @@
 	var/fire_sound_text = "gunshot"
 	var/fire_anim = null
 	var/screen_shake = 0 //shouldn't be greater than 2 unless zoomed
+	var/space_recoil = 0 //knocks back in space
 	var/silenced = FALSE
 	var/accuracy = 0   //accuracy is measured in tiles. +1 accuracy means that everything is effectively one tile closer for the purpose of miss chance, -1 means the opposite. launchers are not supported, at the moment.
 	var/accuracy_power = 5  //increase of to-hit chance per 1 point of accuracy
@@ -263,7 +264,7 @@
 			process_point_blank(projectile, user, target)
 
 		if(process_projectile(projectile, user, target, user.zone_sel?.selecting, clickparams))
-			handle_post_fire(user, target, pointblank, reflex)
+			handle_post_fire(user, target, pointblank, reflex, projectile)
 			update_icon()
 
 		if(i < burst)
@@ -303,7 +304,7 @@
 	user.visible_message(SPAN_WARNING("[user] squeezes the trigger of \the [src] but it doesn't move!"), SPAN_WARNING("You squeeze the trigger but it doesn't move!"), range = 3)
 
 //called after successfully firing
-/obj/item/gun/proc/handle_post_fire(mob/user, atom/target, pointblank=0, reflex=0)
+/obj/item/gun/proc/handle_post_fire(mob/user, atom/target, pointblank = 0, reflex = 0, obj/projectile)
 	if(fire_anim)
 		flick(fire_anim, src)
 
@@ -360,6 +361,16 @@
 			var/obj/item/rig/R = H.back
 			for(var/obj/item/rig_module/stealth_field/S in R.installed_modules)
 				S.deactivate()
+
+	if(space_recoil && !user.check_space_footing())
+		var/old_dir = user.dir
+		var/mob/living/carbon/human/H = user
+		var/obj/item/tank/jetpack/jetpack = H.get_jetpack()
+		if(jetpack && !jetpack.stabilization_on)
+			user.inertia_ignore = projectile
+			step(user,get_dir(target,user))
+			user.set_dir(old_dir)
+
 
 	update_icon()
 

--- a/code/modules/projectiles/guns/launcher.dm
+++ b/code/modules/projectiles/guns/launcher.dm
@@ -6,6 +6,8 @@
 	w_class = ITEM_SIZE_HUGE
 	obj_flags =  OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_BACK
+	screen_shake = 1
+	space_recoil = 1
 
 	var/release_force = 0
 	var/throw_distance = 10

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -7,6 +7,7 @@
 	w_class = ITEM_SIZE_NORMAL
 	matter = list(MATERIAL_STEEL = 1000)
 	screen_shake = 1
+	space_recoil = 1
 	combustion = 1
 
 	var/caliber = CALIBER_PISTOL		//determines which casings will fit

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -57,6 +57,8 @@
 	var/agony = 0
 	var/embed = FALSE // whether or not the projectile can embed itself in the mob
 	var/penetration_modifier = 0.2 //How likely this projectile is to embed or rupture artery
+	var/knockback = 0 //SIERRA
+	var/space_knockback = 0	//whether or not it will knock things back in space
 
 	var/hitscan = FALSE		// whether the projectile should be hitscan
 	var/step_delay = 1	// the delay between iterations if not a hitscan projectile
@@ -111,6 +113,17 @@
 		var/turf/T = get_turf(A)
 		if(T)
 			T.hotspot_expose(700, 5)
+
+	if(space_knockback && ismovable(A))
+		var/atom/movable/AM = A
+		if(!AM.anchored && !AM.has_gravity())
+			if(ismob(AM))
+				var/mob/M = AM
+				if(M.check_space_footing())
+					return
+			var/old_dir = AM.dir
+			step(AM,get_dir(firer,AM))
+			AM.set_dir(old_dir)
 
 //Checks if the projectile is eligible for embedding. Not that it necessarily will.
 /obj/item/projectile/can_embed()
@@ -542,3 +555,6 @@
 		SP.SetName((name != "shrapnel")? "[name] shrapnel" : "shrapnel")
 		SP.desc += " It looks like it was fired from [shot_from]."
 		return SP
+
+/obj/item/projectile/Process_Spacemove()
+	return TRUE	//Bullets don't drift in space

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -7,6 +7,7 @@
 	damage_flags = DAMAGE_FLAG_BULLET | DAMAGE_FLAG_SHARP
 	embed = TRUE
 	penetration_modifier = 1.0
+	space_knockback = 1
 	var/mob_passthrough_check = 0
 	var/is_pellet = FALSE
 

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -139,8 +139,7 @@
 		icon_state = "net_roll"
 
 /obj/item/stack/net/proc/attach_wall_check()//checks if wall can be attached to something vertical such as walls or another net-wall
-	var/area/A = get_area(src)
-	if (!A.has_gravity)
+	if (!has_gravity())
 		return 1
 	var/turf/T = get_turf(src)
 	for (var/turf/AT in T.CardinalTurfs(FALSE))

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -48,7 +48,7 @@ exactly 25 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 5 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 348 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 346 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 0 "anchored = 0/1" 'anchored\s*=\s*\d' -P
 exactly 2 "density = 0/1" 'density\s*=\s*\d' -P


### PR DESCRIPTION
Ported from https://github.com/NebulaSS13/Nebula/pull/290 who ported it from TG


> This PR should hopefully greatly improve space combat for nebula.
> I might've made more hot messy spaghetti than a soup kitchen, don't kill me
> ### Features:
> - Allows for objects to drift through space
> - Makes magboots effective at reducing a lot of space related movement
> - Adds in fancy gun knock back recoil, and recoil for being shot
> - Nothing will ever be thrown indefinitely through the void, spacedrift should take over.
> - Improve throwing momentum, allow you to knock other things around with throws
> - Fixes pinning mob to walls for crossbow and spear
> - Fixed lost in space for carbon/human
> - Reduces the usages of spawn, Yay!
> - Reworked all spaceslips failure; using a jetpack with untrained EVA is now a high stress activity


### Changelog

🆑 ImJustKisik
rscadd: Adds SpaceDrift subsystem, that: allows for objects to drift through space, makes magboots effective at reducing a lot of space related movement, adds in fancy gun knock back recoil, and recoil for being shot, improve throwing momentum, allow you to knock other things around with throws.
tweak: Reworked all spaceslips failure - Using a jetpack with untrained EVA is now a high stress activity
/🆑


Thanks @ImJustKisik for porting ♥