### PR TITLE
Exoplanet ruins fixes and tweaks

### DIFF
--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -6,7 +6,7 @@ GLOBAL_LIST_INIT(crashed_pod_areas, new)
 	description = "A crashed survival pod from a destroyed ship."
 	suffixes = list("crashed_pod/crashed_pod.dmm")
 	spawn_cost = 1.5
-	player_cost = 4
+	player_cost = 2
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	ruin_tags = RUIN_HUMAN|RUIN_WRECK
 	spawn_weight = 0.33

--- a/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dm
@@ -7,6 +7,7 @@
 	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN
+	ban_ruins = list(/datum/map_template/ruin/exoplanet/oldlab2)
 
 	// Areas //
 

--- a/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dm
@@ -7,6 +7,7 @@
 	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN
+	ban_ruins = list(/datum/map_template/ruin/exoplanet/oldlab)
 
 	// Areas //
 
@@ -63,7 +64,7 @@
 /area/map_template/oldlab2/living6
 	name = "\improper Living Quarters"
 	icon_state = "surgery"
-	
+
 /area/map_template/oldlab2/cso
 	name = "\improper CSO Office"
 	icon_state = "surgery"
@@ -75,35 +76,35 @@
 /area/map_template/oldlab2/mess
 	name = "\improper Mess Hall"
 	icon_state = "surgery"
-	
+
 /area/map_template/oldlab2/bathroom
 	name = "\improper Bathroom"
 	icon_state = "surgery"
-	
+
 /area/map_template/oldlab2/server
 	name = "\improper Archives"
 	icon_state = "surgery"
-	
+
 /area/map_template/oldlab2/fixedsecurity
 	name = "\improper Security Office"
 	icon_state = "surgery"
-	
+
 /area/map_template/oldlab2/test1
 	name = "\improper Testing Lab"
 	icon_state = "surgery"
-	
+
 /area/map_template/oldlab2/test2
 	name = "\improper Special Testing Lab"
 	icon_state = "surgery"
-	
+
 /area/map_template/oldlab2/mess
 	name = "\improper Mess Hall"
 	icon_state = "surgery"
-	
+
 /area/map_template/oldlab2/engineerhall
 	name = "\improper Engineering Hall"
 	icon_state = "surgery"
-	
+
 /area/map_template/oldlab2/lab
 	name = "\improper Materials Lab"
 	icon_state = "surgery"


### PR DESCRIPTION
🆑 Jux
tweak: Exoplanet ruins with player_cost (colony, survival pod) now use that when being generated.
tweak: The oldlabs prevent each other from spawning.
/🆑 

Probably not the cleanest way of implementing it, but it worked in my testing. Also cuts the player_cost of the survival pod in half, because that's the one most dependent on other maps. Didn't include that in the changelog because the previous cost didn't have any effect.