### PR TITLE
Vitals Monitor Upgrades

### DIFF
--- a/code/game/machinery/vitals_monitor.dm
+++ b/code/game/machinery/vitals_monitor.dm
@@ -26,11 +26,14 @@
 	var/list/alerts = null
 	var/list/last_alert = null
 
+	///Does it give info on fractures and arterial?
+	var/detailed = FALSE
+
 /obj/machinery/vitals_monitor/Initialize()
 	. = ..()
 	alerts = new /list(3)
 	last_alert = new /list(3)
-	for(dir in list(NORTH,EAST,SOUTH,WEST))
+	for (dir in list(NORTH,EAST,SOUTH,WEST))
 		connected_optable = locate(/obj/machinery/optable, get_step(src, dir))
 		if (connected_optable)
 			connected_optable.connected_monitor = src
@@ -43,69 +46,102 @@
 
 /obj/machinery/vitals_monitor/examine(mob/user)
 	. = ..()
-	if(victim)
-		if(!is_powered())
+	if (victim)
+		if (!is_powered())
 			to_chat(user, SPAN_NOTICE("It's unpowered."))
 			return
 		to_chat(user, SPAN_NOTICE("Vitals of [victim]:"))
 		to_chat(user, SPAN_NOTICE("Pulse: [victim.get_pulse(GETPULSE_TOOL)]"))
+		to_chat(user, SPAN_NOTICE("Blood pressure: [victim.get_blood_pressure()]"))
+		to_chat(user, SPAN_NOTICE("Blood oxygenation: [victim.get_blood_oxygenation()]%"))
+		to_chat(user, SPAN_NOTICE("Body temperature: [victim.bodytemperature-T0C]&deg;C ([victim.bodytemperature*1.8-459.67]&deg;F)"))
 
 		var/brain_activity = "none"
 		var/obj/item/organ/internal/brain/brain = victim.internal_organs_by_name[BP_BRAIN]
-		if(istype(brain) && victim.stat != DEAD && !(victim.status_flags & FAKEDEATH))
-			if(user.skill_check(SKILL_MEDICAL, SKILL_BASIC))
-				switch(brain.get_current_damage_threshold())
-					if(0 to 2)
+		var/danger = FALSE
+		if (istype(brain) && victim.stat != DEAD && !GET_FLAGS(victim.status_flags, FAKEDEATH))
+			if (user.skill_check(SKILL_MEDICAL, SKILL_BASIC))
+				switch (brain.get_current_damage_threshold())
+					if (0)
 						brain_activity = "normal"
-					if(3 to 5)
+					if (1 to 2)
+						brain_activity = "minor brain damage"
+					if (3 to 5)
 						brain_activity = "weak"
-					if(6 to INFINITY)
+						danger = TRUE
+					if (6 to 8)
 						brain_activity = "extremely weak"
+						danger = TRUE
+					if (9 to INFINITY)
+						brain_activity = "fading"
+						danger = TRUE
+
 			else
 				brain_activity = "some"
-		to_chat(user, SPAN_NOTICE("Brain activity: [brain_activity]"))
+		if (!danger)
+			to_chat(user, SPAN_NOTICE("Brain activity: [brain_activity]"))
+		else
+			to_chat(user, SPAN_WARNING("Brain activity: [brain_activity]"))
 
 		var/breathing = "none"
 		var/obj/item/organ/internal/lungs/lungs = victim.internal_organs_by_name[BP_LUNGS]
-		if(istype(lungs) && !(victim.status_flags & FAKEDEATH))
-			if(lungs.breath_fail_ratio < 0.3)
+		if (istype(lungs) && !GET_FLAGS(victim.status_flags, FAKEDEATH))
+			if (lungs.breath_fail_ratio < 0.3)
 				breathing = "normal"
-			else if(lungs.breath_fail_ratio < 1)
+			else if (lungs.breath_fail_ratio < 1)
 				breathing = "shallow"
 
 		to_chat(user, SPAN_NOTICE("Breathing: [breathing]"))
-	if(connected_optable)
-		to_chat(user, SPAN_NOTICE("Connected to adjacent [connected_optable]."))
+
+		if (detailed && user.skill_check(SKILL_MEDICAL, SKILL_TRAINED))
+			for (var/name in victim.organs_by_name)
+				var/obj/item/organ/external/organ = victim.organs_by_name[name]
+				if (!organ)
+					continue
+				var/limb = organ.name
+				var/dat = null
+				if (GET_FLAGS(organ.status, ORGAN_BROKEN | ORGAN_ARTERY_CUT))
+					dat += "[limb]: "
+				if (GET_FLAGS(organ.status, ORGAN_BROKEN))
+					dat += SPAN_CLASS("scan_warning", "Bone fracture. ")
+				if (GET_FLAGS(organ.status, ORGAN_ARTERY_CUT))
+					dat += SPAN_CLASS("scan_warning", "Arterial bleeding.")
+				if (dat)
+					dat = capitalize(dat)
+					to_chat(user, SPAN_WARNING("[dat]"))
+
+	if (connected_optable)
+		to_chat(user, SPAN_NOTICE("Connected to \the [connected_optable]."))
 
 /obj/machinery/vitals_monitor/Process()
-	if(QDELETED(victim))
+	if (QDELETED(victim))
 		update_victim()
-	if(victim && !Adjacent(victim))
+	if (victim && !Adjacent(victim))
 		update_victim()
-	if(connected_optable && !Adjacent(connected_optable))
+	if (connected_optable && !Adjacent(connected_optable))
 		update_victim()
 		update_optable()
-	if(victim)
+	if (victim)
 		update_icon()
 
 /obj/machinery/vitals_monitor/proc/update_victim(new_victim = null)
 	var/old_victim = victim
 	victim = new_victim
-	if(victim)
+	if (victim)
 		visible_message(SPAN_NOTICE("\The [src] is now showing data for \the [victim]."))
 	else
-		if(old_victim != new_victim) // Protects against qdel edge case. In all other cases we want a message printed.
+		if (old_victim != new_victim) // Protects against qdel edge case. In all other cases we want a message printed.
 			visible_message(SPAN_NOTICE("\The [src] is no longer showing data from [isnull(old_victim)? "any patient" : "\the [old_victim]"]."))
 	update_use_power(isnull(victim)? POWER_USE_IDLE : POWER_USE_ACTIVE)
 	update_icon()
 
 /obj/machinery/vitals_monitor/proc/update_optable(obj/machinery/optable/new_optable = null)
-	if(new_optable == connected_optable)
+	if (new_optable == connected_optable)
 		return
-	if(connected_optable) //gotta clear existing connections first
+	if (connected_optable) //gotta clear existing connections first
 		connected_optable.connected_monitor = null
 	connected_optable = new_optable
-	if(connected_optable)
+	if (connected_optable)
 		connected_optable.connected_monitor = src
 		visible_message(SPAN_NOTICE("\The [src] is now relaying information from \the [connected_optable]"))
 		//In case there's already a patient on the table
@@ -114,20 +150,20 @@
 		visible_message(SPAN_NOTICE("\The [src] is no longer relaying data from a connected operating table."))
 
 /obj/machinery/vitals_monitor/MouseDrop(over_object, src_location, over_location)
-	if(!CanMouseDrop(over_object))
+	if (!CanMouseDrop(over_object))
 		return
 	update_optable()
-	if(victim)
+	if (victim)
 		update_victim()
-	else if(ishuman(over_object))
+	else if (ishuman(over_object))
 		update_victim(over_object)
-	else if(istype(over_object, /obj/machinery/optable))
+	else if (istype(over_object, /obj/machinery/optable))
 		var/obj/machinery/optable/new_table_connection = over_object
 		update_optable(new_table_connection)
 
 /obj/machinery/vitals_monitor/on_update_icon()
 	overlays.Cut()
-	if(!is_powered())
+	if (!is_powered())
 		return
 	overlays += image(icon, icon_state = "screen")
 
@@ -137,86 +173,86 @@
 	handle_alerts()
 
 /obj/machinery/vitals_monitor/proc/handle_pulse()
-	if(!victim)
+	if (!victim)
 		return
 	var/obj/item/organ/internal/heart/heart = victim.internal_organs_by_name[BP_HEART]
-	if(istype(heart) && !BP_IS_ROBOTIC(heart))
-		switch(victim.pulse())
-			if(PULSE_NONE)
+	if (istype(heart) && !BP_IS_ROBOTIC(heart))
+		switch (victim.pulse())
+			if (PULSE_NONE)
 				overlays += image(icon, icon_state = "pulse_flatline")
 				overlays += image(icon, icon_state = "pulse_warning")
-				if(beep)
+				if (beep)
 					playsound(src, 'sound/machines/flatline.ogg', 20)
-				if(read_alerts)
+				if (read_alerts)
 					alerts[PULSE_ALERT] = "Cardiac flatline detected!"
-			if(PULSE_SLOW, PULSE_NORM,)
+			if (PULSE_SLOW, PULSE_NORM,)
 				overlays += image(icon, icon_state = "pulse_normal")
-				if(beep)
+				if (beep)
 					playsound(src, 'sound/machines/quiet_beep.ogg', 40)
-			if(PULSE_FAST, PULSE_2FAST)
+			if (PULSE_FAST, PULSE_2FAST)
 				overlays += image(icon, icon_state = "pulse_veryfast")
-				if(beep)
+				if (beep)
 					playsound(src, 'sound/machines/quiet_double_beep.ogg', 40)
-			if(PULSE_THREADY)
+			if (PULSE_THREADY)
 				overlays += image(icon, icon_state = "pulse_thready")
 				overlays += image(icon, icon_state = "pulse_warning")
-				if(beep)
+				if (beep)
 					playsound(src, 'sound/machines/ekg_alert.ogg', 40)
-				if(read_alerts)
+				if (read_alerts)
 					alerts[PULSE_ALERT] = "Excessive heartbeat! Possible Shock Detected!"
 	else
 		overlays += image(icon, icon_state = "pulse_warning")
 
 /obj/machinery/vitals_monitor/proc/handle_brain()
-	if(!victim)
+	if (!victim)
 		return
 	var/obj/item/organ/internal/brain/brain = victim.internal_organs_by_name[BP_BRAIN]
-	if(istype(brain) && victim.stat != DEAD && !(victim.status_flags & FAKEDEATH))
-		switch(brain.get_current_damage_threshold())
-			if(0 to 2)
+	if (istype(brain) && victim.stat != DEAD && !(victim.status_flags & FAKEDEATH))
+		switch (brain.get_current_damage_threshold())
+			if (0 to 2)
 				overlays += image(icon, icon_state = "brain_ok")
-			if(3 to 5)
+			if (3 to 5)
 				overlays += image(icon, icon_state = "brain_bad")
-				if(read_alerts)
+				if (read_alerts)
 					alerts[BRAIN_ALERT] = "Weak brain activity!"
-			if(6 to INFINITY)
+			if (6 to INFINITY)
 				overlays += image(icon, icon_state = "brain_verybad")
 				overlays += image(icon, icon_state = "brain_warning")
-				if(read_alerts)
+				if (read_alerts)
 					alerts[BRAIN_ALERT] = "Very weak brain activity!"
 	else
 		overlays += image(icon, icon_state = "brain_warning")
 
 /obj/machinery/vitals_monitor/proc/handle_lungs()
-	if(!victim)
+	if (!victim)
 		return
 	var/obj/item/organ/internal/lungs/lungs = victim.internal_organs_by_name[BP_LUNGS]
-	if(istype(lungs) && !(victim.status_flags & FAKEDEATH))
-		if(lungs.breath_fail_ratio < 0.3)
+	if (istype(lungs) && !(victim.status_flags & FAKEDEATH))
+		if (lungs.breath_fail_ratio < 0.3)
 			overlays += image(icon, icon_state = "breathing_normal")
-		else if(lungs.breath_fail_ratio < 1)
+		else if (lungs.breath_fail_ratio < 1)
 			overlays += image(icon, icon_state = "breathing_shallow")
-			if(read_alerts)
+			if (read_alerts)
 				alerts[LUNGS_ALERT] = "Abnormal breathing detected!"
 		else
 			overlays += image(icon, icon_state = "breathing_warning")
-			if(read_alerts)
+			if (read_alerts)
 				alerts[LUNGS_ALERT] = "Patient is not breathing!"
 	else
 		overlays += image(icon, icon_state = "breathing_warning")
 
 /obj/machinery/vitals_monitor/proc/handle_alerts()
-	if(!victim || !read_alerts) //Clear our alerts
+	if (!victim || !read_alerts) //Clear our alerts
 		alerts[PULSE_ALERT] = ""
 		alerts[BRAIN_ALERT] = ""
 		alerts[LUNGS_ALERT] = ""
 		return
-	if(last_alert_time + alert_cooldown < world.time)
-		if(alerts[PULSE_ALERT] && alerts[PULSE_ALERT] != last_alert[PULSE_ALERT])
+	if (last_alert_time + alert_cooldown < world.time)
+		if (alerts[PULSE_ALERT] && alerts[PULSE_ALERT] != last_alert[PULSE_ALERT])
 			audible_message(SPAN_WARNING("<b>\The [src]</b> beeps, \"[alerts[PULSE_ALERT]]\""))
-		if(alerts[BRAIN_ALERT] && alerts[BRAIN_ALERT] != last_alert[BRAIN_ALERT])
+		if (alerts[BRAIN_ALERT] && alerts[BRAIN_ALERT] != last_alert[BRAIN_ALERT])
 			audible_message(SPAN_WARNING("<b>\The [src]</b> alarms, \"[alerts[BRAIN_ALERT]]\""))
-		if(alerts[LUNGS_ALERT] && alerts[LUNGS_ALERT] != last_alert[LUNGS_ALERT])
+		if (alerts[LUNGS_ALERT] && alerts[LUNGS_ALERT] != last_alert[LUNGS_ALERT])
 			audible_message(SPAN_WARNING("<b>\The [src]</b> warns, \"[alerts[LUNGS_ALERT]]\""))
 		last_alert = alerts.Copy()
 		last_alert_time = world.time
@@ -229,10 +265,10 @@
 	set src in view(1)
 
 	var/mob/user = usr
-	if(!istype(user))
+	if (!istype(user))
 		return
 
-	if(CanPhysicallyInteract(user))
+	if (CanPhysicallyInteract(user))
 		beep = !beep
 		to_chat(user, SPAN_NOTICE("You turn the sound on \the [src] [beep ? "on" : "off"]."))
 
@@ -242,10 +278,10 @@
 	set src in view(1)
 
 	var/mob/user = usr
-	if(!istype(user))
+	if (!istype(user))
 		return
 
-	if(CanPhysicallyInteract(user))
+	if (CanPhysicallyInteract(user))
 		read_alerts = !read_alerts
 		to_chat(user, SPAN_NOTICE("You turn the alert reader on \the [src] [read_alerts ? "on" : "off"]."))
 
@@ -257,8 +293,17 @@
 		/obj/item/stock_parts/console_screen = 1)
 	additional_spawn_components = list(
 		/obj/item/stock_parts/power/battery/buildable/stock = 1,
-		/obj/item/cell/high = 1
+		/obj/item/cell/high = 1,
+		/obj/item/stock_parts/scanning_module = 2
 	)
+
+/obj/machinery/vitals_monitor/RefreshParts()
+	..()
+	var/T = total_component_rating_of_type(/obj/item/stock_parts/scanning_module)
+	if (T >= 6)
+		detailed = TRUE
+	else
+		detailed = FALSE
 
 #undef PULSE_ALERT
 #undef BRAIN_ALERT


### PR DESCRIPTION
**VeyMed Vitals Monitoring Operating System (VM2OS)**
**Patch Notes v9.0.136**

- Integrated scanning modules into dorsal and ventral network moduli for increased monitoring effectiveness.
- At base level, VM2OS v9.0 is now capable of identifying circulatory pressure, blood oxygen saturation, and patient temperature in both Celsius and Fahrenheit, to match handheld scanner designs.
- Updated firmware to benefit from latest scanning module matrix blueprints. Note that the firmware update requires upgraded scanning modules, and is unavailable in older models using VM2OS.
- With firmware update installed and scanning modules capable of phasic analysis, VM2OS can rapidly determine and diagnose fractured bones and internal hemorrhages, such as from arterial bleeding. Do note that some level of medical proficiency may be required.
- Low brain activity warning text on the VM2OS diagnosis screen has been changed from blue to red based on consumer feedback.
- VM2OS beeping has been made 18% more acoustically pleasant.

The VM2OS v9.0 upgrade has been transmitted to all systems running v8.6.1 or above. For systems running v8.5.317 or below, contact VeyMed technical support at tech+vm2os@support.vm with the reference code |CRANE|.

-------

TL;DR: Vitals monitors (the ones in the ORs, **NOT** the crew monitor app on computers) show BP, BO and temperature, and can be upgraded. If they're upgraded with max-tier scanning modules, they'll also show the location of broken bones and arterial bleeding if you have Trained Medicine skill or higher. It doesn't do anything the green scanner can't, and you're still going to want a pre-op scan for organ damage, but it should help cut down on unnecessary mid-op scans and streamline the process.

:cl: TheNightingale
rscadd: Vitals monitors can now be upgraded with scanning modules to show broken bones and arterial bleeding.
tweak: Vitals monitors now show BP, BO and temperature by default.
/:cl: