### PR TITLE
Fixes Scoped Guns. Makes Panther Usable.

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -548,11 +548,10 @@
 			screen_shake = round(screen_shake*zoom_amount+1) //screen shake is worse when looking through a scope
 
 //make sure accuracy and screen_shake are reset regardless of how the item is unzoomed.
-/obj/item/gun/zoom()
+/obj/item/gun/unzoom()
 	..()
-	if(!zoom)
-		accuracy = initial(accuracy)
-		screen_shake = initial(screen_shake)
+	accuracy = initial(accuracy)
+	screen_shake = initial(screen_shake)
 
 /obj/item/gun/examine(mob/user)
 	. = ..()

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -111,10 +111,10 @@
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/rifle
 	allowed_magazines = /obj/item/ammo_magazine/rifle
-	one_hand_penalty = 9
-	scoped_accuracy = 6
+	one_hand_penalty = 8
+	scoped_accuracy = 8
 	scope_zoom = 1
-	accuracy_power = 9
+	accuracy_power = 8
 	accuracy = 4
 	bulk = GUN_BULK_RIFLE
 	wielded_item_state = "dmr-wielded"


### PR DESCRIPTION
:cl:
bugfix: Scoped guns now no longer throw your camera across the map with recoil and will properly reset to initial values.
tweak: The Panther has 2 tiles extra of scoped accuracy to be more usable at below Master WE.
/:cl:

Scoping with the AMR and DMR no longer sends your client to the shadow realm. Raa.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->