### PR TITLE
Limb emissive block

### DIFF
--- a/code/_helpers/emissives.dm
+++ b/code/_helpers/emissives.dm
@@ -10,6 +10,7 @@
 /proc/emissive_blocker(icon, icon_state = "", layer = FLOAT_LAYER, alpha = 255, appearance_flags = EMPTY_BITFIELD, source = null)
 	var/mutable_appearance/appearance = mutable_appearance(icon = icon, icon_state = icon_state, layer = layer, plane = EMISSIVE_PLANE, flags = appearance_flags|EMISSIVE_APPEARANCE_FLAGS)
 	appearance.color = GLOB.em_block_color
+	appearance.alpha = alpha
 	if(source)
 		appearance.render_source = source
 		// Since only render_target handles transform we don't get any applied transform "stacking"

--- a/code/_helpers/icons.dm
+++ b/code/_helpers/icons.dm
@@ -744,6 +744,9 @@ The _flatIcons list is a cache for generated icon files.
 
 	for(var/I in layers)
 
+		if(I:plane == EMISSIVE_PLANE) //Just replace this with whatever it is TG is doing these days sometime. Getflaticon breaks emissives
+			continue
+
 		if(I:alpha == 0)
 			continue
 

--- a/code/modules/clothing/glasses/eyepatch.dm
+++ b/code/modules/clothing/glasses/eyepatch.dm
@@ -64,19 +64,10 @@
 	if(active)
 		var/image/eye = overlay_image(res.icon, "[icon_state]_eye", flags=RESET_COLOR)
 		eye.color = eye_color
-		//eye.layer = ABOVE_HUMAN_LAYER
 		eye.layer = FLOAT_LAYER
 		res.overlays += eye
 		res.overlays += emissive_appearance(res.icon, "[icon_state]_eye", -15)
 		user_mob.z_flags |= ZMM_MANGLE_PLANES
-	return res
-
-/obj/item/clothing/glasses/eyepatch/hud/test/get_mob_overlay(mob/user_mob, slot)
-	var/image/res = ..()
-	if(active)
-		var/image/eyeglow = emissive_appearance(res.icon, "[icon_state]_eye")
-		eyeglow.layer = ABOVE_HUMAN_LAYER
-		res.overlays += eyeglow
 	return res
 
 /obj/item/clothing/glasses/eyepatch/hud/security

--- a/code/modules/clothing/glasses/eyepatch.dm
+++ b/code/modules/clothing/glasses/eyepatch.dm
@@ -64,10 +64,19 @@
 	if(active)
 		var/image/eye = overlay_image(res.icon, "[icon_state]_eye", flags=RESET_COLOR)
 		eye.color = eye_color
-		eye.layer = ABOVE_LIGHTING_LAYER
-		eye.plane = EFFECTS_ABOVE_LIGHTING_PLANE
+		//eye.layer = ABOVE_HUMAN_LAYER
+		eye.layer = FLOAT_LAYER
 		res.overlays += eye
+		res.overlays += emissive_appearance(res.icon, "[icon_state]_eye", -15)
 		user_mob.z_flags |= ZMM_MANGLE_PLANES
+	return res
+
+/obj/item/clothing/glasses/eyepatch/hud/test/get_mob_overlay(mob/user_mob, slot)
+	var/image/res = ..()
+	if(active)
+		var/image/eyeglow = emissive_appearance(res.icon, "[icon_state]_eye")
+		eyeglow.layer = ABOVE_HUMAN_LAYER
+		res.overlays += eyeglow
 	return res
 
 /obj/item/clothing/glasses/eyepatch/hud/security

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -3,7 +3,7 @@
 	mob_push_flags = ~HEAVY
 	mob_swap_flags = ~HEAVY
 
-	blocks_emissive = EMISSIVE_BLOCK_UNIQUE
+	blocks_emissive = EMISSIVE_BLOCK_NONE //Humans need to decide per bodypart if they block or not, therefore we ignore baseline functionality
 
 	/// The style of head hair applied to this mob
 	var/head_hair_style = "Bald"

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -394,31 +394,14 @@ var/global/list/damage_icon_parts = list()
 		base_icon = human_icon_cache[icon_key]
 	else
 		//BEGIN CACHED ICON GENERATION.
+		base_icon = new() //Probably can get rid of this?
+		var/list/overlays
+
 		var/obj/item/organ/external/chest = get_organ(BP_CHEST)
-		base_icon = chest.get_icon()
+		overlays += chest.get_overlays()
 
 		for(var/obj/item/organ/external/part in (organs-chest))
-			var/icon/temp = part.get_icon()
-			//That part makes left and right legs drawn topmost and lowermost when human looks WEST or EAST
-			//And no change in rendering for other parts (they icon_position is 0, so goes to 'else' part)
-			if(part.icon_position & (LEFT | RIGHT))
-				var/icon/temp2 = new('icons/mob/human.dmi',"blank")
-				temp2.Insert(new/icon(temp,dir=NORTH),dir=NORTH)
-				temp2.Insert(new/icon(temp,dir=SOUTH),dir=SOUTH)
-				if(!(part.icon_position & LEFT))
-					temp2.Insert(new/icon(temp,dir=EAST),dir=EAST)
-				if(!(part.icon_position & RIGHT))
-					temp2.Insert(new/icon(temp,dir=WEST),dir=WEST)
-				base_icon.Blend(temp2, ICON_OVERLAY)
-				if(part.icon_position & LEFT)
-					temp2.Insert(new/icon(temp,dir=EAST),dir=EAST)
-				if(part.icon_position & RIGHT)
-					temp2.Insert(new/icon(temp,dir=WEST),dir=WEST)
-				base_icon.Blend(temp2, ICON_UNDERLAY)
-			else if(part.icon_position & UNDER)
-				base_icon.Blend(temp, ICON_UNDERLAY)
-			else
-				base_icon.Blend(temp, ICON_OVERLAY)
+			overlays += part.get_overlays()
 
 		if(!skeleton)
 			if(husk)

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -328,13 +328,6 @@ var/global/list/damage_icon_parts = list()
 	var/list/icon_render_keys = list()
 
 /mob/living/carbon/human/proc/update_body(update_icons=1)
-
-
-	var/husk = (MUTATION_HUSK in src.mutations)
-	var/fat = (MUTATION_FAT in src.mutations)
-	var/hulk = (MUTATION_HULK in src.mutations)
-	var/skeleton = (MUTATION_SKELETON in src.mutations)
-
 	//Update all limbs and visible organs one by one
 	var/list/needs_update = list()
 	var/limb_count_update = FALSE
@@ -343,134 +336,34 @@ var/global/list/damage_icon_parts = list()
 	for(var/organ_tag in species.has_limbs)
 		var/obj/item/organ/external/limb = organs_by_name[organ_tag]
 		if(!isnull(limb))
-			limb.update_icon() //Regenerate limb keys - TODO, it probably makes more sense to break out some of that code into its own function
 			var/old_key = icon_render_keys?[organ_tag] //Checks the mob's icon render key list for the bodypart
-			icon_render_keys[organ_tag] = !husk ? json_encode(limb.generate_icon_key()) : json_encode(limb.generate_husk_key()) //Generates a key for the current bodypart
+			var/new_key = json_encode(limb.get_icon_key()) //Generates a key for the current bodypart
+			icon_render_keys[organ_tag] = new_key
 
 			if(icon_render_keys[organ_tag] != old_key) //If the keys match, that means the limb doesn't need to be redrawn
 				needs_update += limb
 		else
 			//Limb is missing?
 			missing_bodyparts += organ_tag
+			limb_count_update = TRUE
 
 	for(var/missing_limb in missing_bodyparts)
-		icon_render_keys -= missing_limb //Removes dismembered limbs from the key list
+		icon_render_keys -= missing_limb
 
-	if(!needs_update.len && !limb_count_update)
-		return
-
-	//GENERATE NEW LIMBS
-	var/list/new_limbs = list()
-	for(var/obj/item/organ/external/limb in organs)
-		if(limb in needs_update)
-			var/list/limb_overlays = limb.get_overlays()
-			GLOB.limb_overlays_cache[icon_render_keys[limb.organ_tag]] = limb_overlays
-			new_limbs += limb_overlays
-		else
-			new_limbs += GLOB.limb_overlays_cache[icon_render_keys[limb.organ_tag]]
-
-	if(new_limbs.len)
-		overlays_standing[HO_BODY_LAYER] = new_limbs
-
-	return
-
-
-	//CACHING: Generate an index key from visible bodyparts.
-	//0 = destroyed, 1 = normal, 2 = robotic, 3 = necrotic.
-
-	//Create a new, blank icon for our mob to use.
-	// if(stand_icon)
-	// 	qdel(stand_icon)
-	// stand_icon = new(species.icon_template ? species.icon_template : 'icons/mob/human.dmi',"blank")
-
-	var/g = "male"
-	if(gender == FEMALE)
-		g = "female"
-
-	var/icon_key = "[species.get_race_key(src)][g][skin_tone][skin_color]"
-	if(makeup_style)
-		icon_key += "[makeup_style]"
-	else
-		icon_key += "nolips"
-	var/obj/item/organ/internal/eyes/eyes = internal_organs_by_name[species.vision_organ ? species.vision_organ : BP_EYES]
-	if(istype(eyes))
-		icon_key += "[rgb(eyes.eye_colour[1], eyes.eye_colour[2], eyes.eye_colour[3])]"
-	else
-		icon_key += "#000000"
-
-	for(var/organ_tag in species.has_limbs)
-		var/obj/item/organ/external/part = organs_by_name[organ_tag]
-		if(isnull(part) || part.is_stump())
-			icon_key += "0"
-			continue
-		for (var/E in part.markings)
-			var/datum/sprite_accessory/marking/M = E
-			var/color = part.markings[E]
-			icon_key += "[M.name][color]"
-		if(part)
-			icon_key += "[part.species.get_race_key(part.owner)]"
-			icon_key += "[part.dna.GetUIState(DNA_UI_GENDER)]"
-			icon_key += "[part.skin_tone]"
-			icon_key += "[part.base_skin]"
-			if(part.s_col && length(part.s_col) >= 3)
-				icon_key += "[rgb(part.s_col[1],part.s_col[2],part.s_col[3])]"
-				icon_key += "[part.s_col_blend]"
-			if(part.body_hair && part.h_col && length(part.h_col) >= 3)
-				icon_key += "[rgb(part.h_col[1],part.h_col[2],part.h_col[3])]"
+	if(length(needs_update) || limb_count_update)
+		//GENERATE NEW LIMBS
+		var/list/new_limbs = list()
+		for(var/obj/item/organ/external/limb in organs)
+			if(limb in needs_update)
+				var/list/limb_overlays = limb.get_overlays()
+				GLOB.limb_overlays_cache[icon_render_keys[limb.organ_tag]] = limb_overlays
+				new_limbs += limb_overlays
 			else
-				icon_key += "#000000"
-			for(var/E in part.markings)
-				var/datum/sprite_accessory/marking/M = E
-				var/color = part.markings[E]
-				icon_key += "[M.name][color]"
-		if(BP_IS_ROBOTIC(part))
-			icon_key += "2[part.model ? "-[part.model]": ""]"
-		else if(part.status & ORGAN_DEAD)
-			icon_key += "3"
-		else
-			icon_key += "1"
+				new_limbs += GLOB.limb_overlays_cache[icon_render_keys[limb.organ_tag]]
 
-	icon_key = "[icon_key][husk ? 1 : 0][fat ? 1 : 0][hulk ? 1 : 0][skeleton ? 1 : 0]"
+		if(length(new_limbs))
+			overlays_standing[HO_BODY_LAYER] = new_limbs
 
-	var/icon/base_icon
-	if(human_icon_cache[icon_key])
-		base_icon = human_icon_cache[icon_key]
-	else
-		//BEGIN CACHED ICON GENERATION.
-		base_icon = new() //Probably can get rid of this?
-		var/list/overlays
-
-		var/obj/item/organ/external/chest = get_organ(BP_CHEST)
-		overlays += chest.get_overlays()
-
-		for(var/obj/item/organ/external/part in (organs-chest))
-			overlays += part.get_overlays()
-
-		if(!skeleton)
-			if(husk)
-				base_icon.ColorTone(husk_color_mod)
-			else if(hulk)
-				var/list/tone = ReadRGB(hulk_color_mod)
-				base_icon.MapColors(rgb(tone[1],0,0),rgb(0,tone[2],0),rgb(0,0,tone[3]))
-
-		//Handle husk overlay.
-		if(husk)
-			var/husk_icon = species.get_husk_icon(src)
-			if(husk_icon)
-				var/icon/mask = new(base_icon)
-				var/blood = species.get_blood_colour(src)
-				var/icon/husk_over = new(species.husk_icon,"")
-				mask.MapColors(0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,0)
-				husk_over.Blend(mask, ICON_ADD)
-				husk_over.Blend(blood, ICON_MULTIPLY)
-				base_icon.Blend(husk_over, ICON_OVERLAY)
-
-		human_icon_cache[icon_key] = base_icon
-
-	//END CACHED ICON GENERATION.
-	stand_icon.Blend(base_icon,ICON_OVERLAY)
-
-	//tail
 	update_tail_showing(0)
 
 	if(update_icons)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -13,7 +13,7 @@
 	mob_push_flags = ~HEAVY //trundle trundle
 	skillset = /datum/skillset/silicon/robot
 
-	blocks_emissive = EMISSIVE_BLOCK_UNIQUE
+	blocks_emissive = EMISSIVE_BLOCK_NONE
 
 	var/lights_on = FALSE
 	var/used_power_this_tick = 0
@@ -878,8 +878,12 @@
 			var/image/eye_overlay = eye_overlays[eye_icon_state]
 			if(!eye_overlay)
 				eye_overlay = image(icon, eye_icon_state)
-				eye_overlay.plane = EFFECTS_ABOVE_LIGHTING_PLANE
-				eye_overlay.layer = EYE_GLOW_LAYER
+				var/mutable_appearance/A = emissive_appearance(icon, eye_icon_state)
+				A.render_target = "*I am testing stuff ok"
+				eye_overlay.filters += filter(type = "layer", render_source = "*I am testing stuff ok")
+				eye_overlay.overlays += A
+				//eye_overlay.plane = EFFECTS_ABOVE_LIGHTING_PLANE
+				//eye_overlay.layer = EYE_GLOW_LAYER
 				eye_overlays[eye_icon_state] = eye_overlay
 				z_flags |= ZMM_MANGLE_PLANES
 			overlays += eye_overlay

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -20,6 +20,8 @@
 
 	new_player_panel()
 
+	CreateRenderers()
+
 	if(!SScharacter_setup.initialized)
 		SScharacter_setup.newplayers_requiring_init += src
 	else

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -34,7 +34,6 @@
 	var/model                          // Used when caching robolimb icons.
 	var/force_icon                     // Used to force override of species-specific limb icons (for prosthetics).
 	var/list/mob_overlays              // Cached limb overlays
-	var/list/mob_underlays              // Cached limb underlays
 	var/skin_tone                         // Skin tone.
 	var/base_skin = ""                    // Skin base.
 	var/list/s_col                     // skin colour
@@ -100,7 +99,7 @@
 	if(owner)
 		replaced(owner)
 		sync_colour_to_human(owner)
-	get_icon()
+	get_overlays()
 
 	slowdown = species.get_slowdown(owner)
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -33,7 +33,8 @@
 	var/icon_position = 0              // Used in mob overlay layering calculations.
 	var/model                          // Used when caching robolimb icons.
 	var/force_icon                     // Used to force override of species-specific limb icons (for prosthetics).
-	var/icon/mob_icon                  // Cached icon for use in mob overlays.
+	var/list/mob_overlays              // Cached limb overlays
+	var/list/mob_underlays              // Cached limb underlays
 	var/skin_tone                         // Skin tone.
 	var/base_skin = ""                    // Skin base.
 	var/list/s_col                     // skin colour

--- a/code/modules/organs/external/_external_icons.dm
+++ b/code/modules/organs/external/_external_icons.dm
@@ -12,8 +12,8 @@ var/global/list/limb_icon_cache = list()
 	for(var/obj/item/organ/external/organ in contents)
 		if(organ.children && length(organ.children))
 			for(var/obj/item/organ/external/child in organ.children)
-				overlays += child.mob_icon
-		overlays += organ.mob_icon
+				overlays += child.mob_overlays
+		overlays += organ.mob_overlays
 
 /obj/item/organ/external/proc/sync_colour_to_human(mob/living/carbon/human/human)
 	skin_tone = null
@@ -59,27 +59,74 @@ var/global/list/limb_icon_cache = list()
 		addtimer(new Callback(owner, /mob/living/carbon/human/proc/update_hair), 1, TIMER_UNIQUE)
 	..()
 
-	var/list/sorted = list()
+/obj/item/organ/external/proc/get_icon_key()
+	RETURN_TYPE(/list)
+	. = list()
+
+	var/gender = "_m"
+	if(!(limb_flags & ORGAN_FLAG_GENDERED_ICON))
+		gender = null
+	else if (dna && dna.GetUIState(DNA_UI_GENDER))
+		gender = "_f"
+	else if(owner && owner.gender == FEMALE)
+		gender = "_f"
+
+	. += "[gender]-"
+	. += "[organ_tag]-"
+	. += "[species.get_race_key(owner)]"
+
+	if(species.base_skin_colours && !isnull(species.base_skin_colours[base_skin]))
+		. += "-[species.base_skin_colours[base_skin]]"
+
+	if(force_icon)
+		. += "[force_icon]"
+	else if (BP_IS_ROBOTIC(src))
+		. += "robot"
+	else if (status & ORGAN_MUTATED)
+		. += "deformed"
+	else if (owner && (MUTATION_SKELETON in owner.mutations))
+		. += "skeleton"
+	else if (owner && (MUTATION_HUSK in owner.mutations))
+		. += "husk"
+	else if (owner && (MUTATION_HULK in owner.mutations))
+		. += "hulk"
+
+	//Colour, maybe simplify this one day and actually calculate it once
+	if(status & ORGAN_DEAD)
+		. += "_dead"
+
+	if(skin_tone)
+		. += "_tone_[skin_tone]"
+
+	if(species.appearance_flags & SPECIES_APPEARANCE_HAS_SKIN_COLOR)
+		if(s_col && length(s_col) >= 3)
+			. += "_color_[s_col[1]]_[s_col[2]]_[s_col[3]]_[s_col_blend]"
+
 	for(var/E in markings)
 		var/datum/sprite_accessory/marking/M = E
 		if (M.draw_target == MARKING_TARGET_SKIN)
-			var/color = markings[E]
-			var/state = M.icon_state
-			if (M.use_organ_tag)
-				state = "[state]-[organ_tag]"
-			var/icon/I = icon(M.icon, state)
-			I.Blend(color, M.blend)
-			icon_cache_key += "[M.name][color]"
-			ADD_SORTED(sorted, list(list(M.draw_order, I, M)), /proc/cmp_marking_order)
-	for (var/entry in sorted)
-		overlays |= entry[2]
-		mob_icon.Blend(entry[2], entry[3]["layer_blend"])
+			. += "-[M.name][color]"
 
-/obj/item/organ/external/var/icon_cache_key
+	if(body_hair && islist(h_col) && length(h_col) >= 3)
+		. += "[body_hair]-[icon_name]-[h_col[1]][h_col[2]][h_col[3]]"
+
+	if(model)
+		. += "_model_[model]"
+
+	if(is_stump())
+		. += "-stump"
+
+	return .
+
 /obj/item/organ/external/on_update_icon(regenerate = 0)
+
+	mob_overlays = list()
+
 	var/husk_color_mod = rgb(96,88,80)
 	var/hulk_color_mod = rgb(48,224,40)
 
+	var/husk = owner && (MUTATION_HUSK in owner.mutations)
+	var/hulk = owner && (MUTATION_HULK in owner.mutations)
 
 	var/gender = "_m"
 	if(!(limb_flags & ORGAN_FLAG_GENDERED_ICON))
@@ -97,8 +144,6 @@ var/global/list/limb_icon_cache = list()
 	if(species.base_skin_colours && !isnull(species.base_skin_colours[base_skin]))
 		chosen_icon_state += species.base_skin_colours[base_skin]
 
-	icon_cache_key = "[chosen_icon_state]_[species ? species.name : SPECIES_HUMAN]"
-
 	if(force_icon)
 		chosen_icon = force_icon
 	else if (BP_IS_ROBOTIC(src))
@@ -114,9 +159,9 @@ var/global/list/limb_icon_cache = list()
 
 	var/icon/mob_icon = apply_colouration(new/icon(chosen_icon, chosen_icon_state))
 
-	if (owner && (MUTATION_HUSK in owner.mutations))
+	if (husk)
 		mob_icon.ColorTone(husk_color_mod)
-	if (owner && (MUTATION_HULK in owner.mutations))
+	if (hulk)
 		var/list/tone = ReadRGB(hulk_color_mod)
 		mob_icon.MapColors(rgb(tone[1],0,0),rgb(0,tone[2],0),rgb(0,0,tone[3]))
 
@@ -125,12 +170,12 @@ var/global/list/limb_icon_cache = list()
 		var/husk_icon = species.get_husk_icon(src)
 		if(husk_icon)
 			var/icon/mask = new/icon(chosen_icon)
-			var/blood = species.get_blood_colour(src)
+			var/blood = species.get_blood_colour(owner)
 			var/icon/husk_over = new(species.husk_icon,"")
 			mask.MapColors(0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,0)
 			husk_over.Blend(mask, ICON_ADD)
 			husk_over.Blend(blood, ICON_MULTIPLY)
-			base_icon.Blend(husk_over, ICON_OVERLAY)
+			mob_icon.Blend(husk_over, ICON_OVERLAY)
 
 	var/list/sorted = list()
 	for(var/E in markings)
@@ -142,9 +187,9 @@ var/global/list/limb_icon_cache = list()
 				state = "[state]-[organ_tag]"
 			var/icon/I = icon(M.icon, state)
 			I.Blend(color, M.blend)
-			icon_cache_key += "[M.name][color]"
 			ADD_SORTED(sorted, list(list(M.draw_order, I, M)), /proc/cmp_marking_order)
-	for (var/entry in sorted)
+
+	for (var/entry in sorted) //Revisit this with blendmodes
 		mob_icon.Blend(entry[2], entry[3]["layer_blend"])
 
 	if(body_hair && islist(h_col) && length(h_col) >= 3)
@@ -152,44 +197,41 @@ var/global/list/limb_icon_cache = list()
 		if(!limb_icon_cache[cache_key])
 			var/icon/I = icon(species.get_icobase(owner), "[icon_name]_[body_hair]")
 			I.Blend(rgb(h_col[1],h_col[2],h_col[3]), ICON_ADD)
-			limb_icon_cache[cache_key] = I
 		mob_icon.Blend(limb_icon_cache[cache_key], ICON_OVERLAY)
-
-	if(model)
-		icon_cache_key += "_model_[model]"
 
 	//Fix leg layering here
 	//Alternatively you could use masks but it's about same amount of work
-	//if(icon_position & (LEFT | RIGHT))
-	if(false)
+	//Note: This really only works because everything up until now was icon ops to build an icon we can work with
+	// If we ever move to pure overlays for body hair / modifiers / cosmetic changes to a limb, look up daedalusdock's implementation
+	if(icon_position & (LEFT | RIGHT))
 		var/icon/under_icon = new('icons/mob/human.dmi',"blank")
 		under_icon.Insert(new/icon(mob_icon,dir=NORTH),dir=NORTH)
 		under_icon.Insert(new/icon(mob_icon,dir=SOUTH),dir=SOUTH)
 		if(!(icon_position & LEFT))
 			under_icon.Insert(new/icon(mob_icon,dir=EAST),dir=EAST)
-		if(!(part.icon_position & RIGHT))
+		if(!(icon_position & RIGHT))
 			under_icon.Insert(new/icon(mob_icon,dir=WEST),dir=WEST)
 		//At this point, the icon has all the valid states for both left and right leg overlays
-		var/mutable_appearance/upper_appearance = mutable_appearance(under_icon, chosen_icon_state)
+		var/mutable_appearance/upper_appearance = mutable_appearance(under_icon, chosen_icon_state, flags = DEFAULT_APPEARANCE_FLAGS)
 		upper_appearance.layer = FLOAT_LAYER
 		mob_overlays += upper_appearance
 
-		if(part.icon_position & LEFT)
+		if(icon_position & LEFT)
 			under_icon.Insert(new/icon(mob_icon,dir=EAST),dir=EAST)
-		if(part.icon_position & RIGHT)
+		if(icon_position & RIGHT)
 			under_icon.Insert(new/icon(mob_icon,dir=WEST),dir=WEST)
 
-		var/mutable_appearance/under_appearance = mutable_appearance(under_icon, chosen_icon_state)
+		var/mutable_appearance/under_appearance = mutable_appearance(under_icon, chosen_icon_state, flags = DEFAULT_APPEARANCE_FLAGS)
 		upper_appearance.layer = BODYPARTS_LOW_LAYER
 		mob_overlays += under_appearance
 	else
-		var/mutable_appearance/limb_appearance = mutable_appearance(mob_icon, chosen_icon_state)
-		if(part.icon_position & UNDER)
+		var/mutable_appearance/limb_appearance = mutable_appearance(mob_icon, chosen_icon_state, flags = DEFAULT_APPEARANCE_FLAGS)
+		if(icon_position & UNDER)
 			limb_appearance.layer = BODYPARTS_LOW_LAYER
 		mob_overlays += limb_appearance
 
 	if(blocks_emissive)
-		var/mutable_appearance/limb_em_block = emissive_blocker(chosen_icon, chosen_icon_state, FLOAT_LAYER, alpha = limb_appearance.alpha)
+		var/mutable_appearance/limb_em_block = emissive_blocker(chosen_icon, chosen_icon_state, FLOAT_LAYER)
 		limb_em_block.dir = dir
 		mob_overlays += limb_em_block
 
@@ -216,20 +258,24 @@ var/global/list/robot_hud_colours = list("#ffffff","#cccccc","#aaaaaa","#888888"
 	// icon_cache_key is set by any get_icon() calls that are made.
 	// This looks convoluted, but it's this way to avoid icon proc calls.
 	if(!hud_damage_image)
-		var/cache_key = "dambase-[icon_cache_key]"
-		if(!icon_cache_key || !limb_icon_cache[cache_key])
-			limb_icon_cache[cache_key] = icon(get_icon(), null, SOUTH)
-		var/image/temp = image(limb_icon_cache[cache_key])
-		if(species)
-			// Calculate the required colour matrix.
-			var/r = 0.30 * species.health_hud_intensity
-			var/g = 0.59 * species.health_hud_intensity
-			var/b = 0.11 * species.health_hud_intensity
-			temp.color = list(r, r, r, g, g, g, b, b, b)
-		temp.pixel_x = owner.default_pixel_x
-		temp.pixel_y = owner.default_pixel_y
+		var/cache_key = "dambase-[json_encode(get_icon_key())]"
+		if(!cache_key || !limb_icon_cache[cache_key])
+			var/list/appearances = get_overlays()
+			for(var/image/I as anything in appearances) //Mutable appearances are a type of image
+				I.dir = SOUTH
+				I.icon_state = null
+				if(species)
+				// Calculate the required colour matrix.
+					var/r = 0.30 * species.health_hud_intensity
+					var/g = 0.59 * species.health_hud_intensity
+					var/b = 0.11 * species.health_hud_intensity
+					I.color = list(r, r, r, g, g, g, b, b, b)
+				I.pixel_x = owner.default_pixel_x
+				I.pixel_y = owner.default_pixel_y
+			limb_icon_cache[cache_key] = appearances
+		var/list/appearances = limb_icon_cache[cache_key]
 		hud_damage_image = image(null)
-		hud_damage_image.overlays += temp
+		hud_damage_image.overlays += appearances
 
 	// Calculate the required color index.
 	var/dam_state = min(1,((brute_dam+burn_dam)/max(1,max_damage)))
@@ -252,7 +298,6 @@ var/global/list/robot_hud_colours = list("#ffffff","#cccccc","#aaaaaa","#888888"
 		applying += rgb(,,,180) // Makes the icon translucent, SO INTUITIVE TY BYOND
 
 	else if(status & ORGAN_DEAD)
-		icon_cache_key += "_dead"
 		applying.ColorTone(rgb(10,50,0))
 		applying.SetIntensity(0.7)
 
@@ -261,11 +306,9 @@ var/global/list/robot_hud_colours = list("#ffffff","#cccccc","#aaaaaa","#888888"
 			applying.Blend(rgb(skin_tone, skin_tone, skin_tone), ICON_ADD)
 		else
 			applying.Blend(rgb(-skin_tone,  -skin_tone,  -skin_tone), ICON_SUBTRACT)
-		icon_cache_key += "_tone_[skin_tone]"
 	if(species.appearance_flags & SPECIES_APPEARANCE_HAS_SKIN_COLOR)
 		if(s_col && length(s_col) >= 3)
 			applying.Blend(rgb(s_col[1], s_col[2], s_col[3]), s_col_blend)
-			icon_cache_key += "_color_[s_col[1]]_[s_col[2]]_[s_col[3]]_[s_col_blend]"
 
 	return applying
 

--- a/code/modules/organs/external/_external_icons.dm
+++ b/code/modules/organs/external/_external_icons.dm
@@ -77,6 +77,10 @@ var/global/list/limb_icon_cache = list()
 
 /obj/item/organ/external/var/icon_cache_key
 /obj/item/organ/external/on_update_icon(regenerate = 0)
+	var/husk_color_mod = rgb(96,88,80)
+	var/hulk_color_mod = rgb(48,224,40)
+
+
 	var/gender = "_m"
 	if(!(limb_flags & ORGAN_FLAG_GENDERED_ICON))
 		gender = null
@@ -93,7 +97,7 @@ var/global/list/limb_icon_cache = list()
 	if(species.base_skin_colours && !isnull(species.base_skin_colours[base_skin]))
 		chosen_icon_state += species.base_skin_colours[base_skin]
 
-	icon_cache_key = "[icon_state]_[species ? species.name : SPECIES_HUMAN]"
+	icon_cache_key = "[chosen_icon_state]_[species ? species.name : SPECIES_HUMAN]"
 
 	if(force_icon)
 		chosen_icon = force_icon
@@ -109,6 +113,24 @@ var/global/list/limb_icon_cache = list()
 		chosen_icon = species.get_icobase(owner)
 
 	var/icon/mob_icon = apply_colouration(new/icon(chosen_icon, chosen_icon_state))
+
+	if (owner && (MUTATION_HUSK in owner.mutations))
+		mob_icon.ColorTone(husk_color_mod)
+	if (owner && (MUTATION_HULK in owner.mutations))
+		var/list/tone = ReadRGB(hulk_color_mod)
+		mob_icon.MapColors(rgb(tone[1],0,0),rgb(0,tone[2],0),rgb(0,0,tone[3]))
+
+	//Handle husk overlay.
+	if(husk)
+		var/husk_icon = species.get_husk_icon(src)
+		if(husk_icon)
+			var/icon/mask = new/icon(chosen_icon)
+			var/blood = species.get_blood_colour(src)
+			var/icon/husk_over = new(species.husk_icon,"")
+			mask.MapColors(0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,1, 0,0,0,0)
+			husk_over.Blend(mask, ICON_ADD)
+			husk_over.Blend(blood, ICON_MULTIPLY)
+			base_icon.Blend(husk_over, ICON_OVERLAY)
 
 	var/list/sorted = list()
 	for(var/E in markings)
@@ -138,7 +160,8 @@ var/global/list/limb_icon_cache = list()
 
 	//Fix leg layering here
 	//Alternatively you could use masks but it's about same amount of work
-	if(icon_position & (LEFT | RIGHT))
+	//if(icon_position & (LEFT | RIGHT))
+	if(false)
 		var/icon/under_icon = new('icons/mob/human.dmi',"blank")
 		under_icon.Insert(new/icon(mob_icon,dir=NORTH),dir=NORTH)
 		under_icon.Insert(new/icon(mob_icon,dir=SOUTH),dir=SOUTH)

--- a/code/modules/organs/external/species/diona.dm
+++ b/code/modules/organs/external/species/diona.dm
@@ -130,8 +130,9 @@
 	var/icon/I = get_eyes()
 	if(glowing_eyes)
 		var/image/eye_glow = image(I)
-		eye_glow.layer = EYE_GLOW_LAYER
-		eye_glow.plane = EFFECTS_ABOVE_LIGHTING_PLANE
+		eye_glow.overlays += emissive_appearance(eye_icon_location, "")
+		eye_glow.layer = FLOAT_LAYER
+		//eye_glow.plane = EFFECTS_ABOVE_LIGHTING_PLANE
 		return eye_glow
 
 /obj/item/organ/external/head/diona/get_eyes()

--- a/maps/using.dm
+++ b/maps/using.dm
@@ -1,4 +1,4 @@
 //Easily change which map to build by uncommenting ONE below.
 
-//#include "example\map.dm"
-#include "torch\map.dm"
+#include "example\map.dm"
+//#include "torch\map.dm"

--- a/maps/using.dm
+++ b/maps/using.dm
@@ -1,4 +1,4 @@
 //Easily change which map to build by uncommenting ONE below.
 
-#include "example\map.dm"
-//#include "torch\map.dm"
+//#include "example\map.dm"
+#include "torch\map.dm"


### PR DESCRIPTION
Essentially makes it so limbs block emissives, mob caches are per limb now, moves a lot of icon generation to organ itself.

🆑 CrimsonShrike
tweak: Ipatch now uses new emissive system and will glow in dark when on.
bugfix: Fixes mobs occluding all emissives, including their own
/🆑