### PR TITLE
ZLevel travel time fix

### DIFF
--- a/code/modules/xenoarcheaology/tools/transport_drone.dm
+++ b/code/modules/xenoarcheaology/tools/transport_drone.dm
@@ -223,7 +223,7 @@
 		var/flight_time = 10 SECONDS //At least 10 seconds to get there, regardless
 
 		if (other && self && (other.z == self.z)) //Can visitables even not be in same overmap level?
-			flight_time += get_dist(other, self) * 15 SECONDS
+			flight_time += get_dist(other, self) * tile_travel_time
 		current_flight.time_of_arrival = world.time +  flight_time
 
 		designator.audible_message(SPAN_NOTICE("<b>\The [designator]</b> pings, Request acknowledged. Drone en route. Delivery expected in T - [ (flight_time) / (1 SECOND)] seconds."))


### PR DESCRIPTION
```yml
🆑SuhEugene
bugfix: Transport drone pad scanners upgrade now works
/🆑
```

idk why it was hardcoded, but it's a variable that isn't used so i thought this is a bug