### PR TITLE
Make titlescreen fade out and game fade in

### DIFF
--- a/code/_onclick/hud/fullscreen.dm
+++ b/code/_onclick/hud/fullscreen.dm
@@ -95,6 +95,13 @@
 	screen_loc = "WEST,SOUTH to EAST,NORTH"
 	layer = BLIND_LAYER
 
+/obj/screen/fullscreen/blackout/above_hud
+	icon = 'icons/mob/screen1.dmi'
+	icon_state = "black"
+	screen_loc = "WEST,SOUTH to EAST,NORTH"
+	plane = HUD_PLANE
+	layer = HUD_ABOVE_HUD_LAYER
+
 /obj/screen/fullscreen/impaired
 	icon_state = "impairedoverlay"
 	layer = IMPAIRED_LAYER

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -236,6 +236,12 @@
 
 	SSjobs.assign_role(src, job.title, 1)
 
+	close_spawn_windows()
+	spawning = TRUE
+	GLOB.using_map.fade_titlescreen(client)
+	addtimer(new Callback(src, .proc/latespawn_create_character, job, spawn_turf, spawnpoint), 2 SECONDS)
+
+/mob/new_player/proc/latespawn_create_character(datum/job/job, turf/spawn_turf, datum/spawnpoint/spawnpoint)
 	var/mob/living/character = create_character(spawn_turf)	//creates the human and transfers vars and mind
 	if(!character)
 		return 0

--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -413,6 +413,10 @@
 	new_character.regenerate_icons()
 
 	new_character.key = key		//Manually transfer the key to log them in
+
+	new_character.overlay_fullscreen("init_blackout", /obj/screen/fullscreen/blackout/above_hud)
+	new_character.clear_fullscreen("init_blackout", 30)
+
 	return new_character
 
 /mob/new_player/proc/ViewManifest()

--- a/code/modules/submaps/submap_join.dm
+++ b/code/modules/submaps/submap_join.dm
@@ -60,6 +60,12 @@
 	joining.faction = name
 	job.current_positions++
 
+	joining.close_spawn_windows()
+	joining.spawning = TRUE
+	GLOB.using_map.fade_titlescreen(joining.client)
+	addtimer(new Callback(src, .proc/join_as_create_character, joining, job, spawn_turf), 2 SECONDS)
+
+/datum/submap/proc/join_as_create_character(mob/new_player/joining, datum/job/submap/job, turf/spawn_turf)
 	var/mob/living/character = joining.create_character(spawn_turf)
 	if(istype(character))
 

--- a/html/lobby_titlescreen.html
+++ b/html/lobby_titlescreen.html
@@ -29,4 +29,20 @@
 		<img id="bg-image" src='titlescreen.png'>
 	</body>
 
+	<script>
+		var backgroundImage = document.getElementById("bg-image");
+		function fadeTitlescreen() {
+      // 1/0.04 = 25 iterations
+      // 25*50ms = 1250ms = 1.25s
+      var opacity = 1;
+      var fadeInterval = setInterval(function () {
+        opacity -= 0.04;
+        if (opacity <= 0) {
+          opacity = 0;
+          clearInterval(fadeInterval);
+        }
+        backgroundImage.style.opacity = opacity;
+      }, 50);
+    }
+	</script>
 </html>

--- a/html/lobby_titlescreen.html
+++ b/html/lobby_titlescreen.html
@@ -1,5 +1,8 @@
 <html>
 	<head>
+		<meta http-equiv="Content-Type" content="text/html;charset=UTF-8">
+		<meta http-equiv="X-UA-Compatible" content="IE=IE8">
+		<meta name="viewport" content="width=device-width,initial-scale=1">
 		<style type='text/css'>
 			body, html {
 				margin: 0;
@@ -8,18 +11,22 @@
 				text-align: center;
 				background-color: black;
 			}
-
-			img {
-				display: inline-block;
+			img { border-style: none; }
+			#bg-image {
+				position: absolute;
 				width: auto;
-				height: 100%;
+				height: 100vmin;
+				min-width: 100vmin;
+				min-height: 100vmin;
+				top: 50%;
+				left: 50%;
+				transform: translate(-50%, -50%);
 			}
-
 		</style>
 	</head>
 
 	<body>
-		<img src='titlescreen.png'>
+		<img id="bg-image" src='titlescreen.png'>
 	</body>
 
 </html>

--- a/maps/mapsystem/maps.dm
+++ b/maps/mapsystem/maps.dm
@@ -519,6 +519,9 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 		// Hide title screen, allowing player to see the map
 		winset(C, "lobbybrowser", "is-disabled=true;is-visible=false")
 
+/datum/map/proc/fade_titlescreen(client/C)
+	send_output(C, null, "lobbybrowser:fadeTitlescreen")
+
 /datum/map/proc/roundend_player_status()
 	for(var/mob/Player in GLOB.player_list)
 		if(Player.mind && !isnewplayer(Player))


### PR DESCRIPTION
## Contents
- b6e6f4b **Fade in**
  Makes game fade in from solid black.
- 46f0ad3 **Better titlescreen positioning**
  The titlescreen image stays always in the center of the screen and is never cropped.
- ef6ecf4cbef **Titlescreen fade out**
  Before game fades in, titlescreen will fade out.
  Works only for latejoin.
  <details>
  <summary><i>I have no idea how to make it work on roundstart spawn.</i></summary>

  https://github.com/Baystation12/Baystation12/assets/32931701/7aeeb74f-48ca-404b-84ba-058dd111bf1a

  </details>

## Changelog
```yml
🆑SuhEugene
rscadd: Game fades when player spawns as carbon.
rscadd: Titlescreen fades out on latejoin.
tweak: Pinned titlescreen to the center of the screen.
/🆑
```