### PR TITLE
Self destruct tile fixes

### DIFF
--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -452,7 +452,6 @@ var/global/bomb_set
 	deployable = 1
 	extended = 1
 
-	var/list/flash_tiles = list()
 	var/list/inserters = list()
 	var/last_turf_state
 
@@ -464,14 +463,17 @@ var/global/bomb_set
 	maxTime = 900
 
 /obj/machinery/nuclearbomb/station/Initialize()
-	. = ..()
+	..()
 	verbs -= /obj/machinery/nuclearbomb/verb/toggle_deployable
-	for(var/turf/simulated/floor/T in get_area(src))
-		if(istype(T.flooring, /singleton/flooring/reinforced/circuit/red))
-			flash_tiles += T
-	update_icon()
 	for(var/obj/machinery/self_destruct/ch in get_area(src))
 		inserters += ch
+	return INITIALIZE_HINT_LATELOAD
+
+
+/obj/machinery/nuclearbomb/station/LateInitialize(mapload, ...)
+	// Relies on turfs to have their `flooring` var set, which is done during init.
+	queue_icon_update()
+
 
 /obj/machinery/nuclearbomb/station/attackby(obj/item/O as obj, mob/user as mob)
 	if(isWrench(O))
@@ -499,10 +501,6 @@ var/global/bomb_set
 		return
 	..()
 
-/obj/machinery/nuclearbomb/station/Destroy()
-	flash_tiles.Cut()
-	return ..()
-
 /obj/machinery/nuclearbomb/station/Process()
 	..()
 	if(timeleft > 0 && GAME_STATE < RUNLEVEL_POSTGAME)
@@ -527,27 +525,29 @@ var/global/bomb_set
 
 /obj/machinery/nuclearbomb/station/on_update_icon()
 	var/target_icon_state
+	var/turf_color = COLOR_BLACK
 	if(lighthack)
 		target_icon_state = "rcircuit_off"
 		icon_state = "idle"
 	else if(timing == -1)
 		target_icon_state = "rcircuitanim"
 		icon_state = "exploding"
+		turf_color = COLOR_RED
 	else if(timing)
 		target_icon_state = "rcircuitanim"
 		icon_state = "urgent"
+		turf_color = COLOR_RED
 	else if(!safety)
 		target_icon_state = "rcircuit"
 		icon_state = "greenlight"
+		turf_color = COLOR_RED
 	else
 		target_icon_state = "rcircuit_off"
 		icon_state = "idle"
 
 	if(!last_turf_state || target_icon_state != last_turf_state)
-		for(var/thing in flash_tiles)
-			var/turf/simulated/floor/T = thing
-			if(!istype(T.flooring, /singleton/flooring/reinforced/circuit/red))
-				flash_tiles -= T
-				continue
-			T.icon_state = target_icon_state
+		for (var/turf/simulated/floor/floor in get_area(src))
+			if (istype(floor.flooring, /singleton/flooring/reinforced/circuit/selfdestruct))
+				floor.icon_state = target_icon_state
+				floor.set_light(l_color = turf_color)
 		last_turf_state = target_icon_state

--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -307,8 +307,11 @@
 
 /singleton/flooring/reinforced/circuit/red
 	icon_base = "rcircuit"
+
+/singleton/flooring/reinforced/circuit/selfdestruct
+	icon_base = "rcircuit_off"
 	flags = TURF_ACID_IMMUNE
-	can_paint = 0
+	can_paint = FALSE
 
 /singleton/flooring/reinforced/cult
 	name = "engraved floor"

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -23,7 +23,7 @@
 	light_max_bright = 3
 	light_color = COLOR_GREEN
 
-/turf/simulated/floor/blackgrid
+/turf/simulated/floor/redgrid
 	name = "mainframe floor"
 	icon = 'icons/turf/flooring/circuit.dmi'
 	icon_state = "rcircuit"

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -32,6 +32,15 @@
 	light_max_bright = 2
 	light_color = COLOR_RED
 
+/turf/simulated/floor/selfestructgrid
+	name = "self-destruct mainframe floor"
+	icon = 'icons/turf/flooring/circuit.dmi'
+	icon_state = "rcircuit_off"
+	initial_flooring = /singleton/flooring/reinforced/circuit/selfdestruct
+	light_outer_range = 2
+	light_max_bright = 2
+	light_color = COLOR_BLACK
+
 /turf/simulated/floor/wood
 	name = "wooden floor"
 	icon = 'icons/turf/flooring/wood.dmi'

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -22423,7 +22423,7 @@
 /obj/machinery/keycard_auth/torch{
 	pixel_x = -28
 	},
-/turf/simulated/floor/blackgrid,
+/turf/simulated/floor/redgrid,
 /area/security/nuke_storage)
 "mGj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -22436,7 +22436,7 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/blackgrid,
+/turf/simulated/floor/redgrid,
 /area/security/nuke_storage)
 "mHr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -22555,7 +22555,7 @@
 	dir = 4
 	},
 /obj/random_multi/single_item/poppy,
-/turf/simulated/floor/blackgrid,
+/turf/simulated/floor/redgrid,
 /area/security/nuke_storage)
 "mOb" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -22635,7 +22635,7 @@
 /obj/machinery/nuclearbomb/station{
 	name = "ship self-destruct terminal"
 	},
-/turf/simulated/floor/blackgrid,
+/turf/simulated/floor/redgrid,
 /area/security/nuke_storage)
 "mVW" = (
 /obj/effect/wallframe_spawn/reinforced/polarized{
@@ -22721,7 +22721,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/blackgrid,
+/turf/simulated/floor/redgrid,
 /area/security/nuke_storage)
 "nfb" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -22923,11 +22923,11 @@
 /obj/machinery/keycard_auth/torch{
 	pixel_x = -28
 	},
-/turf/simulated/floor/blackgrid,
+/turf/simulated/floor/redgrid,
 /area/security/nuke_storage)
 "nob" = (
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/blackgrid,
+/turf/simulated/floor/redgrid,
 /area/security/nuke_storage)
 "npb" = (
 /obj/structure/table/standard,

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -22423,7 +22423,7 @@
 /obj/machinery/keycard_auth/torch{
 	pixel_x = -28
 	},
-/turf/simulated/floor/redgrid,
+/turf/simulated/floor/selfestructgrid,
 /area/security/nuke_storage)
 "mGj" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -22436,7 +22436,7 @@
 	dir = 1;
 	icon_state = "warning"
 	},
-/turf/simulated/floor/redgrid,
+/turf/simulated/floor/selfestructgrid,
 /area/security/nuke_storage)
 "mHr" = (
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -22555,7 +22555,7 @@
 	dir = 4
 	},
 /obj/random_multi/single_item/poppy,
-/turf/simulated/floor/redgrid,
+/turf/simulated/floor/selfestructgrid,
 /area/security/nuke_storage)
 "mOb" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -22635,7 +22635,7 @@
 /obj/machinery/nuclearbomb/station{
 	name = "ship self-destruct terminal"
 	},
-/turf/simulated/floor/redgrid,
+/turf/simulated/floor/selfestructgrid,
 /area/security/nuke_storage)
 "mVW" = (
 /obj/effect/wallframe_spawn/reinforced/polarized{
@@ -22721,7 +22721,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/turf/simulated/floor/redgrid,
+/turf/simulated/floor/selfestructgrid,
 /area/security/nuke_storage)
 "nfb" = (
 /obj/effect/floor_decal/industrial/warning{
@@ -22923,11 +22923,11 @@
 /obj/machinery/keycard_auth/torch{
 	pixel_x = -28
 	},
-/turf/simulated/floor/redgrid,
+/turf/simulated/floor/selfestructgrid,
 /area/security/nuke_storage)
 "nob" = (
 /obj/effect/floor_decal/industrial/warning,
-/turf/simulated/floor/redgrid,
+/turf/simulated/floor/selfestructgrid,
 /area/security/nuke_storage)
 "npb" = (
 /obj/structure/table/standard,


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Circuitry in the self-destruct room now starts the round with the correct unlit state.
bugfix: Circuitry in the self-destruct room now properly update their lighting color.
/:cl:

## Other Changes
- Self-destruct circuit flooring is now a separate, specific subtype, including both the premade turf and the flooring singleton.