### PR TITLE
Adds rarity functionality to vending machines

### DIFF
--- a/code/game/machinery/vending/_vending.dm
+++ b/code/game/machinery/vending/_vending.dm
@@ -47,9 +47,15 @@
 	var/status_message = "" // Status screen messages like "insufficient funds", displayed in NanoUI
 	var/status_error = 0 // Set to 1 if status_message is an error
 	var/list/prices = list() // Prices for each product as (/item/path = price). Unlisted items are free.
-	var/list/products	= list() // Stock for each product as (/item/path = count)
-	var/list/contraband	= list() // Stock for products hidden by the contraband wire as (/item/path = count)
-	var/list/premium = list() // Stock for products hidden by coin insertion as (/item/path = count)
+
+	/// Stock for each product as (/item/path = count). Set to '0' if you want the vendor to randomly spawn between 1 and 10 items.
+	var/list/products	= list()
+	///Probability of each rare product of spawning in, max amount increases with large value. Need to have value of '0' associated with it in product list for this to work.
+	var/list/rare_products = list()
+	/// Stock for products hidden by the contraband wire as (/item/path = count)
+	var/list/contraband	= list()
+	/// Stock for products hidden by coin insertion as (/item/path = count)
+	var/list/premium = list()
 
 	var/list/product_records = list()
 	var/product_slogans = "" //String of slogans spoken out loud, separated by semicolons
@@ -481,8 +487,11 @@
 		for (var/entry in current_list[1])
 			var/datum/stored_items/vending_products/product = new/datum/stored_items/vending_products(src, entry)
 			product.price = (entry in prices) ? prices[entry] : 0
+			product.rarity = (entry in rare_products) ? rare_products[entry] : 100
 			if (populate_parts)
-				product.amount = (current_list[1][entry]) ? current_list[1][entry] : 1
+				product.amount = current_list[1][entry]
+				if (!product.amount)
+					product.amount = prob(product.rarity) * rand(1,ceil(product.rarity/10))
 			product.category = category
 			product_records.Add(product)
 

--- a/code/game/machinery/vending/_vending_products.dm
+++ b/code/game/machinery/vending/_vending_products.dm
@@ -2,10 +2,12 @@
 	var/price
 	var/display_color
 	var/category
+	var/rarity
 
 
-/datum/stored_items/vending_products/New(atom/vending_machine, path, name, amount, price, color, category)
+/datum/stored_items/vending_products/New(atom/vending_machine, path, name, amount, price, color, category, rarity)
 	..()
 	price = price
 	display_color = color
 	category = category
+	rarity = rarity

--- a/code/game/machinery/vending/cola.dm
+++ b/code/game/machinery/vending/cola.dm
@@ -26,7 +26,9 @@
 		/obj/item/reagent_containers/food/drinks/cans/waterbottle = 2,
 		/obj/item/reagent_containers/food/drinks/cans/space_up = 1,
 		/obj/item/reagent_containers/food/drinks/cans/iced_tea = 1,
-		/obj/item/reagent_containers/food/drinks/cans/grape_juice = 1
+		/obj/item/reagent_containers/food/drinks/cans/grape_juice = 1,
+		/obj/item/reagent_containers/food/drinks/cans/cola_pork = 10,
+		/obj/item/reagent_containers/food/drinks/cans/syndicola = 5
 	)
 	products = list(
 		/obj/item/reagent_containers/food/drinks/cans/cola = 10,
@@ -36,7 +38,14 @@
 		/obj/item/reagent_containers/food/drinks/cans/waterbottle = 10,
 		/obj/item/reagent_containers/food/drinks/cans/space_up = 10,
 		/obj/item/reagent_containers/food/drinks/cans/iced_tea = 10,
-		/obj/item/reagent_containers/food/drinks/cans/grape_juice = 10
+		/obj/item/reagent_containers/food/drinks/cans/grape_juice = 10,
+		/obj/item/reagent_containers/food/drinks/cans/cola_pork = 0,
+		/obj/item/reagent_containers/food/drinks/cans/syndicola = 0
+	)
+	rare_products = list(
+		/obj/item/reagent_containers/food/drinks/cans/cola_pork = 75,
+		/obj/item/reagent_containers/food/drinks/cans/syndicola = 30
+
 	)
 	contraband = list(
 		/obj/item/reagent_containers/food/drinks/cans/thirteenloko = 5,


### PR DESCRIPTION
🆑 emmanuelbassil
tweak: Vending machines now have the ability to spawn 'rare' items based on chance. Functionality to randomize amount of stuff in the machine as well.
tweak: Cola vending machine now has a random chance to spawn with two rare drinks.
/🆑 

Did this for the medal vendor, might as well merge the functionality in. Wanted to implement it somewhere to have an example without rocking the boat, figured adding one drink not found on the map and another only found in soviet soda would be fine. 
