### PR TITLE
Fixes some issues with emissive blocker changes

### DIFF
--- a/code/_helpers/emissives.dm
+++ b/code/_helpers/emissives.dm
@@ -10,7 +10,6 @@
 /proc/emissive_blocker(icon, icon_state = "", layer = FLOAT_LAYER, alpha = 255, appearance_flags = EMPTY_BITFIELD, source = null)
 	var/mutable_appearance/appearance = mutable_appearance(icon = icon, icon_state = icon_state, layer = layer, plane = EMISSIVE_PLANE, flags = appearance_flags|EMISSIVE_APPEARANCE_FLAGS)
 	appearance.color = GLOB.em_block_color
-	appearance.alpha = alpha
 	if(source)
 		appearance.render_source = source
 		// Since only render_target handles transform we don't get any applied transform "stacking"

--- a/code/modules/organs/external/_external_icons.dm
+++ b/code/modules/organs/external/_external_icons.dm
@@ -8,12 +8,7 @@ var/global/list/limb_icon_cache = list()
 
 /obj/item/organ/external/proc/compile_icon()
 	overlays.Cut()
-	 // This is a kludge, only one icon has more than one generation of children though.
-	for(var/obj/item/organ/external/organ in contents)
-		if(organ.children && length(organ.children))
-			for(var/obj/item/organ/external/child in organ.children)
-				overlays += child.mob_overlays
-		overlays += organ.mob_overlays
+	update_icon()
 
 /obj/item/organ/external/proc/sync_colour_to_human(mob/living/carbon/human/human)
 	skin_tone = null
@@ -105,7 +100,7 @@ var/global/list/limb_icon_cache = list()
 	for(var/E in markings)
 		var/datum/sprite_accessory/marking/M = E
 		if (M.draw_target == MARKING_TARGET_SKIN)
-			. += "-[M.name][color]"
+			. += "-[M.name][markings[E]]"
 
 	if(body_hair && islist(h_col) && length(h_col) >= 3)
 		. += "[body_hair]-[icon_name]-[h_col[1]][h_col[2]][h_col[3]]"
@@ -119,7 +114,7 @@ var/global/list/limb_icon_cache = list()
 	return .
 
 /obj/item/organ/external/on_update_icon(regenerate = 0)
-
+	overlays.Cut()
 	mob_overlays = list()
 
 	var/husk_color_mod = rgb(96,88,80)

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -97,7 +97,7 @@
 /obj/item/organ/external/head/get_icon_key()
 	. = ..()
 
-	if(owner.makeup_style && !BP_IS_ROBOTIC(src) && (species && (species.appearance_flags & SPECIES_APPEARANCE_HAS_LIPS)))
+	if(owner?.makeup_style && !BP_IS_ROBOTIC(src) && (species && (species.appearance_flags & SPECIES_APPEARANCE_HAS_LIPS)))
 		. += "[owner.makeup_style]"
 	else
 		. += "nolips"
@@ -131,7 +131,7 @@
 
 /obj/item/organ/external/head/proc/get_hair_icon()
 	var/image/res = image(species.icon_template,"")
-	if(owner.facial_hair_style)
+	if(owner?.facial_hair_style)
 		var/datum/sprite_accessory/facial_hair_style = GLOB.facial_hair_styles_list[owner.facial_hair_style]
 		if(facial_hair_style)
 			if(!facial_hair_style.species_allowed || (species.get_bodytype(owner) in facial_hair_style.species_allowed))
@@ -141,7 +141,7 @@
 						facial_s.Blend(owner.facial_hair_color, facial_hair_style.blend)
 					res.overlays |= facial_s
 
-	if (owner.head_hair_style)
+	if (owner?.head_hair_style)
 		var/icon/HI
 		var/datum/sprite_accessory/hair/H = GLOB.hair_styles_list[owner.head_hair_style]
 		if ((owner.head?.flags_inv & BLOCKHEADHAIR) && !(H.flags & VERY_SHORT))


### PR DESCRIPTION
Setting alpha after setting colour was a bad idea, will revisit concept of semi transparent blockers one day, but until then. Removed.

Fixes some issues with markings not updating instantly and some runtimes with head flying off.

also fixes body parts not having right icons on delimb. some bespoke logic lingered.