### PR TITLE
PAssthrough standard health procs to living mob procs

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2122,6 +2122,7 @@
 #include "code\modules\mob\living\living.dm"
 #include "code\modules\mob\living\living_defense.dm"
 #include "code\modules\mob\living\living_defines.dm"
+#include "code\modules\mob\living\living_health.dm"
 #include "code\modules\mob\living\living_maneuvers.dm"
 #include "code\modules\mob\living\living_powers.dm"
 #include "code\modules\mob\living\login.dm"

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -257,13 +257,13 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		user.do_attack_animation(src)
 		var/damage_flags = weapon.damage_flags()
 		if (!can_damage_health(weapon.force, weapon.damtype, damage_flags))
-			playsound(src, damage_hitsound, 50, TRUE)
+			playsound(src, use_weapon_hitsound ? weapon.hitsound : damage_hitsound, 50, TRUE)
 			user.visible_message(
 				SPAN_WARNING("\The [user] hits \the [src] with \a [weapon], but it bounces off!"),
 				SPAN_WARNING("You hit \the [src] with \the [weapon], but it bounces off!")
 			)
 			return TRUE
-		playsound(src, damage_hitsound, 75, TRUE)
+		playsound(src, use_weapon_hitsound ? weapon.hitsound : damage_hitsound, 75, TRUE)
 		user.visible_message(
 			SPAN_DANGER("\The [user] hits \the [src] with \a [weapon]!"),
 			SPAN_DANGER("You hit \the [src] with \the [weapon]!")

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -534,7 +534,7 @@
 		return FALSE
 	if (get_max_health())
 		fire_act(air, temperature)
-		if (!health_dead)
+		if (!health_dead())
 			return FALSE
 	visible_message(SPAN_DANGER("\The [src] sizzles and melts away, consumed by the lava!"))
 	playsound(src, 'sound/effects/flare.ogg', 100, 3)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -294,7 +294,7 @@
 			damage = P.get_structure_damage()
 		if (!can_damage_health(damage, P.damage_type, P.damage_flags))
 			return
-		playsound(src, damage_hitsound, 75)
+		playsound(src, use_weapon_hitsound ? P.hitsound : damage_hitsound, 75)
 		damage_health(damage, P.damage_type, P.damage_flags, skip_can_damage_check = TRUE)
 
 /**
@@ -557,10 +557,14 @@
 		var/damage = 0
 		var/damage_type = DAMAGE_BRUTE
 		var/damage_flags = EMPTY_BITFIELD
+		var/damage_hitsound = src.damage_hitsound
 		if (isobj(AM))
 			var/obj/O = AM
 			damage = O.throwforce
 			damage_type = O.damtype
+			if (use_weapon_hitsound && isitem(O))
+				var/obj/item/I = O
+				damage_hitsound = I.hitsound
 		else if (ismob(AM))
 			var/mob/M = AM
 			damage = M.mob_size

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -42,6 +42,14 @@
 /atom/proc/health_damaged()
 	return get_current_health() < get_max_health()
 
+
+/**
+ * Whether or not the atom is currently dead.
+ */
+/atom/proc/health_dead()
+	return health_dead
+
+
 /**
  * Retrieves the atom's current damage, or `null` if not using health.
  */
@@ -77,7 +85,7 @@
 	SHOULD_CALL_PARENT(TRUE)
 	if (!get_max_health())
 		return FALSE
-	if (health_dead)
+	if (health_dead())
 		return FALSE
 	if (!damage || damage < health_min_damage)
 		return FALSE
@@ -239,7 +247,7 @@
 /atom/proc/examine_damage_state(mob/user)
 	var/datum/pronouns/pronouns = choose_from_pronouns()
 
-	if (health_dead)
+	if (health_dead())
 		to_chat(user, SPAN_DANGER("[pronouns.He] look[pronouns.s] broken."))
 		return
 
@@ -256,7 +264,7 @@
 
 /mob/examine_damage_state(mob/user)
 	var/datum/pronouns/pronouns = choose_from_pronouns()
-	if (health_dead)
+	if (health_dead())
 		to_chat(user, SPAN_DANGER("[pronouns.He] look[pronouns.s] severely hurt and [pronouns.is] not moving or responding to anything around [pronouns.him]."))
 		return
 

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -22,6 +22,9 @@
 /// Sound effect played when hit
 /atom/var/damage_hitsound = 'sound/weapons/genhit.ogg'
 
+/// Boolean. If set, uses the item's hit sound file instead of the source atom's when attacked.
+/atom/var/use_weapon_hitsound = FALSE
+
 /**
  * Retrieves the atom's current health, or `null` if not using health
  */

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -281,6 +281,8 @@
 
 /**
  * Copies the state of health from one atom to another.
+ *
+ * Does not support mobs that don't use standardized health.
  */
 /proc/copy_health(atom/source_atom, atom/target_atom)
 	if (!source_atom || QDELETED(target_atom) || !source_atom.health_max || !target_atom.health_max)

--- a/code/game/machinery/bluespace_drive.dm
+++ b/code/game/machinery/bluespace_drive.dm
@@ -118,7 +118,7 @@
 
 
 /obj/machinery/bluespacedrive/examine_damage_state(mob/user)
-	if (health_dead)
+	if (health_dead())
 		to_chat(user, SPAN_DANGER("Its field is completely destroyed, the core revealed under the arcing debris."))
 		return
 	var/damage_percentage = get_damage_percentage()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -270,7 +270,7 @@
 /obj/machinery/door/post_health_change(health_mod, prior_health, damage_type)
 	. = ..()
 	queue_icon_update()
-	if (health_mod < 0 && !health_dead)
+	if (health_mod < 0 && !health_dead())
 		var/initial_damage_percentage = round((prior_health / get_max_health()) * 100)
 		var/damage_percentage = get_damage_percentage()
 		if (damage_percentage >= 75 && initial_damage_percentage < 75)

--- a/code/game/machinery/stasis_cage.dm
+++ b/code/game/machinery/stasis_cage.dm
@@ -74,7 +74,7 @@ var/global/const/STASISCAGE_WIRE_LOCK      = 4
 	if (!is_powered())
 		to_chat(user, SPAN_WARNING("\The [src] is unpowered."))
 		return
-	if (health_dead)
+	if (health_dead())
 		to_chat(usr, SPAN_NOTICE("\The [src] is completely destroyed."))
 		return
 
@@ -100,7 +100,7 @@ var/global/const/STASISCAGE_WIRE_LOCK      = 4
 	if (!is_powered())
 		to_chat(usr, SPAN_WARNING("\The [src] is unpowered."))
 		return
-	if (health_dead)
+	if (health_dead())
 		to_chat(usr, SPAN_WARNING("\The [src] is completely destroyed."))
 		return
 	user.visible_message(
@@ -173,7 +173,7 @@ var/global/const/STASISCAGE_WIRE_LOCK      = 4
 
 	// Coil - Repair cage
 	if (isCoil(tool))
-		if (health_dead)
+		if (health_dead())
 			if (contained)
 				USE_FEEDBACK_FAILURE("\The [src] must be emptied before repairs can be done!")
 				return TRUE
@@ -204,7 +204,7 @@ var/global/const/STASISCAGE_WIRE_LOCK      = 4
 	// Wrench - Repair lid
 	if (isWrench(tool))
 		if (broken)
-			if (health_dead)
+			if (health_dead())
 				USE_FEEDBACK_FAILURE("You need to repair the rest of \the [src] first!")
 				return TRUE
 			user.visible_message(
@@ -249,7 +249,7 @@ var/global/const/STASISCAGE_WIRE_LOCK      = 4
 	return ..()
 
 /obj/machinery/stasis_cage/emp_act(severity)
-	if (health_dead)
+	if (health_dead())
 		return
 	if (inoperable())
 		return
@@ -272,7 +272,7 @@ var/global/const/STASISCAGE_WIRE_LOCK      = 4
 
 /obj/machinery/stasis_cage/on_update_icon()
 	overlays.Cut()
-	if (health_dead)
+	if (health_dead())
 		icon_state = "[initial(icon_state)]_dead"
 	else if (is_powered())
 		if (contained)

--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -154,7 +154,7 @@
 
 /obj/effect/spider/spiderling/post_use_item(obj/item/tool, mob/user, interaction_handled, use_call, click_params)
 	. = ..()
-	if (interaction_handled && !health_dead)
+	if (interaction_handled && !health_dead())
 		disturbed()
 
 

--- a/code/game/objects/items/weapons/material/ashtray.dm
+++ b/code/game/objects/items/weapons/material/ashtray.dm
@@ -27,7 +27,7 @@
 		overlays |= image('icons/obj/objects.dmi',"ashtray_half")
 
 /obj/item/material/ashtray/attackby(obj/item/W as obj, mob/user as mob)
-	if (health_dead)
+	if (health_dead())
 		return
 
 	if (user.a_intent == I_HURT)

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -56,7 +56,7 @@
 	update_icon()
 
 /obj/structure/displaycase/on_update_icon()
-	if(health_dead)
+	if(health_dead())
 		icon_state = "glassboxb"
 	else
 		icon_state = "glassbox"
@@ -66,7 +66,7 @@
 
 /obj/structure/displaycase/attack_hand(mob/user as mob)
 	add_fingerprint(user)
-	if(!health_dead)
+	if(!health_dead())
 		to_chat(usr, text(SPAN_WARNING("You kick the display case.")))
 		visible_message(SPAN_WARNING("[usr] kicks the display case."))
 		damage_health(2, DAMAGE_BRUTE)

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -129,7 +129,7 @@
 
 /obj/structure/inflatable/bullet_act(obj/item/projectile/Proj)
 	. = ..()
-	if (health_dead)
+	if (health_dead())
 		return PROJECTILE_CONTINUE
 
 /obj/structure/inflatable/ex_act(severity)

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -532,7 +532,7 @@
 		)
 
 /obj/structure/window/proc/deanchor(atom/impact_origin)
-	if (!health_dead && get_damage_percentage() >= 85)
+	if (!health_dead() && get_damage_percentage() >= 85)
 		set_anchored(FALSE)
 		step(src, get_dir(impact_origin, src))
 

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -92,7 +92,7 @@
 	var/damage = rand(damage_min, damage_max)
 	var/damage_type = pick(DAMAGE_BRUTE, DAMAGE_BURN)
 
-	if (T.density && !T.health_dead)
+	if (T.density && !T.health_dead())
 		visible_message(SPAN_DANGER("A tendril flies out from \the [src] and smashes into \the [T]!"))
 		playsound(loc, 'sound/effects/attackblob.ogg', 50, 1)
 		T.damage_health(damage)

--- a/code/modules/hydroponics/spreading/spreading_growth.dm
+++ b/code/modules/hydroponics/spreading/spreading_growth.dm
@@ -57,7 +57,7 @@
 
 	//Take damage from bad environment if any
 	damage_health(seed.handle_environment(T, T.return_air(), null, 1))
-	if(health_dead)
+	if(health_dead())
 		return
 
 	//Vine fight!

--- a/code/modules/mob/living/living_health.dm
+++ b/code/modules/mob/living/living_health.dm
@@ -1,6 +1,9 @@
 /mob/living/health_resistances = null // Not currently supported in health passthrough
 
 
+/mob/living/use_weapon_hitsound = TRUE
+
+
 /mob/living/get_current_health()
 	if (maxHealth)
 		return health

--- a/code/modules/mob/living/living_health.dm
+++ b/code/modules/mob/living/living_health.dm
@@ -1,0 +1,130 @@
+/mob/living/health_resistances = null // Not currently supported in health passthrough
+
+
+/mob/living/get_current_health()
+	if (maxHealth)
+		return health
+	return ..()
+
+
+/mob/living/get_max_health()
+	if (maxHealth)
+		return getMaxHealth()
+	return ..()
+
+
+/mob/living/health_dead()
+	if (stat == DEAD)
+		return TRUE
+	return ..()
+
+
+/mob/living/mod_health(health_mod, damage_type, skip_death_state_change)
+	if (maxHealth)
+		crash_with("Living mob using legacy health attempted to call mod_health. This is not currently supported and should not be possible.")
+		return FALSE
+	return ..()
+
+
+/mob/living/set_health(new_health, skip_death_state_change)
+	if (maxHealth)
+		crash_with("Living mob using legacy health attempted to call set_health. This is not currently supported and should not be possible.")
+		return FALSE
+	return ..()
+
+
+/mob/living/proc/general_health_adjustment(damage, damage_type, damage_flags = EMPTY_BITFIELD)
+	var/prior_death_state = health_dead()
+	// Convert damage types to types recognized by legacy mob health
+	switch (damage_type)
+		if (DAMAGE_EMP, DAMAGE_FIRE)
+			return FALSE // These damages are handled separately by existing legacy code
+		if (DAMAGE_SHOCK)
+			damage_type = DAMAGE_BURN
+		if (DAMAGE_BIO)
+			damage_type = DAMAGE_TOXIN
+		if (DAMAGE_EXPLODE, DAMAGE_PSIONIC)
+			damage_type = DAMAGE_BRUTE
+	// Apply damage
+	switch (damage_type)
+		if (DAMAGE_RADIATION)
+			apply_radiation(damage)
+		if (DAMAGE_STUN, DAMAGE_PAIN)
+			adjustHalLoss(damage)
+		if (DAMAGE_BRAIN)
+			adjustBrainLoss(damage)
+		else
+			apply_damage(damage, damage_type, damage_flags = damage_flags, silent = TRUE)
+	return prior_death_state != health_dead()
+
+
+/mob/living/restore_health(damage, damage_type, skip_death_state_change, skip_can_restore_check)
+	if (maxHealth)
+		if (!can_restore_health(damage, damage_type))
+			return FALSE
+		return general_health_adjustment(-damage, damage_type)
+	return ..()
+
+
+/mob/living/damage_health(damage, damage_type, damage_flags, severity, skip_can_damage_check)
+	if (maxHealth)
+		if (!can_damage_health(damage, damage_type, damage_flags))
+			return FALSE
+		return general_health_adjustment(damage, damage_type, damage_flags)
+	return ..()
+
+
+/mob/living/kill_health()
+	if (maxHealth)
+		if (health_dead())
+			return FALSE
+		death()
+		return TRUE
+	return ..()
+
+
+/mob/living/revive_health()
+	if (maxHealth)
+		var/prior_death_state = health_dead()
+		rejuvenate()
+		return prior_death_state != health_dead()
+	return ..()
+
+
+/mob/living/set_max_health(new_max_health, set_current_health, use_standardized_health = FALSE)
+	if (use_standardized_health)
+		if (maxHealth)
+			maxHealth = 0
+			health_current = health
+			health = 0
+		..()
+		return
+	setMaxHealth(new_max_health)
+	if (set_current_health)
+		rejuvenate()
+	else
+		updatehealth()
+
+
+/mob/living/set_damage_resistance(damage_type, resistance_value)
+	if (maxHealth)
+		return
+	..()
+
+
+/mob/living/remove_damage_resistance(damage_type)
+	if (maxHealth)
+		return
+	..()
+
+
+/mob/living/get_damage_resistance(damage_type)
+	if (maxHealth)
+		return 1
+	return ..()
+
+
+/mob/living/is_damage_immune(damage_type)
+	if (maxHealth)
+		return FALSE
+	return ..()

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -12,6 +12,7 @@
 	response_harm   = "kicks"
 	faction = "goat"
 	health = 40
+	maxHealth = 40
 	natural_weapon = /obj/item/natural_weapon/hooves
 
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/goat
@@ -126,6 +127,7 @@
 	response_disarm = "gently pushes aside"
 	response_harm   = "kicks"
 	health = 50
+	maxHealth = 50
 
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/beef
 	meat_amount = 6
@@ -260,6 +262,7 @@ var/global/chicken_count = 0
 	response_disarm = "gently pushes aside"
 	response_harm   = "kicks"
 	health = 10
+	maxHealth = 10
 	pass_flags = PASS_FLAG_TABLE
 	holder_type = /obj/item/holder
 	mob_size = MOB_SMALL
@@ -406,6 +409,7 @@ var/global/chicken_count = 0
 	response_disarm = "gently pushes aside"
 	response_harm   = "kicks"
 	health = 100
+	maxHealth = 100
 
 	meat_type = /obj/item/reagent_containers/food/snacks/meat/thoom
 	meat_amount = 10

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -73,7 +73,7 @@
 		data["max_health"] = sensors.get_max_health()
 		data["heat"] = sensors.heat
 		data["critical_heat"] = sensors.critical_heat
-		if(sensors.health_dead)
+		if(sensors.health_dead())
 			data["status"] = "DESTROYED"
 		else if(!sensors.powered())
 			data["status"] = "NO POWER"
@@ -229,7 +229,7 @@
 	overlays.Cut()
 	if(use_power)
 		icon_state = "sensors"
-	if(health_dead)
+	if(health_dead())
 		icon_state = "sensors_broken"
 	else
 		icon_state = "sensors_off"
@@ -238,7 +238,7 @@
 	. = ..()
 
 /obj/machinery/shipsensors/proc/toggle()
-	if(!use_power && (health_dead || !in_vacuum()))
+	if(!use_power && (health_dead() || !in_vacuum()))
 		return // No turning on if broken or misplaced.
 	if(!use_power) //need some juice to kickstart
 		use_power_oneoff(idle_power_usage*5)

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -122,7 +122,7 @@ var/global/solar_gen_rate = 1500
 
 /obj/machinery/power/solar/set_broken(new_state)
 	. = ..()
-	if(. && new_state && !health_dead)
+	if(. && new_state && !health_dead())
 		kill_health()
 
 /obj/machinery/power/solar/on_death()

--- a/code/modules/psionics/null/material_weapon.dm
+++ b/code/modules/psionics/null/material_weapon.dm
@@ -3,7 +3,7 @@
 
 /obj/item/material/withstand_psi_stress(stress, atom/source)
 	. = ..(stress, source)
-	if(!health_dead && . > 0 && disrupts_psionics())
+	if(!health_dead() && . > 0 && disrupts_psionics())
 		damage_health(.)
 		. = max(0, -(get_current_health()))
 

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -37,7 +37,7 @@
 
 /obj/machinery/shield/post_health_change(health_mod, prior_health, damage_type)
 	. = ..()
-	if (health_dead)
+	if (health_dead())
 		return
 	if (health_mod < -1) // To prevent slow degradation proccing this constantly
 		set_opacity(TRUE)

--- a/code/modules/tables/interactions.dm
+++ b/code/modules/tables/interactions.dm
@@ -44,7 +44,7 @@
 
 /obj/structure/table/bullet_act(obj/item/projectile/P)
 	. = ..()
-	if (health_dead)
+	if (health_dead())
 		return PROJECTILE_CONTINUE
 
 /obj/structure/table/CheckExit(atom/movable/O as mob|obj, target as turf)

--- a/code/modules/xenoarcheaology/anomaly_container.dm
+++ b/code/modules/xenoarcheaology/anomaly_container.dm
@@ -116,7 +116,7 @@
 
 /obj/machinery/artifact/MouseDrop(obj/machinery/anomaly_container/over_object, mob/user)
 	if(istype(over_object) && CanMouseDrop(over_object, usr))
-		if (over_object.health_dead)
+		if (over_object.health_dead())
 			visible_message(SPAN_WARNING("\The [over_object]'s containment is broken shut."))
 			return
 		if (!over_object.allowed(usr))

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -49,7 +49,7 @@
 		SPAN_NOTICE("\The [user] starts cutting through \the [src] with \a [weapon]."),
 		SPAN_NOTICE("You start cutting through \the [src] with \the [weapon].")
 	)
-	while (!health_dead)
+	while (!health_dead())
 		if (!do_after(user, 2 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, weapon))
 			return TRUE
 		user.visible_message(


### PR DESCRIPTION
A less efficient but hopefully more compatible version of #33438

:cl: SierraKomodo
refactor: Standardized damage sources should now consistently affect living mobs.
/:cl: