### PR TITLE
Buff simple mob movement speeds

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/_giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/_giant_spider.dm
@@ -14,7 +14,6 @@
 	icon_state = "generic"
 	icon_living = "generic"
 	icon_dead = "generic_dead"
-	// has_eye_glow = TRUE
 
 	faction = "spiders"
 	maxHealth = 110
@@ -33,9 +32,10 @@
 
 	response_harm   = "punches"
 
-	pry_time = 8 SECONDS
+	pry_time = 6 SECONDS
 	pry_desc = "clawing"
 
+	movement_cooldown = 2
 
 	heat_damage_per_tick = 20
 	cold_damage_per_tick = 20
@@ -47,8 +47,10 @@
 	ai_holder = /datum/ai_holder/simple_animal/melee
 
 	var/poison_type = /datum/reagent/toxin/venom	// The reagent that gets injected when it attacks.
-	var/poison_chance = 20			// Chance for injection to occur.
-	var/poison_per_bite = 5			// Amount added per injection.
+	/// Chance for injection to occur.
+	var/poison_chance = 20
+	/// Amount added per injection.
+	var/poison_per_bite = 5
 
 	var/image/eye_layer
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/phorogenic.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/phorogenic.dm
@@ -16,7 +16,7 @@
 
 	attack_armor_pen = 15
 
-	movement_cooldown = 10
+	movement_cooldown = 4
 
 	poison_chance = 30
 	poison_per_bite = 0.5
@@ -27,9 +27,9 @@
 	var/explosion_max_power = EX_ACT_DEVASTATING
 
 	/// Lower bound for explosion delay.
-	var/explosion_delay_lower	= 3 SECONDS
+	var/explosion_delay_lower	= 1 SECONDS
 	/// Upper bound for explosion delay.
-	var/explosion_delay_upper	= 5 SECONDS
+	var/explosion_delay_upper	= 3 SECONDS
 
 /mob/living/simple_animal/hostile/giant_spider/phorogenic/Initialize()
 	SetTransform(scale = 1.25)

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -82,7 +82,7 @@
 	var/obj/item/card/id/myid// An ID card if they have one to give them access to stuff.
 
 	//Movement things.
-	var/movement_cooldown = 5			// Lower is faster.
+	var/movement_cooldown = 3			// Lower is faster.
 	var/movement_sound = null			// If set, will play this sound when it moves on its own will.
 	var/turn_sound = null				// If set, plays the sound when the mob's dir changes in most cases.
 	var/movement_shake_radius = 0		// If set, moving will shake the camera of all living mobs within this radius slightly.


### PR DESCRIPTION
:cl: Mucker
tweak: Most simple mobs have had their movement speed increased to match current player speeds, so you can no longer out-walk them. 
tweak: Phoron spiders will explode in 1-3 seconds instead of 3-5.
/:cl: