### PR TITLE
Action button tooltips

### DIFF
--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -121,6 +121,12 @@
 	var/datum/action/owner
 	screen_loc = "WEST,NORTH"
 
+
+/obj/screen/movable/action_button/Initialize(mapload, _owner)
+	. = ..(mapload)
+	owner = _owner
+
+
 /obj/screen/movable/action_button/Click(location,control,params)
 	var/list/modifiers = params2list(params)
 	if(modifiers["shift"])

--- a/code/_onclick/hud/action.dm
+++ b/code/_onclick/hud/action.dm
@@ -120,11 +120,15 @@
 /obj/screen/movable/action_button
 	var/datum/action/owner
 	screen_loc = "WEST,NORTH"
+	/// String. Title of the tooltip displayed on hover. Set during `Initialize()`, defaults to `owner.target.name`.
+	var/tooltip_title
 
 
 /obj/screen/movable/action_button/Initialize(mapload, _owner)
 	. = ..(mapload)
 	owner = _owner
+	if (owner?.target)
+		tooltip_title = owner.target.name
 
 
 /obj/screen/movable/action_button/Click(location,control,params)
@@ -136,6 +140,15 @@
 		return
 	owner.Trigger()
 	return 1
+
+
+/obj/screen/movable/action_button/MouseEntered(location, control, params)
+	openToolTip(usr, src, params, tooltip_title, name)
+
+
+/obj/screen/movable/action_button/MouseExited(location, control, params)
+	closeToolTip(usr)
+
 
 /obj/screen/movable/action_button/proc/UpdateIcon()
 	if(!owner)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -378,8 +378,7 @@
 	for(var/datum/action/A in actions)
 		button_number++
 		if(A.button == null)
-			var/obj/screen/movable/action_button/N = new(hud_used)
-			N.owner = A
+			var/obj/screen/movable/action_button/N = new(hud_used, A)
 			A.button = N
 
 		var/obj/screen/movable/action_button/B = A.button


### PR DESCRIPTION
:cl: SierraKomodo
rscadd: Action buttons now have tooltips denoting the target object and the action.
/:cl:

![dreamseeker_HVck2mhdGG](https://github.com/Baystation12/Baystation12/assets/11140088/17699707-6ef1-47d2-b6cd-c79dc27faaab)
