### PR TITLE
Lets EMP affect energy melee and e-shields + some eshield related stuff

### DIFF
--- a/code/datums/uplink/devices and tools.dm
+++ b/code/datums/uplink/devices and tools.dm
@@ -4,11 +4,20 @@
 /datum/uplink_item/item/tools
 	category = /datum/uplink_category/tools
 
+
 /datum/uplink_item/item/tools/personal_shield
 	name = "Personal Shield"
 	desc = "A very expensive device that uses energy to block bullets and lasers from tearing you a new hole."
-	item_cost = 60
+	item_cost = 40
 	path = /obj/item/device/personal_shield
+
+
+/datum/uplink_item/item/tools/eshield
+	name = "Energy Shield"
+	desc = "An extendable hardlight shield projector."
+	item_cost = 24
+	path = /obj/item/shield/energy
+
 
 /datum/uplink_item/item/tools/toolbox
 	name = "Fully Loaded Toolbox"
@@ -17,11 +26,13 @@
 	item_cost = 8
 	path = /obj/item/storage/toolbox/syndicate
 
+
 /datum/uplink_item/item/tools/ductape
 	name = "Duct Tape"
 	desc = "A roll of duct tape."
 	item_cost = 2
 	path = /obj/item/tape_roll
+
 
 /datum/uplink_item/item/tools/money
 	name = "Operations Funding"
@@ -31,17 +42,20 @@
 	. = ..()
 	desc = "A briefcase with 10,000 untraceable [GLOB.using_map.local_currency_name]. Makes a great bribe if they're willing to take you up on your offer."
 
+
 /datum/uplink_item/item/tools/clerical
 	name = "Morphic Clerical Kit"
 	desc = "Comes with everything you need to fake paperwork, assuming you know how to forge the required documents."
 	item_cost = 16
 	path = /obj/item/storage/backpack/satchel/syndie_kit/clerical
 
+
 /datum/uplink_item/item/tools/plastique
 	name = "C-4"
 	desc = "Set this on a wall to put a hole exactly where you need it."
 	item_cost = 16
 	path = /obj/item/plastique
+
 
 /datum/uplink_item/item/tools/heavy_armor
 	name = "Heavy Armor Vest and Helmet"
@@ -50,17 +64,20 @@
 	item_cost = 16
 	path = /obj/item/storage/backpack/satchel/syndie_kit/armor
 
+
 /datum/uplink_item/item/tools/encryptionkey_radio
 	name = "Encrypted Radio Channel Key"
 	desc = "This headset encryption key will allow you to speak on a hidden, encrypted radio channel. Use a screwdriver on your headset to exchange keys."
 	item_cost = 1
 	path = /obj/item/device/encryptionkey/syndicate
 
+
 /datum/uplink_item/item/tools/shield_diffuser
 	name = "Handheld Shield Diffuser"
 	desc = "A small device used to disrupt energy barriers, and allow passage through them."
 	item_cost = 16
 	path = /obj/item/shield_diffuser
+
 
 /datum/uplink_item/item/tools/suit_sensor_mobile
 	name = "Suit Sensor Jamming Device"
@@ -70,6 +87,7 @@
 	item_cost = 20
 	path = /obj/item/device/suit_sensor_jammer
 
+
 /datum/uplink_item/item/tools/encryptionkey_binary
 	name = "Binary Translator Key"
 	desc = "This headset encryption key will allow you to both listen and speak on the binary channel that \
@@ -77,6 +95,7 @@
 	Use a screwdriver on your headset to exchange keys."
 	item_cost = 20
 	path = /obj/item/device/encryptionkey/binary
+
 
 /datum/uplink_item/item/tools/emag
 	name = "Cryptographic Sequencer"
@@ -87,6 +106,7 @@
 	item_cost = 24
 	path = /obj/item/card/emag
 
+
 /datum/uplink_item/item/tools/hacking_tool
 	name = "Door Hacking Tool"
 	item_cost = 24
@@ -95,6 +115,7 @@
 			While in hacking mode, this device will grant full access to any airlock in 20 to 40 seconds. \
 			This device will be able to continuously reaccess the last 6 to 8  airlocks it was used on."
 
+
 /datum/uplink_item/item/tools/space_suit
 	name = "Voidsuit and Tactical Mask"
 	desc = "A satchel containing a non-regulation voidsuit, voidsuit helmet, tactical mask, and oxygen tank. \
@@ -102,11 +123,13 @@
 	item_cost = 28
 	path = /obj/item/storage/backpack/satchel/syndie_kit/space
 
+
 /datum/uplink_item/item/tools/divinghelmet
 	name = "Diving Helmet"
 	desc = "An antique diver's helmet that was designed to withstand immense pressures. Works as a space helmet. Only fits humans."
 	item_cost = 12
 	path = /obj/item/clothing/head/helmet/divinghelmet
+
 
 /datum/uplink_item/item/tools/thermal
 	name = "Thermal Imaging Glasses"
@@ -115,11 +138,13 @@
 	path = /obj/item/clothing/glasses/thermal/syndi
 	antag_roles = list(MODE_TRAITOR)
 
+
 /datum/uplink_item/item/tools/flashdark
 	name = "Flashdark"
 	desc = "A device similar to a flash light that absorbs the surrounding light, casting a shadowy, black mass."
 	item_cost = 32
 	path = /obj/item/device/flashlight/flashdark
+
 
 /datum/uplink_item/item/tools/powersink
 	name = "Powersink (DANGER!)"
@@ -129,12 +154,14 @@
 	item_cost = 40
 	path = /obj/item/device/powersink
 
+
 /datum/uplink_item/item/tools/ai_module
 	name = "Hacked AI Upload Module"
 	desc = "A module that can be used anonymously add a singular, top level law to an active AI. \
 	All you need to do is write in the law and insert it into any available AI Upload Console."
 	item_cost = 52
 	path = /obj/item/aiModule/syndicate
+
 
 /datum/uplink_item/item/tools/supply_beacon
 	name = "Hacked Supply Beacon (DANGER!)"
@@ -144,6 +171,7 @@
 	item_cost = 52
 	path = /obj/item/supply_beacon
 
+
 /datum/uplink_item/item/tools/camera_mask
 	name = "Camera MIU"
 	desc = "Wearing this mask allows you to remotely view any cameras you currently have access to. Take the mask off to stop viewing."
@@ -151,11 +179,13 @@
 	antag_costs = list(MODE_MERCENARY = 30)
 	path = /obj/item/clothing/mask/ai
 
+
 /datum/uplink_item/item/tools/interceptor
 	name = "Radio Interceptor"
 	item_cost = 30
 	path = /obj/item/device/radio/intercept
 	desc = "A receiver-like device that can intercept secure radio channels. This item is too big to fit into your pockets."
+
 
 /datum/uplink_item/item/tools/ttv
 	name = "Binary Gas Bomb"
@@ -164,6 +194,7 @@
 	desc = "A remote-activated phoron-oxygen bomb assembly with an included signaler. \
 			A flashing disclaimer begins with the warning 'SOME DISASSEMBLY/REASSEMBLY REQUIRED.'"
 
+
 /datum/uplink_item/item/tools/polychromic_dye_bottle
 	name = "Extra-Strength Polychromic Dye"
 	item_cost = 10
@@ -171,6 +202,7 @@
 	desc = "15 units of a tasteless dye that causes chemical mixtures to take on the color of the dye itself. \
 			Very useful for disguising poisons to the untrained eye; even large amounts of reagents can be fully recolored with only a few drops of dye. \
 			Like the mundane variety of polychromic dye, you can use the bottle in your hand to change the dye's color to suit your needs."
+
 
 /datum/uplink_item/item/tools/handcuffs
 	name = "Handcuffs"

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -229,7 +229,7 @@
 	_input_on = 1;
 	_output_maxed = 1;
 	_output_on = 1;
-	uncreated_component_parts = list(/obj/item/stock_parts/smes_coil/super_io = 1, /obj/item/stock_parts/smes_coil/super_capacity = 1)
+	uncreated_component_parts = list(/obj/item/stock_parts/smes_coil/super_io=1,/obj/item/stock_parts/smes_coil/super_capacity=1)
 	},
 /obj/structure/cable{
 	d2 = 8;
@@ -286,7 +286,7 @@
 /area/map_template/merc_shuttle)
 "cM" = (
 /obj/machinery/computer/ship/engines{
-	uncreated_component_parts = list(/obj/item/stock_parts/power/battery/buildable/responsive = 1, /obj/item/cell/high = 1)
+	uncreated_component_parts = list(/obj/item/stock_parts/power/battery/buildable/responsive=1,/obj/item/cell/high=1)
 	},
 /obj/item/device/radio/intercom/hailing{
 	dir = 4;
@@ -297,7 +297,7 @@
 "cN" = (
 /obj/machinery/computer/shuttle_control/explore/merc_shuttle{
 	req_access = list("ACCESS_SYNDICATE");
-	uncreated_component_parts = list(/obj/item/stock_parts/power/battery/buildable/responsive = 1, /obj/item/cell/high = 1)
+	uncreated_component_parts = list(/obj/item/stock_parts/power/battery/buildable/responsive=1,/obj/item/cell/high=1)
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
@@ -480,13 +480,15 @@
 /obj/structure/table/rack{
 	pixel_x = -1
 	},
-/obj/item/shield/energy,
-/obj/item/shield/energy,
-/obj/item/shield/energy,
-/obj/item/shield/energy,
-/obj/item/shield/energy,
-/obj/item/shield/energy,
 /obj/effect/floor_decal/corner/red/mono,
+/obj/item/storage/box/handcuffs{
+	pixel_x = 4;
+	pixel_y = 2
+	},
+/obj/item/storage/box/handcuffs{
+	pixel_x = 4;
+	pixel_y = 2
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/map_template/merc_spawn)
 "fa" = (
@@ -935,7 +937,7 @@
 	_input_on = 1;
 	_output_maxed = 1;
 	_output_on = 1;
-	uncreated_component_parts = list(/obj/item/stock_parts/smes_coil/super_io = 1, /obj/item/stock_parts/smes_coil/super_capacity = 1)
+	uncreated_component_parts = list(/obj/item/stock_parts/smes_coil/super_io=1,/obj/item/stock_parts/smes_coil/super_capacity=1)
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
 /obj/structure/cable/green{
@@ -1575,14 +1577,6 @@
 /obj/item/clothing/glasses/night,
 /obj/item/clothing/glasses/night,
 /obj/item/clothing/glasses/night,
-/obj/item/storage/box/handcuffs{
-	pixel_x = 4;
-	pixel_y = 2
-	},
-/obj/item/storage/box/handcuffs{
-	pixel_x = 4;
-	pixel_y = 2
-	},
 /obj/item/clothing/glasses/night,
 /obj/item/clothing/glasses/night,
 /obj/item/clothing/glasses/night,


### PR DESCRIPTION
:cl:
tweak: E-Shields will now be damaged by EMP if active during blast, and be unable to be used, temporarily.
tweak: E-Swords/E-Melee weapons will now be damaged by EMP if active during blast, and be unable to be used temporarily.
tweak: E-Shields are now buyable for 24 TC on uplink.
tweak: Personal Belt Shield is now buyable for 40 TC.
maptweak: E-Shields aren't available freely on the merc-base anymore.
/:cl:

If the energy melee gets hit with minor severity, it will be unusable for 30 seconds, heavy to 90 seconds.
If the energy shield gets hit with minor severity, it will be unusable for 30 seconds, heavy to 60 seconds.

I should've made the e-shield uplink and mercbase changes on a different PR but ee.

Personal Belt Shield was literally never used. Dumbed down the cost to 40 from 60.

Also NUFC, Shield has a activate/deactivate proc now.