### PR TITLE
Add stat lines to evacuation subsystem

### DIFF
--- a/code/controllers/evacuation/evacuation.dm
+++ b/code/controllers/evacuation/evacuation.dm
@@ -186,3 +186,35 @@ var/global/datum/evacuation_controller/evacuation_controller
 
 /datum/evacuation_controller/proc/should_call_autotransfer_vote()
 	return (state == EVAC_IDLE)
+
+
+/datum/evacuation_controller/proc/UpdateStat()
+	var/stat_text = "Invalid State"
+	switch (state)
+		if (EVAC_IDLE)
+			stat_text = "Idle"
+		if (EVAC_PREPPING)
+			stat_text = "Preparing"
+			stat_text += " | Emergency: [emergency_evacuation ? "Y" : "N"]"
+			stat_text += " | Called At: [worldtime2stationtime(evac_called_at)]"
+			stat_text += " | Ready In: [time_to_readable(evac_ready_time - world.time)]"
+			stat_text += " | No Return: [world.time > evac_no_return ? "Y" : "In [time_to_readable(evac_no_return - world.time)]"]"
+			stat_text += " | Recall: [recall ? "Y ([time_to_readable(auto_recall_time - world.time)])" : "N"]"
+		if (EVAC_LAUNCHING)
+			stat_text = "Launching"
+			stat_text += " | Emergency: [emergency_evacuation ? "Y" : "N"]"
+			stat_text += " | Called At: [worldtime2stationtime(evac_called_at)]"
+			stat_text += " | Launch In: [time_to_readable(evac_launch_time - world.time)]"
+		if (EVAC_IN_TRANSIT)
+			stat_text = "In Transit"
+			stat_text += " | Emergency: [emergency_evacuation ? "Y" : "N"]"
+			stat_text += " | Called At: [worldtime2stationtime(evac_called_at)]"
+			stat_text += " | Arrive In: [time_to_readable(evac_arrival_time - world.time)]"
+		if (EVAC_COOLDOWN)
+			stat_text = "Cooldown"
+			stat_text += " | Emergency: [emergency_evacuation ? "Y" : "N"]"
+			stat_text += " | Idle In: [time_to_readable(evac_cooldown_time - world.time)]"
+		if (EVAC_COMPLETE)
+			stat_text = "Complete"
+			stat_text += " | Emergency: [emergency_evacuation ? "Y" : "N"]"
+	return stat_text

--- a/code/controllers/subsystems/evac.dm
+++ b/code/controllers/subsystems/evac.dm
@@ -12,7 +12,9 @@ SUBSYSTEM_DEF(evac)
 
 
 /datum/controller/subsystem/evac/UpdateStat(time)
-	return ..()
+	if (PreventUpdateStat(time))
+		return ..()
+	return ..(evacuation_controller.UpdateStat())
 
 
 /datum/controller/subsystem/evac/fire(resumed, no_mc_tick)


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
admin: Evacuation subsystem now displays stat information in the MC tab, including current stage, time to next stage, time evac was called, and the point of no return status.
/:cl:

![dreamseeker_OqjCXBxZyK](https://github.com/Baystation12/Baystation12/assets/11140088/d1da568d-d057-4742-9a5e-af7bed997f37)
