### PR TITLE
SE tweaks

### DIFF
--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -21,18 +21,18 @@
 		/datum/mil_rank/fleet/e7,
 		/datum/mil_rank/fleet/e8,
 	)
-	min_skill = list(   SKILL_COMPUTER     = SKILL_BASIC,
-	                    SKILL_EVA          = SKILL_TRAINED,
-	                    SKILL_CONSTRUCTION = SKILL_TRAINED,
-	                    SKILL_ELECTRICAL   = SKILL_TRAINED,
-	                    SKILL_ATMOS        = SKILL_BASIC,
-	                    SKILL_ENGINES      = SKILL_TRAINED)
+	min_skill = list(   SKILL_COMPUTER     = SKILL_TRAINED,
+						SKILL_EVA          = SKILL_TRAINED,
+						SKILL_CONSTRUCTION = SKILL_TRAINED,
+						SKILL_ELECTRICAL   = SKILL_TRAINED,
+						SKILL_ATMOS        = SKILL_TRAINED,
+						SKILL_ENGINES      = SKILL_TRAINED)
 
 	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,
-	                    SKILL_ELECTRICAL   = SKILL_MAX,
-	                    SKILL_ATMOS        = SKILL_MAX,
-	                    SKILL_ENGINES      = SKILL_MAX)
-	skill_points = 24
+						SKILL_ELECTRICAL   = SKILL_MAX,
+						SKILL_ATMOS        = SKILL_MAX,
+						SKILL_ENGINES      = SKILL_MAX)
+	skill_points = 20
 
 	access = list(
 		access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -705,7 +705,7 @@
 /obj/machinery/door/airlock/highsecurity{
 	autoset_access = 0;
 	name = "Secure Tech Storage";
-	req_access = list("ACCESS_BRIDGE","ACCESS_TECH_STORAGE")
+	req_access = list("ACCESS_TORCH_SENIOR_ENG","ACCESS_TECH_STORAGE")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,


### PR DESCRIPTION
Expands Senior Engineer Access slightly, requires they have trained in all engi skills + IT, and reduces their skill points by 4.

This is, technically, a buff for senior engineers, because of the expanded access. The skills changes only amount to one extra point, if I understand correctly, but if the skills changes are undesirable, or if they shouldn't have their points reduced, or if either of the access changes are bad, I will fix.

Secure tech storage change was to let SE's access it- the bridge access requirement meant really only the CE, XO and CO could before.

🆑 jux
tweak: Secure tech storage now requires Tech Storage + Senior Engi Access, instead of Tech + Bridge access
tweak: Senior engineers now always have trained IT and atmospherics, but lose 4 skill points
/🆑 
