### PR TITLE
Rigsuit Retraction Removal Redaction

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -529,6 +529,13 @@
 	safety = 0
 	wielded = 1
 
+/obj/item/shockpaddles/rig/attack()
+	var/obj/item/rig_module/device/defib/module = src.loc
+	if(!module.holder.hands_deployed)
+		make_announcement("buzzes, \"Error - Hardsuit gauntlets are not deployed.\"", "warning")
+		return 1
+	..()
+
 /obj/item/shockpaddles/rig/check_charge(charge_amt)
 	if(istype(src.loc, /obj/item/rig_module/device/defib))
 		var/obj/item/rig_module/device/defib/module = src.loc

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -55,6 +55,9 @@
 	if(!check() || !device)
 		return 0
 
+	if(!holder.hands_deployed)
+		to_chat(holder.wearer, SPAN_DANGER("You can't activate the flash without deploying your [holder.gloves.name]"))
+
 	if(!holder.cell.check_charge(use_power_cost * CELLRATE))
 		to_chat(holder.wearer,SPAN_WARNING("Not enough stored power."))
 		return 0
@@ -134,6 +137,10 @@
 		return 0
 
 	var/mob/living/carbon/human/H = holder.wearer
+
+	if(!holder.chest_deployed)
+		to_chat(H, SPAN_DANGER("You can't fire the [src] without deploying your [holder.chest.name]"))
+		return 0
 
 	if(!charge_selected)
 		to_chat(H, SPAN_DANGER("You have not selected a grenade type."))
@@ -220,6 +227,10 @@
 	if(!..() || !gun)
 		return 0
 
+	if(!holder.chest_deployed)
+		to_chat(holder.wearer, SPAN_DANGER("You can't fire \the [gun] without deploying your [holder.chest.name]."))
+		return 0
+
 	if(!target)
 		gun.attack_self(holder.wearer)
 		return
@@ -286,6 +297,9 @@
 
 	if(!check() || !gun)
 		return 0
+
+	if(!holder.hands_deployed)
+		to_chat(holder.wearer, SPAN_DANGER("You can't fire \the [gun] without deploying your [holder.chest.name]."))
 
 	if(holder.wearer.a_intent == I_HURT || !target.Adjacent(holder.wearer))
 		gun.Fire(target,holder.wearer)

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -37,6 +37,10 @@
 
 	var/mob/living/carbon/human/H = holder.wearer
 
+	if(!(holder.chest_deployed || holder.boots_deployed || holder.hands_deployed || holder.helmet_deployed))
+		to_chat(H, SPAN_WARNING("You cannot cloak without fully deploying your hardsuit."))
+		return 0
+
 	if(H.add_cloaking_source(src))
 		anim(H, 'icons/effects/effects.dmi', "electricity",null,20,null)
 
@@ -84,6 +88,10 @@
 /obj/item/rig_module/teleporter/engage(atom/target, notify_ai)
 
 	var/mob/living/carbon/human/H = holder.wearer
+
+	if(!(holder.chest_deployed || holder.boots_deployed || holder.hands_deployed || holder.helmet_deployed))
+		to_chat(H, SPAN_WARNING("You cannot use the teleport without fully deploying your hardsuit."))
+		return 0
 
 	if(!istype(H.loc, /turf))
 		to_chat(H, SPAN_WARNING("You cannot teleport out of your current location."))

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -61,6 +61,12 @@
 	origin_tech = list(TECH_MATERIAL = 6, TECH_POWER = 4, TECH_ENGINEERING = 6)
 	device = /obj/item/pickaxe/diamonddrill
 
+/obj/item/rig_module/device/drill/engage()
+	if(!holder.hands_deployed)
+		to_chat(holder.wearer, SPAN_DANGER ("You can't use \the [src] without deploying your [initial(holder.gloves.name)]"))
+		return 0
+	..()
+
 /obj/item/rig_module/device/anomaly_scanner
 	name = "anomaly scanner module"
 	desc = "You think it's called an Elder Sarsparilla or something."
@@ -115,6 +121,10 @@
 
 /obj/item/rig_module/device/engage(atom/target)
 	if(!..() || !device)
+		return 0
+
+	if(!holder.hands_deployed)
+		to_chat(holder.wearer, SPAN_DANGER ("You can't use \the [src] without deploying your [initial(holder.gloves.name)]"))
 		return 0
 
 	if(!target)
@@ -210,6 +220,9 @@
 		return 0
 
 	var/mob/living/carbon/human/H = holder.wearer
+
+	if(holder.hands_deployed)
+		to_chat(H, SPAN_DANGER("You can't use \the [src] without deploying your [initial(holder.gloves.name)]."))
 
 	if(!charge_selected)
 		to_chat(H, SPAN_DANGER("You have not selected a chemical type."))
@@ -312,6 +325,9 @@
 
 	if(!..())
 		return 0
+
+	if(!holder.helmet_deployed)
+		to_chat(holder.wearer, SPAN_DANGER("You can't use \the [src] without deploying your [holder.helmet.name]"))
 
 	var/choice= input("Would you like to toggle the synthesiser or set the name?") as null|anything in list("Enable","Disable","Set Name")
 
@@ -539,6 +555,8 @@
 
 /obj/item/rig_module/kinetic_module/engage(atom/target, mob/living/user, inrange, params)
 	. = ..()
+	if(!holder.hands_deployed)
+		to_chat(user, SPAN_DANGER("You can't use \the [src] without deploying your [initial(holder.gloves.name)]."))
 	if(.)
 		if(!locked && (get_dist(holder.wearer, target) <= max_dist))
 			var/atom/movable/AM = target

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -88,6 +88,12 @@
 	var/offline = 1                                           // Should we be applying suit maluses?
 	var/online_slowdown = 1                                   // If the suit is deployed and powered, it sets slowdown to this.
 	var/offline_slowdown = 3                                  // If the suit is deployed and unpowered, it sets slowdown to this.
+
+	var/helmet_deployed = 0                                   // Keeps track of if the part is deployed for module checks
+	var/chest_deployed = 0
+	var/hands_deployed = 0
+	var/boots_deployed = 0
+
 	var/vision_restriction = TINT_NONE
 	var/offline_vision_restriction = TINT_HEAVY               // tint value given to helmet
 	var/airtight = 1 //If set, will adjust ITEM_FLAG_AIRTIGHT flags on components. Otherwise it should leave them untouched.
@@ -203,15 +209,18 @@
 		air_supply = new air_type(src)
 	if(glove_type)
 		gloves = new glove_type(src)
+		verbs |= /obj/item/rig/proc/toggle_gauntlets
 	if(helm_type)
 		helmet = new helm_type(src)
 		verbs |= /obj/item/rig/proc/toggle_helmet
 	if(boot_type)
 		boots = new boot_type(src)
+		verbs |= /obj/item/rig/proc/toggle_boots
 	if(chest_type)
 		chest = new chest_type(src)
 		if(allowed)
 			chest.allowed = allowed
+		verbs |= /obj/item/rig/proc/toggle_chest
 
 	for(var/obj/item/piece in list(gloves,helmet,boots,chest))
 		if(!istype(piece))
@@ -789,6 +798,15 @@
 						use_obj.canremove = 1
 						holder.drop_from_inventory(use_obj, src)
 						use_obj.canremove = 0
+					switch(piece)
+						if("helmet")
+							helmet_deployed = 0
+						if("gauntlets")
+							hands_deployed = 0
+						if("boots")
+							boots_deployed = 0
+						if("chest")
+							chest_deployed = 0
 
 		else if (deploy_mode != ONLY_RETRACT)
 			if(check_slot && check_slot == use_obj)
@@ -804,6 +822,15 @@
 					return
 			else
 				to_chat(wearer, SPAN_NOTICE("Your [use_obj.name] [use_obj.gender == PLURAL ? "deploy" : "deploys"] swiftly."))
+				switch(piece)
+					if("helmet")
+						helmet_deployed = 1
+					if("gauntlets")
+						hands_deployed = 1
+					if("boots")
+						boots_deployed = 1
+					if("chest")
+						chest_deployed = 1
 
 	if(piece == "helmet" && helmet)
 		helmet.update_light(wearer)

--- a/code/modules/clothing/spacesuits/rig/rig_verbs.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_verbs.dm
@@ -55,6 +55,50 @@
 
 	toggle_piece("helmet",wearer)
 
+/obj/item/rig/proc/toggle_chest()
+
+	set name = "Toggle Chestpiece"
+	set desc = "Deploys or retracts your chestpiece."
+	set category = "Hardsuit"
+	set src = usr.contents
+
+	if(!check_suit_access(usr))
+		return
+
+	toggle_piece("chest",wearer)
+
+/obj/item/rig/proc/toggle_gauntlets()
+
+	set name = "Toggle Gauntlets"
+	set desc = "Deploys or retracts your gauntlets."
+	set category = "Hardsuit"
+	set src = usr.contents
+
+	if(!istype(wearer) || !wearer.back == src)
+		to_chat(usr, "<span class='warning'>The hardsuit is not being worn.</span>")
+		return
+
+	if(!check_suit_access(usr))
+		return
+
+	toggle_piece("gauntlets",wearer)
+
+/obj/item/rig/proc/toggle_boots()
+
+	set name = "Toggle Boots"
+	set desc = "Deploys or retracts your boots."
+	set category = "Hardsuit"
+	set src = usr.contents
+
+	if(!istype(wearer) || !wearer.back == src)
+		to_chat(usr, "<span class='warning'>The hardsuit is not being worn.</span>")
+		return
+
+	if(!check_suit_access(usr))
+		return
+
+	toggle_piece("boots",wearer)
+
 /obj/item/rig/verb/deploy_suit()
 
 	set name = "Deploy Hardsuit"

--- a/nano/templates/hardsuit.tmpl
+++ b/nano/templates/hardsuit.tmpl
@@ -1,11 +1,11 @@
-<!-- 
+<!--
 Title: Integrated Hardsuit Controller
 Used In File(s): /code/modules/clothing/spacesuits/rig/rig.dm
  -->
 
 <style type="text/css">
 	.inlineBlock {
-		padding: 2px; 
+		padding: 2px;
 		display: inline-block;
 	}
 	.extraTopPadding {
@@ -16,7 +16,7 @@ Used In File(s): /code/modules/clothing/spacesuits/rig/rig.dm
 		margin-left: 5px;
 	}
 	.paddedBorderBlue {
-		border: 1px solid #517087; 
+		border: 1px solid #517087;
 		padding: 2px;
 	}
 	.redText {
@@ -136,6 +136,11 @@ Used In File(s): /code/modules/clothing/spacesuits/rig/rig.dm
 				<div class='fixedLeftWider'>
 					{{:helper.capitalizeFirstLetter(data.gauntlets)}}
 				</div>
+				{{if data.sealing != 1}}
+					<div class='fixedLeft'>
+						{{:helper.link('Toggle', 'circle-arrow-s', {'toggle_piece' : 'gauntlets'}, null)}}
+					</div>
+				{{/if}}
 			</div>
 			<div class='inlineBlock'>
 				<div class='fixedLeft boldText'>
@@ -144,6 +149,11 @@ Used In File(s): /code/modules/clothing/spacesuits/rig/rig.dm
 				<div class='fixedLeftWider'>
 					{{:helper.capitalizeFirstLetter(data.boots)}}
 				</div>
+				{{if data.sealing != 1}}
+					<div class='fixedLeft'>
+						{{:helper.link('Toggle', 'circle-arrow-s', {'toggle_piece' : 'boots'}, null)}}
+					</div>
+				{{/if}}
 			</div>
 			<div class='inlineBlock'>
 				<div class='fixedLeft boldText'>
@@ -152,6 +162,11 @@ Used In File(s): /code/modules/clothing/spacesuits/rig/rig.dm
 				<div class='fixedLeftWider'>
 					{{:helper.capitalizeFirstLetter(data.chest)}}
 				</div>
+				{{if data.sealing != 1}}
+					<div class='fixedLeft'>
+						{{:helper.link('Toggle', 'circle-arrow-s', {'toggle_piece' : 'chest'}, null)}}
+					</div>
+				{{/if}}
 			</div>
 		</div>
 
@@ -200,7 +215,7 @@ Used In File(s): /code/modules/clothing/spacesuits/rig/rig.dm
 		{{if data.seals == 1 || data.sealing == 1}}
 			<h3><div class = 'bad'>HARDSUIT SYSTEMS OFFLINE</div></h3>
 		{{else}}
-			<h3>Selected primary system: 
+			<h3>Selected primary system:
 				{{if data.primarysystem}}
 					{{:helper.capitalizeFirstLetter(data.primarysystem)}}
 				{{else}}
@@ -225,9 +240,9 @@ Used In File(s): /code/modules/clothing/spacesuits/rig/rig.dm
 									{{/if}}
 									<div class='floatLeft' style='width: 100%; clear: left'>
 										<div class='caption floatLeft average' style='width: 20%; margin: 0'>
-												Engage: {{:value.engagecost}} 
-												Activate: {{:value.activecost}} 
-												Passive: {{:value.passivecost}} 
+												Engage: {{:value.engagecost}}
+												Activate: {{:value.activecost}}
+												Passive: {{:value.passivecost}}
 										</div>
 										<div class='caption floatLeft' style='width: 25%; margin: 0'>
 												{{:value.desc}}


### PR DESCRIPTION
:cl: PurplePineapple
rscadd: Adds a check for which part of a RIG suit is currently deployed.
tweak: RIG suit parts can be independently retracted while the suit is active.
tweak: Certain modules require certain parts to be deployed in order to use them to avoid previous issues with retracting RIGs
/:cl:

RIG suits can now be retracted while active. Modules now depend on parts related to them to be deployed to be used to prevent the issues that got retracting parts removed in the first place.

- Mounted guns/grenade launchers require the torso piece to be deployed, being as they are shoulder mounted.
- Plasma cutters. gravikinetic and drill modules require the gauntlets to be deployed, being as they are wrist mounted
- Defibrillators and injectors require the gauntlets to be deployed, being as they are wrist/palm devices.
- Cloaking and teleporting modules for Ninja require the entire suit be deployed. You can't teleport just your head, silly.

Any other restrictions can be recommended and will be added.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->