### PR TITLE
Improve light break/fix admin secrets

### DIFF
--- a/code/modules/admin/secrets/fun_secrets/break_all_lights.dm
+++ b/code/modules/admin/secrets/fun_secrets/break_all_lights.dm
@@ -3,5 +3,27 @@
 
 /datum/admin_secret_item/fun_secret/break_all_lights/execute(mob/user)
 	. = ..()
-	if(.)
-		lightsout(0,0)
+	if (!.)
+		return
+
+	var/choice = input("Which lights to break?") in list("Changed my mind", "My area", "My Z-Level", "Station", "All lights")
+	switch (choice)
+		if ("My area")
+			var/area/usr_area = get_area(user)
+			if (!usr_area) return to_chat(user, SPAN_DANGER("Invalid area!"))
+			for (var/obj/machinery/power/apc/apc in usr_area)
+				apc.overload_lighting()
+
+		if ("My Z-Level")
+			var/user_z = get_z(user)
+			if (!user_z) return to_chat(user, SPAN_DANGER("Invalid Z-Level!"))
+			for (var/obj/machinery/power/apc/apc in SSmachines.machinery)
+				if (apc.z == user_z) apc.overload_lighting()
+
+		if ("Station")
+			for (var/obj/machinery/power/apc/apc in SSmachines.machinery)
+				if (apc.z in GLOB.using_map.station_levels)
+					apc.overload_lighting()
+
+		if ("All lights")
+			lightsout(0, 0)

--- a/code/modules/admin/secrets/fun_secrets/fix_all_lights.dm
+++ b/code/modules/admin/secrets/fun_secrets/fix_all_lights.dm
@@ -3,8 +3,28 @@
 
 /datum/admin_secret_item/fun_secret/fix_all_lights/execute(mob/user)
 	. = ..()
-	if(!.)
+	if (!.)
 		return
 
-	for(var/obj/machinery/light/L in world)
-		L.fix()
+	var/choice = input("Which lights to fix?") in list("Changed my mind", "My area", "My Z-Level", "Station", "All lights")
+	switch (choice)
+		if ("My area")
+			var/area/usr_area = get_area(user)
+			if (!usr_area) return to_chat(user, SPAN_DANGER("Invalid area!"))
+			for (var/obj/machinery/light/light in usr_area)
+				light.fix()
+
+		if ("My Z-Level")
+			var/user_z = get_z(user)
+			if (!user_z) return to_chat(user, SPAN_DANGER("Invalid Z-Level!"))
+			for (var/obj/machinery/light/light in SSmachines.machinery)
+				if (light.z == user_z) light.fix()
+
+		if ("Station")
+			for (var/obj/machinery/light/light in SSmachines.machinery)
+				if (light.z in GLOB.using_map.station_levels)
+					light.fix()
+
+		if ("All lights")
+			for (var/obj/machinery/light/light in SSmachines.machinery)
+				light.fix()


### PR DESCRIPTION
At the moment, it is impossible not to destroy all the lights on away sites when the event is taking place on the main ship.
This PR allows you to choose more specific area to destroy/fix lights in.

### Changelog
```yml
🆑SuhEugene
admin: Added selection of a specific lights fix or destruction zone.
/🆑
```