### PR TITLE
Fix falldown sound constantly triggering

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -106,9 +106,9 @@
 /mob/living/carbon/human/Weaken(amount)
 	amount *= species.weaken_mod
 	if(amount <= 0 || (MUTATION_HULK in mutations)) return
-	..(amount)
-	if (species?.bodyfall_sound)
+	if (!lying && species?.bodyfall_sound)
 		playsound(loc, species.bodyfall_sound, 50, TRUE, -1)
+	..(amount)
 
 /mob/living/carbon/human/Paralyse(amount)
 	amount *= species.paralysis_mod


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed the fall-down sound constantly triggering in some cases. 
/:cl: