### PR TITLE
CSO changes

### DIFF
--- a/maps/torch/items/rigs.dm
+++ b/maps/torch/items/rigs.dm
@@ -297,9 +297,8 @@
 		/obj/item/device/core_sampler,
 		/obj/item/device/gps,
 		/obj/item/pinpointer/radio,
-		/obj/item/pickaxe/xeno,
-		/obj/item/storage/bag/fossils,
-		/obj/item/rig_module/grenade_launcher/light
+		/obj/item/pickaxe,
+		/obj/item/storage/bag/fossils
 	)
 
 /obj/item/clothing/shoes/magboots/rig/command/science
@@ -308,6 +307,7 @@
 
 /obj/item/rig/command/science/equipped
 	initial_modules = list(
+		/obj/item/rig_module/ai_container,
 		/obj/item/rig_module/maneuvering_jets,
 		/obj/item/rig_module/device/flash,
 		/obj/item/rig_module/device/anomaly_scanner,

--- a/maps/torch/structures/closets/research.dm
+++ b/maps/torch/structures/closets/research.dm
@@ -34,8 +34,6 @@
 		/obj/item/gun/energy/confuseray,
 		/obj/item/device/megaphone,
 		/obj/item/device/tape/random = 3,
-		/obj/item/device/camera,
-		/obj/item/material/clipboard/steel,
 		/obj/item/clothing/glasses/welding/superior,
 		/obj/item/clothing/suit/armor/pcarrier/medium/command,
 		/obj/item/clothing/head/helmet/solgov/command,

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -11217,12 +11217,6 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/cell3)
-"AS" = (
-/obj/structure/table/glass,
-/obj/item/modular_computer/tablet/lease/preset/command,
-/obj/item/book/manual/nt_regs,
-/turf/simulated/floor/lino,
-/area/shuttle/petrov/rd)
 "AT" = (
 /obj/structure/table/steel,
 /obj/machinery/chemical_dispenser/bar_soft/full,
@@ -11654,7 +11648,7 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/phoron)
 "CJ" = (
-/obj/structure/bed/chair/office/comfy/red{
+/obj/structure/bed/chair/office/comfy/purple{
 	dir = 1
 	},
 /turf/simulated/floor/lino,
@@ -11878,7 +11872,6 @@
 /area/shuttle/petrov/phoron)
 "Du" = (
 /obj/structure/table/glass,
-/obj/item/device/paicard,
 /turf/simulated/floor/lino,
 /area/shuttle/petrov/rd)
 "Dv" = (
@@ -12707,12 +12700,12 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/hallwaya)
 "GX" = (
-/obj/structure/bed/chair/padded/red,
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/structure/bed/chair/padded/purple,
 /turf/simulated/floor/lino,
 /area/shuttle/petrov/rd)
 "Ha" = (
@@ -42822,7 +42815,7 @@ MN
 LW
 eW
 GX
-AS
+Du
 PR
 wu
 LA

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -2868,7 +2868,6 @@
 /area/space)
 "fl" = (
 /obj/structure/table/glass,
-/obj/random/clipboard,
 /obj/random_multi/single_item/memo_research,
 /obj/random_multi/single_item/memo_exploration,
 /turf/simulated/floor/tiled,
@@ -10775,7 +10774,6 @@
 	pixel_x = 32
 	},
 /obj/structure/table/rack,
-/obj/item/aicard,
 /obj/item/pinpointer,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/device/multitool,
@@ -12139,6 +12137,12 @@
 /obj/effect/floor_decal/corner/research/half{
 	dir = 1
 	},
+/obj/machinery/button/windowtint{
+	id = "rd_windows";
+	pixel_x = 28;
+	pixel_y = 18;
+	range = 11
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/rd)
 "IW" = (
@@ -12616,7 +12620,6 @@
 /area/maintenance/bridge/foreport)
 "Lv" = (
 /obj/structure/table/glass,
-/obj/item/book/manual/nt_regs,
 /obj/item/stamp/rd,
 /obj/effect/floor_decal/corner/research{
 	dir = 5
@@ -13952,12 +13955,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/bridge/aftstarboard)
 "Rj" = (
-/obj/machinery/button/windowtint{
-	id = "rd_windows";
-	pixel_x = 6;
-	pixel_y = -24;
-	range = 11
-	},
 /obj/machinery/light_switch{
 	pixel_x = -6;
 	pixel_y = -24


### PR DESCRIPTION
:cl: Sbotkin
tweak: The CSO now has an AI module in their hardsuit and can carry drills in the suit slot.
maptweak: Removed duplicate items from the CSO office(s).
/:cl:

- Added an AI module for the only person onboard who gets a pAI in their office. Feels logical.
- Added the ability to carry various pickaxes and drills, on par with the excavation suits. Very important equipment for xenoarcheology.
- Removed duplicates from the offices (two tablets, three clipboards, two cameras)
- Removed the corpo regulations books, we are uniformed now 💪
- Removed the intelicard from the Bridge Storage since we don't have an AI anymore.