### PR TITLE
makes things wibbly

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -1,7 +1,7 @@
 /atom/movable
 	layer = OBJ_LAYER
 
-	glide_size = 5
+	glide_size = 4
 
 	animate_movement = SLIDE_STEPS
 

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -1,6 +1,7 @@
 /obj
 	layer = OBJ_LAYER
 	animate_movement = 2
+	glide_size = 3
 
 	var/obj_flags
 


### PR DESCRIPTION
speculative - people might hate it.

/atom/movable glide size is ~~5~~ 4 post-40fps.
This makes /obj glide size 3.
It makes dragging stuff look like this.

https://github.com/Baystation12/Baystation12/assets/918997/03b1cd49-1b6f-447e-984f-8df455d72f5c

