### PR TITLE
List menu -> radial menu conversions

### DIFF
--- a/code/datums/extensions/holster/holster.dm
+++ b/code/datums/extensions/holster/holster.dm
@@ -140,9 +140,8 @@
 			return
 	else
 		holster_name = holsters[1]
-
 	var/datum/extension/holster/H = holsters[holster_name]
-	if(!H)
+	if (!H || !usr.use_sanity_check(H.atom_holder))
 		return
 
 	if(!H.holstered)

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -93,8 +93,34 @@
 
 /obj/item/rcd/attack_self(mob/user)
 	//Change the mode
+	var/list/options = list(
+		"Airlocks" = mutable_appearance('icons/screen/radial.dmi', "airlock"),
+		"Floors & Walls" = mutable_appearance('icons/screen/radial.dmi', "wallfloor"),
+		"Wall Frames" = mutable_appearance('icons/screen/radial.dmi', "grillewindow"),
+		"Machine Frame" = mutable_appearance('icons/screen/radial.dmi', "machine"),
+		"Computer Frame" = mutable_appearance('icons/screen/radial.dmi', "computer_dir"),
+		"Deconstruction" = mutable_appearance('icons/screen/radial.dmi', "delete"),
+	)
+	var/choice = show_radial_menu(user, src, options, require_near = TRUE, radius = 42, tooltips = TRUE, check_locs = list(src))
+
+	if (!choice || !user.use_sanity_check(src))
+		return
+
+
+	switch(choice)
+		if ("Airlocks")
+			work_mode = GET_SINGLETON(/singleton/hierarchy/rcd_mode/airlock)
+		if ("Floors & Walls")
+			work_mode = GET_SINGLETON(/singleton/hierarchy/rcd_mode/floor_and_walls)
+		if ("Wall Frames")
+			work_mode = GET_SINGLETON(/singleton/hierarchy/rcd_mode/wall_frame)
+		if ("Machine & Computer Frame")
+			work_mode = GET_SINGLETON(/singleton/hierarchy/rcd_mode/machine_frame)
+		if ("Deconstruction")
+			work_mode = GET_SINGLETON(/singleton/hierarchy/rcd_mode/deconstruction)
+
 	work_id++
-	work_mode = next_in_list(work_mode, work_modes)
+
 	to_chat(user, SPAN_NOTICE("Changed mode to '[work_mode]'"))
 	playsound(src.loc, 'sound/effects/pop.ogg', 50, 0)
 	if(prob(20)) src.spark_system.start()

--- a/code/modules/clothing/under/accessories/holster.dm
+++ b/code/modules/clothing/under/accessories/holster.dm
@@ -36,27 +36,6 @@
 	var/datum/extension/holster/H = get_extension(src, /datum/extension/holster)
 	H.examine_holster(user)
 
-
-/obj/item/clothing/accessory/storage/holster/on_attached(obj/item/clothing/under/S, mob/user as mob)
-	..()
-	parent.verbs += /atom/proc/holster_verb
-
-
-/obj/item/clothing/accessory/storage/holster/on_removed(mob/user as mob)
-	if (parent)
-		var/remove_verb = TRUE
-		if (has_extension(parent, /datum/extension/holster))
-			remove_verb = FALSE
-		for (var/obj/accessory in parent.accessories)
-			if (accessory == src)
-				continue
-			if (has_extension(accessory, /datum/extension/holster))
-				remove_verb = FALSE
-		if (remove_verb)
-			parent.verbs -= /atom/proc/holster_verb
-	..()
-
-
 /obj/item/clothing/accessory/storage/holster/armpit
 	name = "armpit holster"
 	desc = "A worn-out handgun holster. Perfect for concealed carry."

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -105,9 +105,9 @@
 	if(!LAZYLEN(attached_organs))
 		to_chat(user, SPAN_WARNING("You can't find any organs to separate."))
 	else
-		if(length(attached_organs) == 1)
-			return attached_organs[1]
-		return show_radial_menu(user, tool, attached_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
+		var/choice = show_radial_menu(user, tool, attached_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
+		if (choice && user.use_sanity_check(target, tool))
+			return choice
 	return FALSE
 
 /singleton/surgery_step/internal/detatch_organ/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -157,9 +157,9 @@
 		if(!LAZYLEN(removable_organs))
 			to_chat(user, SPAN_WARNING("You can't find any removable organs."))
 		else
-			if (length(removable_organs) == 1)
-				return removable_organs[1]
-			return show_radial_menu(user, tool, removable_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
+			var/choice = show_radial_menu(user, tool, removable_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
+			if (choice && user.use_sanity_check(target, tool))
+				return choice
 	return FALSE
 
 /singleton/surgery_step/internal/remove_organ/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
@@ -334,7 +334,7 @@
 		return FALSE
 
 	var/obj/item/organ/organ_to_replace = show_radial_menu(user, tool, attachable_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
-	if(!organ_to_replace)
+	if(!organ_to_replace || !user.use_sanity_check(target, tool))
 		return FALSE
 
 	if(organ_to_replace.parent_organ != affected.organ_tag)
@@ -421,10 +421,8 @@
 			LAZYSET(dead_organs, I, radial_button)
 	if(!length(dead_organs))
 		return FALSE
-	var/obj/item/organ/internal/organ_to_fix = dead_organs[1]
-	if(length(dead_organs) > 1)
-		organ_to_fix = show_radial_menu(user, tool, dead_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
-	if(!organ_to_fix)
+	var/obj/item/organ/internal/organ_to_fix = show_radial_menu(user, tool, dead_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
+	if(!organ_to_fix || !user.use_sanity_check(target, tool))
 		return FALSE
 	if(!organ_to_fix.can_recover())
 		to_chat(user, SPAN_WARNING("The [organ_to_fix.name] is necrotic and can't be saved, it will need to be replaced."))

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -99,15 +99,15 @@
 	for(var/organ in target.internal_organs_by_name)
 		var/obj/item/organ/I = target.internal_organs_by_name[organ]
 		if(I && !(I.status & ORGAN_CUT_AWAY) && I.parent_organ == target_zone)
-			LAZYDISTINCTADD(attached_organs, organ)
+			var/image/radial_button = image(icon = I.icon, icon_state = I.icon_state)
+			radial_button.name = "Detach \the [I.name]"
+			LAZYSET(attached_organs, I.organ_tag, radial_button)
 	if(!LAZYLEN(attached_organs))
 		to_chat(user, SPAN_WARNING("You can't find any organs to separate."))
 	else
-		var/obj/item/organ/organ_to_remove = attached_organs[1]
-		if(length(attached_organs) > 1)
-			organ_to_remove = input(user, "Which organ do you want to separate?") as null|anything in attached_organs
-		if(organ_to_remove)
-			return organ_to_remove
+		if(length(attached_organs) == 1)
+			return attached_organs[1]
+		return show_radial_menu(user, tool, attached_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
 	return FALSE
 
 /singleton/surgery_step/internal/detatch_organ/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -151,15 +151,15 @@
 		var/list/removable_organs
 		for(var/obj/item/organ/internal/I in affected.implants)
 			if(I.status & ORGAN_CUT_AWAY)
-				LAZYDISTINCTADD(removable_organs, I)
+				var/image/radial_button = image(icon = I.icon, icon_state = I.icon_state)
+				radial_button.name = "Remove \the [I.name]"
+				LAZYSET(removable_organs, I, radial_button)
 		if(!LAZYLEN(removable_organs))
 			to_chat(user, SPAN_WARNING("You can't find any removable organs."))
 		else
-			var/obj/item/organ/organ_to_remove = removable_organs[1]
-			if(length(removable_organs) > 1)
-				organ_to_remove = input(user, "Which organ do you want to remove?") as null|anything in removable_organs
-			if(organ_to_remove)
-				return organ_to_remove
+			if (length(removable_organs) == 1)
+				return removable_organs[1]
+			return show_radial_menu(user, tool, removable_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
 	return FALSE
 
 /singleton/surgery_step/internal/remove_organ/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
@@ -326,12 +326,14 @@
 
 	for(var/obj/item/organ/I in affected.implants)
 		if(I && (I.status & ORGAN_CUT_AWAY))
-			LAZYADD(attachable_organs, I)
+			var/image/radial_button = image(icon = I.icon, icon_state = I.icon_state)
+			radial_button.name = "Attach \the [I.name]"
+			LAZYSET(attachable_organs, I, radial_button)
 
 	if(!LAZYLEN(attachable_organs))
 		return FALSE
 
-	var/obj/item/organ/organ_to_replace = input(user, "Which organ do you want to reattach?") as null|anything in attachable_organs
+	var/obj/item/organ/organ_to_replace = show_radial_menu(user, tool, attachable_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
 	if(!organ_to_replace)
 		return FALSE
 
@@ -414,12 +416,14 @@
 	var/list/obj/item/organ/internal/dead_organs = list()
 	for(var/obj/item/organ/internal/I in target.internal_organs)
 		if(I && !(I.status & ORGAN_CUT_AWAY) && (I.status & ORGAN_DEAD) && I.parent_organ == affected.organ_tag && !BP_IS_ROBOTIC(I))
-			dead_organs |= I
+			var/image/radial_button = image(icon = I.icon, icon_state = I.icon_state)
+			radial_button.name = "Attach \the [I.name]"
+			LAZYSET(dead_organs, I, radial_button)
 	if(!length(dead_organs))
 		return FALSE
 	var/obj/item/organ/internal/organ_to_fix = dead_organs[1]
 	if(length(dead_organs) > 1)
-		organ_to_fix = input(user, "Which organ do you want to regenerate?") as null|anything in dead_organs
+		organ_to_fix = show_radial_menu(user, tool, dead_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
 	if(!organ_to_fix)
 		return FALSE
 	if(!organ_to_fix.can_recover())

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -418,8 +418,9 @@
 		to_chat(user, SPAN_WARNING("There are no appropriate internal components to decouple."))
 		return FALSE
 	var/organ_to_remove = show_radial_menu(user, tool, attached_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
-	if(organ_to_remove)
+	if (organ_to_remove && user.use_sanity_check(target, tool))
 		return organ_to_remove
+	return FALSE
 
 /singleton/surgery_step/robotics/detatch_organ_robotic/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("[user] starts to decouple [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool].", \
@@ -470,7 +471,7 @@
 		radial_button.name = "Reattach \the [organ.name]"
 		LAZYSET(candidates, organ, radial_button)
 	var/obj/item/organ/selected = show_radial_menu(user, tool, candidates, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
-	if (!selected)
+	if (!selected || !user.use_sanity_check(target, tool))
 		return FALSE
 	if (istype(selected, /obj/item/organ/internal/augment))
 		var/obj/item/organ/internal/augment/augment = selected

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -411,11 +411,13 @@
 	for(var/organ in target.internal_organs_by_name)
 		var/obj/item/organ/I = target.internal_organs_by_name[organ]
 		if(I && !(I.status & ORGAN_CUT_AWAY) && !BP_IS_CRYSTAL(I) && I.parent_organ == target_zone)
-			LAZYADD(attached_organs, organ)
+			var/image/radial_button = image(icon = I.icon, icon_state = I.icon_state)
+			radial_button.name = "Detach \the [I.name]"
+			LAZYSET(attached_organs, I.organ_tag, radial_button)
 	if(!LAZYLEN(attached_organs))
 		to_chat(user, SPAN_WARNING("There are no appropriate internal components to decouple."))
 		return FALSE
-	var/organ_to_remove = input(user, "Which organ do you want to prepare for removal?") as null|anything in attached_organs
+	var/organ_to_remove = show_radial_menu(user, tool, attached_organs, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
 	if(organ_to_remove)
 		return organ_to_remove
 
@@ -464,12 +466,12 @@
 			continue
 		if (organ.organ_tag in target.internal_organs_by_name)
 			continue
-		candidates += organ
-	candidates = list_to_map(candidates, /proc/ltm_by_atom_name_numbered)
-	var/obj/item/organ/selected = input(user, "Which organ do you want to reattach?") as null | anything in candidates
+		var/image/radial_button = image(icon = organ.icon, icon_state = organ.icon_state)
+		radial_button.name = "Reattach \the [organ.name]"
+		LAZYSET(candidates, organ, radial_button)
+	var/obj/item/organ/selected = show_radial_menu(user, tool, candidates, radius = 42, require_near = TRUE, use_labels = TRUE, check_locs = list(tool))
 	if (!selected)
 		return FALSE
-	selected = candidates[selected]
 	if (istype(selected, /obj/item/organ/internal/augment))
 		var/obj/item/organ/internal/augment/augment = selected
 		if (~augment.augment_flags & AUGMENT_MECHANICAL)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -191,7 +191,9 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 	for(var/singleton in all_surgeries)
 		var/singleton/surgery_step/S = all_surgeries[singleton]
 		if(S.name && S.tool_quality(src) && S.can_use(user, M, zone, src))
-			LAZYSET(possible_surgeries, S, TRUE)
+			var/image/radial_button = image(icon = icon, icon_state = icon_state)
+			radial_button.name = S.name
+			LAZYSET(possible_surgeries, S, radial_button)
 
 	// Which surgery, if any, do we actually want to do?
 	var/singleton/surgery_step/S
@@ -199,7 +201,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 		S = possible_surgeries[1]
 	else if(LAZYLEN(possible_surgeries) >= 1)
 		if(user.client) // In case of future autodocs.
-			S = input(user, "Which surgery would you like to perform?", "Surgery") as null|anything in possible_surgeries
+			S = S = show_radial_menu(user, M, possible_surgeries, radius = 42, use_labels = TRUE, require_near = TRUE, check_locs = list(src))
 		if(S && !user.skill_check_multiple(S.get_skill_reqs(user, M, src, zone)))
 			S = pick(possible_surgeries)
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -197,12 +197,11 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 
 	// Which surgery, if any, do we actually want to do?
 	var/singleton/surgery_step/S
-	if(LAZYLEN(possible_surgeries) == 1)
-		S = possible_surgeries[1]
-	else if(LAZYLEN(possible_surgeries) >= 1)
-		if(user.client) // In case of future autodocs.
-			S = S = show_radial_menu(user, M, possible_surgeries, radius = 42, use_labels = TRUE, require_near = TRUE, check_locs = list(src))
-		if(S && !user.skill_check_multiple(S.get_skill_reqs(user, M, src, zone)))
+	if (user.client && length(possible_surgeries))
+		S = show_radial_menu(user, M, possible_surgeries, radius = 42, use_labels = TRUE, require_near = TRUE, check_locs = list(src))
+		if (!user.use_sanity_check(M))
+			S = null
+		if (S && !user.skill_check_multiple(S.get_skill_reqs(user, M, src, zone)))
 			S = pick(possible_surgeries)
 
 	var/obj/item/gripper/gripper = user.get_active_hand()


### PR DESCRIPTION
:cl: Mucker
rscadd: The RCD now uses a radial menu for swapping modes.
rscadd: Surgery steps now use a radial menu for picking organs.
rscadd: The holstering verb now uses a radial menu to choose a holster if there are more than one.
/:cl: