### PR TITLE
more BSD event tweaks

### DIFF
--- a/code/game/machinery/bluespace_drive.dm
+++ b/code/game/machinery/bluespace_drive.dm
@@ -144,11 +144,11 @@
 
 
 /// Creates a blinding flash of light that will blind and deafen those in range, and change turfs to bluespace
-/obj/machinery/bluespacedrive/proc/create_flash(change_turf)
+/obj/machinery/bluespacedrive/proc/create_flash(change_turf, range)
 	playsound(src, "sound/effects/supermatter.ogg", 100, TRUE)
 	var/list/victims = list()
 	var/list/objs = list()
-	get_mobs_and_objs_in_view_fast(loc, 7, victims, objs)
+	get_mobs_and_objs_in_view_fast(loc, range, victims, objs)
 	for (var/mob/living/living in victims)
 		if (living.client)
 			to_chat(living, SPAN_DANGER(FONT_LARGE("The Drive's field cracks open briefly, emitting a blinding flash of blue light and a deafenening screech!")))
@@ -159,8 +159,8 @@
 		living.ear_deaf = max(living.ear_deaf, 15)
 	if (!change_turf)
 		return
-	for (var/turf/simulated/floor/floor in range(4, src))
-		if (prob(40))
+	for (var/turf/simulated/floor/floor in range(range, src))
+		if (prob(25))
 			continue
 		floor.ChangeTurf(/turf/simulated/floor/bluespace)
 

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -391,4 +391,4 @@
 			SPAN_WARNING("\The [L] starts flickering in and out of existence as they step onto the bluespace!"),
 			SPAN_WARNING("You feel your entire body tingle, and something pulling you away!")
 		)
-		addtimer(new Callback(GLOBAL_PROC, /proc/do_unstable_teleport_safe, L, GetConnectedZlevels(L.z)), rand(30, 80))
+		addtimer(new Callback(GLOBAL_PROC, /proc/do_unstable_teleport_safe, L, GetConnectedZlevels(L.z)), rand(5, 15))

--- a/code/modules/events/bsd_instability.dm
+++ b/code/modules/events/bsd_instability.dm
@@ -1,5 +1,5 @@
 /datum/event/bsd_instability
-	endWhen	= 800
+	endWhen	= 350
 
 	var/list/obj/machinery/tele_pad/pads = list()
 	var/list/obj/machinery/bluespacedrive/drives = list()
@@ -9,6 +9,7 @@
 	var/effects_per_tick = 5
 	var/maximum_mobs = 10
 	var/mob_spawn_chance = 3
+	var/turf_conversion_range = 5
 
 	/// Whether or not the 'pulse' should happen, changed to true if the probability check passes in setup()
 	var/should_do_pulse = FALSE
@@ -52,7 +53,7 @@
 		drive.set_light(1, 8, 25, 15, COLOR_CYAN_BLUE)
 		if (severity <= EVENT_LEVEL_MODERATE)
 			continue
-		addtimer(new Callback(drive, /obj/machinery/bluespacedrive/proc/create_flash, TRUE), 2 SECONDS)
+		addtimer(new Callback(drive, /obj/machinery/bluespacedrive/proc/create_flash, TRUE, turf_conversion_range), 2 SECONDS)
 	if (severity <= EVENT_LEVEL_MODERATE)
 		return
 	for (var/obj/structure/stairs/stair in world)
@@ -107,7 +108,7 @@
 	for (var/obj/machinery/bluespacedrive/drive in drives)
 		drive.instability_event_active = FALSE
 		drive.set_light(1, 5, 15, 10, COLOR_CYAN)
-		for (var/turf/simulated/floor/floor in range(3, drive))
+		for (var/turf/simulated/floor/floor in range(turf_conversion_range, drive))
 			if (istype(floor.flooring, /singleton/flooring/bluespace))
 				floor.set_flooring(GET_SINGLETON(initial(floor.flooring)))
 	for (var/obj/structure/stairs/stair in stairs)

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -175,7 +175,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Toilet Flooding",						/datum/event/toilet_clog/flood,			50, 	list(ASSIGNMENT_JANITOR = 20)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Drone Uprising",						/datum/event/rogue_maint_drones,		25,		list(ASSIGNMENT_ENGINEER = 30)),
 		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Supermatter Power Surge",				/datum/event/power_surge,				100,	list(ASSIGNMENT_ENGINEER = 10)),
-		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Bluespace Drive Instability",			/datum/event/bsd_instability,			100,	list(ASSIGNMENT_ENGINEER = 10)),
+		new /datum/event_meta(EVENT_LEVEL_MODERATE, "Bluespace Drive Instability",			/datum/event/bsd_instability,			50),
 	)
 
 /datum/event_container/major
@@ -189,7 +189,7 @@ var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT
 		new /datum/event_meta/no_overmap(EVENT_LEVEL_MAJOR, "Electrical Storm",		/datum/event/electrical_storm, 		0,	list(ASSIGNMENT_ENGINEER = 10, ASSIGNMENT_JANITOR = 5)),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Drone Revolution",				/datum/event/rogue_maint_drones,	0,	list(ASSIGNMENT_ENGINEER = 10,ASSIGNMENT_MEDICAL = 10,ASSIGNMENT_SECURITY = 10)),
 		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Spider Infestation",				/datum/event/spider_infestation, 	0,	list(ASSIGNMENT_SECURITY = 10), 1),
-		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Bluespace Drive Instability",	/datum/event/bsd_instability,		100,list(ASSIGNMENT_ENGINEER = 10), 1),
+		new /datum/event_meta(EVENT_LEVEL_MAJOR, "Bluespace Drive Instability",	/datum/event/bsd_instability,		0,		null, 1),
 	)
 
 /datum/event_container/exo


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed some bluespace turfs not reverting after the BSD event runs. 
tweak: The BSD event now only runs for about 18 minutes.
tweak: The BSD event should happen less often now (it's not THAT broken).
/:cl: