### PR TITLE
haha suit sensor go beep

### DIFF
--- a/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
+++ b/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
@@ -9,10 +9,11 @@
 	extended_desc = "This program connects to life signs monitoring system to provide basic information on crew health."
 	required_access = access_medical
 	requires_ntnet = TRUE
-	network_destination = "crew lifesigns monitoring system"
+	network_destination = "crew life signs monitoring system"
 	size = 11
 	category = PROG_MONITOR
 	var/has_alert = FALSE
+	var/beeping = FALSE
 
 /datum/computer_file/program/suit_sensors/process_tick()
 	..()
@@ -22,9 +23,14 @@
 		if(!has_alert)
 			program_icon_state = "crew-red"
 			ui_header = "crew_red.gif"
+			if(!beeping)
+				computer.visible_notification(SPAN_WARNING("Warning: vital signs beyond acceptable parameters."))
+				computer.audible_notification("sound/machines/twobeep.ogg")
+				beeping = TRUE //For medical sanity purposes, it'll only beep once per emergency.
 		else
 			program_icon_state = "crew"
 			ui_header = "crew_green.gif"
+			beeping = FALSE
 		update_computer_icon()
 		has_alert = !has_alert
 


### PR DESCRIPTION
Suit sensor consoles now beep when someone's critically injured and the sensors turn red. They will _only_ beep when turning from green to red -- so if the console is already red, it won't beep again. There's already a visual cue (the sprite changes), but now there's an audio and text cue as well.

also fixes the program title to be consistent with the description because that was bugging me

:cl: TheNightingale
tweak: Suit sensor consoles now beep when someone's critical.
/:cl: