### PR TITLE
Radial fixes

### DIFF
--- a/code/_onclick/hud/radial.dm
+++ b/code/_onclick/hud/radial.dm
@@ -138,7 +138,7 @@ var/global/list/radial_menus = list()
 		if(length(current) == max_elements)
 			page_data[page] = current
 			page++
-			length(page_data)++
+			LIST_INC(page_data)
 			current = list()
 		if(paged && length(current) == max_elements - 1)
 			current += NEXT_PAGE_ID

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -178,8 +178,8 @@
 		if (ass.accessory_flags & ACCESSORY_REMOVABLE)
 			removables |= ass
 
-	if(LAZYLEN(accessories) > 1)
-		A = show_radial_menu(usr, usr, make_item_radial_menu_choices(accessories), radius = 42, tooltips = TRUE)
+	if(length(removables) > 1)
+		A = show_radial_menu(usr, usr, make_item_radial_menu_choices(removables), radius = 42, tooltips = TRUE)
 	else
 		A = accessories[1]
 	src.remove_accessory(usr,A)


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed radial menus breaking with too many options.
bugfix: Fixed being able to remove non-removable accessories. 
/:cl:

- Fixes #33834