### PR TITLE
Removes most of the Torch's Cameras

### DIFF
--- a/code/__defines/machinery.dm
+++ b/code/__defines/machinery.dm
@@ -41,16 +41,17 @@
 #define AI_CAMERA_LUMINOSITY 6
 
 // Camera networks
-#define NETWORK_CRESCENT "Crescent"
-#define NETWORK_ENGINEERING "Engineering"
-#define NETWORK_ERT "ZeEmergencyResponseTeam"
-#define NETWORK_EXODUS "Exodus"
-#define NETWORK_MEDICAL "Medical"
-#define NETWORK_MERCENARY "MercurialNet"
-#define NETWORK_MINE "Mining"
-#define NETWORK_RESEARCH "Research"
-#define NETWORK_SECURITY "Security"
-#define NETWORK_THUNDER "Thunderdome"
+var/global/const/NETWORK_CRESCENT       = "Crescent"
+var/global/const/NETWORK_ENGINEERING       = "Engineering"
+var/global/const/NETWORK_ERT       = "ERT"
+var/global/const/NETWORK_EXODUS       = "Exodus"
+var/global/const/NETWORK_MEDICAL       = "Medical"
+var/global/const/NETWORK_MERCENARY       = "MercurialNet"
+var/global/const/NETWORK_MINE       = "Mining"
+var/global/const/NETWORK_RESEARCH       = "Research"
+var/global/const/NETWORK_SECURITY       = "Security"
+var/global/const/NETWORK_THUNDER       = "Thunderdome"
+var/global/const/NETWORK_HELMETS       = "Helmet Cameras"
 
 #define NETWORK_ALARM_ATMOS "Atmosphere Alarms"
 #define NETWORK_ALARM_CAMERA "Camera Alarms"

--- a/code/game/machinery/camera/presets.dm
+++ b/code/game/machinery/camera/presets.dm
@@ -22,6 +22,9 @@
 /obj/machinery/camera/network/thunder
 	network = list(NETWORK_THUNDER)
 
+/obj/machinery/camera/network/helmet
+	network = list(NETWORK_HELMETS)
+
 // EMP
 
 /obj/machinery/camera/emp_proof/Initialize()

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -65,7 +65,7 @@
 
 /obj/item/clothing/head/helmet/space/rig/industrial
 	light_overlay = "helmet_light_wide"
-	camera = /obj/machinery/camera/network/mining
+	camera = /obj/machinery/camera/network/helmet
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_IPC)
 
 /obj/item/clothing/suit/space/rig/industrial
@@ -131,7 +131,7 @@
 
 /obj/item/clothing/head/helmet/space/rig/eva
 	light_overlay = "helmet_light_alt"
-	camera = /obj/machinery/camera/network/engineering
+	camera = /obj/machinery/camera/network/helmet
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_IPC)
 	sprite_sheets = list(
 		SPECIES_SKRELL = 'icons/mob/species/skrell/onmob_head_skrell.dmi',
@@ -220,7 +220,7 @@
 
 /obj/item/clothing/head/helmet/space/rig/ce
 	light_overlay = "helmet_light_alt"
-	camera = /obj/machinery/camera/network/engineering
+	camera = /obj/machinery/camera/network/helmet
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_IPC)
 	sprite_sheets = list(
 		SPECIES_UNATHI = 'icons/mob/species/unathi/onmob_head_unathi.dmi',
@@ -278,7 +278,7 @@
 
 /obj/item/clothing/head/helmet/space/rig/hazmat
 	light_overlay = "helmet_light_dual"
-	camera = /obj/machinery/camera/network/research
+	camera = /obj/machinery/camera/network/helmet
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_IPC)
 
 /obj/item/clothing/suit/space/rig/hazmat
@@ -342,7 +342,7 @@
 
 /obj/item/clothing/head/helmet/space/rig/medical
 	light_overlay = "helmet_light_wide"
-	camera = /obj/machinery/camera/network/medbay
+	camera = /obj/machinery/camera/network/helmet
 	species_restricted = list(SPECIES_HUMAN, SPECIES_UNATHI, SPECIES_SKRELL, SPECIES_IPC)
 	sprite_sheets = list(
 		SPECIES_UNATHI = 'icons/mob/species/unathi/onmob_head_unathi.dmi',
@@ -409,7 +409,7 @@
 
 /obj/item/clothing/head/helmet/space/rig/hazard
 	light_overlay = "helmet_light_dual"
-	camera = /obj/machinery/camera/network/security
+	camera = /obj/machinery/camera/network/helmet
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI, SPECIES_IPC)
 
 /obj/item/clothing/suit/space/rig/hazard

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -20,6 +20,8 @@
 			return access_research
 		if(NETWORK_THUNDER)
 			return 0
+		if(NETWORK_HELMETS)
+			return access_eva
 
 	return access_security // Default for all other networks
 

--- a/maps/torch/items/clothing/solgov-head.dm
+++ b/maps/torch/items/clothing/solgov-head.dm
@@ -430,7 +430,7 @@
 	accessories = null
 
 /obj/item/clothing/head/helmet/space/void/exploration
-	camera = /obj/machinery/camera/network/exploration
+	camera = /obj/machinery/camera/network/helmet
 
 //SolGov Hardsuits
 

--- a/maps/torch/items/rigs.dm
+++ b/maps/torch/items/rigs.dm
@@ -34,7 +34,7 @@
 	light_overlay = "helmet_light_dual"
 	icon = 'maps/torch/icons/obj/obj_head_solgov.dmi'
 	item_icons = list(slot_head_str = 'maps/torch/icons/mob/onmob_head_solgov.dmi')
-	camera = /obj/machinery/camera/network/command
+	camera = /obj/machinery/camera/network/helmet
 	species_restricted = list(SPECIES_HUMAN,SPECIES_IPC) //no available icons for aliens
 
 /obj/item/clothing/suit/space/rig/command
@@ -348,7 +348,7 @@
 	siemens_coefficient = 0
 
 /obj/item/clothing/head/helmet/space/rig/command/exploration
-	camera = /obj/machinery/camera/network/exploration
+	camera = /obj/machinery/camera/network/helmet
 	icon_state = "command_exp_rig"
 	light_overlay = "helmet_light_wide"
 	brightness_on = 0.8
@@ -384,4 +384,4 @@
  */
 
 /obj/item/clothing/head/helmet/space/rig/industrial
-	camera = /obj/machinery/camera/network/supply
+	camera = /obj/machinery/camera/network/helmet

--- a/maps/torch/robot/module_flying_surveyor.dm
+++ b/maps/torch/robot/module_flying_surveyor.dm
@@ -5,7 +5,7 @@
 		"Science" = TRUE,
 		"Exploration" = TRUE
 	)
-	networks = list(NETWORK_EXPEDITION)
+	networks = list(NETWORK_RESEARCH)
 	sprites = list(
 		"Drone"  = "drone-science",
 		"Eyebot" = "eyebot-science"

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -309,6 +309,10 @@
 	dir = 10
 	},
 /obj/machinery/light,
+/obj/machinery/camera/network/fifth_deck{
+	c_tag = "Fifth Deck Hallway - Lift";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/fore)
 "aJ" = (
@@ -790,9 +794,6 @@
 	name = "Atmospheric Sensors";
 	sensor_tag = "charon_out"
 	},
-/obj/machinery/camera/network/exploration_shuttle{
-	c_tag = "Charon - Crew Compartment"
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/exploration_shuttle/crew)
 "bF" = (
@@ -1200,9 +1201,6 @@
 /obj/random/medical,
 /obj/structure/table/steel_reinforced,
 /obj/item/bodybag/cryobag,
-/obj/machinery/camera/network/exploration_shuttle{
-	c_tag = "Charon - Medical Compartment"
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -1920,10 +1918,6 @@
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/firecloset,
-/obj/machinery/camera/network/exploration_shuttle{
-	c_tag = "Charon - Cargo Compartment";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/cargo)
 "ee" = (
@@ -2632,10 +2626,6 @@
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/structure/cable/yellow,
-/obj/machinery/camera/network/exploration_shuttle{
-	c_tag = "Charon - Power Compartment";
-	dir = 1
-	},
 /obj/item/stack/material/phoron/ten,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/exploration_shuttle/power)
@@ -3025,17 +3015,25 @@
 /turf/simulated/wall/prepainted,
 /area/quartermaster/shuttlefuel)
 "gP" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/floodlight,
-/obj/machinery/camera/network/supply{
-	c_tag = "Supply Office - Warehouse Aft";
-	dir = 1
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/effect/floor_decal/industrial/warning{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/quartermaster/storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/camera/network/research{
+	c_tag = "Petrov - Hallway Fore"
+	},
+/turf/simulated/floor/tiled/white,
+/area/shuttle/petrov/hallwaya)
 "gT" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/floodlight,
@@ -3509,7 +3507,9 @@
 /turf/simulated/floor/plating,
 /area/guppy_hangar/start)
 "ir" = (
-/obj/machinery/camera/network/hangar,
+/obj/machinery/camera/network/fifth_deck{
+	c_tag = "Hangar - Midships Starboard"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
 "iu" = (
@@ -3752,10 +3752,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/camera/network/exploration{
-	c_tag = "Exploration Equipment";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/exploration)
 "iP" = (
@@ -3852,9 +3848,6 @@
 "ja" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8
-	},
-/obj/machinery/camera/network/supply{
-	c_tag = "Supply Office - Warehouse Fore"
 	},
 /obj/machinery/computer/guestpass{
 	pixel_y = 32
@@ -4103,6 +4096,10 @@
 	dir = 1;
 	icon_state = "warningcorner"
 	},
+/obj/machinery/camera/network/fifth_deck{
+	c_tag = "Hangar - Fore Starboard";
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "jC" = (
@@ -4126,10 +4123,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/camera/network/exploration{
-	c_tag = "Exploration EVA";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/exploration)
 "jF" = (
@@ -4152,10 +4145,6 @@
 "jG" = (
 /obj/structure/table/steel,
 /obj/machinery/chemical_dispenser/bar_soft/full,
-/obj/machinery/camera/network/exploration{
-	c_tag = "Pilot's Lounge";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/pilot)
 "jH" = (
@@ -5080,10 +5069,6 @@
 	},
 /obj/structure/ladder/up,
 /obj/machinery/light/small,
-/obj/machinery/camera/network/hangar{
-	c_tag = "Expedition Storage";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/expedition/storage)
 "lz" = (
@@ -5223,10 +5208,6 @@
 	name = "east bump";
 	pixel_y = -24;
 	req_access = list()
-	},
-/obj/machinery/camera/network/pod{
-	c_tag = "General Utility Pod - Crew Compartment";
-	dir = 4
 	},
 /obj/structure/cable/green{
 	d2 = 4;
@@ -5564,10 +5545,6 @@
 /area/quartermaster/hangar)
 "mG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
-/obj/machinery/camera/network/exploration_shuttle{
-	c_tag = "Charon - Atmospherics Compartment";
-	dir = 8
-	},
 /obj/structure/handrail{
 	dir = 8
 	},
@@ -5661,6 +5638,10 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
+	},
+/obj/machinery/camera/network/fifth_deck{
+	c_tag = "Fifth Deck Hallway - Stairs";
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/fore)
@@ -6050,9 +6031,6 @@
 "nA" = (
 /obj/machinery/suit_storage_unit/science,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/expedition{
-	c_tag = "Expedition - EVA Prep"
-	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/expedition/eva)
 "nB" = (
@@ -6707,7 +6685,9 @@
 /area/quartermaster/hangar)
 "oI" = (
 /obj/effect/catwalk_plated,
-/obj/machinery/camera/network/hangar,
+/obj/machinery/camera/network/fifth_deck{
+	c_tag = "Hangar - Aft Starboard"
+	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "oJ" = (
@@ -6716,9 +6696,6 @@
 /area/hallway/primary/fifthdeck/fore)
 "oL" = (
 /obj/effect/catwalk_plated,
-/obj/machinery/camera/network/hangar{
-	dir = 8
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -6732,22 +6709,17 @@
 /area/quartermaster/hangar)
 "oM" = (
 /obj/effect/catwalk_plated,
-/obj/machinery/camera/network/hangar{
+/obj/machinery/camera/network/fifth_deck{
+	c_tag = "Hangar - Fore Port";
 	dir = 4
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "oN" = (
 /obj/effect/catwalk_plated,
-/obj/machinery/camera/network/hangar{
+/obj/machinery/camera/network/fifth_deck{
+	c_tag = "Hangar - Aft Port";
 	dir = 8
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
-"oO" = (
-/obj/effect/catwalk_plated,
-/obj/machinery/camera/network/hangar{
-	dir = 1
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
@@ -6812,10 +6784,6 @@
 /obj/effect/floor_decal/corner/mauve/half,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/light,
-/obj/machinery/camera/network/fifth_deck{
-	c_tag = "Fifth Deck Hallway - Lift";
-	dir = 1
-	},
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
@@ -7397,10 +7365,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/fuel{
 	dir = 8
 	},
-/obj/machinery/camera/network/exploration_shuttle{
-	c_tag = "Charon - Fuel Compartment";
-	dir = 4
-	},
 /obj/structure/handrail{
 	dir = 4
 	},
@@ -7864,10 +7828,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Substation - Fifth Deck";
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
 	icon_state = "warning"
@@ -8228,10 +8188,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/camera/network/fifth_deck{
-	c_tag = "Fifth Deck Hallway - Stairwell";
-	dir = 4
-	},
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/fore)
 "rN" = (
@@ -8512,10 +8468,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/fore)
 "sp" = (
-/obj/machinery/camera/network/expedition{
-	c_tag = "Expedition - Prep";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -9061,9 +9013,6 @@
 /area/shuttle/petrov/hallwaya)
 "tO" = (
 /obj/effect/catwalk_plated,
-/obj/machinery/camera/network/hangar{
-	dir = 4
-	},
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 4
 	},
@@ -9765,6 +9714,10 @@
 	dir = 1
 	},
 /obj/structure/handrail{
+	dir = 4
+	},
+/obj/machinery/camera/network/research{
+	c_tag = "Petrov - Anomalies Fore";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white/monotile,
@@ -11018,9 +10971,6 @@
 /obj/item/device/radio/intercom{
 	pixel_y = 23
 	},
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Cockpit"
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -11170,6 +11120,10 @@
 /area/maintenance/fifthdeck/aftstarboard)
 "Ao" = (
 /obj/structure/handrail{
+	dir = 1
+	},
+/obj/machinery/camera/network/research{
+	c_tag = "Petrov - Entryway";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/white,
@@ -11795,10 +11749,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/camera/network/hangar{
-	c_tag = "Fuel Bay";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/quartermaster/shuttlefuel)
 "Dc" = (
@@ -11976,10 +11926,6 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/hallwaya)
 "DE" = (
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - EVA";
-	dir = 4
-	},
 /obj/machinery/light_switch{
 	pixel_x = -24;
 	pixel_y = 12
@@ -12036,10 +11982,6 @@
 	},
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Anomaly Aft";
-	dir = 8
 	},
 /obj/item/device/radio/intercom{
 	dir = 8;
@@ -12237,10 +12179,6 @@
 	pixel_x = -24;
 	pixel_y = 12
 	},
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Toxins";
-	dir = 4
-	},
 /obj/structure/cable/cyan{
 	d1 = 1;
 	d2 = 2;
@@ -12313,10 +12251,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "EJ" = (
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Desublimation";
-	dir = 4
-	},
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -12329,10 +12263,6 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/phoron)
 "EK" = (
-/obj/machinery/camera/network/hangar{
-	c_tag = "Atmospheric Storage";
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/outline/blue,
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/dark,
@@ -12492,10 +12422,6 @@
 /turf/space,
 /area/space)
 "FU" = (
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Hallway Aft";
-	dir = 1
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 1;
 	level = 2
@@ -12911,6 +12837,10 @@
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/machinery/camera/network/research{
+	c_tag = "Petrov - Hallway Aft";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
 "Hv" = (
@@ -13208,9 +13138,6 @@
 /area/shuttle/petrov/equipment)
 "IB" = (
 /obj/machinery/disposal,
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Fabrication"
-	},
 /obj/machinery/light_switch{
 	pixel_x = -6;
 	pixel_y = 24
@@ -13636,10 +13563,6 @@
 /area/shuttle/petrov/rnd)
 "Ki" = (
 /obj/effect/floor_decal/industrial/warning/fulltile,
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Hallway Fore";
-	dir = 1
-	},
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
@@ -14267,10 +14190,6 @@
 "Mz" = (
 /obj/machinery/stasis_cage,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Equipment";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/equipment)
 "MB" = (
@@ -14622,6 +14541,9 @@
 	tag_south = 3;
 	tag_west = 1
 	},
+/obj/machinery/camera/network/research{
+	c_tag = "Petrov - Anomalies Aft"
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/isolation)
 "NY" = (
@@ -14936,10 +14858,6 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Anomaly Fore";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/isolation)
 "Pt" = (
@@ -15128,10 +15046,6 @@
 	name = "Biohazard Shutter Control";
 	pixel_x = -5;
 	pixel_y = -3
-	},
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Security";
-	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -15557,10 +15471,6 @@
 /obj/item/anobattery{
 	pixel_x = 6;
 	pixel_y = 6
-	},
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Analysis";
-	dir = 4
 	},
 /obj/structure/cable/cyan{
 	d2 = 4;
@@ -16022,7 +15932,7 @@
 /area/shuttle/petrov/analysis)
 "TL" = (
 /obj/machinery/camera/network/fifth_deck{
-	c_tag = "Fifth Deck Hallway - Ladders";
+	c_tag = "Fifth Deck - Ladders";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/purple{
@@ -16494,10 +16404,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Chief Science Officer";
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -16506,6 +16412,10 @@
 "VN" = (
 /obj/structure/closet/hydrant{
 	pixel_x = -32
+	},
+/obj/machinery/camera/network/fifth_deck{
+	c_tag = "Hangar - Midships Port";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
@@ -17249,10 +17159,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/petrov{
-	c_tag = "Petrov - Entry";
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_pump/on,
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
 	dir = 4;
@@ -33020,12 +32926,12 @@ ev
 aX
 aX
 aX
-oM
+aX
 kU
 aX
 aX
 aX
-aX
+oM
 lQ
 lM
 jZ
@@ -34212,7 +34118,7 @@ EK
 tV
 lz
 lY
-ir
+UH
 ih
 ee
 aA
@@ -34439,7 +34345,7 @@ np
 np
 yp
 fS
-oO
+aX
 gO
 gO
 gO
@@ -36662,7 +36568,7 @@ Ho
 Ho
 Ho
 hT
-oO
+aX
 aJ
 CX
 sk
@@ -39694,7 +39600,7 @@ hR
 iG
 mD
 jl
-gP
+jl
 Em
 uh
 pt
@@ -44526,7 +44432,7 @@ RZ
 xr
 bb
 bb
-BM
+gP
 Wn
 Yk
 Yk

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -5795,6 +5795,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled,
 /area/storage/primary)
 "tZ" = (

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -1353,10 +1353,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/shuttle/escape_pod7/station)
 "eA" = (
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Mess Hall - Officer's Mess";
-	dir = 4
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -1469,10 +1465,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Starboard Escape Pods";
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/green/half{
 	dir = 8
 	},
@@ -1530,7 +1522,7 @@
 	name = "plastic table frame"
 	},
 /obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Fore Starboard Docking Access";
+	c_tag = "Fourth Deck - Fore Starboard Airlock";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red{
@@ -2856,10 +2848,6 @@
 /area/quartermaster/hangar/catwalks_starboard)
 "kc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/command{
-	c_tag = "EVA - Suit Cyclers";
-	dir = 8
-	},
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 21
@@ -2890,10 +2878,6 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
-	},
-/obj/machinery/camera/network/exploration{
-	c_tag = "Pathfinder's Office";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/command/pathfinder)
@@ -3122,6 +3106,10 @@
 /obj/effect/floor_decal/corner/green{
 	dir = 6
 	},
+/obj/machinery/camera/network/fourth_deck{
+	c_tag = "Fourth Deck - Ladders";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fourthdeck/aft)
 "kZ" = (
@@ -3179,8 +3167,8 @@
 /obj/item/stack/material/glass{
 	amount = 50
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "EVA - Center";
+/obj/machinery/camera/network/fourth_deck{
+	c_tag = "Fourth Deck - EVA";
 	dir = 4
 	},
 /obj/machinery/firealarm{
@@ -3373,6 +3361,10 @@
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 4
 	},
+/obj/machinery/camera/network/fourth_deck{
+	c_tag = "Fourth Deck - Aft Port Airlock";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark,
 /area/hallway/primary/fourthdeck/aft)
 "lK" = (
@@ -3461,10 +3453,6 @@
 /area/eva)
 "md" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "EVA - Storage";
 	dir = 8
 	},
 /obj/effect/floor_decal/corner/blue{
@@ -3650,10 +3638,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck Hallway - Stairwell";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
@@ -3683,6 +3667,9 @@
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/corner/red/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/camera/network/fourth_deck{
+	c_tag = "Fourth Deck Hallway - Stairs"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/fore)
 "my" = (
@@ -4419,7 +4406,7 @@
 /area/command/captainmess)
 "pz" = (
 /obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Hangar Bridge";
+	c_tag = "Fourth Deck Hallway - Midships";
 	dir = 1
 	},
 /turf/simulated/floor/tiled,
@@ -4510,9 +4497,6 @@
 "pP" = (
 /obj/structure/closet/crate,
 /obj/random/tank,
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Teleporter"
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/teleporter/fourthdeck)
 "pQ" = (
@@ -5803,17 +5787,12 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/teleporter/fourthdeck)
 "tY" = (
-/obj/structure/table/standard,
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/random/tech_supply,
 /obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck Hallway - Tool Storage";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -6154,10 +6133,6 @@
 "uR" = (
 /obj/machinery/power/breakerbox/activated{
 	RCon_tag = "Fourth Deck Substation Bypass"
-	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Substation - Fourth Deck";
-	dir = 1
 	},
 /obj/effect/floor_decal/industrial/warning{
 	dir = 8;
@@ -6715,10 +6690,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck Hallway - Primary Tool Storage";
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/warning/fulltile,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6974,6 +6945,16 @@
 	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head/deck4)
+"xF" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 9
+	},
+/obj/machinery/camera/network/fourth_deck{
+	c_tag = "Fourth Deck Hallway - Aft Starboard";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/fourthdeck/aft)
 "xJ" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -7724,10 +7705,6 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck Hallway - Port";
-	dir = 4
-	},
 /obj/item/device/radio/intercom{
 	dir = 4;
 	pixel_x = -21
@@ -7961,10 +7938,6 @@
 /area/maintenance/fourthdeck/aft)
 "AN" = (
 /obj/effect/floor_decal/corner/red/mono,
-/obj/machinery/camera/network/security{
-	c_tag = "Checkpoint - Deck Four";
-	dir = 1
-	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
@@ -8568,6 +8541,19 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/aft)
+"DK" = (
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/sign/warning/docking_area{
+	name = "\improper ESCAPE POD LAUNCH PATHWAY";
+	pixel_x = 32
+	},
+/obj/machinery/camera/network/fourth_deck{
+	c_tag = "Fourth Deck - Aft Starboard Airlock";
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/hallway/primary/fourthdeck/aft)
 "DL" = (
 /obj/structure/table/rack,
 /obj/random/tech_supply,
@@ -8886,16 +8872,6 @@
 "ET" = (
 /obj/machinery/light/small{
 	dir = 1
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/lounge)
-"EW" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Lounge Aft";
-	name = "security camera"
 	},
 /turf/simulated/floor/carpet,
 /area/crew_quarters/lounge)
@@ -9220,6 +9196,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden,
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/camera/network/fourth_deck{
+	c_tag = "Fourth Deck Hallway - Aft Port";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "FV" = (
@@ -9255,7 +9235,7 @@
 	name = "plastic table frame"
 	},
 /obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Fore Port Docking Access";
+	c_tag = "Fourth Deck - Fore Port Airlock";
 	dir = 4
 	},
 /obj/effect/floor_decal/corner/red{
@@ -9740,17 +9720,6 @@
 /obj/machinery/computer/shuttle_control/lift/cargo,
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/cargo_lift)
-"HP" = (
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Adherent Maintenance";
-	dir = 8
-	},
-/obj/structure/sign/warning/caution{
-	dir = 8;
-	pixel_x = 32
-	},
-/turf/simulated/floor/crystal,
-/area/crew_quarters/adherent)
 "HQ" = (
 /obj/structure/catwalk,
 /obj/structure/cable/green{
@@ -12381,10 +12350,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/camera/network/supply{
-	c_tag = "Supply Office - Sorting";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/sorting)
 "PH" = (
@@ -12897,10 +12862,6 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Laundry Room";
-	dir = 8
-	},
 /obj/structure/closet/crate/secure/biohazard,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/laundry)
@@ -12966,10 +12927,6 @@
 "Rv" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 6
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "EVA - Suit Storage";
-	dir = 1
 	},
 /obj/item/device/radio/intercom{
 	dir = 1;
@@ -13269,10 +13226,6 @@
 	dir = 4
 	},
 /obj/structure/table/standard,
-/obj/machinery/camera/network/supply{
-	c_tag = "Supply Office - Deck Officer";
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -14289,10 +14242,6 @@
 	pixel_y = 7
 	},
 /obj/item/pen,
-/obj/machinery/camera/network/supply{
-	c_tag = "Supply Office - Desk";
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/office)
 "UJ" = (
@@ -14685,10 +14634,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "EVA - Miscellaneous Suit Storage";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/eva)
 "VJ" = (
@@ -14712,10 +14657,6 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/center)
 "VL" = (
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck Hallway - Ladders";
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
 	},
@@ -15272,22 +15213,12 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
-"Xt" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Lounge Fore";
-	name = "security camera"
-	},
-/turf/simulated/floor/carpet,
-/area/crew_quarters/lounge)
 "Xv" = (
 /obj/effect/floor_decal/corner/brown{
 	dir = 10
 	},
 /obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck Hallway - Aft";
+	c_tag = "Fourth Deck Hallway - Aft Center";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -15719,10 +15650,6 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/light,
-/obj/machinery/camera/network/fourth_deck{
-	c_tag = "Fourth Deck - Ladders";
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
 "YC" = (
@@ -33232,7 +33159,7 @@ EC
 mB
 js
 Sd
-Xt
+ET
 PK
 Zq
 Mu
@@ -34848,7 +34775,7 @@ CG
 Wf
 js
 Sd
-EW
+ET
 PK
 Pe
 Qt
@@ -40487,7 +40414,7 @@ LU
 ag
 ag
 ZP
-ag
+xF
 ag
 mQ
 ag
@@ -40678,7 +40605,7 @@ UT
 QM
 aK
 UR
-bJ
+DK
 sd
 Xc
 Xc
@@ -41503,7 +41430,7 @@ mS
 OB
 QW
 qC
-HP
+uO
 iM
 uO
 IC

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -242,9 +242,6 @@
 /obj/structure/sign/deck/third{
 	pixel_y = 32
 	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck Hallway - Head"
-	},
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},
@@ -301,9 +298,6 @@
 /turf/space,
 /area/space)
 "bc" = (
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck Hallway - Ladders"
-	},
 /obj/effect/floor_decal/corner/yellow{
 	dir = 4
 	},
@@ -414,9 +408,6 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/gym)
 "bx" = (
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Hydroponics -  Storage"
-	},
 /obj/machinery/biogenerator,
 /obj/effect/floor_decal/corner/green{
 	dir = 5
@@ -1628,10 +1619,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Hydroponics - Aft";
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled,
 /area/hydroponics)
@@ -2682,13 +2669,6 @@
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/service_break_room)
-"gi" = (
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Sanitation Supplies";
-	dir = 1
-	},
-/turf/simulated/floor/tiled/steel_grid,
-/area/janitor/storage)
 "gk" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -3158,10 +3138,6 @@
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head)
 "hk" = (
-/obj/machinery/camera/network/engineering{
-	c_tag = "Substation - Third Deck";
-	dir = 1
-	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/thirddeck)
@@ -3528,6 +3504,14 @@
 /obj/structure/window/reinforced/polarized/full,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/head/sauna)
+"hQ" = (
+/obj/effect/floor_decal/industrial/warning/fulltile,
+/obj/machinery/camera/network/third_deck{
+	c_tag = "Third Deck Hallway - Fore";
+	dir = 1
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/hallway/primary/thirddeck/fore)
 "hT" = (
 /obj/structure/stairs/west,
 /obj/effect/floor_decal/corner/yellow/half{
@@ -3632,10 +3616,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/gym)
 "ih" = (
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Mess Hall - Cold Room";
-	dir = 1
-	},
 /obj/structure/closet/crate/freezer,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/galleybackroom)
@@ -4129,9 +4109,6 @@
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
 	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Mess Hall - Center"
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -4207,10 +4184,6 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/head/sauna)
 "jm" = (
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck - Ladders";
-	dir = 1
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
 	},
@@ -5529,10 +5502,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Mess Hall - Bar";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/bar)
 "mm" = (
@@ -5608,10 +5577,6 @@
 	},
 /obj/machinery/alarm{
 	pixel_y = 24
-	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Holodeck Control";
-	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/holocontrol)
@@ -6004,10 +5969,6 @@
 /obj/item/device/radio/intercom{
 	dir = 4;
 	pixel_x = -21
-	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck Hallway - Fore Starboard";
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
@@ -6501,7 +6462,7 @@
 /area/hallway/primary/thirddeck/fore)
 "oW" = (
 /obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck Hallway - Stairwell";
+	c_tag = "Third Deck Hallway - Stairs";
 	dir = 8
 	},
 /obj/item/device/radio/intercom{
@@ -6687,6 +6648,10 @@
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 1
 	},
+/obj/machinery/camera/network/third_deck{
+	c_tag = "Third Deck - Mess Hall";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "pg" = (
@@ -6703,10 +6668,6 @@
 "pi" = (
 /obj/effect/floor_decal/corner/blue/diagonal{
 	dir = 4
-	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Mess Hall - Port";
-	dir = 1
 	},
 /obj/machinery/computer/arcade,
 /turf/simulated/floor/tiled/white,
@@ -7291,9 +7252,6 @@
 /turf/simulated/floor/grass,
 /area/crew_quarters/observation)
 "qU" = (
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck Hallway - Cryogenic Storage"
-	},
 /obj/effect/floor_decal/corner/green{
 	dir = 1
 	},
@@ -7474,9 +7432,6 @@
 /area/hallway/primary/thirddeck/aft)
 "rv" = (
 /obj/machinery/hologram/holopad,
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Holodeck - Center"
-	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm{
 	dir = 4;
@@ -8392,7 +8347,7 @@
 /area/hallway/primary/thirddeck/fore)
 "ts" = (
 /obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck Hallway - Fore Central";
+	c_tag = "Third Deck Hallway - Fore Center";
 	dir = 4
 	},
 /turf/simulated/floor/tiled,
@@ -8539,14 +8494,11 @@
 /area/thruster/d3port)
 "tL" = (
 /obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck Hallway - Center";
-	dir = 1
-	},
-/obj/effect/floor_decal/corner/green{
-	dir = 10
+	c_tag = "Third Deck Hallway - Fore Starboard";
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/center)
+/area/hallway/primary/thirddeck/fore)
 "tN" = (
 /obj/structure/bed/chair/pew/left/mahogany,
 /obj/machinery/light{
@@ -8579,6 +8531,10 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
+	},
+/obj/machinery/camera/network/third_deck{
+	c_tag = "Third Deck Hallway - Midships Aft";
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/center)
@@ -9146,7 +9102,7 @@
 	pixel_y = -28
 	},
 /obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck Hallway - Observation Bubble";
+	c_tag = "Third Deck Hallway - Observation";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
@@ -9575,9 +9531,6 @@
 /obj/machinery/atm{
 	pixel_y = 32
 	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck Hallway - Teleporter"
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "wP" = (
@@ -9653,10 +9606,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/sleep/bunk)
 "wY" = (
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Cryogenic Storage - Fore Starboard";
-	dir = 4
-	},
 /obj/machinery/vending/cola{
 	dir = 4
 	},
@@ -9739,10 +9688,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/seed_storage/garden,
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Hydroponics - Fore";
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/green{
 	dir = 10
 	},
@@ -10028,13 +9973,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/security/habcheck)
-"xV" = (
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck Saferoom"
-	},
-/obj/structure/bed/chair,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/crew_quarters/safe_room/thirddeck)
 "xW" = (
 /obj/machinery/door/window/brigdoor{
 	dir = 8
@@ -10169,7 +10107,7 @@
 /area/crew_quarters/recreation)
 "yk" = (
 /obj/machinery/camera/network/third_deck{
-	c_tag = "Cryogenic Storage - Aft Starboard";
+	c_tag = "Third Deck Cryogenics - Aft";
 	dir = 8
 	},
 /obj/structure/table/standard,
@@ -10255,15 +10193,6 @@
 /obj/item/pen,
 /turf/simulated/floor/carpet/purple,
 /area/chapel/office)
-"yD" = (
-/obj/machinery/suit_storage_unit/engineering/alt/sol,
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - EVA";
-	dir = 8
-	},
-/obj/effect/floor_decal/industrial/outline/yellow,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/engineering/hardstorage)
 "yE" = (
 /obj/structure/table/rack,
 /turf/simulated/floor/plating,
@@ -10933,9 +10862,6 @@
 "AM" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck - Auxillary Storage"
-	},
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
@@ -11370,10 +11296,6 @@
 /area/hallway/primary/thirddeck/fore)
 "Cc" = (
 /obj/structure/table/standard,
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck - Teleporter";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/thirddeck)
 "Cf" = (
@@ -11610,10 +11532,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/hallway/primary/thirddeck/fore)
 "CL" = (
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Chapel";
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -12053,6 +11971,10 @@
 	department = "Cryogenic Storage";
 	pixel_x = -32
 	},
+/obj/machinery/camera/network/third_deck{
+	c_tag = "Third Deck Cryogenics - Fore";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/crew_quarters/sleep/cryo)
 "DO" = (
@@ -12149,8 +12071,8 @@
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/service_break_room)
 "DU" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Fire Control - Storage";
+/obj/machinery/camera/network/bridge{
+	c_tag = "Fire Control - Munitions";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
@@ -12363,20 +12285,12 @@
 	dir = 9
 	},
 /obj/structure/filingcabinet,
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Chief Steward's Office";
-	dir = 1
-	},
 /obj/effect/floor_decal/spline/plain/green{
 	dir = 4
 	},
 /turf/simulated/floor/wood/maple,
 /area/crew_quarters/chief_steward)
 "Et" = (
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Cryogenic Storage - Fore Port";
-	dir = 4
-	},
 /obj/machinery/vending/coffee{
 	dir = 4
 	},
@@ -13574,6 +13488,15 @@
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/thirddeck/port)
+"HF" = (
+/obj/effect/floor_decal/corner/green{
+	dir = 5
+	},
+/obj/machinery/camera/network/third_deck{
+	c_tag = "Third Deck Hallway - Midships Fore"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/thirddeck/center)
 "HG" = (
 /obj/structure/largecrate,
 /obj/random/maintenance/solgov,
@@ -13622,9 +13545,6 @@
 "HL" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Fire Control - Access"
 	},
 /turf/simulated/floor/plating,
 /area/command/disperser)
@@ -13777,6 +13697,10 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/machinery/camera/network/bridge{
+	c_tag = "Fire Control - Operations";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/dark,
 /area/command/disperser)
 "Ih" = (
@@ -13842,10 +13766,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "Ir" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Fire Control - Controls";
-	dir = 4
-	},
 /obj/machinery/computer/ship/disperser{
 	dir = 4
 	},
@@ -15616,9 +15536,6 @@
 	pixel_x = 9;
 	pixel_y = -1
 	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Service Break Room"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/service_break_room)
 "Md" = (
@@ -15877,9 +15794,6 @@
 "MP" = (
 /obj/structure/table/woodentable,
 /obj/effect/floor_decal/spline/fancy/wood,
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Recreation Room"
-	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/recreation)
 "MR" = (
@@ -16781,6 +16695,16 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/thirddeck)
+"Pu" = (
+/obj/effect/floor_decal/corner/yellow{
+	dir = 9
+	},
+/obj/machinery/camera/network/third_deck{
+	c_tag = "Third Deck - Ladders";
+	dir = 4
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/hallway/primary/thirddeck/center)
 "Pv" = (
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/thirddeck/fore)
@@ -17363,9 +17287,6 @@
 	pixel_x = -32
 	},
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/camera/network/third_deck{
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/crew_quarters/gym)
 "Rh" = (
@@ -18299,10 +18220,6 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Computer Lab";
-	dir = 1
-	},
 /turf/simulated/floor/lino,
 /area/crew_quarters/office)
 "TN" = (
@@ -18377,10 +18294,6 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Chapel - Chaplain's Office";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/dark,
 /area/chapel/office)
 "TZ" = (
@@ -18571,10 +18484,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Chapel - Memorial Room";
-	dir = 1
 	},
 /obj/effect/floor_decal/corner/purple{
 	dir = 5
@@ -19847,10 +19756,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/teleporter/thirddeck)
 "XJ" = (
-/obj/machinery/camera/network/security{
-	c_tag = "Checkpoint - Deck Three";
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/red{
 	dir = 10
 	},
@@ -20091,6 +19996,10 @@
 	},
 /obj/structure/closet/crate/hydroponics/beekeeping,
 /obj/effect/floor_decal/industrial/outline/yellow,
+/obj/machinery/camera/network/third_deck{
+	c_tag = "Third Deck - Hydroponics";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hydroponics)
 "Yp" = (
@@ -20116,12 +20025,6 @@
 	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 6
-	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/thirddeck/fore)
-"Yu" = (
-/obj/machinery/camera/network/third_deck{
-	c_tag = "Third Deck Hallway - Commissary"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
@@ -30467,7 +30370,7 @@ gB
 gB
 gB
 gB
-Yu
+VU
 sN
 yH
 ma
@@ -31304,7 +31207,7 @@ bR
 Mf
 uj
 kC
-gi
+el
 eU
 eU
 aa
@@ -31478,7 +31381,7 @@ UP
 sI
 gB
 Ch
-VU
+tL
 WB
 Sd
 mU
@@ -33512,7 +33415,7 @@ CF
 eH
 wR
 xR
-wR
+hQ
 Bm
 jR
 lK
@@ -33716,7 +33619,7 @@ qL
 xT
 xh
 Bm
-xV
+jR
 NY
 tG
 DI
@@ -38959,7 +38862,7 @@ nk
 jc
 OB
 fB
-Xn
+HF
 sj
 dC
 uU
@@ -39163,7 +39066,7 @@ fB
 fB
 tF
 sj
-tL
+dC
 uU
 uU
 uU
@@ -41794,7 +41697,7 @@ OW
 IV
 Pr
 bf
-bf
+Pu
 bg
 AI
 BA
@@ -42995,7 +42898,7 @@ xv
 XC
 ds
 uh
-yD
+uh
 dM
 dM
 eI

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -467,9 +467,6 @@
 /area/storage/tech)
 "aO" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/camera/network/engine{
-	c_tag = "Tech Storage - Secure"
-	},
 /obj/effect/floor_decal/techfloor{
 	dir = 8
 	},
@@ -478,6 +475,9 @@
 	},
 /obj/machinery/firealarm{
 	pixel_y = 21
+	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Secure Tech Storage"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
@@ -508,13 +508,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/morgue)
 "aT" = (
+/obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/camera/network/medbay{
-	c_tag = "Infirmary - Morgue"
+	c_tag = "Medical - Morgue";
+	dir = 4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/medical/morgue)
 "aU" = (
 /obj/structure/morgue{
@@ -644,9 +643,6 @@
 /obj/effect/floor_decal/industrial/warning{
 	dir = 4;
 	icon_state = "warning"
-	},
-/obj/machinery/camera/network/engine{
-	c_tag = "Engine - Prototype SMES"
 	},
 /obj/machinery/light_switch{
 	pixel_x = 6;
@@ -1567,10 +1563,6 @@
 	name = "west bump";
 	pixel_x = -24
 	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Solar Control - Starboard";
-	dir = 1
-	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarstarboard)
@@ -1668,9 +1660,6 @@
 /obj/item/clothing/glasses/meson,
 /obj/machinery/light/small{
 	dir = 1
-	},
-/obj/machinery/camera/network/engine{
-	c_tag = "Tech Storage - Main"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
@@ -2473,9 +2462,6 @@
 /turf/simulated/open,
 /area/maintenance/seconddeck/central)
 "eL" = (
-/obj/machinery/camera/network/engineering{
-	c_tag = "Substation - Second Deck"
-	},
 /obj/machinery/power/terminal,
 /obj/structure/cable{
 	d2 = 4;
@@ -2604,10 +2590,6 @@
 "eV" = (
 /obj/machinery/fabricator,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/engineering{
-	c_tag = "Robotics - Lower";
-	dir = 8
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -2993,9 +2975,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 1
-	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Hallway - Central West"
 	},
 /obj/machinery/light{
 	dir = 1
@@ -4142,9 +4121,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /obj/machinery/door/blast/regular/open{
+	icon_state = "pdoor0";
 	id_tag = "bsdwindow";
-	name = "Drive Containment";
-	icon_state = "pdoor0"
+	name = "Drive Containment"
 	},
 /turf/simulated/floor/tiled,
 /area/engineering/bluespace)
@@ -4175,10 +4154,6 @@
 	icon_state = "console"
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/engineering{
-	c_tag = "Drive Control Room";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/bluespacebay)
 "iW" = (
@@ -4372,10 +4347,6 @@
 /obj/structure/sign/warning/mail_delivery{
 	pixel_y = 32
 	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Equipment";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_bay)
 "jx" = (
@@ -4405,10 +4376,6 @@
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
-	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Containment Control";
-	dir = 4
 	},
 /obj/structure/table/standard,
 /obj/item/storage/toolbox/electrical,
@@ -4597,9 +4564,6 @@
 	name = "north bump";
 	pixel_y = 24
 	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Waste Tank"
-	},
 /obj/machinery/atmospherics/portables_connector,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/wastetank)
@@ -4741,10 +4705,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/central)
 "kr" = (
-/obj/machinery/camera/network/engine{
-	c_tag = "Engine - Entrance";
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/machinery/airlock_sensor{
 	command = "cycle_exterior";
@@ -4891,6 +4851,12 @@
 /obj/structure/closet/secure_closet/engineering_torch,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_bay)
+"kJ" = (
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Engine Room Starboard"
+	},
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/engine_room)
 "kK" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -5187,10 +5153,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck - Stairwell";
-	dir = 4
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
@@ -5389,10 +5351,6 @@
 	dir = 10
 	},
 /obj/machinery/light/small,
-/obj/machinery/camera/network/engine{
-	c_tag = "Engine - Access";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "lR" = (
@@ -5728,10 +5686,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/green,
-/obj/machinery/camera/network/engine{
-	c_tag = "Engine - TEGs";
-	dir = 1
-	},
 /obj/effect/floor_decal/industrial/warning,
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 4
@@ -5881,6 +5835,10 @@
 /obj/effect/floor_decal/industrial/warning/corner{
 	dir = 8;
 	icon_state = "warningcorner"
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Hallway - Fore";
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/fore)
@@ -6077,6 +6035,10 @@
 	icon_state = "warning"
 	},
 /obj/machinery/rotating_alarm/supermatter{
+	dir = 8
+	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Engine Room Center";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -6553,9 +6515,6 @@
 	dir = 4
 	},
 /obj/effect/catwalk_plated,
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Hallway - Central East"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -8107,9 +8066,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "td" = (
-/obj/machinery/camera/network/engine{
-	c_tag = "Engine - Heat Exchangers"
-	},
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 1
 	},
@@ -8301,12 +8257,12 @@
 	dir = 1;
 	pixel_y = -28
 	},
-/obj/machinery/camera/network/engine{
-	c_tag = "Engine - Control";
-	dir = 1
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Supermatter Monitoring";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_monitoring)
@@ -8345,6 +8301,10 @@
 	},
 /obj/structure/table/standard,
 /obj/random/maintenance/solgov,
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Drive Monitoring";
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/bluespacebay)
 "tE" = (
@@ -8395,6 +8355,9 @@
 	icon_state = "4-8"
 	},
 /obj/item/rpd,
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Atmospherics"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "tM" = (
@@ -8439,9 +8402,6 @@
 	name = "CO2 to Hangar";
 	target_pressure = 2500;
 	use_power = 1
-	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Atmospherics - North"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 32
@@ -8964,9 +8924,9 @@
 "vo" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/blast/regular/open{
+	icon_state = "pdoor0";
 	id_tag = "bsdwindow";
-	name = "Drive Containment";
-	icon_state = "pdoor0"
+	name = "Drive Containment"
 	},
 /obj/effect/wallframe_spawn/reinforced_phoron,
 /turf/simulated/floor/tiled,
@@ -8976,6 +8936,10 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
+	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Engine Room Port";
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
@@ -9019,6 +8983,10 @@
 "vy" = (
 /obj/effect/floor_decal/industrial/warning{
 	dir = 9
+	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Robot Upload";
+	dir = 8
 	},
 /turf/simulated/floor/greengrid,
 /area/synth/borg_upload)
@@ -9843,10 +9811,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/seconddeck/foreport)
 "yr" = (
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Shield Bay";
-	dir = 1
-	},
 /obj/machinery/power/terminal{
 	dir = 8
 	},
@@ -10768,7 +10732,7 @@
 	icon_state = "warning"
 	},
 /obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Bay"
+	c_tag = "Engineering - Lobby"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_bay)
@@ -11342,9 +11306,6 @@
 	dir = 8;
 	name = "west bump";
 	pixel_x = -24
-	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Solar Control - Port"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/auxsolarport)
@@ -12439,10 +12400,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/engineering{
-	c_tag = "Atmospherics - West";
-	dir = 1
-	},
 /obj/structure/sign/warning/secure_area{
 	dir = 1;
 	pixel_y = -32
@@ -12579,10 +12536,6 @@
 	},
 /obj/machinery/alarm{
 	pixel_y = 24
-	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Fuel Bay";
-	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/fuelbay)
@@ -13082,6 +13035,9 @@
 /obj/structure/bed/chair/padded/yellow{
 	dir = 4
 	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - RUST Monitoring"
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/vacant/prototype/control)
 "Hg" = (
@@ -13383,9 +13339,6 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/camera/network/engine{
-	c_tag = "Engine - SMES"
-	},
 /turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "Ie" = (
@@ -13641,7 +13594,7 @@
 /area/assembly/robotics/surgery)
 "IM" = (
 /obj/machinery/camera/network/engineering{
-	c_tag = "Drive Containment";
+	c_tag = "Engineering - Bluespace Drive";
 	dir = 4
 	},
 /obj/effect/catwalk_plated,
@@ -13804,6 +13757,26 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
+"Jm" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/yellow{
+	dir = 5
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Hallway - Midships"
+	},
+/turf/simulated/floor/tiled,
+/area/hallway/primary/seconddeck)
 "Jn" = (
 /obj/structure/cable{
 	d1 = 1;
@@ -14111,10 +14084,6 @@
 "Ko" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/machinery/portable_atmospherics/canister/sleeping_agent,
-/obj/machinery/camera/network/engineering{
-	c_tag = "Atmospherics - South";
-	dir = 8
-	},
 /obj/effect/floor_decal/corner/white{
 	dir = 4
 	},
@@ -15240,10 +15209,6 @@
 /area/engineering/storage)
 "Om" = (
 /obj/item/stool,
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Hallway - Elevator Landing";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck/elevator)
 "On" = (
@@ -15333,10 +15298,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/engineering{
-	c_tag = "Cyborg Upload";
-	dir = 4
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/synth/borg_upload)
 "OG" = (
@@ -15403,7 +15364,7 @@
 /area/shuttle/escape_pod10/station)
 "OR" = (
 /obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Hallway - Engineering";
+	c_tag = "Second Deck Hallway - Aft";
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/yellow/half,
@@ -15842,10 +15803,6 @@
 	dir = 4;
 	icon_state = "warning"
 	},
-/obj/machinery/camera/network/engine{
-	c_tag = "Engine - Prototype Chamber Two";
-	dir = 1
-	},
 /turf/simulated/floor/plating,
 /area/vacant/prototype/engine)
 "Qj" = (
@@ -16130,10 +16087,6 @@
 /obj/effect/floor_decal/floordetail/edgedrain{
 	dir = 8
 	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Robotics Surgical Theater";
-	dir = 4
-	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics/surgery)
@@ -16409,10 +16362,6 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Monitoring Room";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engineering_bay)
 "RT" = (
@@ -16496,9 +16445,6 @@
 /obj/structure/closet/crate/radiation,
 /obj/item/stack/material/tritium/ten,
 /obj/item/stack/material/tritium/ten,
-/obj/machinery/camera/network/engine{
-	c_tag = "Engine - Prototype Chamber One"
-	},
 /turf/simulated/floor/reinforced,
 /area/vacant/prototype/engine)
 "Sh" = (
@@ -16540,11 +16486,11 @@
 /area/vacant/prototype/control)
 "Sk" = (
 /obj/effect/floor_decal/industrial/warning,
-/obj/machinery/camera/network/engine{
-	c_tag = "Engine - Core Interior";
+/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Engine Core";
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction,
 /turf/simulated/floor/reinforced{
 	map_airless = 1
 	},
@@ -16562,10 +16508,6 @@
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 5
-	},
-/obj/machinery/camera/network/engine{
-	c_tag = "Engine - Port Area";
-	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
@@ -16875,14 +16817,6 @@
 /obj/structure/sign/warning/vacuum,
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/engine_room)
-"Tq" = (
-/obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/engineering_torch,
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Locker Room"
-	},
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/engineering/engineering_bay)
 "Ts" = (
 /obj/structure/sign/warning/secure_area{
 	dir = 1;
@@ -17066,9 +17000,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/forestarboard)
 "Ug" = (
-/obj/machinery/camera/network/engine{
-	c_tag = "Engine - Prototype Chamber 01"
-	},
 /obj/machinery/computer/modular/preset/engineering{
 	dir = 8;
 	icon_state = "console"
@@ -17301,6 +17232,10 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
+	},
+/obj/machinery/camera/network/engineering{
+	c_tag = "Engineering - Fusion Chamber";
+	dir = 8
 	},
 /turf/simulated/floor/plating,
 /area/vacant/prototype/engine)
@@ -18173,10 +18108,10 @@
 	name = "Drive Containment Chamber"
 	},
 /obj/machinery/door/blast/regular/open{
-	id_tag = "bsd_access";
-	name = "Drive Containment";
+	dir = 4;
 	icon_state = "pdoor0";
-	dir = 4
+	id_tag = "bsd_access";
+	name = "Drive Containment"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/bluespacebay)
@@ -35983,7 +35918,7 @@ qt
 QQ
 fK
 XP
-ge
+Jm
 gD
 Lp
 Lp
@@ -37997,7 +37932,7 @@ aY
 dA
 iF
 iN
-Tq
+kH
 RI
 lz
 MK
@@ -41014,7 +40949,7 @@ GW
 GW
 GW
 as
-Xr
+aT
 zi
 Zu
 MW
@@ -42427,7 +42362,7 @@ aa
 GW
 GW
 GW
-aT
+aH
 oK
 SB
 cB
@@ -44458,7 +44393,7 @@ ax
 do
 gy
 dp
-if
+kJ
 jc
 jM
 kv

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -558,8 +558,7 @@
 	pixel_x = 11
 	},
 /obj/machinery/camera/network/medbay{
-	c_tag = "Infirmary - Autopsy";
-	dir = 8
+	c_tag = "Medical - Autopsy"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/morgue/autopsy)
@@ -829,10 +828,6 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 8
 	},
-/obj/machinery/camera/network/first_deck{
-	c_tag = "Command Hallway - Aft";
-	dir = 4
-	},
 /obj/effect/landmark{
 	name = "lightsout"
 	},
@@ -984,10 +979,6 @@
 "abX" = (
 /obj/machinery/r_n_d/destructive_analyzer,
 /obj/effect/floor_decal/industrial/hatch/yellow,
-/obj/machinery/camera/network/research{
-	c_tag = "Research - Development Laboratory";
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
@@ -1047,10 +1038,6 @@
 	name = "Chemistry Counter Lockdown Control";
 	pixel_x = -6;
 	pixel_y = -24
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Infirmary - Chemistry";
-	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 32
@@ -2310,6 +2297,9 @@
 /obj/machinery/atmospherics/pipe/simple/hidden{
 	dir = 4
 	},
+/obj/machinery/camera/network/medbay{
+	c_tag = "Medical - Lobby"
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
 "aeo" = (
@@ -2995,10 +2985,6 @@
 	dir = 4
 	},
 /obj/machinery/hologram/holopad,
-/obj/machinery/camera/network/medbay{
-	c_tag = "Infirmary - Lobby";
-	dir = 1
-	},
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 1
 	},
@@ -3836,10 +3822,6 @@
 	name = "Infirmary Staging Exit";
 	pixel_y = -23
 	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Infirmary - Staging";
-	dir = 1
-	},
 /obj/effect/floor_decal/sign/tr,
 /obj/machinery/light/spot,
 /turf/simulated/floor/tiled/white,
@@ -4164,10 +4146,6 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Infirmary - Counselor's Office";
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -4225,10 +4203,6 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/counselor)
 "ahv" = (
-/obj/machinery/camera/network/medbay{
-	c_tag = "Infirmary - Counselor's Therapy Room";
-	dir = 4
-	},
 /obj/machinery/light{
 	dir = 8
 	},
@@ -4300,14 +4274,6 @@
 "ahF" = (
 /obj/structure/bed/chair,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/techfloor,
-/area/crew_quarters/safe_room/firstdeck)
-"ahG" = (
-/obj/machinery/camera/network/first_deck{
-	c_tag = "First Deck - Safe Room";
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/firstdeck)
 "ahH" = (
@@ -4461,9 +4427,6 @@
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24
-	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Substation - First Deck"
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -5433,9 +5396,6 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Medical Safe Room"
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
 "akK" = (
@@ -5494,10 +5454,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/firstdeck)
 "akV" = (
-/obj/machinery/camera/network/first_deck{
-	c_tag = "First Deck Fore Hallway - Starboard Maintenence";
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 1
 	},
@@ -6159,10 +6115,6 @@
 	req_access = list("ACCESS_SECURITY")
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/camera/network/security{
-	c_tag = "Security Wing - Evidence Storage";
-	dir = 8
-	},
 /turf/simulated/floor/tiled/dark,
 /area/security/evidence)
 "apf" = (
@@ -7055,10 +7007,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
 	},
-/obj/machinery/camera/network/first_deck{
-	c_tag = "First Deck - Stairs";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/fore)
 "auF" = (
@@ -7242,10 +7190,6 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Infirmary - Examination Room";
-	dir = 1
-	},
 /obj/item/device/radio/intercom/department/medbay{
 	dir = 1;
 	pixel_y = -28
@@ -7307,10 +7251,6 @@
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
-/obj/machinery/camera/network/first_deck{
-	c_tag = "First Deck Hallway - Emergency Armory Entrance";
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/blue/mono,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/aft)
@@ -7493,6 +7433,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel{
 	dir = 4
+	},
+/obj/machinery/camera/network/first_deck{
+	c_tag = "First Deck Hallway - Emergency Armory"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/firstdeck/aft)
@@ -8534,10 +8477,6 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Emergency Armory - Access";
-	dir = 1
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/command/armoury/access)
@@ -9750,7 +9689,7 @@
 /obj/random/maintenance/solgov/clean,
 /obj/random/maintenance/solgov/clean,
 /obj/machinery/camera/network/first_deck{
-	c_tag = "Auxiliary Cryogenic Storage - Port";
+	c_tag = "First Deck Cryogenics - Fore";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white/monotile,
@@ -9777,7 +9716,7 @@
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/personal,
 /obj/machinery/camera/network/first_deck{
-	c_tag = "Auxiliary Cryogenic Storage - Starboard";
+	c_tag = "First Deck Cryogenics - Aft";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/white/monotile,
@@ -10178,6 +10117,10 @@
 "aJm" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/camera/network/bridge{
+	c_tag = "Emergency Armory - Supplies";
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury)
 "aJn" = (
@@ -10435,10 +10378,6 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "aKy" = (
-/obj/machinery/camera/network/security{
-	c_tag = "Security Wing - Equipment Storage";
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 21
@@ -10690,6 +10629,9 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
+/obj/machinery/camera/network/security{
+	c_tag = "Security  - Temporary Confinement"
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/wing)
 "aLE" = (
@@ -10744,7 +10686,7 @@
 /area/security/brig)
 "aLL" = (
 /obj/machinery/camera/network/security{
-	c_tag = "Brig - Center";
+	c_tag = "Security - Extended Confinement";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
@@ -10931,10 +10873,6 @@
 	},
 /obj/effect/floor_decal/corner/red/half,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/machinery/camera/network/security{
-	c_tag = "Security Hallway - Cells";
 	dir = 1
 	},
 /obj/machinery/rotating_alarm/security_alarm{
@@ -11196,7 +11134,7 @@
 	pixel_x = -21
 	},
 /obj/machinery/camera/network/security{
-	c_tag = "Brig - Bunk Room";
+	c_tag = "Security - Extended Bunks";
 	dir = 4
 	},
 /obj/structure/bedsheetbin,
@@ -12163,7 +12101,7 @@
 "aRm" = (
 /obj/machinery/barrier,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/camera/network/command{
+/obj/machinery/camera/network/bridge{
 	c_tag = "Bridge - Emergency Armory - Port";
 	dir = 1
 	},
@@ -13515,10 +13453,6 @@
 /obj/structure/sign/warning/internals_required{
 	pixel_x = 32
 	},
-/obj/machinery/camera/network/research{
-	c_tag = "Xenobiology - Entry";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/xenobiology/entry)
 "aUE" = (
@@ -13653,7 +13587,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/camera/network/research{
-	c_tag = "Xenobiology - Fore"
+	c_tag = "Research - Xenobiology Fore"
 	},
 /obj/machinery/button/blast_door{
 	id_tag = "xenobio1";
@@ -13689,7 +13623,7 @@
 	icon_state = "pipe-c"
 	},
 /obj/machinery/camera/network/research{
-	c_tag = "Xenobiology - Aft"
+	c_tag = "Research - Xenobiology Aft"
 	},
 /obj/machinery/button/blast_door{
 	id_tag = "xenobio4_vent";
@@ -15385,10 +15319,6 @@
 "cDO" = (
 /obj/structure/table/steel,
 /obj/item/storage/box/evidence,
-/obj/machinery/camera/network/security{
-	c_tag = "Security Wing - Processing";
-	dir = 4
-	},
 /obj/item/device/radio/intercom/department/security{
 	dir = 4;
 	pixel_x = -21
@@ -15634,10 +15564,6 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/foyer/storeroom)
 "cWR" = (
-/obj/machinery/camera/network/security{
-	c_tag = "Security Wing - Interview Room 1";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
@@ -16226,6 +16152,9 @@
 /obj/structure/sign/directions/med{
 	pixel_y = 32
 	},
+/obj/machinery/camera/network/first_deck{
+	c_tag = "First Deck Hallway - Midships Aft"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
 "dNb" = (
@@ -16634,10 +16563,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/morgue/autopsy)
 "equ" = (
-/obj/machinery/camera/network/first_deck{
-	c_tag = "First Deck - Ladders";
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/research/half,
 /obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
@@ -18042,9 +17967,6 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/security/storage)
 "hcb" = (
-/obj/machinery/camera/network/first_deck{
-	c_tag = "First Deck Hallway - Ladders"
-	},
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 5
 	},
@@ -19196,9 +19118,6 @@
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 24
 	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Engineering - Robotics Office"
-	},
 /obj/item/book/manual/ripley_build_and_repair,
 /obj/item/book/manual/robotics_cyborgs,
 /turf/simulated/floor/tiled,
@@ -19413,16 +19332,6 @@
 /obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/entry)
-"iPj" = (
-/obj/effect/floor_decal/corner/blue{
-	dir = 9
-	},
-/obj/machinery/camera/network/first_deck{
-	c_tag = "Briefing Room";
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/conference)
 "iPV" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -19561,10 +19470,6 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/machinery/camera/network/first_deck{
-	c_tag = "First Deck Hallway - Aft";
-	dir = 1
-	},
 /obj/machinery/light,
 /obj/effect/floor_decal/corner/research/half,
 /turf/simulated/floor/tiled/monotile,
@@ -19619,7 +19524,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/network/medbay{
-	c_tag = "Infirmary - Treatment Centre";
+	c_tag = "Medical - Treament Center";
 	dir = 4
 	},
 /turf/simulated/floor/tiled/white,
@@ -19856,6 +19761,10 @@
 /obj/effect/floor_decal/corner/paleblue{
 	dir = 10
 	},
+/obj/machinery/camera/network/first_deck{
+	c_tag = "First Deck Hallway - Aft";
+	dir = 1
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
 "jpt" = (
@@ -20014,6 +19923,9 @@
 "jxG" = (
 /obj/effect/floor_decal/corner/paleblue/half{
 	dir = 4
+	},
+/obj/machinery/camera/network/first_deck{
+	c_tag = "First Deck Hallway - Stairs"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/fore)
@@ -20345,12 +20257,12 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "Emergency Armory - Tactical";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/machinery/camera/network/bridge{
+	c_tag = "Emergency Armory - Tactical";
+	dir = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
@@ -20538,11 +20450,6 @@
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -21
-	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Infirmary - Robotics Laboratory";
-	dir = 4;
-	network = list("Medical, Engineering")
 	},
 /obj/effect/floor_decal/corner/yellow/mono,
 /turf/simulated/floor/tiled/white/monotile,
@@ -20742,7 +20649,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/camera/network/security{
-	c_tag = "Security Hallway - Center";
+	c_tag = "Security Hallway - Port";
 	dir = 4
 	},
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -21259,10 +21166,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/assembly/chargebay)
 "lcI" = (
-/obj/machinery/camera/network/security{
-	c_tag = "Security Wing - Armory";
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/structure/table/rack,
 /obj/item/clothing/head/helmet/ablative,
@@ -21342,7 +21245,7 @@
 /area/maintenance/firstdeck/centralport)
 "lgb" = (
 /obj/machinery/camera/network/first_deck{
-	c_tag = "First Deck Hallway - Auxiliary Cryogenic Storage"
+	c_tag = "First Deck Hallway - Midships Fore"
 	},
 /obj/structure/cable/green{
 	d2 = 2;
@@ -21416,9 +21319,6 @@
 	},
 /obj/structure/railing/mapped,
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/machinery/camera/network/research{
-	c_tag = "Research - Entry"
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/rnd/entry)
 "lkp" = (
@@ -21676,7 +21576,7 @@
 	pixel_y = -20
 	},
 /obj/machinery/camera/network/research{
-	c_tag = "Research - Lockers";
+	c_tag = "Research - Lobby";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -22081,7 +21981,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/network/first_deck{
-	c_tag = "First Deck Fore Hallway - Starboard";
+	c_tag = "First Deck Hallway - Fore Starboard";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
@@ -22301,10 +22201,6 @@
 	id_tag = "Cell 2";
 	pixel_x = -24
 	},
-/obj/machinery/camera/network/security{
-	c_tag = "Brig - Cell Two";
-	dir = 4
-	},
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -22
@@ -22382,10 +22278,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Infirmary - Operating Theatre 2";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
 "mzb" = (
@@ -22414,25 +22306,6 @@
 /obj/item/storage/box/swabs,
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
-"mCi" = (
-/obj/structure/bed/padded,
-/obj/item/bedsheet/orange,
-/obj/effect/floor_decal/corner/red{
-	dir = 10
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/camera/network/security{
-	c_tag = "Brig - Cell One";
-	dir = 8
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/simulated/floor/tiled,
-/area/security/wing)
 "mCk" = (
 /obj/structure/table/steel,
 /obj/item/book/manual/sol_sop,
@@ -22589,7 +22462,7 @@
 	},
 /obj/effect/floor_decal/industrial/warning/corner,
 /obj/machinery/camera/network/first_deck{
-	c_tag = "Command Hallway - Fore";
+	c_tag = "First Deck Hallway - Fore";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -22719,8 +22592,8 @@
 /turf/simulated/floor/plating,
 /area/security/detectives_office)
 "mWb" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Vault - Interior";
+/obj/machinery/camera/network/bridge{
+	c_tag = "Self Destruct";
 	dir = 8
 	},
 /obj/effect/floor_decal/industrial/warning{
@@ -22809,10 +22682,6 @@
 /area/security/nuke_storage)
 "ngb" = (
 /obj/structure/table/rack,
-/obj/machinery/camera/network/first_deck{
-	c_tag = "First Deck - Teleporter";
-	dir = 4
-	},
 /obj/random/tech_supply,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/teleporter/firstdeck)
@@ -23026,6 +22895,10 @@
 /obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
+/obj/machinery/camera/network/security{
+	c_tag = "Security Hallway - Starboard";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/security/wing)
 "nqb" = (
@@ -23147,10 +23020,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/camera/network/security{
-	c_tag = "Checkpoint - Deck One";
-	dir = 4
-	},
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32
 	},
@@ -23243,10 +23112,6 @@
 /obj/structure/table/steel,
 /obj/machinery/photocopier/faxmachine{
 	department = "Torch - Brig Chief"
-	},
-/obj/machinery/camera/network/security{
-	c_tag = "Security Wing - Brig Chief";
-	dir = 4
 	},
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32
@@ -23532,7 +23397,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/network/first_deck{
-	c_tag = "First Deck Fore Hallway - Port"
+	c_tag = "First Deck Hallway - Fore Port"
 	},
 /obj/structure/cable/green{
 	d1 = 4;
@@ -23761,10 +23626,6 @@
 /obj/effect/floor_decal/corner/red/mono,
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/closet/secure_closet/security_torch,
-/obj/machinery/camera/network/security{
-	c_tag = "Security Wing - Locker Room";
-	dir = 8
-	},
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 26
@@ -24402,10 +24263,6 @@
 /obj/structure/closet/medical_wall/filled{
 	pixel_y = -32
 	},
-/obj/machinery/camera/network/research{
-	c_tag = "Research - Hallway";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "pdb" = (
@@ -24977,14 +24834,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/rnd/xenobiology/xenoflora)
-"pNb" = (
-/obj/machinery/atmospherics/portables_connector,
-/obj/effect/floor_decal/industrial/outline/blue,
-/obj/machinery/camera/network/research{
-	c_tag = "Research - Miscellaneous Laboratory"
-	},
-/turf/simulated/floor/tiled/white,
-/area/rnd/misc_lab)
 "pOb" = (
 /obj/machinery/seed_extractor,
 /obj/effect/floor_decal/industrial/outline/yellow,
@@ -25592,10 +25441,6 @@
 /obj/structure/bed/chair{
 	dir = 4
 	},
-/obj/machinery/camera/network/first_deck{
-	c_tag = "First Deck - Safe Room Entrance";
-	dir = 4
-	},
 /obj/effect/floor_decal/techfloor,
 /obj/effect/floor_decal/corner_techfloor_grid{
 	dir = 1
@@ -26012,10 +25857,6 @@
 /obj/machinery/atmospherics/pipe/manifold/visible{
 	dir = 8
 	},
-/obj/machinery/camera/network/research{
-	c_tag = "Research - Xenobotany Environment";
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/research/mono,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1;
@@ -26183,7 +26024,7 @@
 "rkb" = (
 /obj/machinery/atmospherics/valve,
 /obj/machinery/camera/network/research{
-	c_tag = "Research - Xenobotany Laboratory";
+	c_tag = "Research - Xenobotany";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/freezer,
@@ -27305,7 +27146,7 @@
 /area/rnd/misc_lab)
 "srb" = (
 /obj/machinery/camera/network/research{
-	c_tag = "Research - Miscellaneous Test Chamber";
+	c_tag = "Research - Misc. Test Chamber";
 	dir = 8;
 	network = list("Research","Miscellaneous Reseach")
 	},
@@ -28102,6 +27943,10 @@
 	pixel_y = -24
 	},
 /obj/structure/cable/green,
+/obj/machinery/camera/network/security{
+	c_tag = "Security - Brig Armory";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "thb" = (
@@ -29443,10 +29288,6 @@
 /area/medical/medicalhallway)
 "vIP" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/camera/network/security{
-	c_tag = "Security Wing - Investigations";
-	dir = 4
-	},
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
 "vJO" = (
@@ -29562,10 +29403,6 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/camera/network/medbay{
-	c_tag = "Infirmary - Equipment Storage";
-	dir = 4
-	},
 /obj/structure/closet/hydrant{
 	pixel_x = -32
 	},
@@ -30002,9 +29839,6 @@
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "Emergency Armory - Starboard"
-	},
 /obj/machinery/suit_cycler/torch,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury)
@@ -30038,10 +29872,6 @@
 	pixel_x = 6;
 	pixel_y = -24
 	},
-/obj/machinery/camera/network/medbay{
-	c_tag = "Infirmary - Operating Theatre 1";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "xxl" = (
@@ -30071,18 +29901,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/rnd/office)
-"xzj" = (
-/obj/effect/floor_decal/techfloor,
-/obj/machinery/camera/network/command{
-	c_tag = "Emergency Armory - Port";
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark,
-/area/command/armoury)
 "xzK" = (
 /obj/structure/bed/chair/padded/red,
 /obj/machinery/camera/network/security{
-	c_tag = "Security Wing - Lobby"
+	c_tag = "Security  - Lobby"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 5
@@ -39552,7 +39374,7 @@ adK
 tWZ
 gvC
 ahE
-ahG
+ahE
 kzy
 adK
 qWE
@@ -39987,7 +39809,7 @@ bob
 jpt
 oby
 nkh
-mCi
+wEb
 aNH
 uKa
 tKE
@@ -42989,7 +42811,7 @@ njj
 alZ
 kCl
 chO
-iPj
+iEb
 iEb
 kCl
 dzG
@@ -54930,7 +54752,7 @@ abk
 jZb
 pfb
 aHi
-pNb
+pKb
 qmb
 qOb
 qSb
@@ -57954,7 +57776,7 @@ aHT
 aBa
 aHT
 uZO
-xzj
+ooN
 aQr
 aRm
 eRU

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -921,15 +921,15 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/hallway/starboard)
 "bS" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Entry Starboard"
-	},
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
+	},
+/obj/machinery/camera/network/bridge{
+	c_tag = "Command Hallway - Fore  Starboard"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/hallway/starboard)
@@ -1045,9 +1045,6 @@
 /obj/structure/cable/green{
 	d2 = 2;
 	icon_state = "0-2"
-	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Substation - Bridge"
 	},
 /obj/machinery/power/sensor{
 	name = "Powernet Sensor - Bridge Subgrid";
@@ -1426,7 +1423,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/catwalk_plated,
 /obj/machinery/camera/network/bridge{
-	c_tag = "Command Hallway - Center Fore Port";
+	c_tag = "Command Hallway - Center Port";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -1678,9 +1675,6 @@
 /obj/item/device/radio/intercom{
 	pixel_y = 23
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Conference Room Starboard"
-	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 5
 	},
@@ -1793,13 +1787,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "df" = (
-/obj/machinery/camera/network/engineering{
-	c_tag = "Command Hallway - Center Fore Staboard";
-	dir = 4;
-	network = list("Bridge")
-	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
+	},
+/obj/machinery/camera/network/bridge{
+	c_tag = "Command Hallway - Center Starboard";
+	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
@@ -2046,10 +2039,6 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
 "dH" = (
-/obj/machinery/camera/network/bridge{
-	c_tag = "Bridge - Stairs";
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 9
 	},
@@ -2111,11 +2100,6 @@
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
 "dN" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Chief Engineer - Office";
-	dir = 1;
-	network = list("Command","Engineering")
-	},
 /obj/machinery/button/alternate/door{
 	desc = "A remote control-switch for the office door.";
 	id_tag = "cedoor";
@@ -2216,11 +2200,11 @@
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
-/obj/machinery/camera/network/command{
+/obj/item/folder/envelope/declassified1,
+/obj/machinery/camera/network/bridge{
 	c_tag = "Bridge";
 	dir = 1
 	},
-/obj/item/folder/envelope/declassified1,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge)
 "dY" = (
@@ -2322,9 +2306,6 @@
 "en" = (
 /obj/machinery/alarm{
 	pixel_y = 24
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Executive Officer - Office"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -2585,10 +2566,6 @@
 /obj/item/device/radio/intercom{
 	dir = 1;
 	pixel_y = -28
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Conference Room Port";
-	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
@@ -3137,10 +3114,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/aquila/cockpit)
 "fL" = (
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Cockpit";
-	dir = 8
-	},
 /obj/machinery/computer/modular/preset/cardslot/command,
 /obj/item/device/radio/intercom/hailing{
 	dir = 8;
@@ -3248,14 +3221,14 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/hallway/port)
 "fT" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Bridge - Entry Port";
-	dir = 1
-	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
 	},
 /obj/machinery/rotating_alarm/security_alarm{
+	dir = 1
+	},
+/obj/machinery/camera/network/bridge{
+	c_tag = "Command Hallway - Fore Port";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
@@ -3446,6 +3419,10 @@
 	dir = 4
 	},
 /obj/structure/bed/chair/shuttle/blue{
+	dir = 1
+	},
+/obj/machinery/camera/network/aquila{
+	c_tag = "Aquila - Cockpit";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -3652,10 +3629,6 @@
 	},
 /area/aquila/cockpit)
 "ha" = (
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Infirmary";
-	dir = 8
-	},
 /obj/machinery/sleeper{
 	dir = 8
 	},
@@ -3816,9 +3789,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/hallway/primary/bridge/aft)
 "hL" = (
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Crew Compartment"
-	},
 /obj/structure/bed/chair/shuttle/blue{
 	dir = 4
 	},
@@ -4533,6 +4503,10 @@
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 8
 	},
+/obj/machinery/camera/network/bridge{
+	c_tag = "Command Hallway - Stairs";
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
 "jU" = (
@@ -4962,10 +4936,6 @@
 	dir = 8
 	},
 /obj/effect/catwalk_plated,
-/obj/machinery/camera/network/bridge{
-	c_tag = "Command Hallway - Center Aft";
-	dir = 4
-	},
 /obj/effect/landmark{
 	name = "lightsout"
 	},
@@ -5347,10 +5317,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "Chief of Security - Office";
-	network = list("Command","Security")
-	},
 /obj/machinery/button/alternate/door{
 	desc = "A remote control-switch for the office door.";
 	id_tag = "cosdoor";
@@ -5438,16 +5404,16 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
 "mW" = (
-/obj/machinery/camera/network/bridge{
-	c_tag = "Bridge Hallway - Lift";
-	dir = 1
-	},
 /obj/machinery/power/apc{
 	name = "south bump";
 	pixel_y = -28
 	},
 /obj/structure/cable/green,
 /obj/effect/floor_decal/corner/blue/half,
+/obj/machinery/camera/network/bridge{
+	c_tag = "Bridge Hallway - Aft";
+	dir = 1
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/bridge/aft)
 "mX" = (
@@ -5487,10 +5453,6 @@
 	},
 /obj/effect/floor_decal/corner/blue{
 	dir = 10
-	},
-/obj/machinery/camera/network/bridge{
-	c_tag = "Bridge Hallway - Aft";
-	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/aft)
@@ -5636,10 +5598,6 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/air)
 "nq" = (
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Seating";
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/effect/floor_decal/industrial/warning{
 	dir = 1
@@ -5660,10 +5618,6 @@
 /obj/machinery/alarm{
 	dir = 8;
 	pixel_x = 24
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Corporate Liaison - Office";
-	dir = 8
 	},
 /obj/item/storage/box/donut,
 /turf/simulated/floor/carpet/green,
@@ -6071,10 +6025,6 @@
 /obj/item/device/radio/intercom{
 	dir = 8;
 	pixel_x = 20
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Chief Medical Officer - Office";
-	network = list("Command","Medical")
 	},
 /obj/machinery/light{
 	dir = 1
@@ -6794,9 +6744,6 @@
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
-/obj/machinery/camera/network/command{
-	c_tag = "CO - Office Port"
-	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/co)
 "qR" = (
@@ -7913,10 +7860,6 @@
 /obj/machinery/newscaster{
 	pixel_x = 32
 	},
-/obj/machinery/camera/network/bridge{
-	c_tag = "Bridge - Safe Room";
-	dir = 8
-	},
 /obj/effect/floor_decal/techfloor{
 	dir = 4
 	},
@@ -8215,13 +8158,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/bridge/fore)
-"uM" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Sol Government Representative - Office";
-	dir = 4
-	},
-/turf/simulated/floor/carpet/blue2,
-/area/crew_quarters/heads/office/sgr)
 "uN" = (
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/item/paper_bin{
@@ -8371,10 +8307,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 6
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "Senior Enlisted Advisor - Office";
-	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/heads/office/sea)
@@ -9023,10 +8955,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "Disciplinary Board Room - Deliberations";
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room/deliberation)
 "wJ" = (
@@ -9065,8 +8993,8 @@
 	dir = 1
 	},
 /obj/effect/floor_decal/corner/blue/mono,
-/obj/machinery/camera/network/command{
-	c_tag = "Disciplinary Board Room";
+/obj/machinery/camera/network/bridge{
+	c_tag = "Bridge - Disciplinary Board";
 	dir = 1
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -10360,7 +10288,7 @@
 	},
 /obj/effect/catwalk_plated,
 /obj/machinery/camera/network/bridge{
-	c_tag = "Command Hallway - Center Starboard";
+	c_tag = "Command Hallway - Aft Starboard";
 	dir = 1
 	},
 /turf/simulated/floor/plating,
@@ -10932,9 +10860,6 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "Eb" = (
-/obj/machinery/camera/network/engineering{
-	c_tag = "Shield Generator - Bridge Deck"
-	},
 /obj/machinery/alarm{
 	dir = 4;
 	pixel_x = -22
@@ -11254,7 +11179,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/network/bridge{
-	c_tag = "Command Hallway - Center Port"
+	c_tag = "Command Hallway - Aft Port"
 	},
 /obj/effect/floor_decal/corner/red{
 	dir = 4
@@ -12081,9 +12006,6 @@
 /obj/effect/floor_decal/spline/fancy/wood{
 	dir = 8
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "CO - Quarters"
-	},
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 24
 	},
@@ -12403,11 +12325,6 @@
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/co)
 "Kj" = (
-/obj/machinery/camera/network/command{
-	c_tag = "Chief Science Officer - Office";
-	dir = 8;
-	network = list("Command","Research")
-	},
 /obj/machinery/papershredder,
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
@@ -13464,10 +13381,6 @@
 /obj/item/device/radio/intercom{
 	pixel_y = 23
 	},
-/obj/machinery/camera/network/engineering{
-	c_tag = "Solar Control - Bridge";
-	dir = 4
-	},
 /obj/machinery/power/smes/buildable/preset/torch/bridge_solar{
 	dir = 4
 	},
@@ -13522,10 +13435,6 @@
 /area/hallway/primary/bridge/fore)
 "Pl" = (
 /obj/structure/closet/secure_closet/liaison,
-/obj/machinery/camera/network/command{
-	c_tag = "Corporate Liaison - Backroom";
-	dir = 8
-	},
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/heads/office/cl/backroom)
 "Pn" = (
@@ -13550,10 +13459,6 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
-	},
-/obj/machinery/camera/network/command{
-	c_tag = "CO - Office Starboard";
-	dir = 1
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/co)
@@ -14539,9 +14444,6 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
-/obj/machinery/camera/network/command{
-	c_tag = "EVA - Command"
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aux_eva)
 "Ti" = (
@@ -15177,10 +15079,6 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/machinery/camera/network/security{
-	c_tag = "Checkpoint - Bridge";
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/red/mono,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/bridgecheck)
@@ -15199,10 +15097,6 @@
 	dir = 8
 	},
 /obj/structure/handrail{
-	dir = 8
-	},
-/obj/machinery/camera/network/aquila{
-	c_tag = "Aquila - Docking Port";
 	dir = 8
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -15706,6 +15600,9 @@
 	},
 /obj/effect/floor_decal/techfloor{
 	dir = 4
+	},
+/obj/machinery/camera/network/aquila{
+	c_tag = "Aquila - Crew Compartment"
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/crew)
@@ -27517,7 +27414,7 @@ rY
 sH
 tt
 uh
-uM
+vY
 Rf
 vX
 wD

--- a/maps/torch/torch_presets.dm
+++ b/maps/torch/torch_presets.dm
@@ -1,17 +1,11 @@
 var/global/const/NETWORK_AQUILA      = "Aquila"
 var/global/const/NETWORK_BRIDGE      = "Bridge"
 var/global/const/NETWORK_CHARON     = "Charon"
-var/global/const/NETWORK_EXPEDITION  = "Expedition"
 var/global/const/NETWORK_FIRST_DECK  = "First Deck"
 var/global/const/NETWORK_FOURTH_DECK = "Fourth Deck"
-var/global/const/NETWORK_POD         = "General Utility Pod"
 var/global/const/NETWORK_SECOND_DECK = "Second Deck"
-var/global/const/NETWORK_SUPPLY      = "Supply"
-var/global/const/NETWORK_HANGAR      = "Hangar"
-var/global/const/NETWORK_EXPLO       = "Exploration"
 var/global/const/NETWORK_THIRD_DECK  = "Third Deck"
 var/global/const/NETWORK_FIFTH_DECK  = "Fifth Deck"
-var/global/const/NETWORK_PETROV  = "Petrov"
 
 /datum/map/torch/get_network_access(network)
 	switch(network)
@@ -21,16 +15,6 @@ var/global/const/NETWORK_PETROV  = "Petrov"
 			return access_heads
 		if(NETWORK_CHARON)
 			return access_expedition_shuttle
-		if(NETWORK_POD)
-			return access_guppy
-		if(NETWORK_SUPPLY)
-			return access_mailsorting
-		if(NETWORK_HANGAR)
-			return access_hangar
-		if(NETWORK_EXPLO)
-			return access_explorer
-		if(NETWORK_PETROV)
-			return access_petrov
 	return get_shared_network_access(network) || ..()
 
 /datum/map/torch
@@ -42,20 +26,12 @@ var/global/const/NETWORK_PETROV  = "Petrov"
 		NETWORK_FOURTH_DECK,
 		NETWORK_FIFTH_DECK,
 		NETWORK_BRIDGE,
-		NETWORK_COMMAND,
 		NETWORK_ENGINEERING,
-		NETWORK_ENGINE,
 		NETWORK_MEDICAL,
 		NETWORK_RESEARCH,
 		NETWORK_SECURITY,
-		NETWORK_SUPPLY,
-		NETWORK_EXPEDITION,
-		NETWORK_EXPLO,
-		NETWORK_HANGAR,
 		NETWORK_AQUILA,
 		NETWORK_CHARON,
-		NETWORK_POD,
-		NETWORK_PETROV,
 		NETWORK_ALARM_ATMOS,
 		NETWORK_ALARM_CAMERA,
 		NETWORK_ALARM_FIRE,
@@ -78,9 +54,6 @@ var/global/const/NETWORK_PETROV  = "Petrov"
 /obj/machinery/camera/network/exploration_shuttle
 	network = list(NETWORK_CHARON)
 
-/obj/machinery/camera/network/expedition
-	network = list(NETWORK_EXPEDITION)
-
 /obj/machinery/camera/network/first_deck
 	network = list(NETWORK_FIRST_DECK)
 
@@ -90,38 +63,17 @@ var/global/const/NETWORK_PETROV  = "Petrov"
 /obj/machinery/camera/network/fifth_deck
 	network = list(NETWORK_FIFTH_DECK)
 
-/obj/machinery/camera/network/pod
-	network = list(NETWORK_POD)
-
 /obj/machinery/camera/network/second_deck
 	network = list(NETWORK_SECOND_DECK)
-
-/obj/machinery/camera/network/supply
-	network = list(NETWORK_SUPPLY)
-
-/obj/machinery/camera/network/hangar
-	network = list(NETWORK_HANGAR)
-
-/obj/machinery/camera/network/exploration
-	network = list(NETWORK_EXPLO)
 
 /obj/machinery/camera/network/third_deck
 	network = list(NETWORK_THIRD_DECK)
 
-/obj/machinery/camera/network/command
-	network = list(NETWORK_COMMAND)
-
 /obj/machinery/camera/network/crescent
 	network = list(NETWORK_CRESCENT)
 
-/obj/machinery/camera/network/engine
-	network = list(NETWORK_ENGINE)
-
 /obj/machinery/camera/network/engineering_outpost
 	network = list(NETWORK_ENGINEERING_OUTPOST)
-
-/obj/machinery/camera/network/petrov
-	network = list(NETWORK_PETROV)
 
 // Motion
 /obj/machinery/camera/motion/engineering_outpost
@@ -129,7 +81,7 @@ var/global/const/NETWORK_PETROV  = "Petrov"
 
 // All Upgrades
 /obj/machinery/camera/all/command
-	network = list(NETWORK_COMMAND)
+	network = list(NETWORK_BRIDGE)
 
 
 //


### PR DESCRIPTION
🆑 Jux
maptweak: Most of the Torch's cameras have been removed. Areas exempt are generally hallways, main ship entrance points, shuttle cockpits, and high traffic or high security areas.
maptweak: Some cameras have had their positions adjusted.
/🆑 

Why? The short answer is antag freedom. Cameras covering almost every inch of the ship meant that the only truly private places were few and far between, especially since removing a camera triggered an alarm. Removing this many cameras may seem excessive, but they were by and large for private rooms like offices, meeting areas, hell, the captain's BEDROOM. I don't believe this is uncalled for.

Some areas, like mess or hydroponics, went from having multiple cameras to one or two- in these cases, I tried to resposition the remaining ones for better coverage.

Shuttles were a tough call for me. I ended up removing all cameras from the Guppy, and most from the Aquila and Charon. Aquila kept the cockpit and crew area, and Charon kept the cockpit and primary airlock.