### PR TITLE
Fix certain floor decals disappearing after icon updates

### DIFF
--- a/code/game/turfs/flooring/flooring_decals.dm
+++ b/code/game/turfs/flooring/flooring_decals.dm
@@ -36,9 +36,8 @@ var/global/list/floor_decals = list()
 				B.color = detail_color
 				I.overlays |= B
 			floor_decals[cache_key] = I
-		if(!T.decals) T.decals = list()
-		T.decals |= floor_decals[cache_key]
-		T.overlays |= floor_decals[cache_key]
+		LAZYADD(T.decals, floor_decals[cache_key])
+		T.queue_icon_update()
 	atom_flags |= ATOM_FLAG_INITIALIZED
 	return INITIALIZE_HINT_QDEL
 

--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -73,7 +73,7 @@ var/global/list/flooring_cache = list()
 
 	if(decals && length(decals))
 		for(var/image/I in decals)
-			if(I.layer != DECAL_PLATING_LAYER)
+			if (I.layer < layer)
 				continue
 			overlays |= I
 


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Fixes certain floor decals disappearing when a turf initializes or updates its icons.
/:cl:

## Bug Fixes
- Fixes #33813

## Other Changes
- Minor optimization of floor decal initialization and how it updates turf decals/overlays.