### PR TITLE
Reverts accuracy change made in #33733

### DIFF
--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -16,7 +16,6 @@
 	handle_casings = HOLD_CASINGS
 	one_hand_penalty = 8
 	bulk = 6
-	accuracy = 1
 	var/recentpump = 0 // to prevent spammage
 	wielded_item_state = "shotgun-wielded"
 	load_sound = 'sound/weapons/guns/interaction/shotgun_instert.ogg'
@@ -150,7 +149,6 @@
 	handle_casings = HOLD_CASINGS
 	one_hand_penalty = 4
 	bulk = 4
-	accuracy = 0
 	wielded_item_state = "rshotgun-wielded"
 	load_sound = 'sound/weapons/guns/interaction/shotgun_instert.ogg'
 
@@ -215,7 +213,6 @@
 	max_shells = 7 //match the ammo box capacity, also it can hold a round in the chamber anyways, for a total of 8.
 	ammo_type = /obj/item/ammo_casing/shotgun
 	one_hand_penalty = 8
-	accuracy = 2
 
 /obj/item/gun/projectile/shotgun/pump/combat/on_update_icon()
 	..()
@@ -248,7 +245,6 @@
 	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 1)
 	ammo_type = /obj/item/ammo_casing/shotgun/beanbag
 	one_hand_penalty = 8
-	accuracy = 1
 	wielded_item_state = "gun_wielded"
 
 	burst_delay = 0
@@ -337,7 +333,6 @@
 	force = 5
 	one_hand_penalty = 4
 	bulk = 2
-	accuracy = 0
 
 /obj/item/gun/projectile/shotgun/doublebarrel/sawn/empty
 	starts_loaded = FALSE

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -99,16 +99,7 @@
 		//whether the pellet actually hits the def_zone or a different zone should still be determined by the parent using get_zone_with_miss_chance().
 		var/old_zone = def_zone
 		def_zone = ran_zone(def_zone, spread)
-		//relatively hacky way of basing a shotgun pellet's likelihood of hitting on the first pellet of the burst while not affecting shrapnel explosions.
-		if (base_spread > 0)
-			if (i == 1)
-				if (..())
-					hits++
-				else
-					return 0
-			else if (..(target_mob, distance, -100))
-				hits++
-		else if (..())
+		if (..())
 			hits++
 		def_zone = old_zone //restore the original zone the projectile was aimed at
 


### PR DESCRIPTION
:cl:
tweak: Reverts accuracy changes to shotguns.
/:cl:

Made shotguns either do no damage or all the damage and removed the scaled damage that it was before. More interesting that way.