### PR TITLE
Various staff sound-related tweaks

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -401,7 +401,7 @@ GLOBAL_VAR_INIT(world_topic_last, world.timeofday)
 		C.received_irc_pm = world.time
 		C.irc_admin = input["sender"]
 
-		sound_to(C, 'sound/ui/pm-notify.ogg')
+		sound_to(C, sound('sound/ui/pm-notify.ogg', volume = 40))
 		to_chat(C, message)
 
 		for(var/client/A as anything in GLOB.admins)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1474,26 +1474,28 @@ GLOBAL_VAR_INIT(skip_allow_lists, FALSE)
 	set name = "Toggle Paralyze"
 	set desc = "Toggles paralyze state, which stuns, blinds and mutes the victim."
 
-	var/msg
-
 	if(!isliving(H))
 		return
 
 	if(check_rights(R_INVESTIGATE))
 		if (!H.admin_paralyzed)
-			H.paralysis = 8000
 			H.admin_paralyzed = TRUE
-			msg = "has paralyzed [key_name(H)]."
-			H.visible_message(SPAN_DEBUG("OOC: \The [H] has been paralyzed by a staff member. Please hold all interactions with them until staff have finished with them."))
+
 			to_chat(H, SPAN_DEBUG("OOC: You have been paralyzed by a staff member. Please refer to your currently open admin help ticket or, if you don't have one, admin help for assistance."))
+			sound_to(H, sound('sound/ui/pm-notify.ogg', volume = 40))
+
+			H.visible_message(SPAN_DEBUG("OOC: \The [H] has been paralyzed by a staff member. Please hold all interactions with them until staff have finished with them."))
+			for(var/mob/M in viewers())
+				sound_to(M, sound('sound/ui/pm-notify.ogg', volume = 40))
+
+			log_and_message_staff("has paralyzed [key_name(H)].")
 		else
-			H.paralysis = 0
 			H.admin_paralyzed = FALSE
-			msg = "has unparalyzed [key_name(H)]."
+
 			H.visible_message(SPAN_DEBUG("OOC: \The [H] has been released from paralysis by staff. You may resume interactions with them."))
 			to_chat(H, SPAN_DEBUG("OOC: You have been released from paralysis by staff and can return to your game."))
-		log_and_message_staff(msg)
 
+			log_and_message_staff("has unparalyzed [key_name(H)].")
 
 /datum/admins/proc/sendFax()
 	set category = "Special Verbs"

--- a/code/modules/admin/verbs/adminhelp.dm
+++ b/code/modules/admin/verbs/adminhelp.dm
@@ -124,7 +124,7 @@ var/global/list/adminhelp_ignored_words = list("unknown","the","a","an","of","mo
 			if(X.is_afk())
 				admin_number_afk++
 			if(X.get_preference_value(/datum/client_preference/staff/play_adminhelp_ping) == GLOB.PREF_HEAR)
-				sound_to(X, 'sound/ui/pm-notify.ogg')
+				sound_to(X, sound('sound/ui/pm-notify.ogg', volume = 40))
 			to_chat(X, msg)
 	//show it to the person adminhelping too
 	to_chat(src, SPAN_CLASS("staff_pm", "PM to-<b>Staff</b> (<a href='?src=\ref[usr];close_ticket=\ref[ticket]'>CLOSE</a>): [original_msg]"))

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -128,7 +128,7 @@
 	//play the receiving admin the adminhelp sound (if they have them enabled)
 	//non-admins shouldn't be able to disable this
 	if(C.get_preference_value(/datum/client_preference/staff/play_adminhelp_ping) == GLOB.PREF_HEAR)
-		sound_to(C, 'sound/ui/pm-notify.ogg')
+		sound_to(C, sound('sound/ui/pm-notify.ogg', volume = 70))
 
 	log_admin("PM: [key_name(src)]->[key_name(C)]: [msg]")
 	send_to_admin_discord(EXCOM_MSG_AHELP, "PM: [key_name(src, highlight_special_characters = FALSE)]->[key_name(C, highlight_special_characters = FALSE)]:[html_decode(msg)]")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -323,16 +323,9 @@
 		if(!isnum(sql_id))
 			return
 
-	var/admin_rank = "Player"
-	if(src.holder)
-		admin_rank = src.holder.rank
-		for(var/client/C in GLOB.clients)
-			if(C.staffwarn)
-				C.mob.send_staffwarn(src, "is connected", 0)
-
 	var/sql_ip = sql_sanitize_text(src.address)
 	var/sql_computerid = sql_sanitize_text(src.computer_id)
-	var/sql_admin_rank = sql_sanitize_text(admin_rank)
+	var/sql_admin_rank = sql_sanitize_text("Player")
 
 
 	if(sql_id)

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -68,7 +68,7 @@
 /mob/living/proc/handle_regular_status_updates()
 	updatehealth()
 	if(stat != DEAD)
-		if(paralysis)
+		if(paralysis || admin_paralyzed)
 			set_stat(UNCONSCIOUS)
 		else if (status_flags & FAKEDEATH)
 			set_stat(UNCONSCIOUS)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -52,7 +52,7 @@
 	if(check_rights((R_ADMIN|R_MOD),0,C))
 		to_chat(C,"[SPAN_CLASS("staffwarn", "StaffWarn: [client.ckey] [action]")]<br>[SPAN_NOTICE("[client.staffwarn]")]")
 		if(noise && C.get_preference_value(/datum/client_preference/staff/play_adminhelp_ping) == GLOB.PREF_HEAR)
-			sound_to(C, 'sound/ui/pm-notify.ogg')
+			sound_to(C, sound('sound/ui/pm-notify.ogg', volume = 25))
 
 /mob
 	var/client/my_client // Need to keep track of this ourselves, since by the time Logout() is called the client has already been nulled

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -33,7 +33,6 @@
 /mob/new_player/proc/deferred_login()
 	if(client)
 		client.playtitlemusic()
-		maybe_send_staffwarns("connected as new player")
 		if(client.get_preference_value(/datum/client_preference/goonchat) == GLOB.PREF_YES)
 			client.chatOutput.start()
 


### PR DESCRIPTION
🆑 Jux
tweak: The adminpm noise is now plays at a lower volume by default, and also plays when someone in your line of sight is paralyzed.
tweak: The staffwarn noise is significantly quieter, and staffwarns only notify staff when a player joins the round.
/🆑 

Admin paralysis is also now a true/false situation now instead of just setting the paralysis timer crazy high. Not that anyone is ever paralyzed for that long, but some things unset paralysis so now they're separate.