### PR TITLE
Cleans up examination code

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2068,6 +2068,7 @@
 #include "code\modules\mining\machinery\mineral_unloader.dm"
 #include "code\modules\mob\animations.dm"
 #include "code\modules\mob\death.dm"
+#include "code\modules\mob\examinations.dm"
 #include "code\modules\mob\gender.dm"
 #include "code\modules\mob\hear_say.dm"
 #include "code\modules\mob\holder.dm"

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -282,7 +282,7 @@
  */
 /atom/proc/ShiftClick(mob/user)
 	if (user.client && user.client.eye == user)
-		user.examinate(src)
+		examinate(user, src)
 		return TRUE
 	return FALSE
 

--- a/code/_onclick/ghost.dm
+++ b/code/_onclick/ghost.dm
@@ -55,7 +55,7 @@
 	if(!istype(user))
 		return
 	if(user.client && user.client.inquisitive_ghost)
-		user.examinate(src)
+		examinate(user, src)
 	return
 
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -366,7 +366,8 @@
  * - `infix` String - String that is appended immediately after the atom's name.
  * - `suffix` String - Additional string appended after the atom's name and infix.
  *
- * Returns boolean.
+ * Returns boolean - The caller always expects TRUE
+ *  This is used rather than SHOULD_CALL_PARENT as it enforces that subtypes of a type that explicitly returns still call parent
  */
 /atom/proc/examine(mob/user, distance, infix = "", suffix = "")
 	//This reformat names to get a/an properly working on item descriptions when they are bloody
@@ -388,6 +389,13 @@
 	else if (distance <= 1 && IsHeatSource())
 		to_chat(user, SPAN_WARNING("It's hot to the touch."))
 
+	return TRUE
+
+/// Works same as /atom/proc/Examine(), only this output comes immediately after any and all made by /atom/proc/Examine()
+/atom/proc/LateExamine(mob/user, distance)
+	SHOULD_NOT_SLEEP(TRUE)
+
+	user.ForensicsExamination(src, distance)
 	return TRUE
 
 /**

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -84,7 +84,7 @@
 /obj/item/device/holowarrant/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	user.visible_message(SPAN_NOTICE("[user] holds up a warrant projector and shows the contents to [M]."), \
 			SPAN_NOTICE("You show the warrant to [M]."))
-	M.examinate(src)
+	examinate(M, src)
 
 /obj/item/device/holowarrant/on_update_icon()
 	if(active)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -251,7 +251,7 @@ var/global/const/NO_EMAG_ACT = -50
 /obj/item/card/id/OnTopic(mob/user, list/href_list)
 	if(href_list["look_at_id"])
 		if(istype(user))
-			user.examinate(src)
+			examinate(user, src)
 			return TOPIC_HANDLED
 
 /obj/item/card/id/examine(mob/user, distance)

--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -408,7 +408,7 @@
 
 /obj/structure/closet/attack_ghost(mob/ghost)
 	if(ghost.client && ghost.client.inquisitive_ghost)
-		ghost.examinate(src)
+		examinate(ghost, src)
 		if (!src.opened)
 			to_chat(ghost, "It contains: [english_list(contents)].")
 

--- a/code/modules/clothing/rings/material.dm
+++ b/code/modules/clothing/rings/material.dm
@@ -33,7 +33,7 @@
 		if(istype(user))
 			var/mob/living/carbon/human/H = get_holder_of_type(src, /mob/living/carbon/human)
 			if(H.Adjacent(user))
-				user.examinate(src)
+				examinate(user, src)
 				return TOPIC_HANDLED
 
 /obj/item/clothing/ring/material/get_examine_line()

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -30,7 +30,7 @@
 /obj/item/clothing/accessory/badge/OnTopic(mob/user, list/href_list)
 	if (href_list["look_at_me"])
 		if (istype(user))
-			user.examinate(src)
+			examinate(user, src)
 			return TOPIC_HANDLED
 
 

--- a/code/modules/detectivework/tools/evidencebag.dm
+++ b/code/modules/detectivework/tools/evidencebag.dm
@@ -98,4 +98,4 @@
 /obj/item/evidencebag/examine(mob/user)
 	. = ..()
 	if (stored_item)
-		user.examinate(stored_item)
+		examinate(user, stored_item)

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -68,7 +68,7 @@
 
 	var/modifiers = params2list(params)
 	if(modifiers["shift"])
-		user.examinate(A)
+		examinate(user, A)
 		return
 
 	if(modifiers["ctrl"])

--- a/code/modules/mob/examinations.dm
+++ b/code/modules/mob/examinations.dm
@@ -1,0 +1,61 @@
+
+/proc/examinate(mob/user, atom/A)
+	if ((is_blind(user) || user.stat) && !isobserver(user))
+		to_chat(user, SPAN_NOTICE("Something is there but you can't see it."))
+		return
+	user.face_atom(A)
+	if (!isghost(user))
+		if (A.loc != user || user.IsHolding(A))
+			for (var/mob/M in viewers(4, user))
+				if (M == user)
+					continue
+				if (M.client && M.client.get_preference_value(/datum/client_preference/examine_messages) == GLOB.PREF_SHOW)
+					if (M.is_blind() || user.is_invisible_to(M))
+						continue
+					to_chat(M, SPAN_SUBTLE("<b>\The [user]</b> looks at \the [A]."))
+	var/distance = INFINITY
+	if (isghost(user) || user.stat == DEAD)
+		distance = 0
+	else
+		var/turf/source_turf = get_turf(user)
+		var/turf/target_turf = get_turf(A)
+		if (source_turf && source_turf.z == target_turf?.z)
+			distance = get_dist(source_turf, target_turf)
+	if (!A.examine(user, distance))
+		crash_with("Improper /examine() override: [log_info_line(A)]")
+	if (!A.LateExamine(user, distance))
+		crash_with("Improper /LateExamine() override: [log_info_line(A)]")
+
+/mob/proc/ForensicsExamination(atom/A, distance)
+	if (!(get_skill_value(SKILL_FORENSICS) >= SKILL_EXPERIENCED && distance <= (get_skill_value(SKILL_FORENSICS) - SKILL_TRAINED)))
+		return
+
+	var/clue = FALSE
+	if (LAZYLEN(A.suit_fibers))
+		to_chat(src, SPAN_NOTICE("You notice some fibers embedded in \the [A]."))
+		clue = TRUE
+	if (LAZYLEN(A.fingerprints))
+		to_chat(src, SPAN_NOTICE("You notice a partial print on \the [A]."))
+		clue = TRUE
+	if (LAZYLEN(A.gunshot_residue))
+		GunshotResidueExamination(A)
+		clue = TRUE
+	// Noticing wiped blood is a bit harder
+	if ((get_skill_value(SKILL_FORENSICS) >= SKILL_MASTER) && LAZYLEN(A.blood_DNA))
+		to_chat(src, SPAN_WARNING("You notice faint blood traces on \the [A]."))
+		clue = TRUE
+	if (clue && has_client_color(/datum/client_color/noir))
+		playsound_local(null, pick('sound/effects/clue1.ogg','sound/effects/clue2.ogg'), 60, is_global = TRUE)
+
+
+/mob/proc/GunshotResidueExamination(atom/A)
+	to_chat(src, SPAN_NOTICE("You notice a faint acrid smell coming from \the [A]."))
+
+/mob/living/GunshotResidueExamination(atom/A)
+	if (isSynthetic())
+		to_chat(src, SPAN_NOTICE("You notice faint black residue on \the [A]."))
+	else
+		to_chat(src, SPAN_NOTICE("You notice a faint acrid smell coming from \the [A]."))
+
+/mob/living/silicon/GunshotResidueExamination(atom/A)
+	to_chat(src, SPAN_NOTICE("You notice faint black residue on \the [A]."))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -385,7 +385,7 @@
 	if (href_list["lookitem"])
 		var/obj/item/I = locate(href_list["lookitem"])
 		if(I)
-			src.examinate(I)
+			examinate(src, I)
 			return TOPIC_HANDLED
 	return ..()
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -324,60 +324,11 @@
 	return
 
 
-/mob/verb/examinate(atom/A as mob|obj|turf in view())
+/mob/verb/ExaminateVerb(atom/A as mob|obj|turf in view())
 	set name = "Examine"
 	set category = "IC"
 
-	if((is_blind(src) || usr && usr.stat) && !isobserver(src))
-		to_chat(src, SPAN_NOTICE("Something is there but you can't see it."))
-		return 1
-	face_atom(A)
-	if(!isghost(src))
-		if(A.loc != src || IsHolding(A))
-			for(var/mob/M in viewers(4, src))
-				if(M == src)
-					continue
-				if(M.client && M.client.get_preference_value(/datum/client_preference/examine_messages) == GLOB.PREF_SHOW)
-					if(M.is_blind() || is_invisible_to(M))
-						continue
-					to_chat(M, SPAN_SUBTLE("<b>\The [src]</b> looks at \the [A]."))
-	var/distance = INFINITY
-	if(isghost(src) || stat == DEAD)
-		distance = 0
-	else
-		var/turf/source_turf = get_turf(src)
-		var/turf/target_turf = get_turf(A)
-		if(source_turf && source_turf.z == target_turf?.z)
-			distance = get_dist(source_turf, target_turf)
-	if(!A.examine(src, distance))
-		crash_with("Improper /examine() override: [log_info_line(A)]")
-	if(get_skill_value(SKILL_FORENSICS) >= SKILL_EXPERIENCED && get_dist(src, A) <= (get_skill_value(SKILL_FORENSICS) - SKILL_TRAINED))
-		var/clue
-		if(LAZYLEN(A.suit_fibers))
-			to_chat(src, SPAN_NOTICE("You notice some fibers embedded in \the [A]."))
-			clue = 1
-		if(LAZYLEN(A.fingerprints))
-			to_chat(src, SPAN_NOTICE("You notice a partial print on \the [A]."))
-			clue = 1
-		if(LAZYLEN(A.gunshot_residue))
-			if(isliving(src))
-				var/mob/living/M = src
-				if(M.isSynthetic())
-					to_chat(src, SPAN_NOTICE("You notice faint black residue on \the [A]."))
-				else
-					to_chat(src, SPAN_NOTICE("You notice a faint acrid smell coming from \the [A]."))
-			else if(isrobot(src))
-				to_chat(src, SPAN_NOTICE("You notice faint black residue on \the [A]."))
-			else
-				to_chat(src, SPAN_NOTICE("You notice a faint acrid smell coming from \the [A]."))
-			clue = 1
-		//Noticing wiped blood is a bit harder
-		if((get_skill_value(SKILL_FORENSICS) >= SKILL_MASTER) && LAZYLEN(A.blood_DNA))
-			to_chat(src, SPAN_WARNING("You notice faint blood traces on \The [A]."))
-			clue = 1
-		if(clue && has_client_color(/datum/client_color/noir))
-			playsound_local(null, pick('sound/effects/clue1.ogg','sound/effects/clue2.ogg'), 60, is_global = TRUE)
-
+	examinate(usr, A)
 
 /mob/verb/pointed(atom/A as mob|obj|turf in view())
 	set name = "Point To"

--- a/code/modules/mob/observer/freelook/eye.dm
+++ b/code/modules/mob/observer/freelook/eye.dm
@@ -40,7 +40,7 @@
 	set_dir(ndir)
 	return 1
 
-/mob/observer/eye/examinate()
+/mob/observer/eye/ExaminateVerb()
 	set popup_menu = 0
 	set src = usr.contents
 	return 0

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -217,7 +217,7 @@
 		user.visible_message("\The [user] crumples \the [src] into a ball!")
 		icon_state = "scrap"
 		return
-	user.examinate(src)
+	examinate(user, src)
 
 /obj/item/paper/attack_ai(mob/living/silicon/ai/user)
 	show_content(user)
@@ -226,7 +226,7 @@
 	if(user.zone_sel.selecting == BP_EYES)
 		user.visible_message(SPAN_NOTICE("You show the paper to [M]. "), \
 			SPAN_NOTICE(" [user] holds up a paper and shows it to [M]. "))
-		M.examinate(src)
+		examinate(M, src)
 
 	else if(user.zone_sel.selecting == BP_MOUTH) // lipstick wiping
 		if(ishuman(M))

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -41,7 +41,7 @@ var/global/photo_count = 0
 	id = photo_count++
 
 /obj/item/photo/attack_self(mob/user as mob)
-	user.examinate(src)
+	examinate(user, src)
 
 /obj/item/photo/on_update_icon()
 	overlays.Cut()

--- a/code/modules/power/cable_structure.dm
+++ b/code/modules/power/cable_structure.dm
@@ -100,7 +100,7 @@ By design, d1 is the smallest direction and d2 is the highest
 // Ghost examining the cable -> tells him the power
 /obj/structure/cable/attack_ghost(mob/user)
 	if(user.client && user.client.inquisitive_ghost)
-		user.examinate(src)
+		examinate(user, src)
 		// following code taken from attackby (multitool)
 		if(powernet && (powernet.avail > 0))
 			to_chat(user, SPAN_WARNING("[get_wattage()] in power network."))


### PR DESCRIPTION
/examinate() is again only responsible for pre-checks and calling examination procs
The examination verb is now a stub calling /examinate()
Conducts some general cleanup of the exminate-code

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->