### PR TITLE
Fix boots loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/footwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/footwear.dm
@@ -14,9 +14,8 @@
 	path = /obj/item/clothing/shoes
 	cost = 2
 
-/datum/gear/shoes/boots/New()
+/datum/gear/shoes/boots/New(boots = list())
 	..()
-	var/boots = list()
 	boots += /obj/item/clothing/shoes/jackboots
 	boots += /obj/item/clothing/shoes/workboots
 	boots += /obj/item/clothing/shoes/dutyboots

--- a/packs/factions/scga/loadout.dm
+++ b/packs/factions/scga/loadout.dm
@@ -1,6 +1,5 @@
 /datum/gear/shoes/boots/scga/New()
-	..()
 	var/boots = list()
 	boots += /obj/item/clothing/shoes/scga/utility
 	boots += /obj/item/clothing/shoes/scga/utility/tan
-	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(boots)
+	..(boots)


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed the boots loadout menu select, jungle boots have been readded as 'tan' SCGA boots. 
/:cl: 