### PR TITLE
Assess bodypart checks for laser and managed incisions

### DIFF
--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -29,6 +29,15 @@
 	min_duration = 90
 	max_duration = 110
 
+/singleton/surgery_step/generic/cut_with_laser/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	. = ..()
+	if(.)
+		var/obj/item/organ/external/affected = .
+		if(affected.how_open())
+			var/datum/wound/cut/incision = affected.get_incision()
+			to_chat(user, SPAN_NOTICE("The [incision.desc] provides enough access."))
+			return FALSE
+
 /singleton/surgery_step/generic/cut_with_laser/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message("[user] starts the bloodless incision on [target]'s [affected.name] with \the [tool].", \
@@ -61,6 +70,15 @@
 	)
 	min_duration = 80
 	max_duration = 120
+
+/singleton/surgery_step/generic/managed/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	. = ..()
+	if(.)
+		var/obj/item/organ/external/affected = .
+		if(affected.how_open())
+			var/datum/wound/cut/incision = affected.get_incision()
+			to_chat(user, SPAN_NOTICE("The [incision.desc] provides enough access."))
+			return FALSE
 
 /singleton/surgery_step/generic/managed/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)


### PR DESCRIPTION
:cl: BoNT
bugfix: Laser scalpels and IMS will check if there is already an existing incision, like regular scalpels.
/:cl:

Adding in the checks that the other surgery steps have, but laser and managed incisions were missing. This prevents endlessly making incisions when one is already present on the target body part.