### PR TITLE
Makes shotguns more accurate and consistent

### DIFF
--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -16,6 +16,7 @@
 	handle_casings = HOLD_CASINGS
 	one_hand_penalty = 8
 	bulk = 6
+	accuracy = 1
 	var/recentpump = 0 // to prevent spammage
 	wielded_item_state = "shotgun-wielded"
 	load_sound = 'sound/weapons/guns/interaction/shotgun_instert.ogg'
@@ -23,6 +24,13 @@
 /obj/item/gun/projectile/shotgun/on_update_icon()
 	..()
 	if(length(loaded))
+		icon_state = initial(icon_state)
+	else
+		icon_state = "[initial(icon_state)]-empty"
+
+/obj/item/gun/projectile/shotgun/pump/on_update_icon()
+	..()
+	if(chambered)
 		icon_state = initial(icon_state)
 	else
 		icon_state = "[initial(icon_state)]-empty"
@@ -140,6 +148,7 @@
 	handle_casings = HOLD_CASINGS
 	one_hand_penalty = 4
 	bulk = 4
+	accuracy = 0
 	wielded_item_state = "rshotgun-wielded"
 	load_sound = 'sound/weapons/guns/interaction/shotgun_instert.ogg'
 
@@ -204,6 +213,7 @@
 	max_shells = 7 //match the ammo box capacity, also it can hold a round in the chamber anyways, for a total of 8.
 	ammo_type = /obj/item/ammo_casing/shotgun
 	one_hand_penalty = 8
+	accuracy = 2
 
 /obj/item/gun/projectile/shotgun/pump/combat/on_update_icon()
 	..()
@@ -233,6 +243,7 @@
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 1)
 	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
 	one_hand_penalty = 8
+	accuracy = 1
 	wielded_item_state = "gun_wielded"
 
 	burst_delay = 0
@@ -321,6 +332,7 @@
 	force = 5
 	one_hand_penalty = 4
 	bulk = 2
+	accuracy = 0
 
 /obj/item/gun/projectile/shotgun/doublebarrel/sawn/empty
 	starts_loaded = FALSE

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -99,7 +99,17 @@
 		//whether the pellet actually hits the def_zone or a different zone should still be determined by the parent using get_zone_with_miss_chance().
 		var/old_zone = def_zone
 		def_zone = ran_zone(def_zone, spread)
-		if (..()) hits++
+		//relatively hacky way of basing a shotgun pellet's likelihood of hitting on the first pellet of the burst while not affecting shrapnel explosions.
+		if (base_spread > 0)
+			if (i == 1)
+				if (..())
+					hits++
+				else
+					return 0
+			else if (..(target_mob, distance, -100))
+				hits++
+		else if (..())
+			hits++
 		def_zone = old_zone //restore the original zone the projectile was aimed at
 
 	pellets -= hits //each hit reduces the number of pellets left


### PR DESCRIPTION
:cl: Karl Johansson
tweak: Buckshot accuracy is now calculated once per shot, rather than individually for each pellet.
tweak: Shotguns are generally more accurate at range (to account for accuracy only being calculated once)
bugfix: Fixes pump shotgun sprites inaccurately displaying the condition of the shotgun
/:cl:

### More information
Buckshot is generally not used currently because it's so inconsistent. Pretty much only at point blank range can you reliably predict how much damage you're going to do. This PR changes that by making shotguns calculate accuracy for the entire burst at once, while also still including pellet drop off so that damage decreases at distance. Because of this, shotguns had to be made more accurate because previously they relied on rolling to hit six times, whereas now they just roll once. The combat shotgun has the most accuracy because I assume it's the only one with actual sights, while sawn-off shotguns are naturally less accurate than their full length counterparts.
Sprites have also been changed, so now they show pump shotguns with the breech closed if they have a shell chambered and the breech open if they do not. I assume this was a bug or an oversight but I will change it to a tweak if it's needed.

**Addressing the comment on line 99 of bullets.dm**
It says "whether the pellet actually hits the def_zone or a different zone should still be determined by the parent using get_zone_with_miss_chance().". Since it was written eight years ago, I believe this was made before the PR that changed ranged attacks to be much more likely to miss outright when failing to hit their target rather than just hitting a different part of the body. I didn't remove it because I think it still has some level of relevance to the code, but I understand if it needs amending.