### PR TITLE
Colored check-paths.sh

### DIFF
--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -14,9 +14,13 @@ exactly() { # exactly N name search [mode] [filter]
 	num="$(grep "$mode" "$search" $filter | wc -l || true)"
 
 	if [ $num -eq $count ]; then
-		echo "$num $name"
+		echo "[1;32mOK[0m $num $name"
 	else
-		echo "$(tput setaf 9)$num $name (expecting exactly $count)$(tput sgr0)"
+		echo "[1;31mFAIL[0m $num $name (expecting exactly $count)"
+		if [ $1 -lt 30 ]; then
+			echo "entries:"
+			grep "$mode" "$search" $filter
+		fi
 		FAILED=1
 	fi
 }


### PR DESCRIPTION
Makes it easier to find errors in the logs

- Success is green `OK`
- Fail is red `FAIL`
- If less than 30 matches are to be found, shows a list of matched grep files


| Before | After |
|------|-------|
| ![image](https://github.com/Baystation12/Baystation12/assets/32931701/55e5768a-1faf-4468-910b-f3911ad2ac3e) | ![image](https://github.com/Baystation12/Baystation12/assets/32931701/c6766949-bd97-440d-a986-2cab3404d351) |


# WHY?
Because tput doesn't work for some reason.
Also with colored labels `FAIL` and `OK` it looks fancier

