### PR TITLE
Overmap tooltips and main tooltips stuff

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3164,6 +3164,7 @@
 #include "code\modules\tables\tables.dm"
 #include "code\modules\tables\update_triggers.dm"
 #include "code\modules\tension\tension.dm"
+#include "code\modules\tooltip\tooltip.dm"
 #include "code\modules\turbolift\_turbolift.dm"
 #include "code\modules\turbolift\turbolift.dm"
 #include "code\modules\turbolift\turbolift_areas.dm"

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -15,6 +15,9 @@
 	var/datum/preferences/prefs = null
 	var/adminobs		= null
 
+	///datum that controls the displaying and hiding of tooltips
+	var/datum/tooltip/tooltips
+
 	var/adminhelped = 0
 
 	var/staffwarn = null

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -211,6 +211,9 @@
 	if(!winexists(src, "asset_cache_browser")) // The client is using a custom skin, tell them.
 		to_chat(src, SPAN_WARNING("Unable to access asset cache browser, if you are using a custom skin file, please allow DS to download the updated version, if you are not, then make a bug report. This is not a critical issue but can cause issues with resource downloading, as it is impossible to know when extra resources arrived to you."))
 
+	if(!tooltips)
+		tooltips = new /datum/tooltip(src)
+
 	if(holder)
 		src.control_freak = 0 //Devs need 0 for profiler access
 

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -5,6 +5,8 @@
 	var/UI_style_color = "#ffffff"
 	var/UI_style_alpha = 255
 
+	var/tooltip_style = "Midnight" //Style for popup tooltips
+
 
 /datum/category_item/player_setup_item/player_global/ui
 	name = "UI"
@@ -41,6 +43,7 @@
 	. += "<b>Custom UI</b> (recommended for White UI):<br>"
 	. += "-Color: <a href='?src=\ref[src];select_color=1'><b>[pref.UI_style_color]</b></a> <table style='display:inline;' bgcolor='[pref.UI_style_color]'><tr><td>__</td></tr></table> <a href='?src=\ref[src];reset=ui'>reset</a><br>"
 	. += "-Alpha(transparency): <a href='?src=\ref[src];select_alpha=1'><b>[pref.UI_style_alpha]</b></a> <a href='?src=\ref[src];reset=alpha'>reset</a><br>"
+	. += "<b>Tooltip Style:</b> <a href='?src=\ref[src];select_tooltip_style=1'><b>[pref.tooltip_style]</b></a><br>"
 	if(can_select_ooc_color(user))
 		. += "<b>OOC Color:</b> "
 		if(pref.ooccolor == initial(pref.ooccolor))
@@ -84,6 +87,13 @@
 			if (target_mob?.client)
 				target_mob.client.fps = pref.clientfps
 			return TOPIC_REFRESH
+
+	else if(href_list["select_tooltip_style"])
+		var/tooltip_style_new = input(user, "Choose tooltip style.", "Global Preference", pref.tooltip_style) as null|anything in all_tooltip_styles
+		if(!tooltip_style_new || !CanUseTopic(user))
+			return TOPIC_NOACTION
+		pref.tooltip_style = tooltip_style_new
+		return TOPIC_REFRESH
 
 	else if(href_list["reset"])
 		switch(href_list["reset"])

--- a/code/modules/client/ui_style.dm
+++ b/code/modules/client/ui_style.dm
@@ -9,6 +9,15 @@ var/global/all_ui_styles = list(
 	"minimalist"   = 'icons/mob/screen/minimalist.dmi'
 	)
 
+var/global/all_tooltip_styles = list(
+	"Midnight", //Default for everyone is the first one,
+	"Plasmafire",
+	"Retro",
+	"Slimecore",
+	"Operative",
+	"Clockwork"
+	)
+
 /proc/ui_style2icon(ui_style)
 	if(ui_style in all_ui_styles)
 		return all_ui_styles[ui_style]

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -130,6 +130,18 @@ GLOBAL_LIST_EMPTY(known_overmap_sectors)
 /obj/effect/overmap/visitable/proc/generate_skybox()
 	return
 
+/obj/effect/overmap/visitable/MouseEntered(location, control, params)
+	openToolTip(user = usr, tip_src = src, params = params, title = name)
+	..()
+
+/obj/effect/overmap/visitable/MouseDown()
+	closeToolTip(usr) //No reason not to, really
+	..()
+
+/obj/effect/overmap/visitable/MouseExited()
+	closeToolTip(usr) //No reason not to, really
+	..()
+
 /obj/effect/overmap/visitable/sector
 	name = "generic sector"
 	desc = "Sector with some stuff in it."

--- a/code/modules/tooltip/tooltip.dm
+++ b/code/modules/tooltip/tooltip.dm
@@ -1,0 +1,117 @@
+/*
+Tooltips v1.1 - 22/10/15
+Developed by Wire (#goonstation on irc.synirc.net)
+- Added support for screen_loc pixel offsets. Should work. Maybe.
+- Added init function to more efficiently send base vars
+Configuration:
+- Set control to the correct skin element (remember to actually place the skin element)
+- Set file to the correct path for the .html file (remember to actually place the html file)
+- Attach the datum to the user client on login, e.g.
+/client/New()
+	src.tooltips = new /datum/tooltip(src)
+Usage:
+- Define mouse event procs on your (probably HUD) object and simply call the show and hide procs respectively:
+/obj/screen/hud
+	MouseEntered(location, control, params)
+		usr.client.tooltip.show(params, title = src.name, content = src.desc)
+	MouseExited()
+		usr.client.tooltip.hide()
+Customization:
+- Theming can be done by passing the theme var to show() and using css in the html file to change the look
+- For your convenience some pre-made themes are included
+Notes:
+- You may have noticed 90% of the work is done via javascript on the client. Gotta save those cycles man.
+- This is entirely untested in any other codebase besides goonstation so I have no idea if it will port nicely. Good luck!
+	- After testing and discussion (Wire, Remie, MrPerson, AnturK) ToolTips are ok and work for /tg/station13
+*/
+
+
+/datum/tooltip
+	var/client/owner
+	var/control = "mainwindow.tooltip"
+	var/showing = FALSE
+	var/queueHide = FALSE
+	var/init = FALSE
+
+
+/datum/tooltip/New(client/C)
+	if (C)
+		owner = C
+		show_browser(owner, file2text('code/modules/tooltip/tooltip.html'), "window=[control]")
+
+	..()
+
+
+/datum/tooltip/proc/show(atom/movable/thing, params = null, title = null, content = null, theme = "default", special = "none")
+	if (!thing || !params || (!title && !content) || !owner || !isnum(world.icon_size))
+		return FALSE
+	if (!init)
+		//Initialize some vars
+		init = TRUE
+		send_output(owner, list2params(list(world.icon_size, control)), "[control]:tooltip.init")
+
+	showing = TRUE
+
+	if (title && content)
+		title = "<h1>[title]</h1>"
+		content = "<p>[content]</p>"
+	else if (title && !content)
+		title = "<p>[title]</p>"
+	else if (!title && content)
+		content = "<p>[content]</p>"
+
+	// Strip macros from item names
+	title = replacetext(title, "\proper", "")
+	title = replacetext(title, "\improper", "")
+
+	//Make our dumb param object
+	params = {"{ "cursor": "[params]", "screenLoc": "[thing.screen_loc]" }"}
+
+	//Send stuff to the tooltip
+	var/view_size = getviewsize(owner.view)
+	send_output(owner, list2params(list(params, view_size[1] , view_size[2], "[title][content]", theme, special)), "[control]:tooltip.update")
+
+	//If a hide() was hit while we were showing, run hide() again to avoid stuck tooltips
+	showing = FALSE
+	if (queueHide)
+		hide()
+
+	return TRUE
+
+
+/datum/tooltip/proc/hide()
+	queueHide = !!showing
+
+	if (queueHide)
+		addtimer(new Callback(src, .proc/do_hide), 1)
+	else
+		do_hide()
+
+	return TRUE
+
+/datum/tooltip/proc/do_hide()
+	winshow(owner, control, FALSE)
+
+/* TG SPECIFIC CODE */
+
+
+//Open a tooltip for user, at a location based on params
+//Theme is a CSS class in tooltip.html, by default this wrapper chooses a CSS class based on the user's UI_style (Midnight, Plasmafire, Retro, etc)
+//Includes sanity.checks
+/proc/openToolTip(mob/user = null, atom/movable/tip_src = null, params = null,title = "",content = "",theme = "")
+	if(istype(user))
+		if(user.client && user.client.tooltips)
+			var/ui_style = user?.client?.prefs?.tooltip_style
+			if(!theme && ui_style)
+				theme = lowertext(ui_style)
+			if(!theme)
+				theme = "default"
+			user.client.tooltips.show(tip_src, params,title,content,theme)
+
+
+//Arbitrarily close a user's tooltip
+//Includes sanity checks.
+/proc/closeToolTip(mob/user)
+	if(istype(user))
+		if(user.client && user.client.tooltips)
+			user.client.tooltips.hide()

--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -1,0 +1,267 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Tooltip</title>
+	<meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
+	<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+	<style type="text/css">
+		body, html {
+			margin: 0;
+			padding: 0;
+			overflow: hidden;
+		}
+
+		.wrap {
+			position: absolute;
+			top: 0;
+			left: 0;
+			max-width: 298px;
+			border: 2px solid #1B2967;
+		}
+
+		.content {
+			font: bold 12px Arial, 'Helvetica Neue', Helvetica, sans-serif;
+			color: #ffffff;
+			padding: 8px;
+			border: 2px solid #0033CC;
+			background: #005CB8;
+		}
+
+		h1 {
+			margin: -5px 0 2px 0;
+			font-size: 1.2em;
+			line-height: 1.4;
+		}
+
+		p {
+			margin: 0;
+			line-height: 1.2;
+		}
+
+		/* Custom Themes */
+		.blob .wrap {border-color: #2E2E2E;}
+		.blob .content {color: #82ED00; border-color: #4E4C4A; background-color: #191918;}
+
+		.parasite .wrap {border-color: #88868D;}
+		.parasite .content {color: #EFEEEF; border-color: #35333A; background-color: #636169;}
+
+		.alien .wrap {border-color: #33165B;}
+		.alien .content {color: #25004A; border-color: #5A3076; background-color: #6D3A8E;}
+
+		.wraith .wrap {border-color: #492136;}
+		.wraith .content {border-color: #331726; background-color: #471962;}
+
+		.cult .wrap {border-color: #292222;}
+		.cult .content {color: #FF0000; border-color: #4C4343; background-color: #3C3434;}
+
+		.clockcult .wrap {border-color: #170800;}
+		.clockcult .content {color: #B18B25; border-color: #000000; background-color: #5F380E;}
+
+		.pod .wrap {border-color: #052401;}
+		.pod .content {border-color: #326D29; background-color: #569F4B;}
+
+		.colo-pod .wrap {border-color: #256fb9;}
+		.colo-pod .content {border-color: #000000; background-color: #000000;}
+
+		.hisgrace .wrap {border-color: #7C1414;}
+		.hisgrace .content {color: #15D512; border-color: #9D1414; background-color: #861414;}
+
+		/* TG: Themes */
+		/* ScreenUI */
+		.midnight .wrap {border-color: #2B2B33;}
+		.midnight .content {color: #6087A0; border-color: #2B2B33; background-color: #36363C;}
+
+		.plasmafire .wrap {border-color: #21213D;}
+		.plasmafire .content {color: #FFA800 ; border-color: #21213D; background-color:#1D1D36;}
+
+		.retro .wrap {border-color: #005E00;}
+		.retro .content {color: #003366; border-color: #005E00; background-color: #00BD00;}
+
+		.slimecore .wrap {border-color: #18640E;}
+		.slimecore .content {color: #6EA161; border-color: #11450B; background-color: #354E35;}
+
+		.operative .wrap {border-color: #1E0101;}
+		.operative .content {color: #FFFFFF; border-color: #750000; background-color: #350000;}
+
+		.clockwork .wrap {border-color: #170800;}
+		.clockwork .content {color: #B18B25; border-color: #000000; background-color: #5F380E;}
+
+
+	</style>
+</head>
+<body>
+	<div id="wrap" class="wrap">
+		<div id="content" class="content"></div>
+	</div>
+	<script type="text/javascript" src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
+	<script type="text/javascript">
+		var tooltip = {
+			'tileSize': 32,
+			'control': '',
+			'params': {},
+			'client_view_w': 0,
+			'client_view_h': 0,
+			'text': '',
+			'theme': '',
+			'padding': 2,
+			init: function(tileSize, control) {
+				tooltip.tileSize = parseInt(tileSize);
+				tooltip.control = control;
+			},
+			hide: function() {
+				window.location = 'byond://winset?id='+tooltip.control+';is-visible=false';
+			},
+			updateCallback: function(map) {
+				if (typeof map === 'undefined' || !map) {return false;}
+
+				//alert(tooltip.params+' | '+tooltip.clientView+' | '+tooltip.text+' | '+tooltip.theme); //DEBUG
+
+				//Some reset stuff to avoid fringe issues with sizing
+				window.location = 'byond://winset?id='+tooltip.control+';anchor1=0,0;size=999x999';
+
+				//Get the real icon size according to the client view
+				//FYI, this bit is even more borrowed from goon, our widescreen broke tooltips so I took a look at how they do it
+				//To improve our code. Thanks gooncoders, very cool
+				var mapWidth 		= map['view-size'].x,
+					mapHeight 		= map['view-size'].y,
+					tilesShownX 	= tooltip.client_view_w
+					tilesShownY 	= tooltip.client_view_h
+					realIconSizeX 	= mapWidth / tilesShownX,
+					realIconSizeY 	= mapHeight / tilesShownY,
+					resizeRatioX	= realIconSizeX / tooltip.tileSize,
+					resizeRatioY	= realIconSizeY / tooltip.tileSize,
+					//Calculate letterboxing offsets
+					leftOffset 		= (map.size.x - mapWidth) / 2,
+					topOffset 		= (map.size.y - mapHeight) / 2;
+
+				//alert(realIconSize + ' | ' +tooltip.tileSize + ' | ' + resizeRatio); //DEBUG
+
+				const parameters = new Object();
+
+				//Parse out the contents of params (e.g. "icon-x=32;icon-y=29;screen-loc=3:10,15:29")
+				//It is worth noting that params is not always ordered in the same way. We therefore need to write the code
+				//To load their values in independantly of their order
+				var paramsA = tooltip.params.cursor.split(';');
+				for (var i = 0; i < paramsA.length; i++) {
+					var entry = paramsA[i];
+					var nameAndValue = entry.split("=");
+					parameters[nameAndValue[0]] = nameAndValue[1];
+				}
+
+				//Sometimes screen-loc is never sent ahaha fuck you byond
+				if (!parameters["icon-x"] || !parameters["icon-y"] || !parameters["screen-loc"]) {
+					return false;
+				}
+				//icon-x
+				var iconX = parseInt(parameters["icon-x"]);
+				//icon-y
+				var iconY = parseInt(parameters["icon-y"]);
+				//screen-loc
+				var screenLoc = parameters["screen-loc"];
+				screenLoc = screenLoc.split(',');
+				if (screenLoc.length < 2) {return false;}
+				var left = screenLoc[0];
+				var top = screenLoc[1];
+				if (!left || !top) {return false;}
+				screenLoc = left.split(':');
+				left = parseInt(screenLoc[0]);
+				var enteredX = parseInt(screenLoc[1]);
+				screenLoc = top.split(':');
+				top = parseInt(screenLoc[0]);
+				var enteredY = parseInt(screenLoc[1]);
+
+				//Screen loc offsets on objects (e.g. "WEST+0:6,NORTH-1:26") can royally mess with positioning depending on where the cursor enters
+				//This is a giant bitch to parse. Note that it only expects screen_loc in the format <west>,<north>.
+				var oScreenLoc = tooltip.params.screenLoc.split(','); //o for original ok
+
+				var west = oScreenLoc[0].split(':');
+				if (west.length > 1) { //Only if west has a pixel offset
+					var westOffset = parseInt(west[1]);
+					if (westOffset !== 0) {
+						if ((iconX + westOffset) !== enteredX) { //Cursor entered on the offset tile
+							left = left + (westOffset < 0 ? 1 : -1);
+						}
+						leftOffset = leftOffset + (westOffset * resizeRatioX);
+					}
+				}
+
+				if (oScreenLoc.length > 1) { //If north is given
+					var north = oScreenLoc[1].split(':');
+					if (north.length > 1) { //Only if north has a pixel offset
+						var northOffset = parseInt(north[1]);
+						if (northOffset !== 0) {
+							if ((iconY + northOffset) === enteredY) { //Cursor entered on the original tile
+								top--;
+								topOffset = topOffset - ((tooltip.tileSize + northOffset) * resizeRatioY);
+							} else { //Cursor entered on the offset tile
+								if (northOffset < 0) { //Offset southwards
+									topOffset = topOffset - ((tooltip.tileSize + northOffset) * resizeRatioY);
+								} else { //Offset northwards
+									top--;
+									topOffset = topOffset - (northOffset * resizeRatioY);
+								}
+							}
+						}
+					}
+				}
+
+				//Handle special cases (for fuck sake)
+				if (tooltip.special !== 'none') {
+					//Put yo special cases here
+				}
+
+				//Clamp values
+				left = (left < 0 ? 0 : (left > tilesShownX ? tilesShownX : left));
+				top = (top < 0 ? 0 : (top > tilesShownY ? tilesShownY : top));
+
+				//Calculate where on the screen the popup should appear (below the hovered tile)
+				var posX = Math.round(((left - 1) * realIconSizeX) + leftOffset + tooltip.padding); //-1 to position at the left of the target tile
+				var posY = Math.round(((tilesShownY - top + 1) * realIconSizeY) + topOffset + tooltip.padding); //+1 to position at the bottom of the target tile
+
+				//alert(mapWidth+' | '+mapHeight+' | '+tilesShown+' | '+realIconSize+' | '+leftOffset+' | '+topOffset+' | '+left+' | '+top+' | '+posX+' | '+posY); //DEBUG
+
+				$('body').attr('class', tooltip.theme);
+
+				var $content = $('#content'),
+					$wrap 	 = $('#wrap');
+				$wrap.attr('style', '');
+				$content.off('mouseover');
+				$content.html(tooltip.text);
+
+				$wrap.width($wrap.width() + 2); //Dumb hack to fix a bizarre sizing bug
+
+				var pixelRatio = 1;
+				if (window.devicePixelRatio) {
+					pixelRatio = window.devicePixelRatio;
+				}
+
+				var docWidth	= Math.floor($wrap.outerWidth() * pixelRatio),
+					docHeight	= Math.floor($wrap.outerHeight() * pixelRatio);
+
+				if (posY + docHeight > map.size.y) { //Is the bottom edge below the window? Snap it up if so
+					posY = (posY - docHeight) - realIconSizeY - tooltip.padding;
+				}
+
+				//Actually size, move and show the tooltip box
+				window.location = 'byond://winset?id='+tooltip.control+';size='+docWidth+'x'+docHeight+';pos='+posX+','+posY+';is-visible=true';
+
+				$content.on('mouseover', function() {
+					tooltip.hide();
+				});
+			},
+			update: function(params, client_vw, client_vh, text, theme, special) {
+				//Assign our global object
+				tooltip.params = $.parseJSON(params);
+				tooltip.client_view_w = parseInt(client_vw);
+				tooltip.client_view_h = parseInt(client_vh);
+				tooltip.text = text;
+				tooltip.theme = theme;
+				tooltip.special = special;
+
+				//Go get the map details
+				window.location = 'byond://winget?callback=tooltip.updateCallback;id=mapwindow.map;property=size,view-size';
+			},
+		};
+	</script>
+</body>
+</html>

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -992,6 +992,16 @@ window "mainwindow"
 		saved-params = "splitter"
 		right = "rpane"
 		is-vert = true
+	elem "tooltip"
+		type = BROWSER
+		pos = 0,0
+		size = 999x999
+		anchor1 = none
+		anchor2 = none
+		background-color = none
+		is-visible = false
+		saved-params = ""
+
 	elem "input"
 		type = INPUT
 		pos = 3,420


### PR DESCRIPTION
Original port from TG (devs are in comment in tooltips.dm) by @ImJustKisik 

And yes, this needs to be tested to not break stuff because of TG port. UPD: I asked, this things are definetly not a part of TGUI or someting, so it must work properly.
(yea, i'm again doing PRs from fork of a fork, cannot do anything with this)

Adds tooltips for usage on overmap. Also adds main instrumentary for tooltips.

Example of working

![221357796-155beb0d-7cb3-40b8-9114-df8c9b4e40f4](https://github.com/Baystation12/Baystation12/assets/77477080/5c7b2e98-f511-42e1-9547-591d5dc4b4d0)


<details>
<summary>Changelog</summary>

```yml
🆑 LordNest
rscadd: Added tooltips for overmap
/🆑
```