### PR TITLE
Fix decals not disappearing when tiles are removed

### DIFF
--- a/code/game/turfs/simulated/floor_icon.dm
+++ b/code/game/turfs/simulated/floor_icon.dm
@@ -73,7 +73,7 @@ var/global/list/flooring_cache = list()
 
 	if(decals && length(decals))
 		for(var/image/I in decals)
-			if (I.layer < layer)
+			if (floor(I.layer) != floor(layer))
 				continue
 			overlays |= I
 


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Decals on turfs now disappear when their tiles are removed.
/:cl: