### PR TITLE
Animated `Point To`

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -389,12 +389,14 @@
 	if(istype(A, /obj/effect/decal/point))
 		return 0
 
-	var/tile = get_turf(A)
+	var/turf/tile = get_turf(A)
 	if (!tile)
 		return 0
 
-	var/obj/P = new /obj/effect/decal/point(tile)
+	var/turf/mob_tile = get_turf(src)
+	var/obj/P = new /obj/effect/decal/point(mob_tile)
 	P.set_invisibility(invisibility)
+	animate(P, pixel_x = (tile.x - mob_tile.x) * world.icon_size + A.pixel_x, pixel_y = (tile.y - mob_tile.y) * world.icon_size + A.pixel_y, time = 3, easing = EASE_OUT)
 	face_atom(A)
 	return 1
 


### PR DESCRIPTION
```yml
🆑SuhEugene
tweak: Point To arrow is animated now and visible only if the pointing player is visible.
/🆑
```

https://github.com/Baystation12/Baystation12/assets/32931701/f61448fb-2535-45ac-96c7-d4af1154bdf8

