### PR TITLE
pipes are not re-added to networks while qdeleting

### DIFF
--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -68,32 +68,28 @@
 	return 1
 
 /obj/machinery/atmospherics/pipe/return_air()
-	if(!parent)
+	if(!parent && !QDELING(src))
 		parent = new /datum/pipeline()
 		parent.build_pipeline(src)
-
-	return parent.air
+	return parent?.air
 
 /obj/machinery/atmospherics/pipe/build_network()
-	if(!parent)
+	if(!parent && !QDELING(src))
 		parent = new /datum/pipeline()
 		parent.build_pipeline(src)
-
-	return parent.return_network()
+	return parent?.return_network()
 
 /obj/machinery/atmospherics/pipe/network_expand(datum/pipe_network/new_network, obj/machinery/atmospherics/pipe/reference)
-	if(!parent)
+	if(!parent && !QDELING(src))
 		parent = new /datum/pipeline()
 		parent.build_pipeline(src)
-
-	return parent.network_expand(new_network, reference)
+	return parent?.network_expand(new_network, reference)
 
 /obj/machinery/atmospherics/pipe/return_network(obj/machinery/atmospherics/reference)
-	if(!parent)
+	if(!parent && !QDELING(src))
 		parent = new /datum/pipeline()
 		parent.build_pipeline(src)
-
-	return parent.return_network(reference)
+	return parent?.return_network(reference)
 
 /obj/machinery/atmospherics/pipe/Destroy()
 	QDEL_NULL(parent)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->