### PR TITLE
Adds Truly Automatic Fire

### DIFF
--- a/code/_onclick/MouseDrag.dm
+++ b/code/_onclick/MouseDrag.dm
@@ -22,10 +22,3 @@
 		var/atom/A = loc
 		if(A.RelayMouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params, src))
 			return
-
-	if(over_object)
-		if(!incapacitated())
-			var/obj/item/gun/gun = get_active_hand()
-			if(istype(gun) && gun.can_autofire())
-				set_dir(get_dir(src, over_object))
-				gun.Fire(get_turf(over_object), src, params, (get_dist(over_object, src) <= 1), FALSE)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -521,3 +521,48 @@ GLOBAL_LIST_INIT(click_catchers, create_click_catcher())
 		if(T)
 			T.Click(location, control, params)
 	. = 1
+
+/client/MouseDown(object, location, control, params)
+	var/delay = mob.CanMobAutoclick(object, location, params)
+	if(delay)
+		selected_target[1] = object
+		selected_target[2] = params
+		while(selected_target[1])
+			Click(selected_target[1], location, control, selected_target[2])
+			sleep(delay)
+
+/client/MouseUp(object, location, control, params)
+	selected_target[1] = null
+
+/client/MouseDrag(src_object,atom/over_object,src_location,over_location,src_control,over_control,params)
+	if(selected_target[1] && over_object.IsAutoclickable())
+		selected_target[1] = over_object
+		selected_target[2] = params
+
+/mob/proc/CanMobAutoclick(object, location, params)
+	return
+
+/mob/living/carbon/CanMobAutoclick(atom/object, location, params)
+	if(!object.IsAutoclickable())
+		return
+	var/obj/item/h = get_active_hand()
+	if(h)
+		. = h.CanItemAutoclick(object, location, params)
+
+/obj/item/proc/CanItemAutoclick(object, location, params)
+	return
+
+/obj/item/gun/CanItemAutoclick(object, location, params)
+	return can_autofire
+
+/obj/item/gun/CanItemAutoclick(object, location, params)
+	return can_autofire
+
+/atom/proc/IsAutoclickable()
+	return TRUE
+
+/obj/screen/IsAutoclickable()
+	return FALSE
+
+/obj/screen/click_catcher/IsAutoclickable()
+	return TRUE

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -22,6 +22,9 @@
 
 	var/staffwarn = null
 
+	/// List that stores the object and parameters related to the selected target during mouse events in the client. Allows the client to remember the target selected during a "MouseDown" event or update the selection during a "MouseDrag" event.
+	var/list/selected_target[2]
+
 		///////////////
 		//SOUND STUFF//
 		///////////////

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -6,14 +6,6 @@
 	restricted_hardpoints = list(HARDPOINT_LEFT_HAND, HARDPOINT_RIGHT_HAND)
 	restricted_software = list(MECH_SOFTWARE_WEAPONS)
 
-/obj/item/mech_equipment/mounted_system/taser/MouseDragInteraction(src_object, over_object, src_location, over_location, src_control, over_control, params, mob/user)
-	. = ..()
-
-	if(over_object)
-		var/obj/item/gun/gun = holding
-		if(istype(gun) && gun.can_autofire())
-			gun.Fire(get_turf(over_object), owner, params, (get_dist(over_object, owner) <= 1), FALSE)
-
 /obj/item/mech_equipment/mounted_system/taser/ion
 	name = "mounted ion rifle"
 	desc = "An exosuit-mounted ion rifle. Handle with care."

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -62,7 +62,7 @@
 	waterproof = FALSE
 
 	var/burst = 1
-	var/can_autofire = FALSE
+	var/can_autofire = FALSE /// checks if the gun will continue firing if the mouse button is held down
 	var/fire_delay = 6 	//delay after shooting before the gun can be used again. Cannot be less than [burst_delay+1]
 	var/burst_delay = 2	//delay between shots, if firing in bursts
 	var/move_delay = 1
@@ -647,9 +647,6 @@
 		target.visible_message(SPAN_DANGER("\The [src] goes off during the struggle!"))
 		afterattack(shoot_to,target)
 		return 1
-
-/obj/item/gun/proc/can_autofire()
-	return (can_autofire && world.time >= next_fire_time)
 
 /obj/item/gun/proc/check_accidents(mob/living/user, message = "[user] fumbles with \the [src] and it goes off!",skill_path = gun_skill, fail_chance = 20, no_more_fail = safety_skill, factor = 2)
 	if(istype(user))


### PR DESCRIPTION
:cl: PurplePineapple, Escalation1984 Developers
rscadd: Adds autoclick functionality to clients.
tweak: can_autofire on guns now uses the autoclick to allow for more natural automatic fire by holding the mouse down in one place.
rscdel: Click-drag automatic fire has been removed now that it has been replaced with the autoclick.
/:cl:
Firing modes on guns with can_autofire = TRUE now fire with the mouse held down as one would expect. Currently, only the L6 SAW (Unobtainable outside admin events) and the Battle Rifle (Merc-Only weapon) can use this feature.


https://github.com/Baystation12/Baystation12/assets/67706292/818fde34-e87d-4268-b806-d7f6499ef016



<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->