### PR TITLE
Adds wound overlays to the health display

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -755,6 +755,16 @@
 						no_damage = 0
 					health_images += E.get_damage_hud_image()
 
+				// Apply wound overlays
+				for(var/obj/item/organ/external/O in organs)
+					if(O.is_stump() || O.damage_state == "00")
+						continue
+					var/icon/doll_wounds = new /icon(species.get_damage_overlays(src), O.damage_state)
+					doll_wounds.Blend(new /icon(species.get_damage_mask(src), O.icon_name), ICON_MULTIPLY)
+					doll_wounds.Blend((BP_IS_ROBOTIC(O) ? SYNTH_BLOOD_COLOUR : O.species.get_blood_colour(src)), ICON_MULTIPLY)
+					health_images += doll_wounds
+					health_images += image(species.bandages_icon, "[O.icon_name][O.bandage_level()]")
+
 				// Apply a fire overlay if we're burning.
 				if(on_fire)
 					health_images += image('icons/mob/screen1_health.dmi',"burning")


### PR DESCRIPTION
:cl: Karl Johansson
rscadd: Adds wound and bandage overlays to the health display on the HUD
/:cl:

## What?
This adds visible wounds to the little doll on the right side of the HUD. This makes it a little easier (but not too easy) to tell how beat up your character is.
![image](https://github.com/Baystation12/Baystation12/assets/77447558/d42fcc5c-9590-4e45-965e-08a50ba407b1) ![image](https://github.com/Baystation12/Baystation12/assets/77447558/575bd1f2-816f-4613-9864-3023629c45df)

## Will this cause problems?
I don't think so. I checked what other PRs to do with emissive overlays were doing, such as https://github.com/Baystation12/Baystation12/pull/33110. It looks like what's being changed is the overlay syntax, which I don't use at all. I'm fine with closing or modifying this PR and coming back later if it's believed that it might impact development elsewhere.
Edit: As it turns out, I completely missed the actual PR I should have been checking this against (https://github.com/Baystation12/Baystation12/pull/33756). I looked over it and I don't think there's any conflicts.

### Did you test this?
I sure did. It works fine with humans, Vox, Skrell, GAS, Unathi, and prosthetics.