### PR TITLE
allows you to fit screwdrivers in your boots (and also gives the holdout revolver a visible sprite)

### DIFF
--- a/code/game/objects/items/weapons/tools/screwdriver.dm
+++ b/code/game/objects/items/weapons/tools/screwdriver.dm
@@ -16,6 +16,7 @@
 	attack_verb = list("stabbed")
 	lock_picking_level = 5
 	sharp = TRUE
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 	var/build_from_parts = TRUE
 	var/valid_colours = list(COLOR_RED, COLOR_CYAN_BLUE, COLOR_PURPLE, COLOR_CHESTNUT, COLOR_GREEN, COLOR_TEAL, COLOR_ASSEMBLY_YELLOW, COLOR_BOTTLE_GREEN, COLOR_VIOLET, COLOR_GRAY80, COLOR_GRAY20)

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -62,7 +62,7 @@
 	name = "holdout revolver"
 	desc = "The al-Maliki & Mosley Partner is a concealed-carry revolver made for people who do not trust automatic pistols any more than the people they're dealing with."
 	icon_state = "holdout"
-	item_state = "pen"
+	item_state = "pistol"
 	caliber = CALIBER_PISTOL_SMALL
 	ammo_type = /obj/item/ammo_casing/pistol/small
 	w_class = ITEM_SIZE_SMALL


### PR DESCRIPTION
🆑Gy1ta23
tweak: screwdrivers can now be hidden in boots like knives
tweak: gave the holdout revolver an inhand sprite, copying the holdout pistol
/🆑

DRD asked me to do this because they have a constitutional lack of diligence, an unfocused mind, a weak head and will, and a lack of any definable coding knowledge (love you, DRD). You can put pistols in your boots, and revolvers in your boots, but only the really small ones, and they are indeed small enough for this to make sense. Screwdrivers are about the same size as knives and are also reasonably hidable. Now any Ensign can live their dreams of walking up and giving their commanding officer a walkthrough first-person perspective tour of Archduke Franz Ferdinand Carl Ludwig Joseph Maria of Austria's June 28th great Sarajevo roadtrip without wasting precious jacket pockets. And, believe me, having played without a backpack (unlike the rest of you cowards) those pocket spaces are indeed precious. Yell at me if I put the flags in the wrong place.

Also, the holdout revolver doesn't have a very visible sprite. In fact, if it didn't say in the code that it had the onmob sprite of a pen, I would have assumed it had no sprite whatsoever. Given the revolver and the pistol are about the same size and shape, and the main coloration difference is in the hidden handle, I simply gave it the pistol sprite until someone decides to do better than that.

I was going to put a paragraph here on the etymology of the term "holdout pistol", but aside from it being a possible reference to a gambling term or the combination of the words "hold" and "out" I can't get anything solid on where it comes from.

🙇