### PR TITLE
Fixes emagging vending machines

### DIFF
--- a/code/game/machinery/vending/_vending.dm
+++ b/code/game/machinery/vending/_vending.dm
@@ -134,7 +134,7 @@
 		return
 	emagged = TRUE
 	req_access.Cut()
-	vendor_wires.UpdateShowContraband(TRUE)
+	UpdateShowContraband(TRUE)
 	SSnano.update_uis(src)
 	to_chat(user, "You short out the product lock on \the [src].")
 	return 1

--- a/code/game/machinery/vending/_vending.dm
+++ b/code/game/machinery/vending/_vending.dm
@@ -114,6 +114,8 @@
 			icon_state = "[initial(icon_state)]-off"
 	if (panel_open)
 		overlays += image(icon, "[initial(icon_state)]-panel")
+	if(!vend_ready)
+		overlays += image(icon, "[initial(icon_state)]-shelf[rand(3)]")
 
 
 /obj/machinery/vending/ex_act(severity)
@@ -381,6 +383,7 @@
 	status_message = "Vending..."
 	status_error = FALSE
 	SSnano.update_uis(src)
+	update_icon()
 	if (product.category & VENDOR_CATEGORY_COIN)
 		if(!coin)
 			to_chat(user, SPAN_NOTICE("You need to insert a coin to get this item."))
@@ -415,6 +418,7 @@
 		status_message = ""
 		status_error = FALSE
 		vend_ready = TRUE
+		update_icon()
 		currently_vending = null
 		SSnano.update_uis(src)
 

--- a/code/game/machinery/vending/hydroseeds.dm
+++ b/code/game/machinery/vending/hydroseeds.dm
@@ -68,11 +68,6 @@
 	)
 
 
-/obj/machinery/vending/hydroseeds/vend(datum/stored_items/vending_products/products, mob/living/user)
-	..()
-	flick("[icon_state]-shelf[rand(3)]", src)
-
-
 /obj/machinery/vending/hydroseeds/build_inventory()
 	var/list/all_products = list(
 		list(products, VENDOR_CATEGORY_NORMAL),


### PR DESCRIPTION
🆑 
bugfix: Emagging a vending machine unlocks hidden items again.
bugfix: Fixes seed vendor disappearing for a second when vending items.
/🆑 

Emags only removed access requirements, did not unlock contraband items even though the code (and common sense) intended them to. 

So I'll be honest. After staring at all the code related to cutting and pulsing and flags and what have you, I figured the only thing that could possibly be causing the bug was this. Not sure why, but I know it now works after testing. If someone can teach me why that worked I'd appreciate it! I figured it's because the proc was already being called under vending and adding vendor_wires. was redundant. 