### PR TITLE
BSD event tweaks

### DIFF
--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -55,11 +55,10 @@
 	tele.teleport(target, destination, precision)
 
 
-/// Teleport an object randomly within the main map
+/// Teleport an object randomly within a set of connected zlevels
 /proc/do_unstable_teleport_safe(atom/movable/target, list/zlevels = GLOB.using_map.station_levels)
 	var/turf/T = pick_area_turf_in_connected_z_levels(
 		list(/proc/is_not_space_area),
-		list(/proc/not_turf_contains_dense_objects),
-		pick(zlevels)
-	)
+		list(/proc/not_turf_contains_dense_objects, /proc/IsTurfAtmosSafe),
+		zlevels[1])
 	do_teleport(target, T)

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -405,7 +405,7 @@
 
 
 /singleton/flooring/bluespace
-	name = "bluespace floor"
+	name = "bluespace"
 	desc = "Infinite bluespace. It gives you a piercing headache if you stare at it for too long."
 	icon = 'icons/turf/space.dmi'
 	icon_base = "bluespace"

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -376,3 +376,19 @@
 	icon = 'icons/turf/flooring/pool.dmi'
 	icon_state = "pool"
 	initial_flooring = /singleton/flooring/pool
+
+/turf/simulated/floor/bluespace
+	name = "bluespace"
+	icon = 'icons/turf/space.dmi'
+	icon_state = "bluespace"
+	initial_flooring = /singleton/flooring/bluespace
+
+/turf/simulated/floor/bluespace/Entered(mob/living/L)
+	. = ..()
+
+	if(istype(L) && prob(75))
+		L.visible_message(
+			SPAN_WARNING("\The [L] starts flickering in and out of existence as they step onto the bluespace!"),
+			SPAN_WARNING("You feel your entire body tingle, and something pulling you away!")
+		)
+		addtimer(new Callback(GLOBAL_PROC, /proc/do_unstable_teleport_safe, L, GetConnectedZlevels(L.z)), rand(30, 80))

--- a/code/modules/events/bsd_instability.dm
+++ b/code/modules/events/bsd_instability.dm
@@ -1,5 +1,5 @@
 /datum/event/bsd_instability
-	endWhen	= 250
+	endWhen	= 800
 
 	var/list/obj/machinery/tele_pad/pads = list()
 	var/list/obj/machinery/bluespacedrive/drives = list()
@@ -7,8 +7,8 @@
 	var/list/obj/structure/ladders = list()
 	var/list/mob/living/simple_animal/hostile/bluespace/mobs = list()
 	var/effects_per_tick = 5
-	var/maximum_mobs = 15
-	var/mob_spawn_chance = 4
+	var/maximum_mobs = 10
+	var/mob_spawn_chance = 3
 
 	/// Whether or not the 'pulse' should happen, changed to true if the probability check passes in setup()
 	var/should_do_pulse = FALSE
@@ -52,7 +52,7 @@
 		drive.set_light(1, 8, 25, 15, COLOR_CYAN_BLUE)
 		if (severity <= EVENT_LEVEL_MODERATE)
 			continue
-		drive.create_flash(TRUE)
+		addtimer(new Callback(drive, /obj/machinery/bluespacedrive/proc/create_flash, TRUE), 2 SECONDS)
 	if (severity <= EVENT_LEVEL_MODERATE)
 		return
 	for (var/obj/structure/stairs/stair in world)
@@ -97,7 +97,8 @@
 		if (isdeaf(mob))
 			continue
 		if (!(get_z(mob) in affecting_z))
-			sound_to(mob, 'sound/ambience/bsd_alarm.ogg')
+			continue
+		sound_to(mob, 'sound/ambience/bsd_alarm.ogg')
 
 
 /datum/event/bsd_instability/end()

--- a/code/modules/mob/living/simple_animal/hostile/bluespace.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bluespace.dm
@@ -27,7 +27,7 @@
 	name = "fractal touch"
 	attack_verb = list("slashed", "phased through", "drained")
 	hitsound = 'sound/hallucinations/growl1.ogg'
-	force = 15
+	force = 10
 	sharp = TRUE
 	edge = TRUE
 

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -24,7 +24,7 @@
 	var/bluespace_affected = FALSE
 
 	///Chance for a person climbing the ladder to be teleported to a random other ladder while bluespace affected.
-	var/displacement_chance = 30
+	var/displacement_chance = 15
 
 
 /obj/structure/ladder/Initialize()
@@ -114,6 +114,13 @@
 	var/obj/structure/ladder/target_ladder = getTargetLadder(M)
 	if(!target_ladder)
 		return
+	if (bluespace_affected && prob(displacement_chance))
+		var/list/obj/structure/ladder/other_ladders= list()
+		var/list/zlevels = GetConnectedZlevels(z)
+		for (var/obj/structure/ladder/ladder)
+			if (src != ladder && (ladder.z in zlevels))
+				other_ladders += ladder
+		target_ladder = pick(other_ladders)
 	if(!M.Move(get_turf(src)))
 		to_chat(M, SPAN_NOTICE("You fail to reach \the [src]."))
 		return
@@ -144,17 +151,6 @@
 	if((!target_up && !target_down) || (target_up && !istype(target_up.loc, /turf/simulated/open) || (target_down && !istype(target_down.loc, /turf))))
 		to_chat(M, SPAN_NOTICE("\The [src] is incomplete and can't be climbed."))
 		return
-
-	if (bluespace_affected)
-		var/list/obj/structure/ladder/other_ladders= list()
-		for (var/obj/structure/ladder/ladder)
-			if (src != ladder && (ladder.z in GetConnectedZlevels(ladder.z)))
-				other_ladders += ladder
-		if (prob(displacement_chance))
-			if (target_up)
-				target_up = pick(other_ladders)
-			if (target_down)
-				target_down = pick(other_ladders)
 
 	if(target_down && target_up)
 		var/direction = alert(M,"Do you want to go up or down?", "Ladder", "Up", "Down", "Cancel")
@@ -244,7 +240,7 @@
 	var/bluespace_affected = FALSE
 
 	/// Chance of a user being displaced to a random set of stairs while its bluespace affected.
-	var/displacement_chance = 30
+	var/displacement_chance = 15
 
 
 /obj/structure/stairs/Initialize()


### PR DESCRIPTION
:cl: Mucker
bugfix: Ladders should no longer be bugged after the BSD event runs.
tweak: BSD event lasts longer.
tweak: Bluespace turfs spawned by the BSD event will teleport mobs to a random place if stepped on (sometimes).
tweak: Mobs affected by the 'pulse' from the BSD event will now have their position swapped with other mobs, instead of teleported randomly.
tweak: Bluespace figments do 5 less damage on hit.
/:cl: