### PR TITLE
Makes Wardrobes anchored

### DIFF
--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -223,7 +223,7 @@
 		return
 	user.visible_message(
 		SPAN_NOTICE("\The [user] [anchored ? "un" : ""]secures \the [src] [anchored ? "from" : "to"] the floor with \a [tool]."),
-		SPAN_NOTICE("You [anchored ? "un" : ""]secures \the [src] [anchored ? "from" : "to"] the floor with \the [tool].")
+		SPAN_NOTICE("You [anchored ? "un" : ""]secure \the [src] [anchored ? "from" : "to"] the floor with \the [tool].")
 	)
 	playsound(src, 'sound/items/Ratchet.ogg', 50, TRUE)
 	anchored = !anchored

--- a/code/game/objects/structures/under_wardrobe.dm
+++ b/code/game/objects/structures/under_wardrobe.dm
@@ -6,6 +6,8 @@
 	icon = 'icons/obj/undies_wardrobe.dmi'
 	icon_state = "closed"
 	density = TRUE
+	anchored = TRUE
+	obj_flags = OBJ_FLAG_ANCHORABLE
 	var/static/list/amount_of_underwear_by_id_card
 
 


### PR DESCRIPTION
I cannot count the number of items I've mistakenly pushed the wardrobe onto the bed in the CO's office; every time I walk into that office.
I know wardrobes are technically meant to be fancy lockers, but unlike lockers there is no gameplay benefit at having them unanchored at baseline. They now start anchored and can be unwrenched if you have an urgent underwear delivery.

Also; fixed a small typo in the wrenching prompt.