### PR TITLE
fix spiders reproducing a little TOO much

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -259,6 +259,9 @@
 					break
 
 		if(amount_grown >= 100)
+			if (GLOB.SPIDER_COUNT >= GLOB.MAX_SPIDER_COUNT)
+				amount_grown = 1
+				return
 			new greater_form(src.loc, src)
 			qdel(src)
 	else if(isorgan(loc))

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/_giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/_giant_spider.dm
@@ -4,6 +4,8 @@
 	Thick material will prevent injections, similar to other means of injections.
 */
 
+GLOBAL_VAR_INIT(MAX_SPIDER_COUNT, 30)
+GLOBAL_VAR_INIT(SPIDER_COUNT, 0)
 
 // The base spider, in the 'walking tank' family.
 /mob/living/simple_animal/hostile/giant_spider
@@ -75,11 +77,12 @@
 	get_light_and_color(parent)
 	spider_randomify()
 	update_icon()
+	GLOB.SPIDER_COUNT += 1
 	. = ..()
 
 /mob/living/simple_animal/hostile/giant_spider/death(gibbed, deathmessage, show_dead_message)
 	. = ..()
-
+	GLOB.SPIDER_COUNT -= 1
 	overlays -= eye_layer
 
 /mob/living/simple_animal/hostile/giant_spider/proc/spider_randomify() //random math nonsense to get their damage, health and venomness values

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
@@ -163,6 +163,10 @@
 	if(!istype(T))
 		return FALSE
 
+	if (GLOB.SPIDER_COUNT >= GLOB.MAX_SPIDER_COUNT)
+		next_egg_time = world.time + rand(minimum_disturbed_time, maximum_disturbed_time)
+		return FALSE
+
 	var/obj/effect/spider/eggcluster/E = locate() in T
 	if(E)
 		return FALSE // Already got eggs here.


### PR DESCRIPTION
:cl: Mucker
bugfix: Giant spider counts are now capped at 30 globally (to start) so they don't consume everything everywhere.
/:cl: