### PR TITLE
Chem dispensers and chemmasters now accept IVs

### DIFF
--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -58,15 +58,15 @@
 
 /obj/machinery/chem_master/attackby(obj/item/B as obj, mob/user as mob)
 
-	if(istype(B, /obj/item/reagent_containers/glass))
+	if(istype(B, /obj/item/reagent_containers/glass) || istype(B, /obj/item/reagent_containers/ivbag))
 
 		if(beaker)
-			to_chat(user, "A beaker is already loaded into the machine.")
+			to_chat(user, "A container is already loaded into the machine.")
 			return
 		if(!user.unEquip(B, src))
 			return
 		beaker = B
-		to_chat(user, "You add the beaker to the machine!")
+		to_chat(user, "You add the container to the machine!")
 		icon_state = "mixer1"
 		atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -83,7 +83,7 @@
 			to_chat(user, SPAN_NOTICE("You remove \the [C] from \the [src]."))
 			C.dropInto(loc)
 
-	else if(istype(W, /obj/item/reagent_containers/glass) || istype(W, /obj/item/reagent_containers/food))
+	else if(istype(W, /obj/item/reagent_containers/glass) || istype(W, /obj/item/reagent_containers/food) || istype(W, /obj/item/reagent_containers/ivbag))
 		if(container)
 			to_chat(user, SPAN_WARNING("There is already \a [container] on \the [src]!"))
 			return
@@ -91,7 +91,7 @@
 		var/obj/item/reagent_containers/RC = W
 
 		if(!accept_drinking && istype(RC,/obj/item/reagent_containers/food))
-			to_chat(user, SPAN_WARNING("This machine only accepts beakers!"))
+			to_chat(user, SPAN_WARNING("This machine only accepts beakers and IV bags!"))
 			return
 
 		if(!RC.is_open_container())


### PR DESCRIPTION
See title. Note that you can't transfer reagents _out_ of an IV bag without a syringe and they won't fit on the thermal regulator (plastic doesn't like being heated, I'd imagine), so they're still worse than large beakers for actual chemistry purposes, but now pharmacists and creative physicians can make mixes inside IVs (for example, replenishing nanoblood).

🆑 TheNightingale
tweak: Chem dispensers and chemmasters now accept IV bags.
/:cl: