### PR TITLE
Assorted Fixes

### DIFF
--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -152,7 +152,7 @@
 		return TRUE
 
 	else if (!(W.item_flags & ITEM_FLAG_WASHER_ALLOWED))
-		if (isScrewdriver(W) || isCrowbar(W) || isWrench(W))
+		if (isScrewdriver(W) || isCrowbar(W) || isWrench(W) || can_add_component(W))
 			return ..()
 
 		to_chat(user, SPAN_WARNING("\The [W] can't be washed in \the [src]!"))

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -84,8 +84,8 @@
 	var/sheet_icon_base = "sheet"
 	/// String. Icon overlay used for reinforced stacks.
 	var/sheet_icon_reinf = "reinf-overlay"
-	/// Boolean (Default `FALSE`). If set, material stacks will not have alt icons for plural or max.
-	var/sheet_no_plural_icon = FALSE
+	/// Boolean (Default `TRUE`). If set, material stacks will have alt icons for plural or max.
+	var/sheet_has_plural_icon = TRUE
 	/// String. Wall base icon state. See header.
 	var/wall_icon_base = "metal"
 	/// String. Icon overlay used for reinforced walls.

--- a/code/modules/materials/definitions/materials_metal.dm
+++ b/code/modules/materials/definitions/materials_metal.dm
@@ -286,7 +286,7 @@
 	wall_name = "bulkhead"
 	stack_type = /obj/item/stack/material/mhydrogen
 	sheet_icon_base = "sheet-mythril"
-	sheet_no_plural_icon = TRUE
+	sheet_has_plural_icon = FALSE
 	icon_colour = "#e6c5de"
 	stack_origin_tech = list(TECH_MATERIAL = 6, TECH_POWER = 6, TECH_MAGNET = 5)
 	is_fusion_fuel = 1

--- a/code/modules/materials/definitions/materials_organic.dm
+++ b/code/modules/materials/definitions/materials_organic.dm
@@ -273,7 +273,7 @@
 	name = MATERIAL_LEATHER_GENERIC
 	icon_colour = "#5c4831"
 	sheet_icon_base = "sheet-leather"
-	sheet_no_plural_icon = TRUE
+	sheet_has_plural_icon = FALSE
 	stack_origin_tech = list(TECH_MATERIAL = 2)
 	flags = MATERIAL_PADDING
 	ignition_point = T0C+300

--- a/code/modules/materials/material_sheets.dm
+++ b/code/modules/materials/material_sheets.dm
@@ -48,14 +48,16 @@
 	if (!override_icon)
 		if (HAS_FLAGS(material_flags, USE_MATERIAL_ICON))
 			base_state = material.sheet_icon_base
-		plural_icon_state = "[base_state]-mult"
-		max_icon_state = "[base_state]-max"
+		if (material.sheet_has_plural_icon)
+			plural_icon_state = "[base_state]-mult"
+			max_icon_state = "[base_state]-max"
 		reinf_state = null
 		if (reinf_material)
 			if (HAS_FLAGS(material_flags, USE_MATERIAL_ICON))
 				reinf_state = material.sheet_icon_reinf
-			plural_reinf_state = "[reinf_state]-mult"
-			max_reinf_state = "[reinf_state]-max"
+			if (material.sheet_has_plural_icon)
+				plural_reinf_state = "[reinf_state]-mult"
+				max_reinf_state = "[reinf_state]-max"
 
 	// Update Attributes
 	stacktype = material.stack_type

--- a/code/modules/synthesized_instruments/real_instruments.dm
+++ b/code/modules/synthesized_instruments/real_instruments.dm
@@ -214,6 +214,7 @@
 	var/datum/instrument/instruments = list()
 	var/path = /datum/instrument
 	var/sound_player = /datum/sound_player
+	obj_flags = OBJ_FLAG_ANCHORABLE
 
 /obj/structure/synthesized_instrument/Initialize()
 	. = ..()

--- a/code/modules/synthesized_instruments/real_instruments/Synthesizer/synthesizer.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Synthesizer/synthesizer.dm
@@ -30,4 +30,4 @@
 	name = "space minimoog"
 	desc = "This is a minimoog, like a space piano, but more spacey!"
 	icon_state = "minimoog"
-	obj_flags = OBJ_FLAG_ROTATABLE
+	obj_flags = OBJ_FLAG_ROTATABLE | OBJ_FLAG_ANCHORABLE


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: You will now be able to dismantle unreinforced windows that spawn in with the map
bugfix: Leather sheets and material hydrogen sheets will no longer disappear when in stacks greater than 2
bugfix: Pianos and the minimoog can be unwrenched and wrenched at your heart's content again.
bugfix: Can now properly disassemble/reassemble washing machines.
/🆑  

Switched sheet_no_plural_icon to sheet_has_plural_icons which is true by default only because only two sheets don't have plural icons and I didn't want to do a double negative. That var was defined but unused, which is why these stacks disappeared.

As for windows, spawned in windows defaulted to a construction state of 2. So you could not wrench unanchored unreinforced windows that were spawned in because the game thought they were still anchored. Used constants similar to particle accelerator.dm to make it more readable.