### PR TITLE
torch jumps during jump

### DIFF
--- a/code/game/gamemodes/endgame/bluespace_jump/bluespace_jump.dm
+++ b/code/game/gamemodes/endgame/bluespace_jump/bluespace_jump.dm
@@ -5,10 +5,20 @@
 	var/list/affected_levels
 	var/list/old_accessible_z_levels
 
+
 /datum/universal_state/bluespace_jump/New(list/zlevels)
 	affected_levels = zlevels
 
 /datum/universal_state/bluespace_jump/OnEnter()
+	var/obj/machinery/bluespacedrive/drive = locate(/obj/machinery/bluespacedrive) in SSmachines.machinery
+
+	if (!drive || !(drive.z in affected_levels))
+		return
+
+	if (HAS_FLAGS(drive.state, drive.STATE_BROKEN))
+		var/datum/event_meta/bsd = new(EVENT_LEVEL_MAJOR, "Bluespace Jump Fracture", add_to_queue = 0)
+		new/datum/event/bsd_instability(bsd) // Destroyed BSD means the ship still jumps, but not without consequences
+
 	var/space_zlevel = GLOB.using_map.get_empty_zlevel() //get a place for stragglers
 	for(var/mob/living/M in SSmobs.mob_list)
 		if(M.z in affected_levels)
@@ -26,6 +36,8 @@
 	old_accessible_z_levels = GLOB.using_map.accessible_z_levels.Copy()
 	for(var/z in affected_levels)
 		GLOB.using_map.accessible_z_levels -= "[z]" //not accessible during the jump
+	GLOB.using_map.ship_jump()
+
 
 /datum/universal_state/bluespace_jump/OnExit()
 	for(var/mob/M in bluespaced)
@@ -36,9 +48,11 @@
 	GLOB.using_map.accessible_z_levels = old_accessible_z_levels
 	old_accessible_z_levels = null
 
+
 /datum/universal_state/bluespace_jump/OnPlayerLatejoin(mob/living/M)
 	if(M.z in affected_levels)
 		apply_bluespaced(M)
+
 
 /datum/universal_state/bluespace_jump/OnTouchMapEdge(atom/A)
 	if((A.z in affected_levels) && (A in bluespaced))
@@ -48,6 +62,7 @@
 		return FALSE
 	return TRUE
 
+
 /datum/universal_state/bluespace_jump/proc/apply_bluespaced(mob/living/M)
 	bluespaced += M
 	if(M.client)
@@ -55,6 +70,7 @@
 		M.overlay_fullscreen("bluespace", /obj/screen/fullscreen/bluespace_overlay)
 	M.confused = 20
 	bluegoasts += new/obj/effect/bluegoast/(get_turf(M),M)
+
 
 /datum/universal_state/bluespace_jump/proc/clear_bluespaced(mob/living/M)
 	if(M.client)
@@ -69,6 +85,7 @@
 		qdel(G)
 	bluegoasts.Cut()
 
+
 /obj/effect/bluegoast
 	name = "bluespace echo"
 	desc = "It's not going to punch you, is it?"
@@ -76,6 +93,7 @@
 	anchored = TRUE
 	var/reality = 0
 	simulated = FALSE
+
 
 /obj/effect/bluegoast/New(nloc, ndaddy)
 	..(nloc)
@@ -89,12 +107,14 @@
 	GLOB.dir_set_event.register(daddy, src, /obj/effect/bluegoast/proc/mirror_dir)
 	GLOB.destroyed_event.register(daddy, src, /datum/proc/qdel_self)
 
+
 /obj/effect/bluegoast/Destroy()
 	GLOB.destroyed_event.unregister(daddy, src)
 	GLOB.dir_set_event.unregister(daddy, src)
 	GLOB.moved_event.unregister(daddy, src)
 	daddy = null
 	. = ..()
+
 
 /obj/effect/bluegoast/proc/mirror(atom/movable/am, old_loc, new_loc)
 	var/ndir = get_dir(new_loc,old_loc)
@@ -112,11 +132,14 @@
 		else
 			to_chat(daddy, SPAN_WARNING("You feel a bit less real. Which one of you two was original again?.."))
 
+
 /obj/effect/bluegoast/proc/mirror_dir(atom/movable/am, old_dir, new_dir)
 	set_dir(GLOB.reverse_dir[new_dir])
 
+
 /obj/effect/bluegoast/examine()
 	return daddy?.examine(arglist(args))
+
 
 /obj/effect/bluegoast/proc/blueswitch()
 	daddy.blueswitch(src)
@@ -139,6 +162,7 @@
 	dust()
 	return clone
 
+
 /mob/living/exosuit/blueswitch(obj/effect/bluegoast/ghost)
 	if (!length(pilots))
 		return
@@ -146,6 +170,7 @@
 		remove_pilot(pilot)
 		var/mob/clone = pilot.blueswitch(ghost)
 		add_pilot(clone)
+
 
 /mob/living/carbon/human/blueswitch(obj/effect/bluegoast/ghost)
 	var/mob/living/carbon/human/clone = new(get_turf(ghost), species.name)

--- a/maps/mapsystem/maps.dm
+++ b/maps/mapsystem/maps.dm
@@ -305,6 +305,9 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 /datum/map/proc/perform_map_generation()
 	return
 
+/datum/map/proc/ship_jump()
+	return
+
 
 /* It is perfectly possible to create loops with TEMPLATE_FLAG_ALLOW_DUPLICATES and force/allow. Don't. */
 /proc/resolve_site_selection(datum/map_template/ruin/away_site/site, list/selected, list/available, list/unavailable, list/by_type)

--- a/maps/torch/torch_procs.dm
+++ b/maps/torch/torch_procs.dm
@@ -56,6 +56,15 @@
 				else
 					to_chat(Player, SPAN_COLOR("red", "<b>You did not survive the events on [station_name()]...</b>"))
 
+
+/datum/map/torch/ship_jump()
+	for(var/obj/effect/overmap/visitable/ship/torch/torch)
+		new /obj/effect/ftl (get_turf(torch))
+		qdel(torch)
+		animate(torch, time = 0.5 SECONDS)
+		animate(alpha = 0, time = 0.5 SECONDS)
+
+
 /datum/map/torch/roundend_summary(list/data)
 	var/desc
 	var/survivors = data["surviving_total"]


### PR DESCRIPTION
:cl:
tweak: The Torch will be removed from the overmap during jump.
tweak: If the drive is missing/destroyed, there will be no jump, round will simply end after the same amount of time.
/:cl:

muh immursion.

Also, trying to find a way to force call a specific event, as I want the jump to be shaky and call the BSD instability event if it jumps like that. Any idea would be welcome, I'll add it to this PR.

