### PR TITLE
Removes shotgun drum mags from being lathable

### DIFF
--- a/code/modules/fabrication/designs/general/designs_arms_ammo.dm
+++ b/code/modules/fabrication/designs/general/designs_arms_ammo.dm
@@ -135,18 +135,6 @@
 	name = "ammunition (en-bloc clip)"
 	path = /obj/item/ammo_magazine/iclipr
 
-/datum/fabricator_recipe/arms_ammo/hidden/slugdrum
-	name = "ammunition (drum magazine, slug)"
-	path = /obj/item/ammo_magazine/shotgunmag
-
-/datum/fabricator_recipe/arms_ammo/hidden/shotdrum
-	name = "ammunition (drum magazine, buckshot)"
-	path = /obj/item/ammo_magazine/shotgunmag/shot
-
-/datum/fabricator_recipe/arms_ammo/hidden/flechettedrum
-	name = "ammunition (drum magazine, flechette)"
-	path = /obj/item/ammo_magazine/shotgunmag/flechette
-
 /datum/fabricator_recipe/arms_ammo/hidden/beandrum
 	name = "ammunition (drum magazine, beanbag)"
 	path = /obj/item/ammo_magazine/shotgunmag/beanbag


### PR DESCRIPTION
:cl:
rscdel: Autoshotgun mags are no longer lathe printable.
/:cl:

They were being used to print flechette shotgun rounds. This is why we can't have nice things, Barry.