### PR TITLE
Removes imprinting implants from uplink

### DIFF
--- a/code/datums/uplink/implants.dm
+++ b/code/datums/uplink/implants.dm
@@ -33,11 +33,3 @@
 	item_cost = round(DEFAULT_TELECRYSTAL_AMOUNT / 2)
 	desc = "This implant holds an uplink containing [IMPLANT_TELECRYSTAL_AMOUNT(DEFAULT_TELECRYSTAL_AMOUNT)] telecrystals, \
 	activatable with an emotive trigger. You will have access to it, as long as it is still inside of you."
-
-/datum/uplink_item/item/implants/imp_imprinting
-	name = "Neural Imprinting Implant"
-	desc = "An implant able to be used on someone who is under the influence of Mindbreaker Toxin to give them a \
-	set of law-like instructions to follow. This kit contains a dose of Mindbreaker Toxin."
-	item_cost = 20
-	path = /obj/item/storage/box/syndie_kit/imp_imprinting
-	antag_roles = list(MODE_TRAITOR)


### PR DESCRIPTION
:cl:
rscdel: Removes imprinting implants from traitor uplinks. The item is still available via other means.
/:cl:

If you need to compel someone to do something, use the threat of force or some other RP skill; this is a cheap shortcut that doesn't improve rounds.

If you _DO_ want them, you have to invest some TC and risk into it. They remain for research and print in the science matrix, and there is still a box in the XO's locker. You can also make a deal with the devil (admin) for one.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->