### PR TITLE
Replaces FT LTL 10mm pistol with LTL 10mm Revolver

### DIFF
--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -58,6 +58,11 @@
 	bulk = 0
 	fire_delay = 9
 
+/obj/item/gun/projectile/revolver/medium/sec
+	ammo_type = /obj/item/ammo_casing/pistol/rubber
+	desc = "The Lumoco Arms' Solid Pro is the less-than-lethal variant of the standard Solid. Utilised by law enforcement parties on select planetary police precincts across Sol."
+	starts_loaded = FALSE
+
 /obj/item/gun/projectile/revolver/holdout
 	name = "holdout revolver"
 	desc = "The al-Maliki & Mosley Partner is a concealed-carry revolver made for people who do not trust automatic pistols any more than the people they're dealing with."

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -147,8 +147,8 @@
 		/obj/item/clothing/gloves/thick,
 		/obj/item/material/knife/folding/swiss/sec,
 		/obj/item/storage/backpack/dufflebag/sec,
-		/obj/item/gun/projectile/pistol/sec/empty,
-		/obj/item/ammo_magazine/pistol/rubber = 2
+		/obj/item/gun/projectile/revolver/medium/sec,
+		/obj/item/ammo_magazine/speedloader/rubber = 2
 	)
 
 /obj/structure/closet/bombclosetsecurity/WillContain()


### PR DESCRIPTION
:cl:
rscadd: Adds the LTL Variant of the 10mm Lumoco Solid.
tweak: Replaces ForTech's LTL Mk58 with the LTL Lumoco Solid variant.
/:cl:

Both take only rubbers. 
The Mk58 has:
	`accuracy = -1`
	`fire_delay = 6`
The LA Solid Pro has:
	`accuracy = 1`
	`fire_delay = 9`

I debated on making it a choice for FTs (like how the COS could choose between the revolver and the standard Peruns before), but due to the stat differences, figured it was not worth the hassle.
Doing the change because it simply seems thematically cooler for the FT to have a revolver and not a pistol. Does it make sense? Not all too much if you consider standardisation. Is it cooler? Yes.
