### PR TITLE
Trials a switch of Torch to ballistics

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -204,6 +204,30 @@
 	name = "box of sniper APDS shells"
 	startswith = list(/obj/item/ammo_casing/shell/apds = 3)
 
+/obj/item/storage/box/ammo/pistol
+	name = "box of pistol magazines - lethal"
+	startswith = list(/obj/item/ammo_magazine/pistol = 7)
+
+/obj/item/storage/box/ammo/pistol/rubber
+	name = "box of pistol magazines - rubber"
+	startswith = list(/obj/item/ammo_magazine/pistol/rubber = 7)
+
+/obj/item/storage/box/ammo/doublestack
+	name = "box of doublestack magazines - lethal"
+	startswith = list(/obj/item/ammo_magazine/pistol/double = 6)
+
+/obj/item/storage/box/ammo/doublestack/rubber
+	name = "box of doublestack magazines - rubber"
+	startswith = list(/obj/item/ammo_magazine/pistol/double/rubber = 6)
+
+/obj/item/storage/box/ammo/smg
+	name = "box of SMG magazines - lethal"
+	startswith = list(/obj/item/ammo_magazine/smg_top = 7)
+
+/obj/item/storage/box/ammo/smg/rubber
+	name = "box of SMG magazines - rubber"
+	startswith = list(/obj/item/ammo_magazine/smg_top/rubber = 7)
+
 /obj/item/storage/box/flashbangs
 	name = "box of flashbangs"
 	desc = "A box containing 7 antipersonnel flashbang grenades.<br> WARNING: These devices are extremely dangerous and can cause blindness or deafness from repeated use."

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -145,7 +145,7 @@
 	slot_flags = SLOT_BELT
 	ammo_type = /obj/item/ammo_casing/pistol/small
 	load_method = MAGAZINE
-	magazine_type = /obj/item/ammo_magazine/smg_top/rubber
+	magazine_type = /obj/item/ammo_magazine/smg_top
 	allowed_magazines = /obj/item/ammo_magazine/smg_top
 	accuracy_power = 7
 	one_hand_penalty = 3
@@ -165,6 +165,9 @@
 		overlays += image(icon, "ammo-ok")
 	else
 		overlays += image(icon, "ammo-bad")
+
+/obj/item/gun/projectile/automatic/sec_smg/empty
+	starts_loaded = FALSE
 
 /obj/item/gun/projectile/automatic/bullpup_rifle
 	name = "bullpup assault rifle"

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -34,6 +34,9 @@
 	fire_delay = 6
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 
+/obj/item/gun/projectile/pistol/sec/empty
+	starts_loaded = FALSE
+
 /obj/item/gun/projectile/pistol/sec/lethal
 	magazine_type = /obj/item/ammo_magazine/pistol
 

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -129,6 +129,8 @@
 
 	return ..()
 
+/obj/item/gun/projectile/shotgun/pump/empty
+	starts_loaded = FALSE
 
 /obj/item/gun/projectile/shotgun/pump/sawn
 	name = "riot shotgun"
@@ -222,6 +224,9 @@
 			var/image/I = image(icon, "shell")
 			I.pixel_x = i * 2
 			overlays += I
+
+/obj/item/gun/projectile/shotgun/pump/combat/empty
+	starts_loaded = FALSE
 
 /obj/item/gun/projectile/shotgun/doublebarrel
 	name = "double-barreled shotgun"

--- a/maps/torch/items/weapons.dm
+++ b/maps/torch/items/weapons.dm
@@ -11,6 +11,8 @@
 	fire_delay = 7
 	ammo_indicator = TRUE
 
+/obj/item/gun/projectile/pistol/m22f/empty
+	starts_loaded = FALSE
 
 /obj/item/gun/projectile/pistol/m19
 	name = "military pistol"
@@ -27,3 +29,6 @@
 	safety_icon = "m19-safety"
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3)
 	fire_delay = 5
+
+/obj/item/gun/projectile/pistol/m19/empty
+	starts_loaded = FALSE

--- a/maps/torch/structures/closets/misc.dm
+++ b/maps/torch/structures/closets/misc.dm
@@ -96,23 +96,29 @@
 /obj/structure/closet/secure_closet/guncabinet/sidearm/WillContain()
 	return list(
 			/obj/item/clothing/accessory/storage/holster/thigh = 2,
-			/obj/item/gun/energy/gun/secure = 3,
+			/obj/item/gun/projectile/pistol/m22f/empty = 2,
+			/obj/item/storage/box/ammo/doublestack
 	)
 
 /obj/structure/closet/secure_closet/guncabinet/sidearm/small
 	name = "personal sidearm cabinet"
 
 /obj/structure/closet/secure_closet/guncabinet/sidearm/small/WillContain()
-	return list(/obj/item/gun/energy/gun/small/secure = 4)
+	return list(
+			/obj/item/gun/projectile/pistol/m19/empty = 4,
+			/obj/item/storage/box/ammo/pistol = 1
+	)
 
 /obj/structure/closet/secure_closet/guncabinet/sidearm/combined
 	name = "combined sidearm cabinet"
 
 /obj/structure/closet/secure_closet/guncabinet/sidearm/combined/WillContain()
 	return list(
-		/obj/item/storage/belt/holster/general = 3,
-		/obj/item/gun/energy/gun/secure = 3,
-		/obj/item/gun/energy/gun/small/secure = 1,
+		/obj/item/storage/belt/holster/general = 4,
+		/obj/item/storage/box/ammo/pistol = 1,
+		/obj/item/storage/box/ammo/doublestack = 1,
+		/obj/item/gun/projectile/pistol/m19/empty = 2,
+		/obj/item/gun/projectile/pistol/m22f/empty = 2
 	)
 
 /obj/structure/closet/secure_closet/guncabinet/PPE
@@ -121,7 +127,8 @@
 
 /obj/structure/closet/secure_closet/guncabinet/PPE/WillContain()
 	return list(
-		/obj/item/gun/energy/gun/small/secure = 3,
+		/obj/item/gun/projectile/pistol/m19/empty = 3,
+		/obj/item/storage/box/ammo/pistol = 1,
 		/obj/item/clothing/suit/armor/pcarrier/medium/command = 3,
 		/obj/item/clothing/head/helmet/solgov/command = 3
 	)

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -52,7 +52,8 @@
 		/obj/item/storage/belt/security,
 		/obj/item/material/knife/folding/swiss/sec,
 		/obj/item/storage/backpack/dufflebag/sec,
-		/obj/item/gun/energy/gun/small/secure
+		/obj/item/gun/projectile/pistol/m19/empty,
+		/obj/item/ammo_magazine/pistol/rubber = 3
 	)
 
 
@@ -73,7 +74,6 @@
 		/obj/item/storage/belt/holster/security/full,
 		/obj/item/storage/belt/security,
 		/obj/item/device/megaphone,
-		/obj/item/gunbox,
 		/obj/item/melee/telebaton,
 		/obj/item/clothing/accessory/storage/black_vest,
 		/obj/item/device/hailer,
@@ -84,7 +84,10 @@
 		/obj/item/device/taperecorder,
 		/obj/item/material/knife/folding/swiss/officer,
 		/obj/item/device/personal_shield,
-		/obj/item/storage/backpack/dufflebag/sec
+		/obj/item/storage/backpack/dufflebag/sec,
+		/obj/item/gun/projectile/pistol/m22f/empty,
+		/obj/item/ammo_magazine/pistol/double = 1,
+		/obj/item/ammo_magazine/pistol/double/rubber = 2
 	)
 
 /obj/structure/closet/secure_closet/brigchief
@@ -102,7 +105,6 @@
 		/obj/item/taperoll/police,
 		/obj/item/storage/belt/holster/security/full,
 		/obj/item/storage/belt/security,
-		/obj/item/gun/energy/gun/secure/preauthorized,
 		/obj/item/clothing/accessory/storage/black_vest,
 		/obj/item/handcuffs,
 		/obj/item/device/hailer,
@@ -111,7 +113,10 @@
 		/obj/item/clothing/gloves/thick,
 		/obj/item/device/flashlight/maglight,
 		/obj/item/material/knife/folding/swiss/sec,
-		/obj/item/storage/backpack/dufflebag/sec
+		/obj/item/storage/backpack/dufflebag/sec,
+		/obj/item/gun/projectile/pistol/m22f/empty,
+		/obj/item/ammo_magazine/pistol/double = 1,
+		/obj/item/ammo_magazine/pistol/double/rubber = 2
 	)
 
 /obj/structure/closet/secure_closet/forensics
@@ -126,7 +131,6 @@
 		/obj/item/device/radio/headset/headset_sec/alt,
 		/obj/item/clothing/head/helmet/solgov/security,
 		/obj/item/clothing/suit/armor/pcarrier/medium/security,
-		/obj/item/gun/energy/gun/small/secure,
 		/obj/item/device/flash,
 		/obj/item/reagent_containers/spray/pepper,
 		/obj/item/taperoll/police,
@@ -142,7 +146,9 @@
 		/obj/item/storage/belt/security,
 		/obj/item/clothing/gloves/thick,
 		/obj/item/material/knife/folding/swiss/sec,
-		/obj/item/storage/backpack/dufflebag/sec
+		/obj/item/storage/backpack/dufflebag/sec,
+		/obj/item/gun/projectile/pistol/sec/empty,
+		/obj/item/ammo_magazine/pistol/rubber = 2
 	)
 
 /obj/structure/closet/bombclosetsecurity/WillContain()

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -11322,15 +11322,9 @@
 /area/thruster/d1port)
 "aOE" = (
 /obj/structure/table/rack,
-/obj/item/gun/energy/gun/secure,
-/obj/item/gun/energy/gun/secure,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/gun/energy/ionrifle,
+/obj/item/gun/energy/ionrifle,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "aOF" = (
@@ -11344,11 +11338,6 @@
 /area/security/armoury)
 "aOG" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/recharger/wallcharger{
-	dir = 8;
-	pixel_x = 23;
-	pixel_y = -3
-	},
 /obj/structure/table/rack,
 /obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/suit/armor/riot,
@@ -16586,11 +16575,11 @@
 /area/medical/sleeper)
 "etI" = (
 /obj/structure/table/rack,
-/obj/item/gun/energy/stunrevolver/rifle,
-/obj/item/gun/energy/stunrevolver/rifle,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/storage/box/ammo/beanbags,
+/obj/item/storage/box/ammo/beanbags,
+/obj/item/gun/projectile/shotgun/pump/empty,
+/obj/item/gun/projectile/shotgun/pump/empty,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "evb" = (
@@ -17259,12 +17248,6 @@
 /obj/structure/flora/pottedplant/flower,
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)
-"fOp" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/armoury)
 "fOr" = (
 /obj/structure/table/steel,
 /obj/random/maintenance/solgov/clean,
@@ -18270,15 +18253,10 @@
 "htK" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/gun/energy/stunrevolver/rifle,
-/obj/item/gun/energy/taser/carbine,
-/obj/item/gun/energy/taser/carbine,
+/obj/item/storage/box/ammo/shotgunammo,
+/obj/item/storage/box/ammo/shotgunammo,
+/obj/item/gun/projectile/shotgun/pump/combat/empty,
+/obj/item/gun/projectile/shotgun/pump/combat/empty,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
 "hub" = (
@@ -18549,17 +18527,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/rnd/entry)
-"hFu" = (
-/obj/structure/table/rack,
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/gun/energy/laser/secure,
-/obj/item/gun/energy/laser/secure,
-/obj/item/gun/energy/laser/secure,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/command/armoury/tactical)
 "hGb" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 8
@@ -18621,10 +18588,9 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/development)
 "hLf" = (
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/recharger/wallcharger{
+	pixel_y = 24
 	},
-/obj/machinery/rotating_alarm/security_alarm,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "hLD" = (
@@ -18636,10 +18602,6 @@
 "hOb" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
 /obj/item/gun/energy/ionrifle,
 /obj/item/gun/energy/ionrifle/small,
 /turf/simulated/floor/tiled/techfloor/grid,
@@ -19133,10 +19095,6 @@
 "iAS" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/item/shield/riot/metal,
 /obj/item/shield/riot/metal,
 /obj/item/shield/riot/metal,
@@ -19602,11 +19560,6 @@
 /area/hallway/primary/firstdeck/aft)
 "jhf" = (
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/recharger/wallcharger{
-	dir = 8;
-	pixel_x = 23;
-	pixel_y = -3
-	},
 /obj/structure/table/rack,
 /obj/item/clothing/head/helmet/ballistic,
 /obj/item/clothing/suit/armor/bulletproof{
@@ -19618,6 +19571,9 @@
 	pixel_y = -2
 	},
 /obj/item/clothing/head/helmet/ballistic,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "jhq" = (
@@ -21023,12 +20979,15 @@
 /area/maintenance/substation/firstdeck)
 "kSs" = (
 /obj/structure/table/rack,
-/obj/item/gun/energy/gun/secure,
-/obj/item/gun/energy/gun/secure,
-/obj/structure/window/reinforced{
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/storage/box/ammo/smg/rubber,
+/obj/item/gun/projectile/automatic/sec_smg/empty,
+/obj/item/gun/projectile/automatic/sec_smg/empty,
+/obj/item/gun/projectile/automatic/sec_smg/empty,
+/obj/item/gun/projectile/automatic/sec_smg/empty,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "kTb" = (
@@ -23860,6 +23819,16 @@
 	},
 /turf/simulated/floor/tiled,
 /area/security/brig)
+"oBI" = (
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/storage/box/ammo/smg,
+/obj/item/storage/box/ammo/smg,
+/obj/item/gun/projectile/automatic/sec_smg/empty,
+/obj/item/gun/projectile/automatic/sec_smg/empty,
+/obj/item/gun/projectile/automatic/sec_smg/empty,
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/command/armoury/tactical)
 "oBZ" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 9
@@ -25614,12 +25583,6 @@
 "qKQ" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
 /obj/item/storage/box/teargas{
 	pixel_x = 3;
 	pixel_y = 2
@@ -25810,13 +25773,10 @@
 /area/security/detectives_office)
 "qWF" = (
 /obj/structure/table/rack,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
+/obj/item/storage/box/ammo/pistol/rubber,
+/obj/item/storage/box/ammo/pistol/rubber,
+/obj/item/storage/box/ammo/doublestack/rubber,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "qYb" = (
@@ -26427,12 +26387,13 @@
 /area/thruster/d1starboard)
 "rEK" = (
 /obj/structure/table/rack,
-/obj/item/gun/energy/ionrifle,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/machinery/door/window/brigdoor/westright{
+	dir = 1;
+	name = "Ammo Storage"
 	},
+/obj/item/storage/box/ammo/smg,
+/obj/item/storage/box/ammo/smg,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "rFb" = (
@@ -27389,10 +27350,6 @@
 /area/rnd/xenobiology/xenoflora)
 "sBg" = (
 /obj/structure/table/rack,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/gun/launcher/grenade,
 /obj/item/storage/box/teargas,
@@ -27943,14 +27900,10 @@
 /turf/simulated/open,
 /area/maintenance/firstdeck/aftport)
 "tgT" = (
-/obj/machinery/power/apc{
-	name = "south bump";
-	pixel_y = -24
-	},
-/obj/structure/cable/green,
-/obj/machinery/camera/network/security{
-	c_tag = "Security - Brig Armory";
-	dir = 1
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
@@ -28621,13 +28574,15 @@
 /area/security/storage)
 "umz" = (
 /obj/structure/table/rack,
-/obj/item/gun/energy/ionrifle,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/window/brigdoor/westleft{
+	dir = 1;
+	name = "Ammo Storage"
 	},
+/obj/item/storage/box/ammo/doublestack,
+/obj/item/storage/box/ammo/pistol,
+/obj/item/storage/box/ammo/pistol,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
 "umI" = (
@@ -29078,12 +29033,12 @@
 "vjY" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/gun/energy/gun/secure,
-/obj/item/gun/energy/gun/secure,
-/obj/item/gun/energy/gun/secure,
+/obj/item/storage/box/ammo/doublestack,
+/obj/item/storage/box/ammo/doublestack,
+/obj/item/gun/projectile/pistol/m22f/empty,
+/obj/item/gun/projectile/pistol/m22f/empty,
+/obj/item/gun/projectile/pistol/m22f/empty,
+/obj/item/gun/projectile/pistol/m22f/empty,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
 "vkW" = (
@@ -29233,13 +29188,11 @@
 /area/medical/equipstorage)
 "vFa" = (
 /obj/structure/table/rack,
-/obj/item/shield/riot,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/machinery/light,
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
 /obj/item/shield/riot,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/armoury)
@@ -29271,6 +29224,21 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/aft)
+"vIe" = (
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
+	},
+/obj/structure/cable/green,
+/obj/machinery/camera/network/security{
+	c_tag = "Security - Brig Armory";
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/security/armoury)
 "vIn" = (
 /obj/effect/floor_decal/industrial/hatch/blue,
 /obj/structure/disposalpipe/segment,
@@ -38403,7 +38371,7 @@ oXv
 rKP
 xRu
 tgT
-tiQ
+vIe
 tAS
 tAS
 aaa
@@ -38803,7 +38771,7 @@ enM
 aLy
 aMC
 tiQ
-fOp
+hLf
 aPu
 aPu
 aPu
@@ -57770,8 +57738,8 @@ acd
 dVw
 dVw
 htK
-hFu
 vjY
+oBI
 hOb
 aBc
 aHT


### PR DESCRIPTION
A convo in maine got me curious how well this would go.

This gives every MA a light milpistol and 3 rubber mags, the FT a "sec" pistol and 2 rubber mags, and the BC and COS each a heavy milpistol with 2 rubber mags and 1 lethal mag. The various weapons lockers around the Torch have also been switched to using light and heavy milpistols, as have the armories. I've also added sec smgs and shotguns to each armory to replace stun carbines/rifles and laser carbines, with the tac-arm getting combat shotguns vs normal pump ones in sec-arm. 

I stopped short of putting light bullpups in tac-arm, because I was iffy about that, but if this goes well it could be done. I did *not* code a special anti-simplemob laser weapon for carp hunting, because I subscribed to the "send sec EVA" club, but if that's desired for a test I could do so.

Sec arm has more rubber ammo & beanbags with the weapons themselves, and behind a brig chief & up set of windoors is lethal ammo + shotgun slugs. Tac-arm, being tac-arm, just has the lethal ammo, and it's with the weapons. Each locker that has pistols has at least one box of ammo for them, but if that's too much we can just toss loose magazines in.

It may be all of this was undesired in the end, because I didn't read the end of the conversation, but if that's the case I will not be offended by this being closed.

🆑 Jux
tweak: The SEV Torch now issues ballistic weapons instead of laser weapons.
/🆑 