### PR TITLE
Add goonchat reload button to the legacy chat

### DIFF
--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -99,6 +99,9 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav"))
 			swaptodarkmode()
 		if ("swaptolightmode")
 			swaptolightmode()
+		if ("reload")
+			loaded = FALSE
+			start()
 	if(data)
 		ehjax_send(data = data)
 
@@ -115,6 +118,7 @@ GLOBAL_DATUM_INIT(iconCache, /savefile, new("data/iconCache.sav"))
 	sendClientData()
 	syncRegex()
 	legacy_chat(owner, SPAN_DANGER("Failed to load fancy chat. Some features won't work.")) // do NOT convert to to_chat()
+	legacy_chat(owner, SPAN_DANGER("Shall we <a href='?_src_=chat&proc=reload'>try again</a>?")) // do NOT convert to to_chat()
 
 
 /datum/chatOutput/proc/showChat()


### PR DESCRIPTION

### Changelog
```yml
🆑SuhEugene
rscadd: Added Try again button to the legacy chat that appears when goonchat load fails.
/🆑
```