### PR TITLE
Fix chat loading as non-newplayer mob

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -104,6 +104,10 @@
 	if(machine)
 		machine.on_user_login(src)
 
+	if (SScharacter_setup.initialized && SSchat.initialized && !isnull(client.chatOutput))
+		if(client.get_preference_value(/datum/client_preference/goonchat) == GLOB.PREF_YES)
+			client.chatOutput.start()
+
 	//set macro to normal incase it was overriden (like cyborg currently does)
 	winset(src, null, "mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true input.background-color=#d3b5b5")
 


### PR DESCRIPTION

`chatOutput.start()` proc is called in three cases:
- `OOC` -> `Fix Chat` verb
- `Use Goonchat` preferences toggle
- On `/mob/new_player` login

It isn't called when other types of mobs log in for some reason.

### Changelog
```yml
🆑SuhEugene
bugfix: Fixed goonchat loading for players re-entering game outside the lobby.
/🆑
```