### PR TITLE
rigs get some storage on the chestpiece

### DIFF
--- a/code/game/objects/items/weapons/storage/internal.dm
+++ b/code/game/objects/items/weapons/storage/internal.dm
@@ -91,6 +91,7 @@
 	max_w_class = slot_size
 	..()
 
-/obj/item/storage/internal/pouch/New(newloc, storage_space)
+/obj/item/storage/internal/pouch/New(newloc, storage_space, max_w_class)
 	max_storage_space = storage_space
+	src.max_w_class = max_w_class || src.max_w_class
 	..()

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -341,18 +341,24 @@
 		if(0)
 			to_chat(usr, "\The [src] now picks up one item at a time.")
 
+
+/obj/item/storage/proc/DoQuickEmpty()
+	var/turf/into = get_turf(src)
+	if (!into)
+		return
+	for(var/atom/movable/movable in contents)
+		remove_from_storage(movable, into, TRUE)
+	finish_bulk_removal()
+
+
 /obj/item/storage/verb/quick_empty()
 	set name = "Empty Contents"
 	set category = "Object"
-
 	if((!ishuman(usr) && (src.loc != usr)) || usr.stat || usr.restrained())
 		return
-
-	var/turf/T = get_turf(src)
 	hide_from(usr)
-	for(var/obj/item/I in contents)
-		remove_from_storage(I, T, 1)
-	finish_bulk_removal()
+	DoQuickEmpty()
+
 
 /obj/item/storage/verb/dump_contents()
 	set name = "Dump Contents"

--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -104,8 +104,8 @@
 			var/list/current_mounts = list()
 			if(cell) current_mounts   += "cell"
 			if(air_supply) current_mounts += "tank"
+			if (length(chest?.storage?.contents)) current_mounts += "storage"
 			if(installed_modules && length(installed_modules)) current_mounts += "system module"
-
 			var/to_remove = input("Which would you like to modify?") as null|anything in current_mounts
 			if(!to_remove)
 				return
@@ -137,6 +137,18 @@
 					user.put_in_hands(air_supply)
 					to_chat(user, "You detach and remove \the [air_supply].")
 					air_supply = null
+
+				if ("storage")
+					if (!length(chest?.storage?.contents))
+						to_chat(user, "There is nothing in the storage to remove.")
+						return
+					chest.storage.DoQuickEmpty()
+					user.visible_message(
+						SPAN_ITALIC("\The [user] ejects the contents of \a [src]'s storage."),
+						SPAN_ITALIC("You eject the contents of \the [src]'s storage."),
+						SPAN_ITALIC("You hear things clatter to the floor."),
+						range = 5
+					)
 
 				if("system module")
 

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -53,15 +53,55 @@
 		)
 	var/list/supporting_limbs = list() //If not-null, automatically splints breaks. Checked when removing the suit.
 	equip_delay = null
+	var/obj/item/storage/internal/storage
+	var/max_w_class = ITEM_SIZE_NORMAL
+	var/slots = 2 STORAGE_FREEFORM
+
+
+/obj/item/clothing/suit/space/rig/Destroy()
+	LAZYCLEARLIST(supporting_limbs)
+	QDEL_NULL(storage)
+	return ..()
+
+
+/obj/item/clothing/suit/space/rig/Initialize()
+	. = ..()
+	if (slots && max_w_class)
+		if (slots < 0)
+			storage = new /obj/item/storage/internal/pouch (src, (-slots) * BASE_STORAGE_COST(max_w_class), max_w_class)
+		else
+			storage = new /obj/item/storage/internal/pockets (src, slots, max_w_class)
+
+
+/obj/item/clothing/suit/space/rig/attack_hand(mob/living/user)
+	if (storage?.handle_attack_hand(user))
+		..(user)
+
+/obj/item/clothing/suit/space/rig/MouseDrop(obj/over)
+	if (storage?.handle_mousedrop(usr, over))
+		..(over)
+
+
+/obj/item/clothing/suit/space/rig/emp_act(severity)
+	storage?.emp_act(severity)
+	..()
+
+
+/obj/item/clothing/suit/space/rig/attempt_store_item(obj/item/I, mob/user, silent)
+	if (storage?.can_be_inserted(I, user, TRUE) && storage.handle_item_insertion(I, silent))
+		return TRUE
+	return ..()
 
 
 /obj/item/clothing/suit/space/rig/equipped(mob/M)
 	check_limb_support(M)
 	..()
 
+
 /obj/item/clothing/suit/space/rig/dropped(mob/user)
 	check_limb_support(user)
 	..()
+
 
 // Some space suits are equipped with reactive membranes that support broken limbs
 /obj/item/clothing/suit/space/rig/proc/can_support(mob/living/carbon/human/user)

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -39,6 +39,8 @@
 		/obj/item/device/suit_cooling_unit,
 		/obj/item/cell
 	)
+	max_w_class = ITEM_SIZE_SMALL
+	slots = 3 STORAGE_FREEFORM
 
 /obj/item/clothing/gloves/rig/light
 	name = "gloves"

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -489,6 +489,8 @@
 		/obj/item/tank,
 		/obj/item/device/suit_cooling_unit
 	)
+	max_w_class = null
+	slots = null
 
 /obj/item/rig/zero/on_update_icon(update_mob_icon)
 	..()


### PR DESCRIPTION
:cl:
tweak: Rigs get some storage on the suit part. Most get 2x normal items of freeform, lights get 3x small, and zeros get nothing. It can be dumped out via the panel->wrench pathway when not worn.
/:cl: