### PR TITLE
atom/use_tool & atom/use_on don't force a parent call

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -349,7 +349,6 @@ avoid code duplication. This includes items that may sometimes act as a standard
  * resolve chain will be called.
  */
 /atom/proc/use_tool(obj/item/tool, mob/living/user, list/click_params)
-	SHOULD_CALL_PARENT(TRUE)
 	return FALSE
 
 
@@ -421,7 +420,6 @@ avoid code duplication. This includes items that may sometimes act as a standard
  * Returns boolean to indicate whether the use call was handled or not.
  */
 /obj/item/proc/use_on(atom/target, mob/user, click_parameters)
-	SHOULD_CALL_PARENT(TRUE)
 	return FALSE
 
 


### PR DESCRIPTION
The purpose of these is to implement unique behaviors - that includes being able to *not* do what the parent does.

Besides that, even when the parent behavior is just the stub on /atom, it's a waste of call overhead.