### PR TITLE
Made spawning chemicals easier

### DIFF
--- a/code/modules/reagents/dispenser/cartridge_spawn.dm
+++ b/code/modules/reagents/dispenser/cartridge_spawn.dm
@@ -1,6 +1,9 @@
-/client/proc/spawn_chemdisp_cartridge(size in list("small", "medium", "large"), reagent in subtypesof(/datum/reagent))
+/client/proc/spawn_chemdisp_cartridge(size in list("small", "medium", "large"))
 	set name = "Spawn Chemical Dispenser Cartridge"
 	set category = "Admin"
+
+	var/reagent
+	reagent = select_subpath(/datum/reagent, /datum/reagent)
 
 	var/obj/item/reagent_containers/chem_disp_cartridge/C
 	switch(size)


### PR DESCRIPTION
:cl: Mucker
tweak: The 'Spawn Chemical Dispenser Cartridge' verb now takes an input for the reagent, instead of a giant list. 
/:cl: