### PR TITLE
stop spiders from growing inside objects

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -280,7 +280,7 @@
 	else if(prob(1))
 		src.visible_message(SPAN_NOTICE("\The [src] skitters."))
 
-	if(amount_grown > 0)
+	if (istype(loc, /turf) && amount_grown > 0)
 		amount_grown += rand(0,2)
 
 /obj/effect/decal/cleanable/spiderling_remains


### PR DESCRIPTION
:cl: Mucker
bugfix: Spiderlings should no longer grow while not on a turf (no more surprise spiders-armies popping out of cocoons)
/:cl: