### PR TITLE
separates nitrile and latex gloves into their own boxes, fills each

### DIFF
--- a/code/datums/supplypacks/medical.dm
+++ b/code/datums/supplypacks/medical.dm
@@ -4,7 +4,10 @@
 
 /singleton/hierarchy/supply_pack/medical/gloves
 	name = "Refills - Sterile gloves"
-	contains = list(/obj/item/storage/box/gloves = 4)
+	contains = list(
+		/obj/item/storage/box/latexgloves = 2,
+		/obj/item/storage/box/nitrilegloves = 2
+	)
 	cost = 20
 	containername = "medical crate"
 
@@ -265,7 +268,8 @@
 					/obj/item/clothing/head/surgery/blue,
 					/obj/item/clothing/head/surgery/green,
 					/obj/item/storage/box/masks,
-					/obj/item/storage/box/gloves)
+					/obj/item/storage/box/latexgloves
+	)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure
 	containername = "medical scrubs crate"
@@ -279,8 +283,9 @@
 					/obj/item/autopsy_scanner,
 					/obj/item/scalpel/basic,
 					/obj/item/storage/box/masks,
-					/obj/item/storage/box/gloves,
-					/obj/item/pen)
+					/obj/item/storage/box/latexgloves,
+					/obj/item/pen
+	)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure
 	containername = "autopsy equipment crate"
@@ -304,7 +309,8 @@
 					/obj/item/clothing/suit/storage/toggle/labcoat/virologist,
 					/obj/item/clothing/suit/storage/toggle/labcoat/chemist,
 					/obj/item/storage/box/masks,
-					/obj/item/storage/box/gloves)
+					/obj/item/storage/box/latexgloves
+	)
 	cost = 15
 	containertype = /obj/structure/closet/crate/secure
 	containername = "medical uniform crate"
@@ -319,7 +325,8 @@
 					/obj/item/clothing/mask/gas = 5,
 					/obj/item/tank/oxygen = 5,
 					/obj/item/storage/box/masks,
-					/obj/item/storage/box/gloves)
+					/obj/item/storage/box/latexgloves
+	)
 	cost = 50
 	containertype = /obj/structure/closet/crate/secure
 	containername = "medical biohazard equipment crate"
@@ -356,8 +363,9 @@
 	contains = list(/obj/item/clothing/under/rank/medical/scrubs/green = 2,
 					/obj/item/clothing/head/surgery/green = 2,
 					/obj/item/storage/box/masks,
-					/obj/item/storage/box/gloves,
-					/obj/item/storage/belt/medical = 3)
+					/obj/item/storage/box/latexgloves,
+					/obj/item/storage/belt/medical = 3
+	)
 	cost = 15
 	containertype = /obj/structure/closet/crate
 	containername = "sterile clothes crate"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -114,12 +114,19 @@
 					/obj/item/reagent_containers/food/snacks/proteinbar = 1,
 					/obj/item/device/oxycandle = 1)
 
-/obj/item/storage/box/gloves
-	name = "box of sterile gloves"
-	desc = "Contains sterile gloves."
+/obj/item/storage/box/latexgloves
+	name = "box of sterile latex gloves"
+	desc = "Contains sterile latex gloves."
 	icon_state = "latex"
-	startswith = list(/obj/item/clothing/gloves/latex = 6,
-					/obj/item/clothing/gloves/latex/nitrile = 2)
+	startswith = list(/obj/item/clothing/gloves/latex = 14)
+
+
+/obj/item/storage/box/nitrilegloves
+	name = "box of sterile nitrile gloves"
+	desc = "Contains sterile nitrile gloves."
+	icon_state = "latex"
+	startswith = list(/obj/item/clothing/gloves/latex/nitrile = 14)
+
 
 /obj/item/storage/box/masks
 	name = "box of sterile masks"

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -762,7 +762,7 @@
 		/obj/item/storage/box/autoinjectors = 3,
 		/obj/item/storage/box/beakers = 4,
 		/obj/item/storage/box/syringes = 4,
-		/obj/item/storage/box/gloves = 4,
+		/obj/item/storage/box/latexgloves = 4,
 		/obj/item/storage/box/large = 3,
 		/obj/item/storage/box/glowsticks = 4,
 		/obj/item/storage/wallet = 2,

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -27,7 +27,7 @@
 		/obj/item/reagent_containers/glass/bottle/antitoxin = 2,
 		/obj/random/firstaid,
 		/obj/item/storage/box/masks,
-		/obj/item/storage/box/gloves
+		/obj/item/storage/box/latexgloves
 	)
 
 /obj/structure/closet/secure_closet/medical2
@@ -180,7 +180,7 @@
 		/obj/item/reagent_containers/syringe/antiviral,
 		/obj/item/reagent_containers/glass/bottle/antitoxin,
 		/obj/item/storage/box/masks,
-		/obj/item/storage/box/gloves,
+		/obj/item/storage/box/latexgloves,
 		/obj/item/clothing/under/rank/virologist,
 		/obj/item/clothing/shoes/white,
 		/obj/item/clothing/suit/storage/toggle/labcoat/virologist,

--- a/maps/antag_spawn/ert/ert_base.dmm
+++ b/maps/antag_spawn/ert/ert_base.dmm
@@ -1013,8 +1013,8 @@
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/gloves,
+/obj/item/storage/box/latexgloves,
+/obj/item/storage/box/nitrilegloves,
 /obj/item/storage/box/masks,
 /turf/unsimulated/floor{
 	dir = 1;

--- a/maps/away/errant_pisces/errant_pisces.dmm
+++ b/maps/away/errant_pisces/errant_pisces.dmm
@@ -4569,7 +4569,7 @@
 /area/errant_pisces/science_wing)
 "ly" = (
 /obj/structure/table/standard,
-/obj/item/storage/box/gloves,
+/obj/item/storage/box/latexgloves,
 /turf/simulated/floor/tiled,
 /area/errant_pisces/science_wing)
 "lz" = (

--- a/maps/away/lar_maria/lar_maria-1.dmm
+++ b/maps/away/lar_maria/lar_maria-1.dmm
@@ -568,7 +568,7 @@
 	},
 /obj/structure/table/glass,
 /obj/item/storage/box/masks,
-/obj/item/storage/box/gloves,
+/obj/item/storage/box/latexgloves,
 /obj/item/reagent_containers/spray/sterilizine,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_main)
@@ -1978,7 +1978,7 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/structure/table/glass,
 /obj/item/storage/box/masks,
-/obj/item/storage/box/gloves,
+/obj/item/storage/box/latexgloves,
 /turf/simulated/floor/tiled/white,
 /area/lar_maria/vir_aux)
 "fs" = (

--- a/maps/away/scavver/scavver_gantry-1.dmm
+++ b/maps/away/scavver/scavver_gantry-1.dmm
@@ -843,7 +843,7 @@
 /obj/item/reagent_containers/food/drinks/cans/waterbottle,
 /obj/item/reagent_containers/ivbag,
 /obj/item/reagent_containers/ivbag,
-/obj/item/storage/box/gloves,
+/obj/item/storage/box/latexgloves,
 /turf/simulated/floor/tiled/white/monotile,
 /area/scavver/calypso)
 "ny" = (

--- a/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
+++ b/maps/away/skrellscoutship/skrellscoutship_revamp.dmm
@@ -1199,7 +1199,7 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
-/obj/item/storage/box/gloves{
+/obj/item/storage/box/nitrilegloves{
 	pixel_x = 7;
 	pixel_y = -3
 	},
@@ -4711,7 +4711,7 @@
 /area/ship/skrellscoutship/crew/rec)
 "Ds" = (
 /obj/structure/table/glass,
-/obj/item/storage/box/gloves,
+/obj/item/storage/box/nitrilegloves,
 /obj/item/storage/box/syringes{
 	pixel_x = 4;
 	pixel_y = 4

--- a/maps/example/example-2.dmm
+++ b/maps/example/example-2.dmm
@@ -187,7 +187,7 @@
 "oW" = (
 /obj/effect/floor_decal/corner/blue/diagonal,
 /obj/structure/table/glass,
-/obj/item/storage/box/gloves,
+/obj/item/storage/box/latexgloves,
 /obj/item/storage/box/masks,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/colony.dmm
@@ -1734,7 +1734,7 @@
 "dL" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/firstaid/adv,
-/obj/item/storage/box/gloves,
+/obj/item/storage/box/latexgloves,
 /turf/simulated/floor/tiled/freezer,
 /area/map_template/colony/surgery)
 "dM" = (

--- a/maps/random_ruins/exoplanet_ruins/playablecolony2/colony2.dmm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony2/colony2.dmm
@@ -478,7 +478,7 @@
 "gw" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/storage/firstaid/adv,
-/obj/item/storage/box/gloves,
+/obj/item/storage/box/latexgloves,
 /turf/simulated/floor/tiled/white,
 /area/map_template/colony2/ship)
 "gD" = (

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -11548,7 +11548,7 @@
 /obj/item/storage/box/beakers,
 /obj/item/storage/box/bodybags,
 /obj/item/storage/box/masks,
-/obj/item/storage/box/gloves{
+/obj/item/storage/box/latexgloves{
 	pixel_x = 4;
 	pixel_y = 4
 	},

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -5692,8 +5692,8 @@
 /obj/structure/table/rack,
 /obj/item/screwdriver,
 /obj/item/storage/box/masks,
-/obj/item/storage/box/gloves,
-/obj/item/storage/box/gloves,
+/obj/item/storage/box/latexgloves,
+/obj/item/storage/box/nitrilegloves,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
 /obj/effect/floor_decal/corner/paleblue/mono,
@@ -25891,7 +25891,7 @@
 /obj/item/clothing/suit/storage/toggle/labcoat,
 /obj/item/storage/box/evidence,
 /obj/item/storage/box/syringes,
-/obj/item/storage/box/gloves,
+/obj/item/storage/box/latexgloves,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/window/reinforced{
 	dir = 8

--- a/maps/torch/z1_admin.dmm
+++ b/maps/torch/z1_admin.dmm
@@ -4717,7 +4717,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/box/autoinjectors,
 /obj/item/storage/box/beakers,
-/obj/item/storage/box/gloves,
+/obj/item/storage/box/latexgloves,
 /obj/item/storage/box/pillbottles,
 /obj/item/bodybag/cryobag,
 /obj/item/bodybag/cryobag,
@@ -6680,7 +6680,7 @@
 /area/centcom/holding)
 "aJo" = (
 /obj/structure/table/standard,
-/obj/item/storage/box/gloves{
+/obj/item/storage/box/latexgloves{
 	pixel_x = 3;
 	pixel_y = 4
 	},
@@ -6725,7 +6725,7 @@
 /area/tdome)
 "aJw" = (
 /obj/structure/table/standard,
-/obj/item/storage/box/gloves{
+/obj/item/storage/box/latexgloves{
 	pixel_x = 3;
 	pixel_y = 4
 	},

--- a/packs/deepmaint/deepmaint_rooms/normal/lab.dmm
+++ b/packs/deepmaint/deepmaint_rooms/normal/lab.dmm
@@ -93,7 +93,7 @@
 "gu" = (
 /obj/structure/table/rack,
 /obj/item/storage/box/masks,
-/obj/item/storage/box/gloves,
+/obj/item/storage/box/latexgloves,
 /obj/effect/floor_decal/corner/lime/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/map_template/deepmaint)


### PR DESCRIPTION
🆑Gy1ta23
tweak: latex gloves and nitrile gloves are now separate
/🆑

Now, we all know latex allergies don't exist in 2311. However, even without the commingling and all that being a health risk, it's still not exactly ideal to have half-filled (or just under) latex glove boxes topped off with two nitrile glove sets, especially given the "half" and "disposable" aspects. Not quite all that efficient, either, having the types mixed, nor entirely sensible by any metric I can dream up. This change will fix this, by turning one box of both types into two of one and filling both appropriately. I appreciate that the sterile glove repacking industry might be upset with this body-blow to their core business, but you always need to break a few knees to make a proper change, as the saying goes.