### PR TITLE
Changes to ballistics selection

### DIFF
--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -131,3 +131,9 @@
 	max_shots = 4
 	projectile_type = /obj/item/projectile/beam/confuseray
 	combustion = 0
+
+/obj/item/gun/energy/confuseray/weak
+	name = "taser"
+	desc = "The W-T Mk. 2 Disorientator is a small, low capacity, and short-ranged energy projector. It suffers some reliability issues compared to later models, but it's very affordable."
+	max_shots = 2
+	projectile_type = /obj/item/projectile/beam/confuseray/weak

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -361,6 +361,25 @@
 
 	return 1
 
+/obj/item/projectile/beam/confuseray/weak
+	name = "taser beam"
+	icon_state = "stun"
+	fire_sound = 'sound/weapons/Taser.ogg'
+
+	muzzle_type = /obj/effect/projectile/stun/muzzle
+	tracer_type = /obj/effect/projectile/stun/tracer
+	impact_type = /obj/effect/projectile/stun/impact
+
+/obj/item/projectile/beam/confuseray/weak/on_hit(atom/target, blocked = 0)
+	if (prob(33))
+		return 0
+	if(istype(target, /mob/living))
+		var/mob/living/L = target
+		agony = 50
+		L.stun_effect_act(stun, agony, def_zone, src)
+
+	return 1
+
 /obj/item/projectile/beam/particle
 	name = "particle lance"
 	icon_state = "particle"

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -52,8 +52,9 @@
 		/obj/item/storage/belt/security,
 		/obj/item/material/knife/folding/swiss/sec,
 		/obj/item/storage/backpack/dufflebag/sec,
+		/obj/item/gun/energy/confuseray/weak,
 		/obj/item/gun/projectile/pistol/m19/empty,
-		/obj/item/ammo_magazine/pistol/rubber = 3
+		/obj/item/ammo_magazine/pistol = 3
 	)
 
 
@@ -84,10 +85,10 @@
 		/obj/item/device/taperecorder,
 		/obj/item/material/knife/folding/swiss/officer,
 		/obj/item/device/personal_shield,
-		/obj/item/storage/backpack/dufflebag/sec,
+		/obj/item/ammo_magazine/pistol/double = 3,
 		/obj/item/gun/projectile/pistol/m22f/empty,
-		/obj/item/ammo_magazine/pistol/double = 1,
-		/obj/item/ammo_magazine/pistol/double/rubber = 2
+		/obj/item/storage/backpack/dufflebag/sec,
+		/obj/item/gun/energy/confuseray
 	)
 
 /obj/structure/closet/secure_closet/brigchief
@@ -115,8 +116,8 @@
 		/obj/item/material/knife/folding/swiss/sec,
 		/obj/item/storage/backpack/dufflebag/sec,
 		/obj/item/gun/projectile/pistol/m22f/empty,
-		/obj/item/ammo_magazine/pistol/double = 1,
-		/obj/item/ammo_magazine/pistol/double/rubber = 2
+		/obj/item/ammo_magazine/pistol/double = 3,
+		/obj/item/gun/energy/confuseray/weak
 	)
 
 /obj/structure/closet/secure_closet/forensics
@@ -148,7 +149,8 @@
 		/obj/item/material/knife/folding/swiss/sec,
 		/obj/item/storage/backpack/dufflebag/sec,
 		/obj/item/gun/projectile/pistol/sec/empty,
-		/obj/item/ammo_magazine/pistol/rubber = 2
+		/obj/item/ammo_magazine/pistol = 3,
+		/obj/item/gun/energy/confuseray/weak
 	)
 
 /obj/structure/closet/bombclosetsecurity/WillContain()


### PR DESCRIPTION
A tweak on the experimental ballistics switch and dependent on it, https://github.com/Baystation12/Baystation12/pull/33822.

Replaces the rubber bullet mags being given with normal bullets and adds a "taser" to bridge the gap between the old long range stunning and needing to be in someones face with a baton whacking them. Should stop security cross-screen stunning minor antags who are trying to flee as the range is limited and has a failure chance to provide a bit of room for luck for antags.

:cl: Fre3bie
tweak: Changes rubber bullets to real bullets and adds a taser.
/:cl: