### PR TITLE
More use_grabs, standardizes checks

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -186,37 +186,11 @@
 		return TRUE
 	return ..()
 
-/obj/machinery/sleeper/proc/user_can_move_target_inside(mob/target, mob/user)
-	if(!user.use_sanity_check(src, target))
-		return FALSE
-	if (!istype(target))
-		to_chat(user, SPAN_WARNING("\The [src] cannot handle such a lifeform!"))
-		return FALSE
-	if (user.incapacitated() || !istype(user))
-		return FALSE
-	if (!target.simulated)
-		return FALSE
-	if (inoperable())
-		to_chat(user, SPAN_WARNING("\The [src] is not functioning."))
-		return FALSE
+/obj/machinery/sleeper/user_can_move_target_inside(mob/target, mob/user)
 	if (occupant)
 		to_chat(user, SPAN_WARNING("\The [src] is already occupied!"))
 		return FALSE
-	if (target.abiotic())
-		to_chat(user, SPAN_WARNING("[user == target ? "You" : "[target]"] can't enter \the [src] while wearing abiotic items."))
-		return FALSE
-	if (target.buckled)
-		to_chat(user, SPAN_WARNING("Unbuckle [user == target ? "yourself" : "\the [target]"] before attempting to [user == target ? "enter \the [src]" : "move them"]."))
-		return FALSE
-	if (panel_open)
-		to_chat(user, SPAN_WARNING("Close the maintenance panel before attempting to place [user == target ? "yourself" : "\the [target]"] in \the [src]."))
-		return FALSE
-	for (var/obj/item/grab/grab in target.grabbed_by)
-		if (grab.assailant == user || grab.assailant == target)
-			continue
-		to_chat(user, SPAN_WARNING("\The [target] is being grabbed by [grab.assailant] and can't be placed in \the [src]."))
-		return FALSE
-	return TRUE
+	return ..()
 
 /obj/machinery/sleeper/MouseDrop_T(mob/target, mob/user)
 	if (!CanMouseDrop(target, user) || !ismob(target))

--- a/code/game/machinery/body_scanner.dm
+++ b/code/game/machinery/body_scanner.dm
@@ -114,37 +114,11 @@
 	else
 		icon_state = "body_scanner_2"
 
-/obj/machinery/bodyscanner/proc/user_can_move_target_inside(mob/target, mob/user)
-	if (!user.use_sanity_check(src, target))
-		return FALSE
-	if (!istype(target))
-		to_chat(user, SPAN_WARNING("\The [src] cannot handle such a lifeform!"))
-		return FALSE
-	if (user.incapacitated() || !istype(user))
-		return FALSE
-	if (!target.simulated)
-		return FALSE
-	if (inoperable())
-		to_chat(user, SPAN_WARNING("\The [src] is not functioning."))
-		return FALSE
+/obj/machinery/bodyscanner/user_can_move_target_inside(mob/target, mob/user)
 	if (occupant)
 		to_chat(user, SPAN_WARNING("\The [src] is already occupied!"))
 		return FALSE
-	if (target.abiotic())
-		to_chat(user, SPAN_WARNING("[user == target ? "You" : "[target]"] can't enter \the [src] while wearing abiotic items."))
-		return FALSE
-	if (target.buckled)
-		to_chat(user, SPAN_WARNING("Unbuckle [user == target ? "yourself" : "\the [target]"] before attempting to [user == target ? "enter \the [src]" : "move them"]."))
-		return FALSE
-	if (panel_open)
-		to_chat(user, SPAN_WARNING("Close the maintenance panel before attempting to place [user == target ? "yourself" : "\the [target]"] in \the [src]."))
-		return FALSE
-	for (var/obj/item/grab/grab in target.grabbed_by)
-		if (grab.assailant == user || grab.assailant == target)
-			continue
-		to_chat(user, SPAN_WARNING("\The [target] is being grabbed by [grab.assailant] and can't be placed in \the [src]."))
-		return FALSE
-	return TRUE
+	return ..()
 
 /obj/machinery/bodyscanner/MouseDrop_T(mob/target, mob/user)
 	if (!CanMouseDrop(target, user) || !ismob(target))

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -316,44 +316,14 @@
 	target.remove_grabs_and_pulls()
 	return TRUE
 
-/obj/machinery/atmospherics/unary/cryo_cell/proc/user_can_move_target_inside(mob/target, mob/user)
-	if (!user.use_sanity_check(src, target))
-		return FALSE
-	if (!istype(target))
-		to_chat(user, SPAN_WARNING("\The [src] cannot handle such a lifeform!"))
-		return FALSE
-	if (user.incapacitated() || !istype(user))
-		return FALSE
-	if (!target.simulated)
-		return FALSE
-	if (inoperable())
-		to_chat(user, SPAN_WARNING("\The [src] is not functioning."))
-		return FALSE
+/obj/machinery/atmospherics/unary/cryo_cell/user_can_move_target_inside(mob/target, mob/user)
 	if (occupant)
 		to_chat(user, SPAN_WARNING("\The [src] is already occupied!"))
 		return FALSE
-	if (target.abiotic())
-		to_chat(user, SPAN_WARNING("[user == target ? "You" : "[target]"] can't enter \the [src] while wearing abiotic items."))
-		return FALSE
-	if (target.buckled)
-		to_chat(user, SPAN_WARNING("Unbuckle [user == target ? "yourself" : "\the [target]"] before attempting to [user == target ? "enter \the [src]" : "move them"]."))
-		return FALSE
-	if (panel_open)
-		to_chat(user, SPAN_WARNING("Close the maintenance panel before attempting to place [user == target ? "yourself" : "\the [target]"] in \the [src]."))
-		return FALSE
-	for (var/mob/living/carbon/slime/slime in range(1,target))
-		if (slime.Victim == target)
-			to_chat(user, "[target] will not fit into \the [src] because they have a slime latched onto their head.")
-			return FALSE
 	if (!node)
 		to_chat(usr, SPAN_WARNING("The cell is not correctly connected to its pipe network!"))
 		return FALSE
-	for (var/obj/item/grab/grab in target.grabbed_by)
-		if (grab.assailant == user || grab.assailant == target)
-			continue
-		to_chat(user, SPAN_WARNING("\The [target] is being grabbed by [grab.assailant] and can't be placed in \the [src]."))
-		return FALSE
-	return TRUE
+	return ..()
 
 /obj/machinery/atmospherics/unary/cryo_cell/MouseDrop_T(mob/target, mob/user)
 	if (!CanMouseDrop(target, user) || !ismob(target))

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -454,33 +454,16 @@
 	log_and_message_admins("placed [target == user ? "themself" : key_name_admin(target)] into \a [src]")
 	target.remove_grabs_and_pulls()
 
-/obj/machinery/cryopod/proc/user_can_move_target_inside(mob/target, mob/user)
-	if (!user.use_sanity_check(src, target))
-		return FALSE
-	if (!istype(target))
-		to_chat(user, SPAN_WARNING("\The [src] cannot handle such a lifeform!"))
-		return FALSE
-	if (user.incapacitated() || !istype(user))
-		return FALSE
-	if (!target.simulated)
-		return FALSE
+/obj/machinery/cryopod/user_can_move_target_inside(mob/target, mob/user)
 	if (occupant)
 		to_chat(user, SPAN_WARNING("\The [src] is already occupied!"))
 		return FALSE
-	if (target.buckled)
-		to_chat(user, SPAN_WARNING("Unbuckle [user == target ? "yourself" : "\the [target]"] before attempting to [user == target ? "enter \the [src]" : "move them"]."))
+	if (!check_occupant_allowed(target))
 		return FALSE
-	for (var/obj/item/grab/grab in target.grabbed_by)
-		if (grab.assailant == user || grab.assailant == target)
-			continue
-		to_chat(user, SPAN_WARNING("\The [target] is being grabbed by [grab.assailant] and can't be placed in \the [src]."))
-		return FALSE
-	return TRUE
+	return ..()
 
 /obj/machinery/cryopod/MouseDrop_T(mob/target, mob/user)
 	if (!CanMouseDrop(target, user) || !ismob(target))
-		return
-	if (!check_occupant_allowed(target))
 		return
 	if (!user_can_move_target_inside(target, user))
 		return
@@ -491,6 +474,7 @@
 /obj/machinery/cryopod/use_grab(obj/item/grab/grab, list/click_params) //Grab is deleted at the level of attempt_enter if all checks are passed.
 	MouseDrop_T(grab.affecting, grab.assailant)
 	return TRUE
+
 /obj/machinery/cryopod/verb/eject()
 	set name = "Eject Pod"
 	set category = "Object"

--- a/code/game/objects/structures/mineral_bath.dm
+++ b/code/game/objects/structures/mineral_bath.dm
@@ -21,7 +21,7 @@
 /obj/structure/adherent_bath/use_grab(obj/item/grab/grab, list/click_params)
 	// Put victim in bath
 	if (enter_bath(grab.affecting, grab.assailant))
-		qdel(grab)
+		grab.affecting.remove_grabs_and_pulls()
 	return TRUE
 
 

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -53,6 +53,9 @@
 	to_chat(user, "A grab on \the [affecting]'s [O.name].")
 
 /obj/item/grab/Process()
+	if (!use_sanity_check(affecting))
+		current_grab.let_go(src)
+		return
 	current_grab.process(src)
 
 /obj/item/grab/attack_self(mob/user)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -284,7 +284,7 @@
 			visible_message(SPAN_DANGER("\The [user] has broken \the [src]'s grip on \the [grab.affecting]!"))
 			success = TRUE
 		spawn(1)
-			qdel(grab)
+			grab.current_grab.let_go(grab)
 
 	return success
 /*

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -581,7 +581,7 @@ default behaviour is:
 			if (prob(75))
 				if(istype(G))
 					M.visible_message(SPAN_WARNING("[G.affecting] has been pulled from [G.assailant]'s grip by [src]!"), SPAN_WARNING("[G.affecting] has been pulled from your grip by [src]!"))
-					qdel(G)
+					G.current_grab.let_go(G)
 		if (!length(M.grabbed_by))
 			M.handle_pull_damage(src)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -538,7 +538,7 @@
 			if(prob(25))
 				visible_message(SPAN_WARNING("\The [src] fails to pull \the [G.assailant] away from \the [G.affecting]!"), SPAN_WARNING("You fail to pull \the [G.assailant] away from \the [G.affecting]!"))
 				return
-			qdel(G) // Makes sure dragging the assailant away from their victim makes them release the grab instead of holding it at long range forever.
+			G.current_grab.let_go(G) // Makes sure dragging the assailant away from their victim makes them release the grab instead of holding it at long range forever.
 
 		if(!can_pull_mobs || !can_pull_size)
 			to_chat(src, SPAN_WARNING("It won't budge!"))

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -62,7 +62,7 @@
 ///Remove all grabs applied to target mob. Useful when mob is entering a compartment where they're not supposed to be grabbed.
 /mob/proc/remove_grabs_and_pulls()
 	for (var/obj/item/grab/G in grabbed_by)
-		qdel(G)
+		G.current_grab.let_go(G)
 	if(pulledby)
 		pulledby.stop_pulling()
 

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -125,7 +125,7 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 					GM.client.eye = src
 				GM.forceMove(src)
 				usr.visible_message(SPAN_DANGER("\The [GM] has been placed in the [src] by \the [user]."))
-				qdel(G)
+				GM.remove_grabs_and_pulls()
 				admin_attack_log(usr, GM, "Placed the victim into \the [src].", "Was placed into \the [src] by the attacker.", "stuffed \the [src] with")
 		return
 


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: Grabbing someone that is weakly grabbed by someone else and walking away should now release the other person's grab. No more infinite range grabs.
bugfix: Fixed not being able to put mobs into suit cyclers. You require a weak grab to put a mob into a suit cycler, suit storage, or gibber. Can click and drag self.
/🆑 


I did a few things:

1. Moved the sanity check for moving a mob inside a machine at the level of obj/machinery to minimize copy pasting.
2. Added use_grab for the suit cyclers and the gibber, also allowed to use mouse to click-drag self (and only self) into then.
3. Removed ability to click drag a mob into gibber. Existing code wanted you to have an upgraded grab or just click drag the person. Can still click drag self.
4. Changes a bunch of qdel(grabs) to either using let_go() (which exists to allow custom flavor for releasing grabs, unused atm) or remove_grabs_and_pulls; which removes all grabs and pulls affecting a mob depending on context. I left qdel(grabs) in cases where the grab is used in combat like table smashes, where you don't want all grabs removed and you don't want custom grab release flavor.
5. Added a sanity check under grab process(); because grabbing someone and dragging him away does not remove the grab of other users on said person allowing an infinite range grab. If this is too intensive, please let me know.
