### PR TITLE
Fix: Schema dump

### DIFF
--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -54,7 +54,7 @@ CREATE TABLE IF NOT EXISTS `erro_player` (
   `lastadminrank` text DEFAULT NULL,
   `staffwarn` text DEFAULT NULL,
   PRIMARY KEY (`id`),
-  UNIQUE KEY `ckey` (`ckey`) USING HASH,
+  UNIQUE KEY `ckey` (`ckey`(768)) USING HASH,
   KEY `ckey_2` (`ckey`(768)),
   KEY `ip` (`ip`(768)),
   KEY `computerid` (`computerid`(768))


### PR DESCRIPTION
`erro_player` schema fails to apply with error:
```
ERROR 1170 (42000): BLOB/TEXT column 'ckey' used in key specification without a key length
```

Google says that text type doesn't have any length and mariadb doesn't know how much to parse and it seems to be true

Banditoz#6474 showd me mariadb docs, where we could find:
> `TEXT` columns can only be indexed over a specified length. This means that they cannot be used as the [primary key](https://mariadb.com/kb/en/getting-started-with-indexes/#primary-key) of a table norm until [MariaDB 10.4](https://mariadb.com/kb/en/what-is-mariadb-104/), can a [unique index](https://mariadb.com/kb/en/getting-started-with-indexes/#unique-index) be created on them.


With length specified it doesn't error ![:okayGe:](https://github.com/Baystation12/Baystation12/assets/32931701/cb428205-b403-437a-8fa7-a31871a3edf7)

