### PR TITLE
Removes the xenofauna carbine

### DIFF
--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -324,9 +324,3 @@
 	containername = "security voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_brig
-
-/singleton/hierarchy/supply_pack/security/xenofauna
-	name = "Weapons - Xenofauna Carbines"
-	contains = list(/obj/item/gun/energy/laser/xenofauna = 3)
-	cost = 40
-	containername = "xenofauna carbine crate"

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -206,41 +206,13 @@
 	max_shots = 4
 
 
-/obj/item/gun/energy/laser/xenofauna
-	name = "xenofauna carbine"
-	desc = "An outdated LP76 energy carbine, repurposed for wildlife control. A safety limiter locks it to a beam capable of frying the nervous system of simple wildlife, but with barely any effect on humans."
+/obj/item/gun/energy/laser/old
+	name = "retro laser carbine"
+	desc = "An outdated LP76 laser carbine, phased out in favor of newer models with more firepower."
 	icon_state = "laserwild"
 	item_state = "laserwild"
-	projectile_type = /obj/item/projectile/beam/xenofauna
+	projectile_type = /obj/item/projectile/beam/smalllaser
 	slot_flags = null
 	wielded_item_state = "laserwild-wielded"
-	max_shots = 12
+	max_shots = 8
 	var/emagged = FALSE
-
-
-/obj/item/gun/energy/laser/xenofauna/emag_act(charges, mob/user)
-	if (!charges)
-		return NO_EMAG_ACT
-	if (emagged)
-		to_chat(user, SPAN_NOTICE("\The [src]'s safety limiter has already been disabled!"))
-		return NO_EMAG_ACT
-	else
-		to_chat(user, SPAN_NOTICE("\The [src]'s safety limiter sparks and dies!"))
-		projectile_type = /obj/item/projectile/beam/smalllaser
-		charge_cost = 30
-	return ..()
-
-
-/obj/item/gun/energy/laser/xenofauna/examine(mob/user, distance)
-	. = ..()
-	if (emagged && distance < 3)
-		to_chat(user, SPAN_DANGER("The safety limiter doesn't look functional."))
-
-
-/obj/item/gun/energy/laser/xenofauna/broken
-	desc = "An outdated LP76 energy carbine, repurposed for wildlife control. This one looks like junk."
-
-
-/obj/item/gun/energy/laser/xenofauna/broken/Initialize()
-	. = ..()
-	emag_act(INFINITY)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -443,32 +443,3 @@
 	muzzle_type = /obj/effect/projectile/laser/blue/muzzle
 	tracer_type = /obj/effect/projectile/laser/blue/tracer
 	impact_type = /obj/effect/projectile/laser/blue/impact
-
-/obj/item/projectile/beam/xenofauna
-	damage = 0
-	agony = 5
-
-	muzzle_type = /obj/effect/projectile/xenofauna/muzzle
-	tracer_type = /obj/effect/projectile/xenofauna/tracer
-	impact_type = /obj/effect/projectile/xenofauna/impact
-
-/obj/effect/projectile/xenofauna
-	light_color = COLOR_RED_LIGHT
-
-/obj/effect/projectile/xenofauna/tracer
-	icon_state = "redstun"
-
-/obj/effect/projectile/xenofauna/muzzle
-	icon_state = "muzzle_redstun"
-
-/obj/effect/projectile/xenofauna/impact
-	icon_state = "impact_redstun"
-
-
-/obj/item/projectile/beam/xenofauna/on_hit(atom/target, blocked)
-	..()
-	if (!istype(target, /mob/living/simple_animal))
-		return
-	if (istype(target, /mob/living/simple_animal/hostile/human))
-		return
-	target.damage_health(35, DAMAGE_BURN)

--- a/maps/away/meatstation/meatstation.dm
+++ b/maps/away/meatstation/meatstation.dm
@@ -254,7 +254,7 @@
 
 /obj/random/single/meatstation/laser
 	icon_state = "laser50"
-	spawn_object = /obj/item/gun/energy/laser/xenofauna/broken
+	spawn_object = /obj/item/gun/energy/laser/old
 
 /obj/random/single/meatstation/low/biocell
 	icon_state = "biocell10"

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -23899,8 +23899,6 @@
 "ozG" = (
 /obj/structure/table/rack,
 /obj/effect/floor_decal/industrial/outline/grey,
-/obj/item/gun/energy/laser/xenofauna,
-/obj/item/gun/energy/laser/xenofauna,
 /turf/simulated/floor/tiled/dark,
 /area/security/secure_storage)
 "oAp" = (


### PR DESCRIPTION
🆑 Jux
tweak: Xenofauna carbines are no longer a thing. They've been changed to just retro laser carbines, using smalllaser beams, and are only found on meatstation.
/🆑 

People were more vocal about this any other PR I've made in a year and a half.