### PR TITLE
telescopic cane goes click-clack

### DIFF
--- a/code/game/objects/items/weapons/cane.dm
+++ b/code/game/objects/items/weapons/cane.dm
@@ -58,6 +58,8 @@
 		w_class = initial(w_class)
 		extended = FALSE
 		can_support = FALSE
+	playsound(src.loc, 'sound/weapons/empty.ogg', 50, 1)
+	update_held_icon()
 
 /obj/item/cane/telescopic/holocane
 	name = "holo-cane"


### PR DESCRIPTION
The cane now does *click* the same way the telescopic baton does.

Also fixes the icon not updating.

:cl: Sbotkin
tweak: Added SFX to the telescopic cane.
/:cl: