### PR TITLE
Remaps security armory

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -19,6 +19,7 @@
  *		For syndicate call-ins see uplink_kits.dm
  */
 
+
 /obj/item/storage/box
 	name = "box"
 	desc = "It's just an ordinary box."
@@ -29,6 +30,7 @@
 	var/foldable = /obj/item/stack/material/cardboard	// BubbleWrap - if set, can be folded (when empty) into a sheet of cardboard
 	allow_slow_dump = TRUE
 
+
 /obj/item/storage/box/large
 	name = "large box"
 	icon_state = "largebox"
@@ -36,15 +38,18 @@
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = DEFAULT_LARGEBOX_STORAGE
 
+
 /obj/item/storage/box/union_cards
 	name = "box of union cards"
 	desc = "A box of spare unsigned union membership cards."
 	startswith = list(/obj/item/card/union = 7)
 
+
 /obj/item/storage/box/large/union_cards
 	name = "large box of union cards"
 	desc = "A large box of spare unsigned union membership cards."
 	startswith = list(/obj/item/card/union = 14)
+
 
 // BubbleWrap - A box can be folded up to make card
 /obj/item/storage/box/attack_self(mob/user as mob)
@@ -74,9 +79,11 @@
 		new src.foldable(get_turf(src))
 	qdel(src)
 
+
 /obj/item/storage/box/make_exact_fit()
 	..()
 	foldable = null //special form fitted boxes should not be foldable.
+
 
 /obj/item/storage/box/survival
 	name = "crew survival kit"
@@ -90,6 +97,7 @@
 					/obj/item/reagent_containers/food/snacks/proteinbar = 1,
 					/obj/item/device/oxycandle = 1)
 
+
 /obj/item/storage/box/vox
 	name = "vox survival kit"
 	desc = "A box decorated in warning colors that contains a limited supply of survival tools. The panel and black stripe indicate this one contains nitrogen."
@@ -100,6 +108,7 @@
 					/obj/item/stack/medical/bruise_pack = 1,
 					/obj/item/device/flashlight/flare/glowstick = 1,
 					/obj/item/reagent_containers/food/snacks/proteinbar = 1)
+
 
 /obj/item/storage/box/engineer
 	name = "engineer survival kit"
@@ -113,6 +122,7 @@
 					/obj/item/device/flashlight/flare/glowstick = 1,
 					/obj/item/reagent_containers/food/snacks/proteinbar = 1,
 					/obj/item/device/oxycandle = 1)
+
 
 /obj/item/storage/box/latexgloves
 	name = "box of sterile latex gloves"
@@ -141,6 +151,7 @@
 	icon_state = "syringe"
 	startswith = list(/obj/item/reagent_containers/syringe = 7)
 
+
 /obj/item/storage/box/syringegun
 	name = "box of syringe gun cartridges"
 	desc = "A box full of compressed gas cartridges."
@@ -153,9 +164,11 @@
 	icon_state = "beaker"
 	startswith = list(/obj/item/reagent_containers/glass/beaker = 7)
 
+
 /obj/item/storage/box/beakers/insulated
 	name = "box of insulated beakers"
 	startswith = list(/obj/item/reagent_containers/glass/beaker/insulated = 7)
+
 
 /obj/item/storage/box/ammo
 	name = "ammo box"
@@ -163,70 +176,92 @@
 	desc = "A sturdy metal box with several warning symbols on the front.<br>WARNING: Live ammunition. Misuse may result in serious injury or death."
 	use_sound = 'sound/effects/closet_open.ogg'
 
+
 /obj/item/storage/box/ammo/blanks
 	name = "box of blank shells"
 	desc = "It has a picture of a gun and several warning symbols on the front."
 	startswith = list(/obj/item/ammo_casing/shotgun/blank = 8)
 
+
 /obj/item/storage/box/ammo/practiceshells
 	name = "box of practice shells"
 	startswith = list(/obj/item/ammo_casing/shotgun/practice = 8)
+
 
 /obj/item/storage/box/ammo/beanbags
 	name = "box of beanbag shells"
 	startswith = list(/obj/item/ammo_magazine/shotholder/beanbag = 2)
 
+
 /obj/item/storage/box/ammo/shotgunammo
 	name = "box of shotgun slugs"
 	startswith = list(/obj/item/ammo_magazine/shotholder = 2)
+
 
 /obj/item/storage/box/ammo/shotgunshells
 	name = "box of shotgun shells"
 	startswith = list(/obj/item/ammo_magazine/shotholder/shell = 2)
 
+
 /obj/item/storage/box/ammo/flechetteshells
 	name = "box of flechette shells"
 	startswith = list(/obj/item/ammo_magazine/shotholder/flechette = 2)
+
 
 /obj/item/storage/box/ammo/flashshells
 	name = "box of illumination shells"
 	startswith = list(/obj/item/ammo_magazine/shotholder/flash = 2)
 
+
 /obj/item/storage/box/ammo/stunshells
 	name = "box of stun shells"
 	startswith = list(/obj/item/ammo_magazine/shotholder/stun = 2)
+
 
 /obj/item/storage/box/ammo/sniperammo
 	name = "box of sniper shells"
 	startswith = list(/obj/item/ammo_casing/shell = 7)
 
+
 /obj/item/storage/box/ammo/sniperammo/apds
 	name = "box of sniper APDS shells"
 	startswith = list(/obj/item/ammo_casing/shell/apds = 3)
+
 
 /obj/item/storage/box/ammo/pistol
 	name = "box of pistol magazines - lethal"
 	startswith = list(/obj/item/ammo_magazine/pistol = 7)
 
+
 /obj/item/storage/box/ammo/pistol/rubber
 	name = "box of pistol magazines - rubber"
 	startswith = list(/obj/item/ammo_magazine/pistol/rubber = 7)
+
 
 /obj/item/storage/box/ammo/doublestack
 	name = "box of doublestack magazines - lethal"
 	startswith = list(/obj/item/ammo_magazine/pistol/double = 6)
 
+
 /obj/item/storage/box/ammo/doublestack/rubber
 	name = "box of doublestack magazines - rubber"
 	startswith = list(/obj/item/ammo_magazine/pistol/double/rubber = 6)
+
 
 /obj/item/storage/box/ammo/smg
 	name = "box of SMG magazines - lethal"
 	startswith = list(/obj/item/ammo_magazine/smg_top = 7)
 
+
 /obj/item/storage/box/ammo/smg/rubber
 	name = "box of SMG magazines - rubber"
 	startswith = list(/obj/item/ammo_magazine/smg_top/rubber = 7)
+
+
+/obj/item/storage/box/ammo/light_bullpup
+	name = "box of light bullpup magazines"
+	startswith = list(/obj/item/ammo_magazine/mil_rifle/light = 6)
+
 
 /obj/item/storage/box/flashbangs
 	name = "box of flashbangs"
@@ -234,11 +269,13 @@
 	icon_state = "flashbang"
 	startswith = list(/obj/item/grenade/flashbang = 7)
 
+
 /obj/item/storage/box/teargas
 	name = "box of pepperspray grenades"
 	desc = "A box containing 7 tear gas grenades. A gas mask is printed on the label.<br> WARNING: Exposure carries risk of serious injury or death. Keep away from persons with lung conditions."
 	icon_state = "flashbang"
 	startswith = list(/obj/item/grenade/chem_grenade/teargas = 7)
+
 
 /obj/item/storage/box/emps
 	name = "box of emp grenades"
@@ -246,11 +283,13 @@
 	icon_state = "flashbang"
 	startswith = list(/obj/item/grenade/empgrenade = 5)
 
+
 /obj/item/storage/box/frags
 	name = "box of frag grenades"
 	desc = "A box containing 5 military grade fragmentation grenades.<br> WARNING: Live explosives. Misuse may result in serious injury or death."
 	icon_state = "flashbang"
 	startswith = list(/obj/item/grenade/frag = 5)
+
 
 /obj/item/storage/box/fragshells
 	name = "box of frag shells"
@@ -258,11 +297,13 @@
 	icon_state = "flashbang"
 	startswith = list(/obj/item/grenade/frag/shell = 5)
 
+
 /obj/item/storage/box/smokes
 	name = "box of smoke bombs"
 	desc = "A box containing 5 smoke bombs."
 	icon_state = "flashbang"
 	startswith = list(/obj/item/grenade/smokebomb = 5)
+
 
 /obj/item/storage/box/anti_photons
 	name = "box of anti-photon grenades"
@@ -270,11 +311,13 @@
 	icon_state = "flashbang"
 	startswith = list(/obj/item/grenade/anti_photon = 5)
 
+
 /obj/item/storage/box/supermatters
 	name = "box of supermatter grenades"
 	desc = "A box containing 5 highly experimental supermatter grenades."
 	icon_state = "radbox"
 	startswith = list(/obj/item/grenade/supermatter = 5)
+
 
 /obj/item/storage/box/trackimp
 	name = "boxed tracking implant kit"
@@ -285,6 +328,7 @@
 		/obj/item/implantpad = 1,
 		/obj/item/locator = 1)
 
+
 /obj/item/storage/box/chemimp
 	name = "boxed chemical implant kit"
 	desc = "Box of stuff used to implant chemicals."
@@ -293,11 +337,13 @@
 					/obj/item/implanter = 1,
 					/obj/item/implantpad = 1)
 
+
 /obj/item/storage/box/rxglasses
 	name = "box of prescription glasses"
 	desc = "This box contains nerd glasses."
 	icon_state = "glasses"
 	startswith = list(/obj/item/clothing/glasses/prescription = 7)
+
 
 /obj/item/storage/box/cdeathalarm_kit
 	name = "death alarm kit"
@@ -307,15 +353,18 @@
 	startswith = list(/obj/item/implanter = 1,
 				/obj/item/implantcase/death_alarm = 6)
 
+
 /obj/item/storage/box/condimentbottles
 	name = "box of condiment bottles"
 	desc = "It has a large ketchup smear on it."
 	startswith = list(/obj/item/reagent_containers/food/condiment = 6)
 
+
 /obj/item/storage/box/cups
 	name = "box of paper cups"
 	desc = "It has pictures of paper cups on the front."
 	startswith = list(/obj/item/reagent_containers/food/drinks/sillycup = 7)
+
 
 //cubed animals
 
@@ -327,25 +376,30 @@
 	can_hold = list(/obj/item/reagent_containers/food/snacks/monkeycube)
 	startswith = list(/obj/item/reagent_containers/food/snacks/monkeycube/wrapped = 5)
 
+
 /obj/item/storage/box/monkeycubes/farwacubes
 	name = "farwa cube box"
 	desc = "Drymate brand farwa cubes, shipped from Nyx. Just add water!"
 	startswith = list(/obj/item/reagent_containers/food/snacks/monkeycube/wrapped/farwacube = 5)
+
 
 /obj/item/storage/box/monkeycubes/stokcubes
 	name = "stok cube box"
 	desc = "Drymate brand stok cubes, shipped from Moghes. Just add water!"
 	startswith = list(/obj/item/reagent_containers/food/snacks/monkeycube/wrapped/stokcube = 5)
 
+
 /obj/item/storage/box/monkeycubes/neaeracubes
 	name = "neaera cube box"
 	desc = "Drymate brand neaera cubes, shipped from Jargon 4. Just add water!"
 	startswith = list(/obj/item/reagent_containers/food/snacks/monkeycube/wrapped/neaeracube = 5)
 
+
 /obj/item/storage/box/monkeycubes/spidercubes
 	name = "spiderling cube box"
 	desc = "Drymate brand Instant spiders. WHY WOULD YOU ORDER THIS!?"
 	startswith = list(/obj/item/reagent_containers/food/snacks/monkeycube/wrapped/spidercube = 5)
+
 
 /obj/item/storage/box/ids
 	name = "box of spare IDs"
@@ -353,11 +407,13 @@
 	icon_state = "id"
 	startswith = list(/obj/item/card/id = 7)
 
+
 /obj/item/storage/box/large/ids
 	name = "box of spare IDs"
 	desc = "Has so, so many empty IDs."
 	icon_state = "id_large"
 	startswith = list(/obj/item/card/id = 14)
+
 
 /obj/item/storage/box/handcuffs
 	name = "box of spare handcuffs"
@@ -365,19 +421,23 @@
 	icon_state = "handcuff"
 	startswith = list(/obj/item/handcuffs = 7)
 
+
 /obj/item/storage/box/mousetraps
 	name = "box of Pest-B-Gon mousetraps"
 	desc = "<B><span style='color: red'>WARNING:</span></B> <I>Keep out of reach of children</I>."
 	icon_state = "mousetraps"
 	startswith = list(/obj/item/device/assembly/mousetrap = 6)
 
+
 /obj/item/storage/box/mousetraps/empty
 	startswith = null
+
 
 /obj/item/storage/box/pillbottles
 	name = "box of pill bottles"
 	desc = "It has pictures of pill bottles on its front."
 	startswith = list(/obj/item/storage/pill_bottle = 7)
+
 
 /obj/item/storage/box/snappops
 	name = "snap pop box"
@@ -386,6 +446,7 @@
 	icon_state = "spbox"
 	can_hold = list(/obj/item/toy/snappop)
 	startswith = list(/obj/item/toy/snappop = 8)
+
 
 /obj/item/storage/box/autoinjectors
 	name = "box of injectors"
@@ -402,15 +463,19 @@
 	item_state = "syringe_kit"
 	use_to_pickup = 1 // for picking up broken bulbs, not that most people will try
 
+
 /obj/item/storage/box/lights/Initialize()
 	. = ..()
 	make_exact_fit()
 
+
 /obj/item/storage/box/lights/bulbs
 	startswith = list(/obj/item/light/bulb = 21)
 
+
 /obj/item/storage/box/lights/bulbs/empty
 	startswith = null
+
 
 /obj/item/storage/box/lights/tubes
 	name = "box of replacement tubes"
@@ -418,11 +483,13 @@
 	startswith = list(/obj/item/light/tube = 17,
 					/obj/item/light/tube/large = 4)
 
+
 /obj/item/storage/box/lights/tubes/random
 	name = "box of replacement tubes -- party pack"
 	icon_state = "lighttube"
 	startswith = list(/obj/item/light/tube/party = 17,
 					/obj/item/light/tube/large/party = 4)
+
 
 /obj/item/storage/box/lights/tubes/empty
 	startswith = null
@@ -434,8 +501,10 @@
 					/obj/item/light/tube/large = 4,
 					/obj/item/light/bulb = 5)
 
+
 /obj/item/storage/box/lights/mixed/empty
 	startswith = null
+
 
 /obj/item/storage/box/glowsticks
 	name = "box of mixed glowsticks"
@@ -443,6 +512,7 @@
 	startswith = list(/obj/item/device/flashlight/flare/glowstick = 1, /obj/item/device/flashlight/flare/glowstick/red = 1,
 					/obj/item/device/flashlight/flare/glowstick/blue = 1, /obj/item/device/flashlight/flare/glowstick/orange = 1,
 					/obj/item/device/flashlight/flare/glowstick/yellow = 1, /obj/item/device/flashlight/flare/glowstick/random = 1)
+
 
 /obj/item/storage/box/greenglowsticks
 	name = "box of green glowsticks"
@@ -460,6 +530,7 @@
 	startswith = list(/obj/item/reagent_containers/food/snacks/checker = 12,
 					/obj/item/reagent_containers/food/snacks/checker/red = 12)
 
+
 /obj/item/storage/box/checkers/chess
 	name = "black chess box"
 	desc = "This box holds all the pieces needed for the black side of the chess board."
@@ -470,6 +541,7 @@
 				/obj/item/reagent_containers/food/snacks/checker/rook = 2,
 				/obj/item/reagent_containers/food/snacks/checker/queen = 1,
 				/obj/item/reagent_containers/food/snacks/checker/king = 1)
+
 
 /obj/item/storage/box/checkers/chess/red
 	name = "red chess box"
@@ -495,10 +567,12 @@
 	desc = "A box full of engineering armbands. For use in emergencies when provisional engineering peronnel are needed."
 	startswith = list(/obj/item/clothing/accessory/armband/engine = 5)
 
+
 /obj/item/storage/box/armband/med
 	name = "box of spare medical armbands"
 	desc = "A box full of medical armbands. For use in emergencies when provisional medical personnel are needed."
 	startswith = list(/obj/item/clothing/accessory/armband/med = 5)
+
 
 /obj/item/storage/box/imprinting
 	name = "box of education implants"
@@ -508,6 +582,7 @@
 		/obj/item/implantpad,
 		/obj/item/implantcase/imprinting = 3
 		)
+
 
 /obj/item/storage/box/detergent
 	name = "detergent pods bag"

--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -322,7 +322,7 @@
 	caliber = CALIBER_RIFLE_MILITARY
 	matter = list(MATERIAL_STEEL = 1800)
 	ammo_type = /obj/item/ammo_casing/rifle/military
-	max_ammo = 15
+	max_ammo = 18
 	multiple_sprites = 1
 
 /obj/item/ammo_magazine/mil_rifle/heavy
@@ -339,7 +339,7 @@
 	icon_state = "bullpup_light"
 	labels = list("light")
 	ammo_type = /obj/item/ammo_casing/rifle/military/light
-	max_ammo = 20
+	max_ammo = 14
 
 /obj/item/ammo_magazine/mil_rifle/light/empty
 	initial_ammo = 0

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -321,7 +321,7 @@
 				attack_mob(M, distance)
 
 	//penetrating projectiles can pass through things that otherwise would not let them
-	if(!passthrough && penetrating > 0)
+	if(!passthrough && penetrating > 3)
 		if(check_penetrate(A))
 			passthrough = 1
 		penetrating--

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -157,7 +157,7 @@
 	fire_sound = 'sound/weapons/gunshot/gunshot_4mm.ogg'
 	damage = 23
 	penetrating = 1
-	armor_penetration = 70
+	armor_penetration = 40
 	embed = FALSE
 	distance_falloff = 2
 
@@ -208,7 +208,6 @@
 	fire_sound = 'sound/weapons/gunshot/gunshot3.ogg'
 	damage = 45
 	armor_penetration = 25
-	penetration_modifier = 1.5
 	penetrating = 1
 	distance_falloff = 1.5
 
@@ -216,7 +215,7 @@
 	fire_sound = 'sound/weapons/gunshot/gunshot2.ogg'
 	damage = 40
 	armor_penetration = 35
-	penetration_modifier = 1
+	distance_falloff = 1
 
 /obj/item/projectile/bullet/rifle/shell
 	fire_sound = 'sound/weapons/gunshot/sniper.ogg'

--- a/maps/torch/structures/closets/misc.dm
+++ b/maps/torch/structures/closets/misc.dm
@@ -95,30 +95,9 @@
 
 /obj/structure/closet/secure_closet/guncabinet/sidearm/WillContain()
 	return list(
-			/obj/item/clothing/accessory/storage/holster/thigh = 2,
-			/obj/item/gun/projectile/pistol/m22f/empty = 2,
-			/obj/item/storage/box/ammo/doublestack
-	)
-
-/obj/structure/closet/secure_closet/guncabinet/sidearm/small
-	name = "personal sidearm cabinet"
-
-/obj/structure/closet/secure_closet/guncabinet/sidearm/small/WillContain()
-	return list(
-			/obj/item/gun/projectile/pistol/m19/empty = 4,
-			/obj/item/storage/box/ammo/pistol = 1
-	)
-
-/obj/structure/closet/secure_closet/guncabinet/sidearm/combined
-	name = "combined sidearm cabinet"
-
-/obj/structure/closet/secure_closet/guncabinet/sidearm/combined/WillContain()
-	return list(
-		/obj/item/storage/belt/holster/general = 4,
-		/obj/item/storage/box/ammo/pistol = 1,
-		/obj/item/storage/box/ammo/doublestack = 1,
-		/obj/item/gun/projectile/pistol/m19/empty = 2,
-		/obj/item/gun/projectile/pistol/m22f/empty = 2
+		/obj/item/clothing/accessory/storage/holster/thigh = 3,
+		/obj/item/gun/projectile/pistol/m19/empty = 3,
+		/obj/item/storage/box/ammo/pistol = 2
 	)
 
 /obj/structure/closet/secure_closet/guncabinet/PPE
@@ -128,7 +107,8 @@
 /obj/structure/closet/secure_closet/guncabinet/PPE/WillContain()
 	return list(
 		/obj/item/gun/projectile/pistol/m19/empty = 3,
-		/obj/item/storage/box/ammo/pistol = 1,
+		/obj/item/storage/box/ammo/pistol = 2,
 		/obj/item/clothing/suit/armor/pcarrier/medium/command = 3,
-		/obj/item/clothing/head/helmet/solgov/command = 3
+		/obj/item/clothing/head/helmet/solgov/command = 3,
+		/obj/item/clothing/accessory/storage/holster/thigh = 3
 	)

--- a/maps/torch/structures/closets/security.dm
+++ b/maps/torch/structures/closets/security.dm
@@ -85,8 +85,8 @@
 		/obj/item/material/knife/folding/swiss/officer,
 		/obj/item/device/personal_shield,
 		/obj/item/storage/backpack/dufflebag/sec,
-		/obj/item/gun/projectile/pistol/m22f/empty,
-		/obj/item/ammo_magazine/pistol/double/rubber = 3
+		/obj/item/gun/projectile/pistol/m19/empty,
+		/obj/item/ammo_magazine/pistol/rubber = 3
 	)
 
 /obj/structure/closet/secure_closet/brigchief
@@ -113,8 +113,8 @@
 		/obj/item/device/flashlight/maglight,
 		/obj/item/material/knife/folding/swiss/sec,
 		/obj/item/storage/backpack/dufflebag/sec,
-		/obj/item/gun/projectile/pistol/m22f/empty,
-		/obj/item/ammo_magazine/pistol/double/rubber = 3
+		/obj/item/gun/projectile/pistol/m19/empty,
+		/obj/item/ammo_magazine/pistol/rubber = 3
 	)
 
 /obj/structure/closet/secure_closet/forensics

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -4862,7 +4862,7 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/firstdeck)
 "aiS" = (
-/obj/structure/closet/secure_closet/guncabinet/sidearm/small,
+/obj/structure/closet/secure_closet/guncabinet/sidearm,
 /obj/effect/floor_decal/techfloor{
 	dir = 5
 	},
@@ -9114,19 +9114,18 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
 "aEw" = (
-/obj/effect/floor_decal/techfloor,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/effect/floor_decal/corner/red{
 	dir = 5
 	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
 /turf/simulated/floor/tiled/dark,
-/area/security/secure_storage)
+/area/security/armoury)
 "aEC" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -10372,12 +10371,14 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/firstdeck/centralport)
 "aKv" = (
-/obj/machinery/alarm{
-	pixel_y = 24
-	},
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/corner/red{
-	dir = 5
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/storage/box/ammo/pistol,
+/obj/item/storage/box/ammo/pistol,
+/obj/item/storage/box/ammo/pistol,
+/obj/item/storage/box/ammo/pistol,
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
@@ -10389,13 +10390,6 @@
 /obj/item/device/flashlight/flare,
 /obj/item/device/flashlight/flare,
 /obj/item/device/flashlight/flare,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "aKy" = (
@@ -10403,6 +10397,8 @@
 	dir = 8;
 	pixel_x = 21
 	},
+/obj/structure/table/steel,
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "aKA" = (
@@ -10569,13 +10565,8 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "aLw" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -10829,9 +10820,15 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury)
 "aMC" = (
-/obj/machinery/light,
+/obj/structure/table/rack,
+/obj/item/storage/box/ammo/doublestack/rubber,
+/obj/item/storage/box/ammo/doublestack/rubber,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/dark,
-/area/security/storage)
+/area/security/secure_storage)
 "aMD" = (
 /obj/effect/floor_decal/corner/red/three_quarters,
 /obj/item/device/radio/intercom/department/security{
@@ -11308,37 +11305,53 @@
 	},
 /area/thruster/d1port)
 "aOE" = (
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
 /obj/effect/floor_decal/techfloor{
-	dir = 8
+	dir = 1
 	},
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/dark,
+/area/security/secure_storage)
+"aOF" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/armoury)
-"aOF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secure_storage)
 "aOG" = (
 /obj/structure/table/rack,
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/accessory/arm_guards/ablative,
+/obj/item/clothing/accessory/arm_guards/ablative,
+/obj/item/clothing/accessory/leg_guards/ablative,
+/obj/item/clothing/accessory/leg_guards/ablative,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/clothing/head/helmet/ablative,
+/obj/item/clothing/head/helmet/ablative,
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/rotating_alarm/security_alarm{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
 /area/security/secure_storage)
 "aOI" = (
 /obj/structure/hygiene/sink{
@@ -11437,18 +11450,14 @@
 /turf/simulated/wall/ocp_wall,
 /area/thruster/d1port)
 "aPu" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 21
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
+/obj/structure/table/rack,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/item/shield/riot,
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/secure_storage)
 "aPv" = (
 /obj/structure/hygiene/toilet{
 	dir = 4
@@ -14004,11 +14013,14 @@
 /turf/space,
 /area/space)
 "aWQ" = (
-/obj/structure/table/rack,
-/obj/item/gun/projectile/shotgun/pump/empty,
-/obj/item/gun/projectile/shotgun/pump/empty,
+/obj/structure/closet/secure_closet/guncabinet/sidearm,
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -28
+	},
+/obj/structure/cable/green,
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "aXb" = (
 /obj/structure/sign/solgov{
@@ -14120,20 +14132,11 @@
 /turf/simulated/floor/tiled/freezer,
 /area/security/brig)
 "bii" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+/obj/effect/floor_decal/techfloor{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/storage)
+/area/security/armoury)
 "biu" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -14330,12 +14333,13 @@
 /turf/simulated/floor/plating,
 /area/security/wing)
 "brN" = (
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/barrier,
 /obj/machinery/light{
-	dir = 4
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/turf/simulated/floor/tiled/dark/monotile,
+/area/security/storage)
 "bta" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 1
@@ -14357,13 +14361,13 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/questioning)
 "buX" = (
-/obj/structure/table/rack,
-/obj/item/storage/box/ammo/smg/rubber,
-/obj/item/storage/box/ammo/smg/rubber,
-/obj/item/storage/box/ammo/smg/rubber,
-/obj/item/storage/box/ammo/smg/rubber,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 21
+	},
+/obj/machinery/mech_recharger,
+/obj/effect/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "bvI" = (
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
@@ -14547,18 +14551,17 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftstarboard)
 "bGh" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Security Armory"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/simulated/floor/tiled/steel_ridged,
+/obj/effect/floor_decal/corner/red{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
 /area/security/secure_storage)
 "bGZ" = (
 /obj/effect/floor_decal/sign/or1,
@@ -15709,17 +15712,6 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/item/airlock_brace,
 /obj/item/airlock_brace,
 /obj/item/airlock_brace,
@@ -16069,16 +16061,12 @@
 /turf/simulated/floor/tiled/dark,
 /area/medical/foyer/storeroom)
 "dIw" = (
-/obj/effect/floor_decal/corner/red{
-	dir = 9
+/obj/structure/sign/warning/secure_area/armory{
+	dir = 1;
+	pixel_y = -32
 	},
 /obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secure_storage)
@@ -16208,23 +16196,17 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
 "dPr" = (
-/obj/structure/sign/warning/secure_area/armory{
-	dir = 1;
-	pixel_y = -32
-	},
 /obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/storage)
+/area/security/armoury)
 "dPA" = (
 /obj/effect/floor_decal/corner/red{
 	dir = 10
@@ -16545,9 +16527,6 @@
 	pixel_x = -4;
 	pixel_y = -4
 	},
-/obj/machinery/light{
-	dir = 1
-	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "emb" = (
@@ -16630,16 +16609,10 @@
 /area/hallway/primary/firstdeck/center)
 "eqZ" = (
 /obj/effect/floor_decal/techfloor{
-	dir = 6
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 1
-	},
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 8
+	dir = 5
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/secure_storage)
+/area/security/armoury)
 "erb" = (
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -16658,9 +16631,6 @@
 /area/medical/sleeper)
 "etI" = (
 /obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red{
 	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
@@ -16817,6 +16787,18 @@
 /obj/effect/floor_decal/corner/pink/mono,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/sleeper)
+"eHp" = (
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/obj/effect/floor_decal/techfloor,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/secure_storage)
 "eIb" = (
 /obj/structure/curtain/open/shower,
 /obj/structure/hygiene/shower{
@@ -16900,6 +16882,19 @@
 /obj/effect/floor_decal/industrial/hatch/blue,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/surgery)
+"ePu" = (
+/obj/structure/table/rack,
+/obj/item/clothing/accessory/leg_guards/ballistic,
+/obj/item/clothing/accessory/leg_guards/ballistic,
+/obj/item/clothing/accessory/arm_guards/ballistic,
+/obj/item/clothing/accessory/arm_guards/ballistic,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/head/helmet/ballistic,
+/obj/item/clothing/head/helmet/ballistic,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/security/secure_storage)
 "eQK" = (
 /obj/effect/floor_decal/techfloor{
 	dir = 9
@@ -18336,10 +18331,20 @@
 "htK" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/storage/box/ammo/shotgunammo,
-/obj/item/storage/box/ammo/shotgunammo,
-/obj/item/gun/projectile/shotgun/pump/combat/empty,
-/obj/item/gun/projectile/shotgun/pump/combat/empty,
+/obj/item/storage/box/ammo/light_bullpup,
+/obj/item/storage/box/ammo/light_bullpup,
+/obj/item/gun/projectile/automatic/bullpup_rifle/light{
+	starts_loaded = 0
+	},
+/obj/item/gun/projectile/automatic/bullpup_rifle/light{
+	starts_loaded = 0
+	},
+/obj/item/gun/projectile/automatic/bullpup_rifle/light{
+	starts_loaded = 0
+	},
+/obj/item/gun/projectile/automatic/bullpup_rifle/light{
+	starts_loaded = 0
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
 "hub" = (
@@ -18364,11 +18369,18 @@
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/entry)
 "huf" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4;
-	level = 2
+/obj/structure/table/rack{
+	dir = 4
 	},
-/turf/simulated/floor/tiled/dark,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/smokes,
+/obj/item/storage/box/smokes,
+/obj/machinery/rotating_alarm/security_alarm{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "hvb" = (
 /obj/machinery/door/firedoor,
@@ -18663,17 +18675,12 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/development)
 "hLf" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
+/obj/effect/floor_decal/techfloor{
+	dir = 1
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/effect/floor_decal/techfloor,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/secure_storage)
 "hLD" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -18684,7 +18691,7 @@
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
 /obj/item/gun/energy/ionrifle,
-/obj/item/gun/energy/ionrifle/small,
+/obj/item/gun/energy/ionrifle,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
 "hOZ" = (
@@ -18755,6 +18762,13 @@
 /obj/item/clothing/accessory/leg_guards,
 /obj/item/clothing/accessory/arm_guards,
 /obj/item/clothing/accessory/arm_guards,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "hUE" = (
@@ -18798,22 +18812,10 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/hardstorage/aux)
 "hWR" = (
-/obj/structure/table/rack,
-/obj/item/gun/projectile/automatic/sec_smg/empty,
-/obj/item/gun/projectile/automatic/sec_smg/empty,
-/obj/item/gun/projectile/automatic/sec_smg/empty,
-/obj/item/gun/projectile/automatic/sec_smg/empty,
-/obj/machinery/power/apc{
-	dir = 8;
-	name = "west bump";
-	pixel_x = -24
+/obj/effect/floor_decal/techfloor{
+	dir = 9
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/structure/cable/green{
-	d2 = 4;
-	icon_state = "0-4"
-	},
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "hYM" = (
 /obj/structure/cable/green{
@@ -19330,19 +19332,14 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/development)
 "iLA" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+/obj/item/device/radio/intercom/department/security{
+	pixel_y = 23
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
+/obj/effect/floor_decal/techfloor{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/storage)
+/turf/simulated/floor/tiled/dark,
+/area/security/secure_storage)
 "iLB" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/machinery/door/firedoor,
@@ -19653,19 +19650,11 @@
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
 "jft" = (
-/obj/structure/table/rack{
-	dir = 4
+/obj/effect/floor_decal/techfloor{
+	dir = 9
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/smokes,
-/obj/item/storage/box/smokes,
-/obj/machinery/rotating_alarm/security_alarm{
-	dir = 8
-	},
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/storage)
+/turf/simulated/floor/tiled/dark,
+/area/security/secure_storage)
 "jhb" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass/civilian,
@@ -19673,24 +19662,15 @@
 /area/hallway/primary/firstdeck/aft)
 "jhf" = (
 /obj/structure/table/rack,
-/obj/item/clothing/accessory/leg_guards/ballistic,
-/obj/item/clothing/accessory/leg_guards/ballistic,
-/obj/item/clothing/accessory/arm_guards/ballistic,
-/obj/item/clothing/accessory/arm_guards/ballistic,
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/head/helmet/ballistic,
-/obj/item/clothing/head/helmet/ballistic,
-/obj/structure/cable/green{
-	d2 = 8;
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "east bump";
-	pixel_x = 24
-	},
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/head/helmet/riot,
 /obj/effect/floor_decal/industrial/outline/grey,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 21
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/security/secure_storage)
 "jhq" = (
@@ -20853,19 +20833,19 @@
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "kCN" = (
+/obj/machinery/door/firedoor,
 /obj/structure/cable/green{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/door/airlock/highsecurity{
+	name = "Security Storage"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/turf/simulated/floor/tiled/dark,
-/area/security/storage)
+/turf/simulated/floor/tiled/steel_ridged,
+/area/security/secure_storage)
 "kDb" = (
 /obj/effect/floor_decal/industrial/warning{
 	icon_state = "warning"
@@ -21102,19 +21082,12 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/substation/firstdeck)
 "kSs" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 8
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 6
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/structure/table/rack,
+/obj/item/gun/energy/ionrifle/small,
+/obj/item/gun/energy/ionrifle/small,
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
-/area/security/armoury)
+/area/security/secure_storage)
 "kTb" = (
 /obj/effect/floor_decal/corner/pink/mono,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
@@ -21251,22 +21224,19 @@
 /turf/simulated/floor/tiled/monotile,
 /area/assembly/chargebay)
 "lcI" = (
-/obj/structure/table/rack,
-/obj/machinery/camera/network/security{
-	c_tag = "Security - Brig Armory";
-	dir = 8
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
 	},
-/obj/item/clothing/accessory/arm_guards/ablative,
-/obj/item/clothing/accessory/arm_guards/ablative,
-/obj/item/clothing/accessory/leg_guards/ablative,
-/obj/item/clothing/accessory/leg_guards/ablative,
-/obj/item/clothing/suit/armor/laserproof,
-/obj/item/clothing/suit/armor/laserproof,
-/obj/item/clothing/head/helmet/ablative,
-/obj/item/clothing/head/helmet/ablative,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/security/secure_storage)
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "lcL" = (
 /obj/machinery/door/window/brigdoor/westleft{
 	dir = 2;
@@ -21898,6 +21868,10 @@
 "mav" = (
 /turf/simulated/wall/prepainted,
 /area/rnd/office)
+"maU" = (
+/obj/effect/floor_decal/techfloor,
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "mbb" = (
 /obj/effect/floor_decal/floordetail/edgedrain{
 	dir = 10
@@ -23921,19 +23895,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/foreport)
 "ozG" = (
-/obj/machinery/door/airlock/highsecurity{
-	name = "Security Armory"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/machinery/door/firedoor,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/steel_ridged,
-/area/security/armoury)
+/obj/structure/table/rack,
+/obj/item/storage/box/ammo/pistol/rubber,
+/obj/item/storage/box/ammo/pistol/rubber,
+/obj/item/storage/box/ammo/pistol/rubber,
+/obj/item/storage/box/ammo/pistol/rubber,
+/obj/effect/floor_decal/industrial/outline/grey,
+/turf/simulated/floor/tiled/dark,
+/area/security/secure_storage)
 "oAp" = (
 /obj/effect/floor_decal/corner/research{
 	dir = 10
@@ -23956,11 +23925,8 @@
 "oBI" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/storage/box/ammo/smg,
-/obj/item/storage/box/ammo/smg,
-/obj/item/gun/projectile/automatic/sec_smg/empty,
-/obj/item/gun/projectile/automatic/sec_smg/empty,
-/obj/item/gun/projectile/automatic/sec_smg/empty,
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/command/armoury/tactical)
 "oBZ" = (
@@ -24313,11 +24279,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/secure_storage)
 "oXx" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/effect/floor_decal/corner/red{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secure_storage)
@@ -24578,13 +24548,13 @@
 /area/rnd/research)
 "pud" = (
 /obj/structure/table/rack,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
-/obj/item/shield/riot,
+/obj/item/gun/projectile/automatic/sec_smg/empty,
+/obj/item/gun/projectile/automatic/sec_smg/empty,
+/obj/item/gun/projectile/automatic/sec_smg/empty,
+/obj/item/gun/projectile/automatic/sec_smg/empty,
 /obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
-/area/security/secure_storage)
+/area/security/armoury)
 "puw" = (
 /obj/effect/floor_decal/industrial/hatch/yellow,
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -24645,11 +24615,14 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
 "pxv" = (
+/obj/structure/table/rack,
+/obj/item/storage/box/ammo/smg/rubber,
+/obj/item/storage/box/ammo/smg/rubber,
+/obj/item/storage/box/ammo/smg/rubber,
+/obj/item/storage/box/ammo/smg/rubber,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/flasher/portable,
-/obj/machinery/light,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/security/storage)
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "pyb" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
@@ -25468,12 +25441,19 @@
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "qyX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/light{
-	dir = 8
+/obj/machinery/door/airlock/highsecurity{
+	name = "Security Armory"
 	},
-/turf/simulated/floor/tiled/dark,
-/area/security/secure_storage)
+/obj/machinery/door/firedoor,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/security/armoury)
 "qzb" = (
 /obj/machinery/atmospherics/pipe/simple/visible,
 /obj/machinery/meter,
@@ -25891,21 +25871,19 @@
 /turf/simulated/wall/prepainted,
 /area/security/detectives_office)
 "qWF" = (
-/obj/structure/table/rack,
-/obj/machinery/rotating_alarm/security_alarm{
-	dir = 8
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/item/storage/box/ammo/pistol/rubber,
-/obj/item/storage/box/ammo/pistol/rubber,
-/obj/item/storage/box/ammo/pistol/rubber,
-/obj/item/storage/box/ammo/pistol/rubber,
-/obj/machinery/camera/network/security{
-	c_tag = "Security - Secure Equipment";
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/security/secure_storage)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 9
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "qYb" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -25998,11 +25976,17 @@
 /area/rnd/xenobiology/xenoflora)
 "rby" = (
 /obj/structure/table/rack,
-/obj/item/gun/energy/ionrifle/small,
-/obj/item/gun/energy/ionrifle/small,
+/obj/item/gun/projectile/shotgun/pump/empty,
+/obj/item/gun/projectile/shotgun/pump/empty,
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/security/secure_storage)
+/obj/machinery/rotating_alarm/security_alarm{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "rcb" = (
 /obj/effect/floor_decal/corner/research/mono,
 /obj/effect/floor_decal/industrial/warning{
@@ -26622,11 +26606,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralport)
 "rKP" = (
-/obj/structure/table/steel,
-/obj/item/storage/box/trackimp,
-/obj/machinery/alarm{
+/obj/structure/sign/warning/secure_area/armory{
 	dir = 1;
-	pixel_y = -22
+	pixel_y = -32
+	},
+/obj/effect/floor_decal/techfloor{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secure_storage)
@@ -27478,16 +27463,10 @@
 /turf/simulated/floor/tiled/freezer,
 /area/rnd/xenobiology/xenoflora)
 "sBg" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4;
-	level = 2
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 10
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 4
-	},
+/obj/structure/table/rack,
+/obj/item/storage/box/ammo/beanbags,
+/obj/item/storage/box/ammo/beanbags,
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "sCb" = (
@@ -27592,8 +27571,8 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/locker)
 "sHN" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/rotating_alarm/security_alarm{
+	dir = 1
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/storage)
@@ -28037,17 +28016,11 @@
 /turf/simulated/open,
 /area/maintenance/firstdeck/aftport)
 "tgT" = (
-/obj/machinery/atmospherics/unary/vent_scrubber/on{
+/obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/item/device/radio/intercom/department/security{
-	pixel_y = 23
-	},
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
 /obj/effect/floor_decal/corner/red{
-	dir = 9
+	dir = 6
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/secure_storage)
@@ -28624,26 +28597,26 @@
 	dir = 4
 	},
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+/obj/item/clothing/accessory/arm_guards/navy,
+/obj/item/clothing/accessory/arm_guards/navy,
+/obj/item/clothing/accessory/leg_guards/navy,
+/obj/item/clothing/accessory/leg_guards/navy,
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 6
 	},
-/obj/item/clothing/accessory/arm_guards/navy,
-/obj/item/clothing/accessory/arm_guards/navy,
-/obj/item/clothing/accessory/leg_guards/navy,
-/obj/item/clothing/accessory/leg_guards/navy,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 6
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "ubf" = (
@@ -28709,12 +28682,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/aftport)
 "uie" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 9
-	},
-/obj/effect/floor_decal/techfloor,
-/obj/effect/floor_decal/corner/red{
-	dir = 5
+/obj/structure/table/rack,
+/obj/effect/floor_decal/industrial/outline/grey,
+/obj/item/storage/box/ammo/stunshells,
+/obj/item/storage/box/ammo/stunshells,
+/obj/machinery/camera/network/security{
+	c_tag = "Security - Brig Secure Armory"
 	},
 /turf/simulated/floor/tiled/dark,
 /area/security/armoury)
@@ -28722,16 +28695,16 @@
 /turf/simulated/wall/prepainted,
 /area/medical/equipstorage)
 "ujx" = (
-/obj/machinery/light{
-	dir = 1
-	},
+/obj/machinery/flasher/portable,
+/obj/effect/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "umz" = (
-/obj/structure/table/rack,
-/obj/item/storage/box/ammo/doublestack,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "umI" = (
 /obj/item/device/radio/intercom{
@@ -28772,14 +28745,12 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/firstdeck/center)
 "usN" = (
-/obj/effect/floor_decal/techfloor{
-	dir = 4
-	},
-/obj/effect/floor_decal/corner/red{
-	dir = 9
+/obj/machinery/light,
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/dark,
-/area/security/secure_storage)
+/area/security/storage)
 "usV" = (
 /obj/structure/railing/mapped{
 	dir = 8;
@@ -28993,6 +28964,23 @@
 /obj/effect/floor_decal/corner/red/half,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/fore)
+"uPo" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark/monotile,
+/area/security/storage)
 "uRO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -29344,12 +29332,14 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/equipstorage)
 "vFa" = (
-/obj/structure/table/rack,
-/obj/item/storage/box/ammo/doublestack/rubber,
-/obj/item/storage/box/ammo/doublestack/rubber,
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/security/secure_storage)
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 6
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/armoury)
 "vFj" = (
 /obj/structure/table/glass,
 /obj/item/device/scanner/reagent,
@@ -29445,15 +29435,15 @@
 /turf/simulated/wall/r_wall/prepainted,
 /area/security/locker)
 "vPW" = (
-/obj/structure/table/rack,
-/obj/item/storage/box/ammo/pistol,
-/obj/item/storage/box/ammo/pistol,
-/obj/machinery/camera/network/security{
-	c_tag = "Security - Brig Secure Armory";
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/obj/effect/floor_decal/techfloor,
+/obj/effect/floor_decal/techfloor{
 	dir = 1
 	},
-/obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
+/turf/simulated/floor/tiled/dark,
 /area/security/armoury)
 "vTH" = (
 /obj/effect/wallframe_spawn/reinforced/polarized{
@@ -29548,6 +29538,20 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/locker)
+"wbE" = (
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/floor_decal/corner/red{
+	dir = 9
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/dark,
+/area/security/secure_storage)
 "wcQ" = (
 /obj/machinery/pager/security{
 	pixel_x = -25
@@ -30108,12 +30112,16 @@
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/firstdeck/centralstarboard)
 "xFx" = (
-/obj/structure/table/rack,
-/obj/item/storage/box/ammo/beanbags,
-/obj/item/storage/box/ammo/beanbags,
+/obj/structure/table/steel,
+/obj/item/storage/box/trackimp,
 /obj/effect/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/security/armoury)
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -28
+	},
+/obj/structure/cable/green,
+/turf/simulated/floor/tiled/dark,
+/area/security/secure_storage)
 "xFL" = (
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/robotics_lift)
@@ -37308,7 +37316,7 @@ tAS
 tAS
 tAS
 tAS
-aaa
+tAS
 aaa
 aaa
 aaa
@@ -37511,7 +37519,7 @@ tAS
 tAS
 tAS
 tAS
-aaa
+tAS
 aaa
 aaa
 aaa
@@ -37706,15 +37714,15 @@ tAS
 tAS
 tAS
 tAS
-xRu
-buX
-hWR
-aWQ
-xFx
 tAS
 tAS
 tAS
-aaa
+tAS
+tAS
+tAS
+tAS
+tAS
+tAS
 aaa
 aaa
 aaa
@@ -37905,18 +37913,18 @@ sik
 nli
 nli
 cZi
-cZi
+brN
 aLv
-pxv
-xRu
+tiQ
+oXv
 aOE
 kSs
-etI
+xRu
 sBg
 vPW
+rEK
 tAS
 tAS
-aaa
 aaa
 aaa
 aaa
@@ -38108,17 +38116,17 @@ nli
 elT
 cZi
 cZi
-aLz
-iLA
+ujx
+tiQ
 ozG
 hLf
 aPu
-brN
+xRu
 uie
 umz
+pxv
 tAS
 tAS
-aaa
 aaa
 aaa
 aaa
@@ -38308,19 +38316,19 @@ vMH
 vMH
 xCS
 wvZ
-huf
+enM
 enM
 sHN
-dPr
-xRu
-xRu
-xRu
+tiQ
+aMC
+eHp
+xFx
 xRu
 aKv
-rEK
+dPr
+aWQ
 tAS
 tAS
-aaa
 aaa
 aaa
 aaa
@@ -38513,16 +38521,16 @@ gGO
 daN
 aKw
 aLw
-bii
 hzl
-oXv
+jft
+wbE
 rKP
 xRu
-xRu
-xRu
+hWR
+lcI
+bii
 tAS
 tAS
-aaa
 aaa
 aaa
 aaa
@@ -38714,7 +38722,7 @@ aMT
 kss
 tZR
 hUc
-aLz
+uPo
 kCN
 bGh
 aOF
@@ -38722,9 +38730,9 @@ oXx
 qyX
 aEw
 qWF
+maU
 tAS
 tAS
-aaa
 aaa
 aaa
 aaa
@@ -38913,20 +38921,20 @@ cor
 cor
 suM
 aMT
-ujx
+aLz
 uRO
 enM
-enM
-aMC
-tiQ
+usN
+hzl
+iLA
 tgT
 dIw
-usN
+xRu
 eqZ
 vFa
+etI
 tAS
 tAS
-aaa
 aaa
 aaa
 aaa
@@ -39118,17 +39126,17 @@ aMT
 lRa
 cxk
 aKy
-aLz
-jft
+huf
 tiQ
+ePu
 aOG
 jhf
-lcI
+xRu
 pud
 rby
+buX
 tAS
 tAS
-aaa
 aaa
 aaa
 aaa
@@ -39321,16 +39329,16 @@ mfg
 hbP
 aMT
 aMT
-aMT
-tiQ
-tiQ
-tiQ
-tiQ
-tiQ
+aNH
+aNH
+aNH
+aNH
+aNH
+aIr
 tAS
 tAS
 tAS
-aaa
+tAS
 aaa
 aaa
 aaa
@@ -39532,7 +39540,7 @@ vrM
 tAS
 tAS
 tAS
-aaa
+tAS
 aaa
 aaa
 aaa

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -7789,7 +7789,7 @@
 	dir = 6
 	},
 /obj/effect/floor_decal/industrial/outline/yellow,
-/obj/structure/closet/secure_closet/guncabinet/sidearm/small,
+/obj/structure/closet/secure_closet/guncabinet/sidearm,
 /turf/simulated/floor/tiled/techfloor,
 /area/aquila/storage)
 "tR" = (
@@ -13078,7 +13078,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/closet/secure_closet/guncabinet/sidearm/combined,
+/obj/structure/closet/secure_closet/guncabinet/sidearm,
 /obj/structure/sign/warning/nosmoking_1{
 	dir = 4;
 	pixel_x = -37


### PR DESCRIPTION
:cl: Jux, Ryan180602
maptweak: Remaps security armoury.
maptweak: Adds stunshells to sec-armoury.
maptweak: E-arm now contains 4 light bullpups and 2 UNSECURE laser carbines instead of SMGs and Shotguns.
tweak: Various ballistics balance adjustments, see github for details.
tweak: All Torch handguns, except those in E-Arm, are now the m19. Hopefully eliminates magazine confusion.
/:cl:

Remaps it a bit. Also incorporates https://github.com/Baystation12/Baystation12/pull/33909

- Rifles and prototype smgs will no longer wallpen.
- Protosmg no longer has the same armor penetration as an antimaterial rifle.
- Non-military rifle bullets no longer have the same penetration modifier as APDS shells.
- Light bullpup mags now carry 6 less bullets, to 14.
- Heavy bullpup mags carry 3 more, to 18.
- Military rifle ammo has less falloff than non-military.


![image](https://github.com/Baystation12/Baystation12/assets/50071611/dbe02e72-a19b-49ad-9200-723553c097bc)
