### PR TITLE
Add: Bullet holes, sparkles and knockback

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -909,6 +909,7 @@
 #include "code\game\objects\effects\chem\chemsmoke.dm"
 #include "code\game\objects\effects\chem\foam.dm"
 #include "code\game\objects\effects\chem\water.dm"
+#include "code\game\objects\effects\decals\bullet_holes.dm"
 #include "code\game\objects\effects\decals\cleanable.dm"
 #include "code\game\objects\effects\decals\contraband.dm"
 #include "code\game\objects\effects\decals\crayon.dm"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1002,3 +1002,26 @@
 	L.Weaken(2)
 	L.visible_message(SPAN_WARNING("\The [L] [pick("ran", "slammed")] into \the [src]!"))
 	playsound(L, "punch", 25, 1, FALSE)
+
+
+/atom/proc/create_bullethole(obj/item/projectile/Proj)
+	var/p_x = Proj.p_x + rand(-8, 8)
+	var/p_y = Proj.p_y + rand(-8, 8)
+	var/obj/effect/overlay/bmark/bullet_mark = new(src)
+
+	bullet_mark.pixel_x = p_x
+	bullet_mark.pixel_y = p_y
+
+	// offset correction
+	bullet_mark.pixel_x--
+	bullet_mark.pixel_y--
+
+	if(Proj.damage >= 50)
+		bullet_mark.icon_state = "scorch"
+		bullet_mark.set_dir(pick(NORTH,SOUTH,EAST,WEST)) // random scorch design
+	else
+		bullet_mark.icon_state = "light_scorch"
+
+/atom/proc/clear_bulletholes()
+	for(var/obj/effect/overlay/bmark/bullet_mark in src)
+		qdel(bullet_mark)

--- a/code/game/objects/effects/decals/bullet_holes.dm
+++ b/code/game/objects/effects/decals/bullet_holes.dm
@@ -1,0 +1,7 @@
+
+/obj/effect/overlay/bmark
+	name = "bullet hole"
+	desc = "Well someone shot something."
+	icon = 'icons/effects/effects.dmi'
+	layer = DECAL_LAYER
+	icon_state = "scorch"

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -104,6 +104,7 @@
 	if(Proj.ricochet_sounds && prob(15))
 		playsound(src, pick(Proj.ricochet_sounds), 100, 1)
 
+	create_bullethole(Proj)//Potentially infinite bullet holes but most walls don't last long enough for this to be a problem.
 	..()
 
 /turf/simulated/wall/proc/clear_plants()
@@ -118,6 +119,7 @@
 
 /turf/simulated/wall/ChangeTurf(newtype, tell_universe = TRUE, force_lighting_update = FALSE, keep_air = FALSE)
 	clear_plants()
+	clear_bulletholes()
 	. = ..(newtype, tell_universe, force_lighting_update, keep_air)
 	var/turf/new_turf = .
 	for (var/turf/simulated/wall/W in RANGE_TURFS(new_turf, 1))
@@ -201,6 +203,7 @@
 			O.forceMove(src)
 
 	clear_plants()
+	clear_bulletholes()
 	material = SSmaterials.get_material_by_name("placeholder")
 	reinf_material = null
 	update_connections(1)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -103,6 +103,7 @@
 
 	if(Proj.ricochet_sounds && prob(15))
 		playsound(src, pick(Proj.ricochet_sounds), 100, 1)
+		new /obj/effect/sparks(get_turf(Proj))
 
 	create_bullethole(Proj)//Potentially infinite bullet holes but most walls don't last long enough for this to be a problem.
 	..()

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -22,4 +22,6 @@
 			src.embed(I, hit_zone, supplied_wound = created_wound)
 			I.has_embedded()
 
+	hit_impact(effective_force)
+
 	return 1

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -498,3 +498,42 @@ meteor_act
 	if (was_burned)
 		fire_act(air, temperature)
 	return FALSE
+
+/mob/living/carbon/human/hit_impact(damage, dir)
+	if(incapacitated(INCAPACITATION_DEFAULT|INCAPACITATION_BUCKLED_PARTIALLY))
+		return
+	if(damage < 30)
+		..()
+		return
+
+	var/r_dir = GLOB.reverse_dir[dir]
+	var/hit_dirs = (r_dir in GLOB.cardinal) ? r_dir : list(r_dir & NORTH|SOUTH, r_dir & EAST|WEST)
+
+	var/stumbled = FALSE
+
+	if(prob(20 + damage))
+		stumbled = TRUE
+		step(src, pick(GLOB.cardinal - hit_dirs))
+
+	for(var/atom/movable/A in oview(1))
+		if(!A.Adjacent(src) || prob(15 + damage))
+			continue
+
+		else if(istype(A, /obj/machinery/door))
+			var/obj/machinery/door/D = A
+			D.Bumped(src)
+
+		else if(istype(A, /obj/machinery/button))
+			A.attack_hand(src)
+
+		else if(istype(A, /obj/item) || prob(33))
+			if(A.anchored)
+				continue
+			step(A, pick(GLOB.cardinal))
+
+		else
+			continue
+		stumbled = TRUE
+
+	if(stumbled)
+		visible_message(SPAN_WARNING("[src] stumbles around."))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -13,6 +13,12 @@
 		. = 1 - (1 - .) * (1 - armor_datum.get_blocked(damage_type, damage_flags, armor_pen, damage)) // multiply the amount we let through
 	. = min(1, .)
 
+
+/mob/living/proc/hit_impact(damage, dir)
+	if(incapacitated(INCAPACITATION_DEFAULT|INCAPACITATION_BUCKLED_PARTIALLY))
+		return
+	shake_animation(damage)
+
 /mob/living/proc/get_armors_by_zone(def_zone, damage_type, damage_flags)
 	. = list()
 	var/natural_armor = get_extension(src, /datum/extension/armor)
@@ -22,6 +28,7 @@
 		. += get_extension(psi, /datum/extension/armor)
 
 /mob/living/bullet_act(obj/item/projectile/P, def_zone)
+
 	if (status_flags & GODMODE)
 		return PROJECTILE_FORCE_MISS
 
@@ -36,8 +43,14 @@
 	var/damage = P.damage
 	var/flags = P.damage_flags()
 	var/damaged
+	var/hit_dir = get_dir(P, src)
+
+	if(P.knockback)
+		throw_at(get_edge_target_turf(src, hit_dir), P.knockback, P.knockback)
+
 	if(!P.nodamage)
 		damaged = apply_damage(damage, P.damage_type, def_zone, flags, P, P.armor_penetration)
+		hit_impact(P.damage, hit_dir)
 		bullet_impact_visuals(P, def_zone, damaged)
 	if(damaged || P.nodamage) // Run the block computation if we did damage or if we only use armor for effects (nodamage)
 		. = get_blocked_ratio(def_zone, P.damage_type, flags, P.armor_penetration, P.damage)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -45,7 +45,8 @@
 	var/projectile_type = /obj/item/projectile
 	var/penetrating = 0 //If greater than zero, the projectile will pass through dense objects as specified by on_penetrate()
 	var/life_span = 50 //This will de-increment every process(). When 0, it will delete the projectile.
-		//Effects
+
+	//Effects
 	var/stun = 0
 	var/weaken = 0
 	var/paralyze = 0
@@ -56,6 +57,7 @@
 	var/agony = 0
 	var/embed = FALSE // whether or not the projectile can embed itself in the mob
 	var/penetration_modifier = 0.2 //How likely this projectile is to embed or rupture artery
+	var/knockback = 0 // does it knockback mobs by hit
 
 	var/hitscan = FALSE		// whether the projectile should be hitscan
 	var/step_delay = 1	// the delay between iterations if not a hitscan projectile

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -165,6 +165,7 @@
 	fire_sound = 'sound/weapons/gunshot/shotgun.ogg'
 	damage = 65
 	armor_penetration = 10
+	knockback = 1
 
 /obj/item/projectile/bullet/shotgun/beanbag		//because beanbags are not bullets
 	name = "beanbag"
@@ -185,6 +186,7 @@
 	pellets = 6
 	range_step = 1
 	spread_step = 50
+	knockback = 1
 
 /obj/item/projectile/bullet/pellet/shotgun/flechette
 	name = "flechette"
@@ -198,6 +200,7 @@
 	spread_step = 2
 	penetration_modifier = 0.5
 	hitchance_mod = 5
+	knockback = 0
 
 /* "Rifle" rounds */
 


### PR DESCRIPTION
+ Adds bullet holes
+ Ricochet causes a spark at the point of deflection of the bullet
+ Added knockback effect to some types of bullets. A mob hit by such a bullet will be pushed back, taking damage if there is an obstacle
+ If a character received 30 or more damage one time, then he will fall, move things and interact with doors and buttons.

![image](https://github.com/SierraBay/SierraBay12/assets/87862013/2da1f41e-232d-4f7f-a0d7-aa059f8c92a7)


### Changelog


🆑 ImJustKisik
rscadd: Bullets now leave holes.
rscadd: Ricochet sparkles.
rscadd: Shotgun blast knocks back whoever is hit.
/🆑


Thanks @ImJustKisik ♥