### PR TITLE
Make the rest verb lay players instanetely

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -700,6 +700,7 @@ default behaviour is:
 	set category = "IC"
 
 	resting = !resting
+	UpdateLyingBuckledAndVerbStatus()
 	to_chat(src, SPAN_NOTICE("You are now [resting ? "resting" : "getting up"]"))
 
 //called when the mob receives a bright flash


### PR DESCRIPTION
:cl:
tweak: The rest verb changes standing/lying state instantly.
/:cl: