### PR TITLE
rubber bullet tweaks

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -100,7 +100,7 @@
 	var/mob/living/L = target
 
 	L.apply_effects(0, weaken, paralyze, stutter, eyeblur, drowsy, 0, blocked)
-	L.stun_effect_act(stun, agony, def_zone, src)
+	L.stun_effect_act(stun, (agony - blocked), def_zone, src)
 	//radiation protection is handled separately from other armour types.
 	L.apply_damage(irradiate, DAMAGE_RADIATION, damage_flags = DAMAGE_FLAG_DISPERSED)
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -153,12 +153,13 @@
 /obj/item/projectile/bullet/pistol/rubber //"rubber" bullets
 	name = "rubber bullet"
 	damage_flags = 0
-	damage = 5
-	agony = 30
+	damage = 15
+	agony = 15
 	embed = FALSE
 
 /obj/item/projectile/bullet/pistol/rubber/holdout
-	agony = 20
+	agony = 10
+	damage = 10
 
 //4mm. Tiny, very low damage, does not embed, but has very high penetration. Only to be used for the experimental SMG.
 /obj/item/projectile/bullet/flechette
@@ -179,9 +180,9 @@
 
 /obj/item/projectile/bullet/shotgun/beanbag		//because beanbags are not bullets
 	name = "beanbag"
-	damage = 25
+	damage = 20
 	damage_flags = 0
-	agony = 60
+	agony = 30
 	embed = FALSE
 	armor_penetration = 0
 	distance_falloff = 3


### PR DESCRIPTION
🆑 jux
tweak: 10mm rubber bullets do 15 brute, up from 5, and 15 agony, down from 30. Holdout rubber bullets do 10 brute, up from 5, and 10 agony, down from 20. Shotgun beanbags do 20 brute, down from 25, and 30 agony, down from 60.
tweak: Projectiles that deal agony reduce agony dealt by the armor blocking it.
/🆑 

Fiddling with values