### PR TITLE
Remove Arithrazine Healing, Buff Peridaxon Healing

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -445,6 +445,7 @@
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	color = "#561ec3"
+	metabolism = REM * 0.5
 	overdose = 10
 	scannable = 1
 	flags = IGNORE_MOB_SIZE
@@ -462,7 +463,7 @@
 					// peridaxon only heals minor brain damage
 					if(I.damage >= I.min_bruised_damage)
 						continue
-				I.heal_damage(removed)
+				I.heal_damage(3 * removed)
 
 /datum/reagent/ryetalyn
 	name = "Ryetalyn"
@@ -554,7 +555,6 @@
 
 /datum/reagent/arithrazine/affect_blood(mob/living/carbon/M, removed)
 	M.radiation = max(M.radiation - 70 * removed, 0)
-	M.adjustToxLoss(-10 * removed)
 	if(prob(60))
 		M.take_organ_damage(4 * removed, 0, ORGAN_DAMAGE_FLESH_ONLY)
 


### PR DESCRIPTION
:cl: Vex8tion
tweak: Removed arithrazine's ability to heal internal organs
tweak: Peridaxon's metabolism rate is now halved, and it now heals for slightly more per tick
/:cl:
Peridaxon's metabolism is now REM * 0.5, i.e. 0.1/tick. It now heals for 0.3 damage per tick, instead of 0.2 like before.
Arithrazine's weird adjustToxLoss healing factor has been removed, so it now only scrubs radiation with brute damage side-effects.