### PR TITLE
Improvement to random vendors

### DIFF
--- a/code/game/machinery/vending/cola.dm
+++ b/code/game/machinery/vending/cola.dm
@@ -31,14 +31,14 @@
 		/obj/item/reagent_containers/food/drinks/cans/syndicola = 5
 	)
 	products = list(
-		/obj/item/reagent_containers/food/drinks/cans/cola = 10,
-		/obj/item/reagent_containers/food/drinks/cans/space_mountain_wind = 10,
-		/obj/item/reagent_containers/food/drinks/cans/dr_gibb = 10,
-		/obj/item/reagent_containers/food/drinks/cans/ionbru = 10,
-		/obj/item/reagent_containers/food/drinks/cans/waterbottle = 10,
-		/obj/item/reagent_containers/food/drinks/cans/space_up = 10,
-		/obj/item/reagent_containers/food/drinks/cans/iced_tea = 10,
-		/obj/item/reagent_containers/food/drinks/cans/grape_juice = 10,
+		/obj/item/reagent_containers/food/drinks/cans/cola = 0,
+		/obj/item/reagent_containers/food/drinks/cans/space_mountain_wind = 0,
+		/obj/item/reagent_containers/food/drinks/cans/dr_gibb = 0,
+		/obj/item/reagent_containers/food/drinks/cans/ionbru = 0,
+		/obj/item/reagent_containers/food/drinks/cans/waterbottle = 0,
+		/obj/item/reagent_containers/food/drinks/cans/space_up = 0,
+		/obj/item/reagent_containers/food/drinks/cans/iced_tea = 0,
+		/obj/item/reagent_containers/food/drinks/cans/grape_juice = 0,
 		/obj/item/reagent_containers/food/drinks/cans/cola_pork = 0,
 		/obj/item/reagent_containers/food/drinks/cans/syndicola = 0
 	)

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -21,8 +21,8 @@
 /obj/structure/largecrate/use_tool(obj/item/tool, mob/user, list/click_params)
 	// Crowbar - Open crate
 	if (isCrowbar(tool))
-		var/obj/item/stack/material/wood = new(loc)
-		transfer_fingerprints_to(wood)
+		var/obj/item/stack/material/wood/A = new(loc)
+		transfer_fingerprints_to(A)
 		for (var/atom/movable/item as anything in contents)
 			item.dropInto(loc)
 		user.visible_message(


### PR DESCRIPTION
🆑 emmanuelbassil
tweak: The amount of soda in the cola machine is now randomly generated. This is an experiment, should not cause any shortages.  
tweak: Vending machines now display rare items in gold, hidden items (contraband wire/emag) in orange.
tweak: Emagging a vendor now makes all items free.
bugfix: Wooden crates now properly spawn wood instead of metal when crowbar'd open.
/🆑 

A few improvements to the randomization code.
First of all; minimum/maximum number when randomizing can now be set per vendor; defaulting to 1 and 10.
Added colors to make rare items stick out; hidden items will also stick out.

Next step will be to randomize more run of the mill vendors, and ensure supply has the ability to refill if needed.