### PR TITLE
Fix double-actions when climbing

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -969,6 +969,7 @@
 	var/mob/living/H = user
 	if(istype(H) && can_climb(H) && target == user)
 		do_climb(target)
+		return TRUE
 	else
 		return ..()
 


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Climbing tables no longer displays a message about buckling.
/:cl: