### PR TITLE
Eris Announcer

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -280,7 +280,7 @@
 	if(.)
 		SSnano.update_uis(src)
 
-/obj/item/device/radio/proc/autosay(message, from, channel) //BS12 EDIT
+/obj/item/device/radio/proc/autosay(message, from, channel, zlevel) //BS12 EDIT
 	var/datum/radio_frequency/connection = null
 	if(channel && channels && length(channels) > 0)
 		if (channel == "department")
@@ -291,6 +291,8 @@
 		channel = null
 	if (!istype(connection))
 		return
+	if(zlevel)
+		z = zlevel
 	var/mob/living/silicon/ai/A = new /mob/living/silicon/ai(src, null, null, 1)
 	A.fully_replace_character_name(from)
 	talk_into(A, message, channel,"states")

--- a/code/procs/announce.dm
+++ b/code/procs/announce.dm
@@ -1,3 +1,6 @@
+#define GET_ANNOUNCEMENT_FREQ(X) GLOB.using_map.use_job_frequency_announcement ? get_announcement_frequency(X) : "Common"
+#define ANNOUNCER_NAME "Automated Announcement System"
+
 var/global/datum/announcement/priority/priority_announcement = new(do_log = 0)
 var/global/datum/announcement/priority/command/command_announcement = new(do_log = 0, do_newscast = 1)
 var/global/datum/announcement/minor/minor_announcement = new(new_sound = 'sound/AI/commandreport.ogg',)
@@ -5,41 +8,39 @@ var/global/datum/announcement/minor/minor_announcement = new(new_sound = 'sound/
 /datum/announcement
 	var/title = "Attention"
 	var/announcer = ""
-	var/log = 0
+	var/log = FALSE
 	var/sound
-	var/newscast = 0
+	var/newscast = FALSE
 	var/channel_name = "Announcements"
 	var/announcement_type = "Announcement"
 
-/datum/announcement/priority
-	title = "Priority Announcement"
-	announcement_type = "Priority Announcement"
-
-/datum/announcement/priority/security
+/datum/announcement/priority/security/New(do_log = TRUE, new_sound = 'sound/misc/notice2.ogg', do_newscast = FALSE)
+	..(do_log, new_sound, do_newscast)
 	title = "Security Announcement"
 	announcement_type = "Security Announcement"
 
-/datum/announcement/New(do_log = 0, new_sound = null, do_newscast = 0)
-	sound = new_sound
-	log = do_log
-	newscast = do_newscast
-
-/datum/announcement/priority/command/New(do_log = 1, new_sound = 'sound/misc/notice2.ogg', do_newscast = 0)
+/datum/announcement/priority/command/New(do_log = TRUE, new_sound = 'sound/misc/notice2.ogg', do_newscast = FALSE)
 	..(do_log, new_sound, do_newscast)
 	title = "[GLOB.using_map.boss_name] Update"
 	announcement_type = "[GLOB.using_map.boss_name] Update"
 
-/datum/announcement/proc/Announce(message as text, new_title = "", new_sound = null, do_newscast = newscast, msg_sanitized = 0, zlevels = GLOB.using_map.contact_levels)
+/datum/announcement/New(do_log = FALSE, new_sound = null, do_newscast = FALSE)
+	sound = new_sound
+	log = do_log
+	newscast = do_newscast
+
+/datum/announcement/proc/Announce(message as text, new_title = "", new_sound = null, do_newscast = newscast, msg_sanitized = FALSE, zlevels = GLOB.using_map.contact_levels, radio_mode = GLOB.using_map.use_radio_announcement)
 	if(!message)
 		return
 	var/message_title = new_title ? new_title : title
 	var/message_sound = new_sound ? new_sound : sound
+	var/zlevel = length(zlevels) ? pick(zlevels) : 1
 
 	if(!msg_sanitized)
 		message = sanitize(message, extra = 0)
 	message_title = sanitizeSafe(message_title)
 
-	var/msg = FormMessage(message, message_title)
+	var/msg = radio_mode ? FormRadioMessage(message, message_title, zlevel) : FormMessage(message, message_title)
 	for(var/mob/M in GLOB.player_list)
 		if(M.client && (get_z(M) in (zlevels | GLOB.using_map.admin_levels)) && !istype(M,/mob/new_player) && !isdeaf(M))
 			to_chat(M, msg)
@@ -60,7 +61,7 @@ var/global/datum/announcement/minor/minor_announcement = new(new_sound = 'sound/
 		. += "<br>[SPAN_CLASS("alert", " -[html_encode(announcer)]")]"
 
 /datum/announcement/minor/FormMessage(message as text, message_title as text)
-	. = "<b>[message]</b>"
+	. = SPAN_BOLD(message)
 
 /datum/announcement/priority/FormMessage(message as text, message_title as text)
 	. = "<h1 class='alert'>[message_title]</h1>"
@@ -73,14 +74,12 @@ var/global/datum/announcement/minor/minor_announcement = new(new_sound = 'sound/
 	. = "<h1 class='alert'>[GLOB.using_map.boss_name] Update</h1>"
 	if (message_title)
 		. += "<br><h2 class='alert'>[message_title]</h2>"
-
 	. += "<br>[SPAN_CLASS("alert", "[message]")]<br>"
 	. += "<br>"
 
 /datum/announcement/priority/security/FormMessage(message as text, message_title as text)
 	. = FONT_HUGE(SPAN_COLOR("red", message_title))
 	. += "<br>[SPAN_COLOR("red", message)]"
-
 
 /datum/announcement/proc/NewsCast(message, list/zlevels)
 	if (!message || !islist(zlevels))
@@ -121,6 +120,39 @@ var/global/datum/announcement/minor/minor_announcement = new(new_sound = 'sound/
 /proc/ion_storm_announcement(list/affecting_z)
 	command_announcement.Announce("It has come to our attention that the [station_name()] passed through an ion storm.  Please monitor all electronic equipment for malfunctions.", "Anomaly Alert", zlevels = affecting_z)
 
+/////// ANNOUNCEMENT PROCS VIA RADIO ///////
+/datum/announcement/proc/FormRadioMessage(message as text, message_title as text, zlevel)
+	GLOB.global_announcer.autosay(SPAN_BOLD(FONT_LARGE("[SPAN_WARNING("[title]:")] [message]")), announcer ? announcer : ANNOUNCER_NAME,, zlevel)
+
+/datum/announcement/minor/FormRadioMessage(message as text, message_title as text, zlevel)
+	GLOB.global_announcer.autosay(message, ANNOUNCER_NAME,, zlevel)
+
+/datum/announcement/priority/FormRadioMessage(message as text, message_title as text, zlevel)
+	GLOB.global_announcer.autosay(SPAN_BOLD(FONT_LARGE("[SPAN_WARNING("[message_title]:")] [message]")), announcer ? announcer : ANNOUNCER_NAME,, zlevel)
+
+/datum/announcement/priority/command/FormRadioMessage(message as text, message_title as text, zlevel)
+	GLOB.global_announcer.autosay(SPAN_BOLD(FONT_LARGE("[SPAN_WARNING("[GLOB.using_map.boss_name] Update[message_title ? " — [message_title]" : ""]:")] [message]")), ANNOUNCER_NAME,, zlevel)
+
+/datum/announcement/priority/security/FormRadioMessage(message as text, message_title as text, zlevel)
+	GLOB.global_announcer.autosay(SPAN_BOLD(FONT_LARGE("[SPAN_WARNING("[message_title]:")] [message]")), ANNOUNCER_NAME,, zlevel)
+
+/////// ANNOUNCEMENT PROCS ///////
+/datum/announcement/proc/Message(message as text, message_title as text)
+	GLOB.global_announcer.autosay(FONT_LARGE("[SPAN_WARNING("[title]:")] [message]"), announcer ? announcer : ANNOUNCER_NAME)
+
+/datum/announcement/minor/Message(message as text, message_title as text)
+	GLOB.global_announcer.autosay(message, ANNOUNCER_NAME)
+
+/datum/announcement/priority/Message(message as text, message_title as text)
+	GLOB.global_announcer.autosay(FONT_LARGE("[SPAN_CLASS("alert", "[message_title]:")] [message]"), announcer ? announcer : ANNOUNCER_NAME)
+
+/datum/announcement/priority/command/Message(message as text, message_title as text)
+	GLOB.global_announcer.autosay(FONT_LARGE("[SPAN_WARNING("[GLOB.using_map.boss_name] [message_title]:")] [message]"), ANNOUNCER_NAME)
+
+/datum/announcement/priority/security/Message(message as text, message_title as text)
+	GLOB.global_announcer.autosay(FONT_LARGE("[SPAN_COLOR("red", "[message_title]:")] [message]"), ANNOUNCER_NAME)
+
+
 /proc/AnnounceArrival(mob/living/carbon/human/character, datum/job/job, join_message)
 	if(!istype(job) || !job.announced)
 		return
@@ -130,7 +162,7 @@ var/global/datum/announcement/minor/minor_announcement = new(new_sound = 'sound/
 	if(character.mind.role_alt_title)
 		rank = character.mind.role_alt_title
 
-	AnnounceArrivalSimple(character.real_name, rank, join_message, get_announcement_frequency(job))
+	AnnounceArrivalSimple(character.real_name, rank, join_message, GET_ANNOUNCEMENT_FREQ(job))
 
 /proc/AnnounceArrivalSimple(name, rank = "visitor", join_message = "has arrived on the [station_name()]", frequency)
 	GLOB.global_announcer.autosay("[name], [rank], [join_message].", "Arrivals Announcement Computer", frequency)

--- a/maps/mapsystem/maps_announcements.dm
+++ b/maps/mapsystem/maps_announcements.dm
@@ -21,6 +21,9 @@
 
 	var/space_time_anomaly_sound
 
+	var/use_job_frequency_announcement = TRUE
+	var/use_radio_announcement = TRUE
+
 	var/unidentified_lifesigns_message = "Unidentified lifesigns detected coming aboard the %STATION_NAME%. Please lockdown all exterior access points, including ducting and ventilation."
 	var/unidentified_lifesigns_sound
 

--- a/maps/torch/torch_announcements.dm
+++ b/maps/torch/torch_announcements.dm
@@ -32,6 +32,9 @@
 	electrical_storm_moderate_sound = sound('sound/AI/torch/electricalstormmoderate.ogg', volume = 45)
 	electrical_storm_major_sound = sound('sound/AI/torch/electricalstormmajor.ogg', volume = 45)
 
+	use_job_frequency_announcement = FALSE
+	use_radio_announcement = TRUE
+
 /datum/map/torch/level_x_biohazard_sound(bio_level)
 	switch(bio_level)
 		if(7)


### PR DESCRIPTION
Adds announcement via radio channels with Z-level check.
Like this
![image](https://github.com/Baystation12/Baystation12/assets/77477080/18e4a83b-90dd-486a-951e-e96d4eb19bfc)


Draft by now, because need to check if naming of the ship correct.
UPD: Un-drafts PR 
<details>
<summary>Changelog</summary>

```yml
🆑 LordNest
rscadd: Added announcement system, which uses radiochannels instead of old red message 
/🆑
```