### PR TITLE
Remove mobs from queue when halting processing

### DIFF
--- a/code/controllers/subsystems/mobs.dm
+++ b/code/controllers/subsystems/mobs.dm
@@ -56,6 +56,7 @@ else {\
 if(MOB.is_processing == SSmobs) {\
 	MOB.is_processing = null;\
 	SSmobs.mob_list -= MOB;\
+	SSmobs.queue -= MOB;\
 }\
 else if (MOB.is_processing) {\
 	crash_with("Failed to stop processing mob. Being processed by [MOB.is_processing] instead.")\


### PR DESCRIPTION
No user-facing changes.

Should fully resolve the random null-reference runtimes from deleted mobs still in the SSMobs queue. 
Tested as best as it can be but this kind of thing is hard to test because of how randomly it can occur.