### PR TITLE
Adds an alert when attempting to late join as a role that is not set in your 'Occupation' preferences

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -234,6 +234,11 @@
 		to_chat(src, alert("[job.title] is not available. Please try another."))
 		return 0
 
+	if (!check_occupation_set(job))
+		var/choice = alert("You do not have [job.title] set as your occupation, are you sure you want to join as this role?", "Occupation Mismatch", "Yes", "No")
+		if (choice != "Yes")
+			return FALSE
+
 	SSjobs.assign_role(src, job.title, 1)
 
 	var/mob/living/character = create_character(spawn_turf)	//creates the human and transfers vars and mind
@@ -486,3 +491,18 @@
 	var/singleton/audio/track/track = GLOB.using_map.get_lobby_track(GLOB.using_map.lobby_track.type)
 	sound_to(src, track.get_sound())
 	to_chat(src, track.get_info())
+
+/mob/new_player/proc/check_occupation_set(datum/job/job)
+	if (!job)
+		return FALSE
+
+	if (job.title == client.prefs.job_high)
+		return TRUE
+
+	if (job.title in client.prefs.job_medium)
+		return TRUE
+
+	if (job.title in client.prefs.job_low)
+		return TRUE
+
+	return FALSE


### PR DESCRIPTION
:cl: Mucker
rscadd: Added an alert when trying to late-join as a role not set in your Occupation preferences. 
/:cl:

![image](https://github.com/Baystation12/Baystation12/assets/1161516/44fea591-0f9e-4ac7-876c-14c6591ae509)
