### PR TITLE
fix spacedrift affecting pulled objects

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -62,7 +62,7 @@
 	if(has_gravity())
 		return 1
 
-	if(length(pulledby))
+	if(pulledby)
 		return 1
 
 	if(throwing)


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed spacedrift affecting objects that were currently being pulled. 
/:cl: