### PR TITLE
Makes attack() only handle unique overrides, move common code to use_weapon()

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -52,7 +52,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define ITEM_FLAG_NOCUFFS                   FLAG(13) // Gloves that have this flag prevent cuffs being applied
 #define ITEM_FLAG_CAN_HIDE_IN_SHOES         FLAG(14) // Items that can be hidden in shoes that permit it
 #define ITEM_FLAG_WASHER_ALLOWED            FLAG(15) // Items that can be washed in washing machines
-#define ITEM_FLAG_TRY_ATTACK                FLAG(16) // Use the item's attack() when set before trying the receiver's attackby()
+#define ITEM_FLAG_TRY_ATTACK                FLAG(16) // Use the item's attack() when set before trying the receiver's resolve_attackby()
 
 // Flags for pass_flags.
 #define PASS_FLAG_TABLE     FLAG(0)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -55,7 +55,7 @@
 	is recieving it.
 	The most common are:
 	* mob/UnarmedAttack(atom,adjacent) - used here only when adjacent, with no item in hand; in the case of humans, checks gloves
-	* atom/attackby(item,user) - used only when adjacent
+	* atom/resolve_attackby(item,user) - used only when adjacent
 	* item/afterattack(atom,user,adjacent,params) - used both ranged and adjacent
 	* mob/RangedAttack(atom,params) - used only ranged, only used for tk and laser eyes but could be changed
 */
@@ -150,7 +150,7 @@
 	if(isturf(A) || isturf(A.loc) || (sdepth != -1 && sdepth <= 1))
 		if(A.Adjacent(src)) // see adjacent.dm
 			if(W)
-				// Return 1 in attackby() to prevent afterattack() effects (when safely moving items for example)
+				// Return TRUE in resolve_attackby() to prevent afterattack() effects (when safely moving items for example)
 				var/resolved = W.resolve_attackby(A,src, modifiers)
 				if(!resolved && A && W)
 					W.afterattack(A, src, 1, modifiers) // 1: clicking something Adjacent

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -427,17 +427,16 @@ avoid code duplication. This includes items that may sometimes act as a standard
 
 //I would prefer to rename this attack_as_weapon(), but that would involve touching hundreds of files.
 /**
- * Called when a mob is clicked while the item is in the active hand and the interaction is not valid for surgery. Generally called by the mob's `attackby()` proc.
+ * Called when a mob is clicked while the item is in the active hand and ITEM_FLAG_TRY_ATTACK is set. Generally called by the mob's `attackby()` proc.
+ * This is called before anything else if set correctly. Returns boolean to indicate whether the item usage was successful or not.
+ * If returns FALSE, the rest of the resolve_attackby() chain is called.
  *
  * **Parameters**:
  * - `subject` - The mob that was clicked.
  * - `user` - The mob that clicked the target.
- * - `target_zone` - The mob targeting zone `user` had selected when clicking.
- * - `animate` (boolean) - Whether or not to show the attack animation.
- *
- * Returns boolean to indicate whether the item usage was successful or not.
+ * * - `click_parameters` - List of click parameters. See BYOND's `Click()` documentation.
  */
-/obj/item/proc/attack(mob/living/subject, mob/living/user, target_zone, animate = TRUE)
+/obj/item/proc/attack(mob/living/subject, mob/living/user, click_parameters)
 	return FALSE
 
 

--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -202,7 +202,8 @@
 	if (a_intent == I_HELP)
 		A.attack_animal(src)
 	else if (get_natural_weapon())
-		A.attackby(get_natural_weapon(), src)
+		var/obj/item/weapon = get_natural_weapon()
+		weapon.resolve_attackby(A, src)
 
 
 /**

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -13,7 +13,8 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "tore", "ripped", "diced", "cut")
 
-/obj/item/melee/cultblade/attack(mob/living/M, mob/living/user, target_zone)
+/obj/item/melee/cultblade/attack(mob/living/M, mob/living/user)
+	. = FALSE
 	if (iscultist(user))
 		return FALSE
 
@@ -37,7 +38,6 @@
 
 	var/spooky = pick('sound/hallucinations/growl1.ogg', 'sound/hallucinations/growl2.ogg', 'sound/hallucinations/growl3.ogg', 'sound/hallucinations/wail.ogg')
 	playsound(loc, spooky, 50, 1)
-
 	return TRUE
 
 /obj/item/melee/cultblade/pickup(mob/living/user as mob)

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -7,17 +7,17 @@
 	edge = TRUE
 	sharp = TRUE
 	w_class = ITEM_SIZE_LARGE
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	force = 30
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
-	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "tore", "ripped", "diced", "cut")
 
 /obj/item/melee/cultblade/attack(mob/living/M, mob/living/user, target_zone)
-	if(iscultist(user))
+	if (iscultist(user))
 		return ..()
 
 	var/zone = (user.hand ? BP_L_ARM : BP_R_ARM)
-
 	var/obj/item/organ/external/affecting = null
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
@@ -38,10 +38,10 @@
 	var/spooky = pick('sound/hallucinations/growl1.ogg', 'sound/hallucinations/growl2.ogg', 'sound/hallucinations/growl3.ogg', 'sound/hallucinations/wail.ogg')
 	playsound(loc, spooky, 50, 1)
 
-	return 1
+	return TRUE
 
 /obj/item/melee/cultblade/pickup(mob/living/user as mob)
-	if(!iscultist(user))
+	if (!iscultist(user))
 		to_chat(user, SPAN_WARNING("An overwhelming feeling of dread comes over you as you pick up the cultist's sword. It would be wise to be rid of this blade quickly."))
 		user.make_dizzy(120)
 

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -15,7 +15,7 @@
 
 /obj/item/melee/cultblade/attack(mob/living/M, mob/living/user, target_zone)
 	if (iscultist(user))
-		return ..()
+		return FALSE
 
 	var/zone = (user.hand ? BP_L_ARM : BP_R_ARM)
 	var/obj/item/organ/external/affecting = null

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -22,6 +22,8 @@
 		to_chat(user, "The scriptures of Nar-Sie, The One Who Sees, The Geometer of Blood. Contains the details of every ritual his followers could think of. Most of these are useless, though.")
 
 /obj/item/book/tome/attack(mob/living/M, mob/living/user)
+	if (!istype(M))
+		return FALSE
 	if (user.a_intent == I_HELP && user.zone_sel.selecting == BP_EYES)
 		user.visible_message(
 			SPAN_NOTICE("\The [user] shows \the [src] to \the [M]."),

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -22,19 +22,21 @@
 		to_chat(user, "The scriptures of Nar-Sie, The One Who Sees, The Geometer of Blood. Contains the details of every ritual his followers could think of. Most of these are useless, though.")
 
 /obj/item/book/tome/attack(mob/living/M, mob/living/user)
-	if (user.a_intent != I_HELP || user.zone_sel.selecting != BP_EYES)
-		return ..()
-	user.visible_message(
-		SPAN_NOTICE("\The [user] shows \the [src] to \the [M]."),
-		SPAN_NOTICE("You open up \the [src] and show it to \the [M].")
-	)
-	if (iscultist(M))
-		if (user != M)
-			to_chat(user, SPAN_NOTICE("But they already know all there is to know."))
-		to_chat(M, SPAN_NOTICE("But you already know all there is to know."))
-	else
-		to_chat(M, SPAN_NOTICE("\The [src] seems full of illegible scribbles. Is this a joke?"))
-	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+	SHOULD_CALL_PARENT(FALSE)
+	if (user.a_intent == I_HELP && user.zone_sel.selecting == BP_EYES)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] shows \the [src] to \the [M]."),
+			SPAN_NOTICE("You open up \the [src] and show it to \the [M].")
+		)
+		if (iscultist(M))
+			if (user != M)
+				to_chat(user, SPAN_NOTICE("But they already know all there is to know."))
+			to_chat(M, SPAN_NOTICE("But you already know all there is to know."))
+		else
+			to_chat(M, SPAN_NOTICE("\The [src] seems full of illegible scribbles. Is this a joke?"))
+		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
+		return TRUE
+	else return FALSE
 
 /obj/item/book/tome/afterattack(atom/A, mob/user, proximity)
 	if(!proximity || !iscultist(user))

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -22,7 +22,6 @@
 		to_chat(user, "The scriptures of Nar-Sie, The One Who Sees, The Geometer of Blood. Contains the details of every ritual his followers could think of. Most of these are useless, though.")
 
 /obj/item/book/tome/attack(mob/living/M, mob/living/user)
-	SHOULD_CALL_PARENT(FALSE)
 	if (user.a_intent == I_HELP && user.zone_sel.selecting == BP_EYES)
 		user.visible_message(
 			SPAN_NOTICE("\The [user] shows \the [src] to \the [M]."),

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -22,6 +22,7 @@
 		to_chat(user, "The scriptures of Nar-Sie, The One Who Sees, The Geometer of Blood. Contains the details of every ritual his followers could think of. Most of these are useless, though.")
 
 /obj/item/book/tome/attack(mob/living/M, mob/living/user)
+	. = FALSE
 	if (!istype(M))
 		return FALSE
 	if (user.a_intent == I_HELP && user.zone_sel.selecting == BP_EYES)
@@ -37,7 +38,6 @@
 			to_chat(M, SPAN_NOTICE("\The [src] seems full of illegible scribbles. Is this a joke?"))
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 		return TRUE
-	else return FALSE
 
 /obj/item/book/tome/afterattack(atom/A, mob/user, proximity)
 	if(!proximity || !iscultist(user))

--- a/code/game/gamemodes/events/holidays/Christmas.dm
+++ b/code/game/gamemodes/events/holidays/Christmas.dm
@@ -4,12 +4,13 @@
 	icon_state = "cracker"
 	desc = "Directions for use: Requires two people, one to pull each end."
 	var/cracked = 0
+	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/toy/xmas_cracker/New()
 	..()
 
 /obj/item/toy/xmas_cracker/attack(mob/target, mob/user)
-	if( !cracked && istype(target,/mob/living/carbon/human) && (target.stat == CONSCIOUS) && !target.get_active_hand() )
+	if (!cracked && istype(target,/mob/living/carbon/human) && (target.stat == CONSCIOUS) && !target.get_active_hand() )
 		target.visible_message(SPAN_NOTICE("[user] and [target] pop \an [src]! *pop*"), SPAN_NOTICE("You pull \an [src] with [target]! *pop*"), SPAN_NOTICE("You hear a *pop*."))
 		var/obj/item/paper/Joke = new /obj/item/paper(user.loc)
 		Joke.SetName("[pick("awful","terrible","unfunny")] joke")
@@ -32,7 +33,7 @@
 		other_half.icon_state = "cracker2"
 		target.put_in_active_hand(other_half)
 		playsound(user, 'sound/effects/snap.ogg', 50, 1)
-		return 1
+		return TRUE
 	return ..()
 
 /obj/item/clothing/head/festive

--- a/code/game/gamemodes/events/holidays/Christmas.dm
+++ b/code/game/gamemodes/events/holidays/Christmas.dm
@@ -10,6 +10,7 @@
 	..()
 
 /obj/item/toy/xmas_cracker/attack(mob/target, mob/user)
+	. = FALSE
 	if (!cracked && istype(target,/mob/living/carbon/human) && (target.stat == CONSCIOUS) && !target.get_active_hand() )
 		target.visible_message(SPAN_NOTICE("[user] and [target] pop \an [src]! *pop*"), SPAN_NOTICE("You pull \an [src] with [target]! *pop*"), SPAN_NOTICE("You hear a *pop*."))
 		var/obj/item/paper/Joke = new /obj/item/paper(user.loc)
@@ -34,7 +35,6 @@
 		target.put_in_active_hand(other_half)
 		playsound(user, 'sound/effects/snap.ogg', 50, 1)
 		return TRUE
-	return ..()
 
 /obj/item/clothing/head/festive
 	name = "festive paper hat"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1142,19 +1142,6 @@ About the new airlock wires panel:
 
 	else if(istype(C, /obj/item/device/paint_sprayer))
 		return
-	else if((inoperable()) && istype(user, /mob/living/simple_animal))
-		var/mob/living/simple_animal/A = user
-		var/obj/item/I = A.get_natural_weapon()
-		if(I.force >= 10)
-			if(density)
-				visible_message(SPAN_DANGER("\The [A] forces \the [src] open!"))
-				open(1)
-			else
-				visible_message(SPAN_DANGER("\The [A] forces \the [src] closed!"))
-				close(1)
-		else
-			visible_message(SPAN_NOTICE("\The [A] strains fruitlessly to force \the [src] [density ? "open" : "closed"]."))
-		return
 	else
 		..()
 	return

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1089,7 +1089,7 @@ About the new airlock wires panel:
 		return src.attack_hand(user)
 	else if(istype(C, /obj/item/pai_cable))	// -- TLE
 		var/obj/item/pai_cable/cable = C
-		cable.plugin(src, user)
+		cable.resolve_attackby(src, user)
 	else if(!repairing && isCrowbar(C))
 		if (p_open && (operating == DOOR_OPERATING_BROKEN || (!operating && welded && !arePowerSystemsOn() && density && !locked)) && !brace)
 			playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -22,7 +22,8 @@
 //	causeerrorheresoifixthis
 	var/obj/item/master = null
 	var/list/origin_tech = null	//Used by R&D to determine what research bonuses it grants.
-	var/list/attack_verb = list("hit") //Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
+	///Used in use_weapon() and attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
+	var/list/attack_verb = list("attacked")
 	var/lock_picking_level = 0 //used to determine whether something can pick a lock, and how well.
 	var/force = 0
 	var/attack_cooldown = DEFAULT_WEAPON_COOLDOWN
@@ -284,8 +285,15 @@
 			if(S.collection_mode) //Mode is set to collect all items
 				if(isturf(src.loc))
 					S.gather_all(src.loc, user)
-			else if(S.can_be_inserted(src, user))
+			else if (S.can_be_inserted(src, user))
 				S.handle_item_insertion(src)
+
+/obj/item/use_on(obj/target, mob/user)
+	if (istype(target, /obj/item/clothing))
+		var/obj/item/clothing/clothes = target
+		if (clothes.attempt_store_item(src, user))
+			return TRUE
+	return ..()
 
 /obj/item/can_embed()
 	if (!canremove)

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -121,8 +121,7 @@
 				to_chat(M, SPAN_WARNING("You ate your crayon!"))
 				qdel(src)
 		return TRUE
-	else
-		return ..()
+	return ..()
 
 
 /obj/random/crayon

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -120,6 +120,7 @@
 			if(uses <= 0)
 				to_chat(M, SPAN_WARNING("You ate your crayon!"))
 				qdel(src)
+		return TRUE
 	else
 		..()
 

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -122,7 +122,7 @@
 				qdel(src)
 		return TRUE
 	else
-		..()
+		return ..()
 
 
 /obj/random/crayon

--- a/code/game/objects/items/devices/auto_cpr.dm
+++ b/code/game/objects/items/devices/auto_cpr.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/auto_cpr.dmi'
 	icon_state = "pumper"
 	w_class = ITEM_SIZE_NORMAL
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	origin_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
 	slot_flags = SLOT_OCLOTHING
 	var/last_pump
@@ -19,19 +20,19 @@
 		return FALSE
 
 /obj/item/auto_cpr/attack(mob/living/carbon/human/M, mob/living/user, target_zone)
-	if(istype(M) && user.a_intent == I_HELP)
-		if(M.wear_suit)
+	if (istype(M) && user.a_intent == I_HELP)
+		if (M.wear_suit)
 			to_chat(user, SPAN_WARNING("Their [M.wear_suit] is in the way, remove it first!"))
-			return 1
+			return TRUE
 		user.visible_message(SPAN_NOTICE("[user] starts fitting [src] onto the [M]'s chest."))
 
-		if(!do_after(user, 2 SECONDS, M, DO_EQUIP))
-			return
+		if (!do_after(user, 2 SECONDS, M, DO_EQUIP))
+			return TRUE
 
-		if(user.unEquip(src))
-			if(!M.equip_to_slot_if_possible(src, slot_wear_suit, TRYEQUIP_REDRAW | TRYEQUIP_SILENT))
+		if (user.unEquip(src))
+			if (!M.equip_to_slot_if_possible(src, slot_wear_suit, TRYEQUIP_REDRAW | TRYEQUIP_SILENT))
 				user.put_in_active_hand(src)
-			return 1
+			return TRUE
 	else
 		return ..()
 

--- a/code/game/objects/items/devices/auto_cpr.dm
+++ b/code/game/objects/items/devices/auto_cpr.dm
@@ -19,7 +19,8 @@
 	else
 		return FALSE
 
-/obj/item/auto_cpr/attack(mob/living/carbon/human/M, mob/living/user, target_zone)
+/obj/item/auto_cpr/attack(mob/living/carbon/human/M, mob/living/user)
+	. = FALSE
 	if (istype(M) && user.a_intent == I_HELP)
 		if (M.wear_suit)
 			to_chat(user, SPAN_WARNING("Their [M.wear_suit] is in the way, remove it first!"))
@@ -33,8 +34,6 @@
 			if (!M.equip_to_slot_if_possible(src, slot_wear_suit, TRYEQUIP_REDRAW | TRYEQUIP_SILENT))
 				user.put_in_active_hand(src)
 			return TRUE
-	else
-		return ..()
 
 /obj/item/auto_cpr/equipped(mob/user, slot)
 	..()

--- a/code/game/objects/items/devices/dna_sampler.dm
+++ b/code/game/objects/items/devices/dna_sampler.dm
@@ -36,6 +36,7 @@
 		src_flavor = ""
 
 /obj/item/device/dna_sampler/attack(mob/living/carbon/human/L, mob/user)
+	. = FALSE
 	if (istype(L) && L.can_inject(user, check_zone(user.zone_sel.selecting)))
 		if (loaded)
 			user.visible_message("\The [src]'s DNA buffer is already full, please flush the existing DNA buffer first")
@@ -50,4 +51,3 @@
 		src_species = L.species.name
 		src_flavor = L.flavor_texts
 		return TRUE
-	else return ..()

--- a/code/game/objects/items/devices/dna_sampler.dm
+++ b/code/game/objects/items/devices/dna_sampler.dm
@@ -2,6 +2,7 @@
 	name = "dna sampler"
 	desc = "An all in one DNA sampling and sequencing device which can be used to deliver a genetic payload to a mimic cube. Requires a DNA sample from the target."
 	w_class = ITEM_SIZE_SMALL
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	origin_tech = list(TECH_BIO = 5, TECH_MATERIAL = 2)
 	icon = 'icons/obj/tools/implanter.dmi'
 	icon_state = "dnainjector0"
@@ -35,18 +36,18 @@
 		src_flavor = ""
 
 /obj/item/device/dna_sampler/attack(mob/living/carbon/human/L, mob/user)
-	var/allow = L.can_inject(user, check_zone(user.zone_sel.selecting))
-	if(!allow)
-		return
-	if (loaded == TRUE)
-		user.visible_message("\The [src]'s DNA buffer is already full, please flush the existing DNA buffer first")
-		return
-	user.visible_message("\The [user] jams \the [src] into \the [L], extracting a viscous orange fluid!")
-	icon_state = "dnainjector"
-	loaded = TRUE
-	src_name = L.real_name
-	src_dna = L.dna
-	src_pronouns = L.pronouns
-	src_faction = L.faction
-	src_species = L.species.name
-	src_flavor = L.flavor_texts
+	if (istype(L) && L.can_inject(user, check_zone(user.zone_sel.selecting)))
+		if (loaded)
+			user.visible_message("\The [src]'s DNA buffer is already full, please flush the existing DNA buffer first")
+			return TRUE
+		user.visible_message("\The [user] jams \the [src] into \the [L], extracting a viscous orange fluid!")
+		icon_state = "dnainjector"
+		loaded = TRUE
+		src_name = L.real_name
+		src_dna = L.dna
+		src_pronouns = L.pronouns
+		src_faction = L.faction
+		src_species = L.species.name
+		src_flavor = L.flavor_texts
+		return TRUE
+	else return ..()

--- a/code/game/objects/items/devices/dociler.dm
+++ b/code/game/objects/items/devices/dociler.dm
@@ -34,7 +34,7 @@
 
 /obj/item/device/dociler/attack(mob/living/L, mob/user)
 	if (!istype(L))
-		return FALSE
+		return ..()
 	if (istype(L, /mob/living/simple_animal))
 		if (!loaded)
 			to_chat(user, SPAN_WARNING("\The [src] isn't loaded!"))

--- a/code/game/objects/items/devices/dociler.dm
+++ b/code/game/objects/items/devices/dociler.dm
@@ -33,8 +33,9 @@
 	to_chat(user, SPAN_NOTICE("It is currently [loaded? "loaded": "recharging"]."))
 
 /obj/item/device/dociler/attack(mob/living/L, mob/user)
+	. = FALSE
 	if (!istype(L))
-		return ..()
+		return FALSE
 	if (istype(L, /mob/living/simple_animal))
 		if (!loaded)
 			to_chat(user, SPAN_WARNING("\The [src] isn't loaded!"))

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -37,8 +37,8 @@
 
 //attack_as_weapon
 /obj/item/device/flash/attack(mob/living/M, mob/living/user, target_zone)
-	. = ..()
-
+	if (!istype(M))
+		return FALSE
 	if (!clown_check(user))
 		return TRUE
 	if (broken)

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -9,6 +9,7 @@
 	throw_speed = 4
 	throw_range = 10
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	origin_tech = list(TECH_MAGNET = 2, TECH_COMBAT = 1)
 
 	var/times_used = 0 //Number of times it's been used.
@@ -36,38 +37,39 @@
 
 //attack_as_weapon
 /obj/item/device/flash/attack(mob/living/M, mob/living/user, target_zone)
-	if(!user || !M)	return 0 //sanity
-	admin_attack_log(user, M, "flashed their victim using \a [src].", "Was flashed by \a [src].", "used \a [src] to flash")
+	. = ..()
 
-	if(!clown_check(user))	return 0
-	if(broken)
+	if (!clown_check(user))
+		return TRUE
+	if (broken)
 		to_chat(user, SPAN_WARNING("\The [src] is broken."))
-		return 0
+		return TRUE
 
 	flash_recharge()
 
 	//spamming the flash before it's fully charged (60seconds) increases the chance of it breaking
 	//It will never break on the first use.
-	switch(times_used)
-		if(0 to 5)
+	switch (times_used)
+		if (0 to 5)
 			last_used = world.time
-			if(prob(times_used))	//if you use it 5 times in a minute it has a 10% chance to break!
+			if (prob(times_used))	//if you use it 5 times in a minute it has a 10% chance to break!
 				broken = 1
 				to_chat(user, SPAN_WARNING("The bulb has burnt out!"))
 				icon_state = "[initial(icon_state)]_burnt"
-				return 0
+				return TRUE
 			times_used++
 		else	//can only use it 5 times a minute
 			to_chat(user, SPAN_WARNING("*click* *click*"))
-			return 0
+			return TRUE
 
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(M)
+	admin_attack_log(user, M, "flashed their victim using \a [src].", "Was flashed by \a [src].", "used \a [src] to flash")
 
 	playsound(src.loc, 'sound/weapons/flash.ogg', 100, 1)
 	var/flashfail = do_flash(M)
 
-	if(isrobot(user))
+	if (isrobot(user))
 		spawn(0)
 			var/atom/movable/fake_overlay/animation = new(user)
 			animation.plane = user.plane
@@ -78,15 +80,15 @@
 			sleep(5)
 			qdel(animation)
 
-	if(!flashfail)
+	if (!flashfail)
 		flick("[initial(icon_state)]_on", src)
-		if(!issilicon(M))
+		if (!issilicon(M))
 			user.visible_message(SPAN_CLASS("disarm", "[user] blinds [M] with \the [src]!"))
 		else
 			user.visible_message(SPAN_NOTICE("[user] overloads [M]'s sensors with \the [src]!"))
 	else
 		user.visible_message(SPAN_NOTICE("[user] fails to blind [M] with \the [src]!"))
-	return 1
+	return TRUE
 
 
 /**

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -36,7 +36,8 @@
 	times_used = max(0,round(times_used)) //sanity
 
 //attack_as_weapon
-/obj/item/device/flash/attack(mob/living/M, mob/living/user, target_zone)
+/obj/item/device/flash/attack(mob/living/M, mob/living/user)
+	. = FALSE
 	if (!istype(M))
 		return FALSE
 	if (!clown_check(user))

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -70,9 +70,9 @@
 	if(on && user.zone_sel.selecting == BP_EYES)
 
 		if((MUTATION_CLUMSY in user.mutations) && prob(50) || user.a_intent == I_HURT)
-			return M.use_weapon(src, user)	//just hit them in the head
+			return M.use_weapon(src, user)
 
-		var/mob/living/carbon/human/H = M	//mob has protective eyewear
+		var/mob/living/carbon/human/H = M
 		if(istype(H))
 			for(var/obj/item/clothing/C in list(H.head,H.wear_mask,H.glasses))
 				if(istype(C) && (C.body_parts_covered & EYES))
@@ -95,7 +95,7 @@
 
 			inspect_vision(vision, user)
 
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN) //can be used offensively
+			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 			if (!(flashlight_flags & FLASHLIGHT_CANNOT_BLIND))
 				M.flash_eyes()
 		return TRUE

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -67,7 +67,7 @@
 		set_light(0)
 
 /obj/item/device/flashlight/attack(mob/living/M as mob, mob/living/user as mob)
-	if(on && user.zone_sel.selecting == BP_EYES)
+	if (istype(M) && on && user.zone_sel.selecting == BP_EYES)
 
 		if((MUTATION_CLUMSY in user.mutations) && prob(50) || user.a_intent == I_HURT)
 			return M.use_weapon(src, user)

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -10,9 +10,11 @@
 	item_state = "flashlight"
 	w_class = ITEM_SIZE_SMALL
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	slot_flags = SLOT_BELT
 
 	matter = list(MATERIAL_PLASTIC = 50, MATERIAL_GLASS = 20)
+	force = 7
 
 	action_button_name = "Toggle Flashlight"
 	var/on = FALSE
@@ -65,29 +67,28 @@
 		set_light(0)
 
 /obj/item/device/flashlight/attack(mob/living/M as mob, mob/living/user as mob)
-	add_fingerprint(user)
 	if(on && user.zone_sel.selecting == BP_EYES)
 
-		if((MUTATION_CLUMSY in user.mutations) && prob(50))	//too dumb to use flashlight properly
-			return ..()	//just hit them in the head
+		if((MUTATION_CLUMSY in user.mutations) && prob(50) || user.a_intent == I_HURT)
+			return M.use_weapon(src, user)	//just hit them in the head
 
 		var/mob/living/carbon/human/H = M	//mob has protective eyewear
 		if(istype(H))
 			for(var/obj/item/clothing/C in list(H.head,H.wear_mask,H.glasses))
 				if(istype(C) && (C.body_parts_covered & EYES))
 					to_chat(user, SPAN_WARNING("You're going to need to remove [C] first."))
-					return
+					return TRUE
 
 			var/obj/item/organ/vision
 			if(!H.species.vision_organ || !H.should_have_organ(H.species.vision_organ))
 				to_chat(user, SPAN_WARNING("You can't find anything on [H] to direct [src] into!"))
-				return
+				return TRUE
 
 			vision = H.internal_organs_by_name[H.species.vision_organ]
 			if(!vision)
 				vision = H.species.has_organ[H.species.vision_organ]
 				to_chat(user, SPAN_WARNING("\The [H] is missing \his [initial(vision.name)]!"))
-				return
+				return TRUE
 
 			user.visible_message(SPAN_NOTICE("\The [user] directs [src] into [M]'s [vision.name]."), \
 								 SPAN_NOTICE("You direct [src] into [M]'s [vision.name]."))
@@ -97,6 +98,7 @@
 			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN) //can be used offensively
 			if (!(flashlight_flags & FLASHLIGHT_CANNOT_BLIND))
 				M.flash_eyes()
+		return TRUE
 	else
 		return ..()
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -67,6 +67,7 @@
 		set_light(0)
 
 /obj/item/device/flashlight/attack(mob/living/M as mob, mob/living/user as mob)
+	. = FALSE
 	if (istype(M) && on && user.zone_sel.selecting == BP_EYES)
 
 		if((MUTATION_CLUMSY in user.mutations) && prob(50) || user.a_intent == I_HURT)
@@ -99,8 +100,6 @@
 			if (!(flashlight_flags & FLASHLIGHT_CANNOT_BLIND))
 				M.flash_eyes()
 		return TRUE
-	else
-		return ..()
 
 /obj/item/device/flashlight/proc/inspect_vision(obj/item/organ/vision, mob/living/user)
 	var/mob/living/carbon/human/H = vision.owner

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -9,6 +9,7 @@
 	throw_speed = 4
 	throw_range = 10
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	slot_flags = SLOT_BELT
 	req_access = list(list(access_heads, access_security))
 	var/datum/computer_file/data/warrant/active
@@ -82,9 +83,12 @@
 
 //hit other people with it
 /obj/item/device/holowarrant/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	user.visible_message(SPAN_NOTICE("[user] holds up a warrant projector and shows the contents to [M]."), \
-			SPAN_NOTICE("You show the warrant to [M]."))
-	examinate(M, src)
+	if(istype(M))
+		user.visible_message(SPAN_NOTICE("[user] holds up a warrant projector and shows the contents to [M]."), \
+				SPAN_NOTICE("You show the warrant to [M]."))
+		examinate(M, src)
+		return TRUE
+	else return ..()
 
 /obj/item/device/holowarrant/on_update_icon()
 	if(active)

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -83,12 +83,12 @@
 
 //hit other people with it
 /obj/item/device/holowarrant/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+	. = FALSE
 	if(istype(M))
 		user.visible_message(SPAN_NOTICE("[user] holds up a warrant projector and shows the contents to [M]."), \
 				SPAN_NOTICE("You show the warrant to [M]."))
 		examinate(M, src)
 		return TRUE
-	else return ..()
 
 /obj/item/device/holowarrant/on_update_icon()
 	if(active)

--- a/code/game/objects/items/devices/inducer.dm
+++ b/code/game/objects/items/devices/inducer.dm
@@ -136,10 +136,6 @@
 	else
 		return 0
 
-/obj/item/inducer/attack(mob/M, mob/user)
-	return
-
-
 /obj/item/inducer/attack_self(mob/user)
 	if(opened && cell)
 		user.visible_message("\The [user] removes \the [cell] from \the [src]!",SPAN_NOTICE("You remove \the [cell]."))

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -52,9 +52,6 @@
 				else
 					to_chat(user, SPAN_NOTICE("[src] is projecting at max capacity!"))
 
-/obj/item/holosign_creator/attack(mob/living/carbon/human/M, mob/user)
-	return
-
 /obj/item/holosign_creator/attack_self(mob/user)
 	if(length(signs))
 		for(var/H in signs)

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -27,6 +27,7 @@
 
 ///Clickon() with medical stacks will never go past attack() because this proc will never return FALSE. If needed, this is where to change it. Returns TRUE if handled and cannot progress.
 /obj/item/stack/medical/attack(mob/living/carbon/M, mob/user)
+	. = FALSE
 	if (!istype(M))
 		return FALSE
 
@@ -78,6 +79,7 @@
 	amount = 10
 
 /obj/item/stack/medical/bruise_pack/attack(mob/living/carbon/M, mob/user)
+	. = FALSE
 	if (..())
 		return TRUE
 
@@ -124,7 +126,7 @@
 			use(used)
 			H.update_bandages(1)
 		return TRUE
-	else return FALSE
+
 /obj/item/stack/medical/ointment
 	name = "ointment"
 	desc = "Used to treat those nasty burns."
@@ -137,6 +139,7 @@
 	apply_sounds = list('sound/effects/ointment.ogg')
 
 /obj/item/stack/medical/ointment/attack(mob/living/carbon/M, mob/user)
+	. = FALSE
 	if (..())
 		return TRUE
 
@@ -159,7 +162,6 @@
 			affecting.salve()
 			affecting.disinfect()
 		return TRUE
-	else return FALSE
 
 /obj/item/stack/medical/advanced/bruise_pack
 	name = "advanced trauma kit"
@@ -173,10 +175,10 @@
 	amount = 10
 
 /obj/item/stack/medical/advanced/bruise_pack/attack(mob/living/carbon/M, mob/user)
+	. = FALSE
 	if (..())
 		return TRUE
 
-	var/list/possible_surgeries
 	var/list/all_surgeries = GET_SINGLETON_SUBTYPE_MAP(/singleton/surgery_step)
 	for (var/singleton in all_surgeries)
 		var/singleton/surgery_step/S = all_surgeries[singleton]
@@ -225,7 +227,6 @@
 			use(used)
 			H.update_bandages(1)
 		return TRUE
-	else return FALSE
 
 /obj/item/stack/medical/advanced/ointment
 	name = "advanced burn kit"
@@ -239,6 +240,7 @@
 
 
 /obj/item/stack/medical/advanced/ointment/attack(mob/living/carbon/M, mob/user)
+	. = FALSE
 	if (..())
 		return TRUE
 
@@ -264,7 +266,6 @@
 			if (M.stat == UNCONSCIOUS && prob(25))
 				to_chat(M, SPAN_NOTICE(SPAN_BOLD("... [pick("feels better", "hurts less")] ...")))
 		return TRUE
-	else return FALSE
 
 /obj/item/stack/medical/splint
 	name = "medical splints"
@@ -278,6 +279,7 @@
 	var/list/splintable_organs = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG, BP_L_HAND, BP_R_HAND, BP_L_FOOT, BP_R_FOOT)	//List of organs you can splint, natch.
 
 /obj/item/stack/medical/splint/attack(mob/living/carbon/M, mob/user)
+	. = FALSE
 	if (..())
 		return TRUE
 
@@ -316,7 +318,6 @@
 				S.dropInto(src.loc) //didn't get applied, so just drop it
 			user.visible_message(SPAN_DANGER("\The [user] fails to apply [src]."), SPAN_DANGER("You fail to apply [src]."), SPAN_DANGER("You hear something being wrapped."))
 		return TRUE
-	else return FALSE
 
 /obj/item/stack/medical/splint/ghetto
 	name = "makeshift splints"
@@ -360,6 +361,7 @@
 
 
 /obj/item/stack/medical/resin/attack(mob/living/carbon/M, mob/user)
+	. = FALSE
 	if (..())
 		return TRUE
 
@@ -399,4 +401,3 @@
 		affecting.heal_damage(heal_brute, heal_burn, robo_repair = TRUE)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		return TRUE
-	else return FALSE

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -28,8 +28,7 @@
 ///Clickon() with medical stacks will never go past attack() because this proc will never return FALSE. If needed, this is where to change it. Returns TRUE if handled and cannot progress.
 /obj/item/stack/medical/attack(mob/living/carbon/M, mob/user)
 	if (!istype(M))
-		to_chat(user, SPAN_WARNING("\The [src] cannot be applied to [M]!"))
-		return TRUE
+		return FALSE
 
 	if (!(istype(user, /mob/living/carbon/human) || \
 			istype(user, /mob/living/silicon)) )
@@ -124,7 +123,8 @@
 					to_chat(user, SPAN_WARNING("\The [src] is used up, but there are more wounds to treat on \the [affecting.name]."))
 			use(used)
 			H.update_bandages(1)
-	return TRUE
+		return TRUE
+	else return FALSE
 /obj/item/stack/medical/ointment
 	name = "ointment"
 	desc = "Used to treat those nasty burns."
@@ -159,6 +159,7 @@
 			affecting.salve()
 			affecting.disinfect()
 		return TRUE
+	else return FALSE
 
 /obj/item/stack/medical/advanced/bruise_pack
 	name = "advanced trauma kit"
@@ -174,6 +175,13 @@
 /obj/item/stack/medical/advanced/bruise_pack/attack(mob/living/carbon/M, mob/user)
 	if (..())
 		return TRUE
+
+	var/list/possible_surgeries
+	var/list/all_surgeries = GET_SINGLETON_SUBTYPE_MAP(/singleton/surgery_step)
+	for (var/singleton in all_surgeries)
+		var/singleton/surgery_step/S = all_surgeries[singleton]
+		if (S.name && S.tool_quality(src) && S.can_use(user, M, user.zone_sel.selecting, src))
+			return FALSE
 
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
@@ -217,6 +225,7 @@
 			use(used)
 			H.update_bandages(1)
 		return TRUE
+	else return FALSE
 
 /obj/item/stack/medical/advanced/ointment
 	name = "advanced burn kit"
@@ -255,6 +264,7 @@
 			if (M.stat == UNCONSCIOUS && prob(25))
 				to_chat(M, SPAN_NOTICE(SPAN_BOLD("... [pick("feels better", "hurts less")] ...")))
 		return TRUE
+	else return FALSE
 
 /obj/item/stack/medical/splint
 	name = "medical splints"
@@ -306,6 +316,7 @@
 				S.dropInto(src.loc) //didn't get applied, so just drop it
 			user.visible_message(SPAN_DANGER("\The [user] fails to apply [src]."), SPAN_DANGER("You fail to apply [src]."), SPAN_DANGER("You hear something being wrapped."))
 		return TRUE
+	else return FALSE
 
 /obj/item/stack/medical/splint/ghetto
 	name = "makeshift splints"
@@ -388,3 +399,4 @@
 		affecting.heal_damage(heal_brute, heal_burn, robo_repair = TRUE)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		return TRUE
+	else return FALSE

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -6,6 +6,7 @@
 	amount = 5
 	max_amount = 5
 	w_class = ITEM_SIZE_SMALL
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	throw_speed = 4
 	throw_range = 20
 
@@ -24,49 +25,50 @@
 	else
 		. = TRUE
 
+///Clickon() with medical stacks will never go past attack() because this proc will never return FALSE. If needed, this is where to change it. Returns TRUE if handled and cannot progress.
 /obj/item/stack/medical/attack(mob/living/carbon/M, mob/user)
-
+	SHOULD_CALL_PARENT(FALSE)
 	if (!istype(M))
 		to_chat(user, SPAN_WARNING("\The [src] cannot be applied to [M]!"))
-		return 1
+		return TRUE
 
-	if ( ! (istype(user, /mob/living/carbon/human) || \
+	if (!(istype(user, /mob/living/carbon/human) || \
 			istype(user, /mob/living/silicon)) )
 		to_chat(user, SPAN_WARNING("You don't have the dexterity to do this!"))
-		return 1
+		return TRUE
 
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
 
-		if(!affecting)
+		if (!affecting)
 			to_chat(user, SPAN_WARNING("\The [M] is missing that body part!"))
-			return 1
+			return TRUE
 
-		if(!check_limb_state(user, affecting))
-			return 1
+		if (!check_limb_state(user, affecting))
+			return TRUE
 
-		if(affecting.organ_tag == BP_HEAD)
-			if(H.head && istype(H.head,/obj/item/clothing/head/helmet/space))
-				to_chat(user, SPAN_WARNING("You can't apply [src] through [H.head]!"))
-				return 1
+		if (affecting.organ_tag == BP_HEAD)
+			if (H.head && istype(H.head,/obj/item/clothing/head/helmet/space))
+				to_chat(user, SPAN_WARNING("You can't apply \the [src] through \the [H.head]!"))
+				return TRUE
 		else
-			if(H.wear_suit && istype(H.wear_suit,/obj/item/clothing/suit/space))
-				to_chat(user, SPAN_WARNING("You can't apply [src] through [H.wear_suit]!"))
-				return 1
+			if (H.wear_suit && istype(H.wear_suit,/obj/item/clothing/suit/space))
+				to_chat(user, SPAN_WARNING("You can't apply \the [src] through \the [H.wear_suit]!"))
+				return TRUE
 
 		H.UpdateDamageIcon()
 
 	else
-
 		M.heal_organ_damage((src.heal_brute/2), (src.heal_burn/2))
 		user.visible_message( \
-			SPAN_NOTICE("[M] has been applied with [src] by [user]."), \
-			SPAN_NOTICE("You apply \the [src] to [M].") \
+			SPAN_NOTICE("\The [M] has been applied with \the [src] by \the [user]."), \
+			SPAN_NOTICE("You apply \the [src] to \the [M].") \
 		)
 		use(1)
 
-	M.updatehealth()
+	M.updatehealth() //No return value here as this is a parent to all the medical stacks. Terminal return values after success in children.
+
 /obj/item/stack/medical/bruise_pack
 	name = "roll of gauze"
 	singular_name = "gauze length"
@@ -78,26 +80,26 @@
 	amount = 10
 
 /obj/item/stack/medical/bruise_pack/attack(mob/living/carbon/M, mob/user)
-	if(..())
-		return 1
+	if (..())
+		return TRUE
 
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting) //nullchecked by ..()
 
-		if(affecting.is_bandaged())
+		if (affecting.is_bandaged())
 			to_chat(user, SPAN_WARNING("The wounds on [M]'s [affecting.name] have already been bandaged."))
-			return 1
+			return TRUE
 		else
 			user.visible_message(SPAN_NOTICE("\The [user] starts treating [M]'s [affecting.name]."), \
 					             SPAN_NOTICE("You start treating [M]'s [affecting.name]."))
 			var/used = 0
 			for (var/datum/wound/W in affecting.wounds)
-				if(W.bandaged)
+				if (W.bandaged)
 					continue
-				if(used == amount)
+				if (used == amount)
 					break
-				if(!do_after(user, W.damage / 5, M, DO_MEDICAL))
+				if (!do_after(user, W.damage / 5, M, DO_MEDICAL))
 					break
 
 				if (W.current_stage <= W.max_bleeding_stage)
@@ -116,14 +118,14 @@
 				playsound(src, pick(apply_sounds), 25)
 				used++
 			affecting.update_damages()
-			if(used == amount)
-				if(affecting.is_bandaged())
+			if (used == amount)
+				if (affecting.is_bandaged())
 					to_chat(user, SPAN_WARNING("\The [src] is used up."))
 				else
 					to_chat(user, SPAN_WARNING("\The [src] is used up, but there are more wounds to treat on \the [affecting.name]."))
 			use(used)
 			H.update_bandages(1)
-
+	return TRUE
 /obj/item/stack/medical/ointment
 	name = "ointment"
 	desc = "Used to treat those nasty burns."
@@ -136,27 +138,28 @@
 	apply_sounds = list('sound/effects/ointment.ogg')
 
 /obj/item/stack/medical/ointment/attack(mob/living/carbon/M, mob/user)
-	if(..())
-		return 1
+	if (..())
+		return TRUE
 
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting) //nullchecked by ..()
 
-		if(affecting.is_salved())
+		if (affecting.is_salved())
 			to_chat(user, SPAN_WARNING("The wounds on [M]'s [affecting.name] have already been salved."))
-			return 1
+			return TRUE
 		else
 			user.visible_message(SPAN_NOTICE("\The [user] starts salving wounds on [M]'s [affecting.name]."), \
 					             SPAN_NOTICE("You start salving the wounds on [M]'s [affecting.name].") )
 			playsound(src, pick(apply_sounds), 25)
-			if(!do_after(user, 1 SECOND, M, DO_MEDICAL))
-				return 1
+			if (!do_after(user, 1 SECOND, M, DO_MEDICAL))
+				return TRUE
 			user.visible_message(SPAN_NOTICE("[user] salved wounds on [M]'s [affecting.name]."), \
 			                         SPAN_NOTICE("You salved wounds on [M]'s [affecting.name].") )
 			use(1)
 			affecting.salve()
 			affecting.disinfect()
+		return TRUE
 
 /obj/item/stack/medical/advanced/bruise_pack
 	name = "advanced trauma kit"
@@ -170,15 +173,15 @@
 	amount = 10
 
 /obj/item/stack/medical/advanced/bruise_pack/attack(mob/living/carbon/M, mob/user)
-	if(..())
-		return 1
+	if (..())
+		return TRUE
 
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting) //nullchecked by ..()
-		if(affecting.is_bandaged() && affecting.is_disinfected())
+		if (affecting.is_bandaged() && affecting.is_disinfected())
 			to_chat(user, SPAN_WARNING("The wounds on [M]'s [affecting.name] have already been treated."))
-			return 1
+			return TRUE
 		else
 			user.visible_message(SPAN_NOTICE("\The [user] starts treating [M]'s [affecting.name]."), \
 					             SPAN_NOTICE("You start treating [M]'s [affecting.name].") )
@@ -186,9 +189,9 @@
 			for (var/datum/wound/W in affecting.wounds)
 				if (W.bandaged && W.disinfected)
 					continue
-				if(used == amount)
+				if (used == amount)
 					break
-				if(!do_after(user, W.damage / 5, M, DO_MEDICAL))
+				if (!do_after(user, W.damage / 5, M, DO_MEDICAL))
 					break
 				if (W.current_stage <= W.max_bleeding_stage)
 					user.visible_message(SPAN_NOTICE("\The [user] cleans \a [W.desc] on [M]'s [affecting.name] and seals the edges with bioglue."), \
@@ -207,13 +210,14 @@
 				if (M.stat == UNCONSCIOUS && prob(25))
 					to_chat(M, SPAN_NOTICE(SPAN_BOLD("... [pick("feels better", "hurts less")] ...")))
 			affecting.update_damages()
-			if(used == amount)
-				if(affecting.is_bandaged())
+			if (used == amount)
+				if (affecting.is_bandaged())
 					to_chat(user, SPAN_WARNING("\The [src] is used up."))
 				else
 					to_chat(user, SPAN_WARNING("\The [src] is used up, but there are more wounds to treat on \the [affecting.name]."))
 			use(used)
 			H.update_bandages(1)
+		return TRUE
 
 /obj/item/stack/medical/advanced/ointment
 	name = "advanced burn kit"
@@ -227,22 +231,22 @@
 
 
 /obj/item/stack/medical/advanced/ointment/attack(mob/living/carbon/M, mob/user)
-	if(..())
-		return 1
+	if (..())
+		return TRUE
 
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting) //nullchecked by ..()
 
-		if(affecting.is_salved())
+		if (affecting.is_salved())
 			to_chat(user, SPAN_WARNING("The wounds on [M]'s [affecting.name] have already been salved."))
-			return 1
+			return TRUE
 		else
 			user.visible_message(SPAN_NOTICE("\The [user] starts salving wounds on [M]'s [affecting.name]."), \
 					             SPAN_NOTICE("You start salving the wounds on [M]'s [affecting.name].") )
 			playsound(src, pick(apply_sounds), 25)
 			if(!do_after(user, 1 SECOND, M, DO_MEDICAL))
-				return 1
+				return TRUE
 			user.visible_message( 	SPAN_NOTICE("[user] covers wounds on [M]'s [affecting.name] with regenerative membrane."), \
 									SPAN_NOTICE("You cover wounds on [M]'s [affecting.name] with regenerative membrane.") )
 			affecting.heal_damage(0,heal_burn)
@@ -251,6 +255,7 @@
 			affecting.disinfect()
 			if (M.stat == UNCONSCIOUS && prob(25))
 				to_chat(M, SPAN_NOTICE(SPAN_BOLD("... [pick("feels better", "hurts less")] ...")))
+		return TRUE
 
 /obj/item/stack/medical/splint
 	name = "medical splints"
@@ -264,44 +269,44 @@
 	var/list/splintable_organs = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG, BP_L_HAND, BP_R_HAND, BP_L_FOOT, BP_R_FOOT)	//List of organs you can splint, natch.
 
 /obj/item/stack/medical/splint/attack(mob/living/carbon/M, mob/user)
-	if(..())
-		return 1
+	if (..())
+		return TRUE
 
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting) //nullchecked by ..()
 		var/limb = affecting.name
-		if(!(affecting.organ_tag in splintable_organs))
+		if (!(affecting.organ_tag in splintable_organs))
 			to_chat(user, SPAN_DANGER("You can't use \the [src] to apply a splint there!"))
-			return
-		if(affecting.splinted)
+			return TRUE
+		if (affecting.splinted)
 			to_chat(user, SPAN_DANGER("[M]'s [limb] is already splinted!"))
-			return
+			return TRUE
 		if (M != user)
 			user.visible_message(SPAN_DANGER("[user] starts to apply \the [src] to [M]'s [limb]."), SPAN_DANGER("You start to apply \the [src] to [M]'s [limb]."), SPAN_DANGER("You hear something being wrapped."))
 		else
-			if(( !user.hand && (affecting.organ_tag in list(BP_R_ARM, BP_R_HAND)) || \
+			if ((!user.hand && (affecting.organ_tag in list(BP_R_ARM, BP_R_HAND)) || \
 				user.hand && (affecting.organ_tag in list(BP_L_ARM, BP_L_HAND)) ))
 				to_chat(user, SPAN_DANGER("You can't apply a splint to the arm you're using!"))
-				return
+				return TRUE
 			user.visible_message(SPAN_DANGER("[user] starts to apply \the [src] to their [limb]."), SPAN_DANGER("You start to apply \the [src] to your [limb]."), SPAN_DANGER("You hear something being wrapped."))
-		if(user.do_skilled(5 SECONDS, SKILL_MEDICAL, M, do_flags = DO_MEDICAL))
-			if((M == user && prob(75)) || prob(user.skill_fail_chance(SKILL_MEDICAL,50, SKILL_TRAINED)))
+		if (user.do_skilled(5 SECONDS, SKILL_MEDICAL, M, do_flags = DO_MEDICAL))
+			if ((M == user && prob(75)) || prob(user.skill_fail_chance(SKILL_MEDICAL,50, SKILL_TRAINED)))
 				user.visible_message(SPAN_DANGER("\The [user] fumbles [src]."), SPAN_DANGER("You fumble [src]."), SPAN_DANGER("You hear something being wrapped."))
-				return
+				return TRUE
 			var/obj/item/stack/medical/splint/S = split(1, TRUE)
-			if(S)
-				if(affecting.apply_splint(S))
+			if (S)
+				if (affecting.apply_splint(S))
 					M.verbs += /mob/living/carbon/human/proc/remove_splints
 					S.forceMove(affecting)
 					if (M != user)
 						user.visible_message(SPAN_DANGER("\The [user] finishes applying [src] to [M]'s [limb]."), SPAN_DANGER("You finish applying \the [src] to [M]'s [limb]."), SPAN_DANGER("You hear something being wrapped."))
 					else
 						user.visible_message(SPAN_DANGER("\The [user] successfully applies [src] to their [limb]."), SPAN_DANGER("You successfully apply \the [src] to your [limb]."), SPAN_DANGER("You hear something being wrapped."))
-					return
+					return TRUE
 				S.dropInto(src.loc) //didn't get applied, so just drop it
 			user.visible_message(SPAN_DANGER("\The [user] fails to apply [src]."), SPAN_DANGER("You fail to apply [src]."), SPAN_DANGER("You hear something being wrapped."))
-		return
+		return TRUE
 
 /obj/item/stack/medical/splint/ghetto
 	name = "makeshift splints"
@@ -345,39 +350,42 @@
 
 
 /obj/item/stack/medical/resin/attack(mob/living/carbon/M, mob/user)
-	. = ..()
-	if(!. && ishuman(M))
+	if (..())
+		return TRUE
+
+	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
-		if((affecting.brute_dam + affecting.burn_dam) <= 0)
+		if ((affecting.brute_dam + affecting.burn_dam) <= 0)
 			to_chat(user, SPAN_WARNING("\The [M]'s [affecting.name] is undamaged."))
 			return TRUE
 		user.visible_message(
 			SPAN_NOTICE("\The [user] starts patching damage on \the [M]'s [affecting.name]."), \
 			SPAN_NOTICE("You start patching damage on \the [M]'s [affecting.name].") )
 		playsound(src, pick(apply_sounds), 25)
-		if(!do_after(user, 2 SECOND, M, DO_MEDICAL))
+		if (!do_after(user, 2 SECOND, M, DO_MEDICAL))
 			to_chat(user, SPAN_NOTICE("You must stand still to patch damage."))
 			return TRUE
 		user.visible_message( \
 			SPAN_NOTICE("\The [user] patches the damage on \the [M]'s [affecting.name] with resin."), \
 			SPAN_NOTICE("You patch damage on \the [M]'s [affecting.name] with resin."))
 		use(1)
-		if(BP_IS_CRYSTAL(affecting))
+		if (BP_IS_CRYSTAL(affecting))
 			if(prob(75))
 				to_chat(M, SPAN_NOTICE("Fresh crystals seem to form over your [affecting.name]."))
 			affecting.heal_damage(rand(heal_brute - 2, heal_brute + 4), rand(heal_burn - 2, heal_burn + 4), robo_repair = TRUE)
 			return TRUE
-		if(BP_IS_BRITTLE(affecting))
-			if(!prob(user.get_skill_value(SKILL_DEVICES) * 20)) //80% to 0% chance, depending on skill, for your brittle organ to hurt and then heal.
+		if (BP_IS_BRITTLE(affecting))
+			if (!prob(user.get_skill_value(SKILL_DEVICES) * 20)) //80% to 0% chance, depending on skill, for your brittle organ to hurt and then heal.
 				to_chat(H, SPAN_DANGER("Crystals are forming around your [affecting.name], damaging internal integrity!"))
-				for(var/i = 1 to rand(1,3))
+				for (var/i = 1 to rand(1,3))
 					new /obj/item/material/shard(get_turf(affecting), MATERIAL_STEEL)
 				affecting.take_external_damage(rand(20,40), 0)
 			if(prob(30))
-				if(!M.isSynthetic())
+				if (!M.isSynthetic())
 					M.emote("scream")
 					M.Weaken(2)
 				affecting.status |= ORGAN_BRITTLE // 30% chance to brittle your limb/organ, and if you're organic, you get weakened.
 		affecting.heal_damage(heal_brute, heal_burn, robo_repair = TRUE)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		return TRUE

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -27,7 +27,6 @@
 
 ///Clickon() with medical stacks will never go past attack() because this proc will never return FALSE. If needed, this is where to change it. Returns TRUE if handled and cannot progress.
 /obj/item/stack/medical/attack(mob/living/carbon/M, mob/user)
-	SHOULD_CALL_PARENT(FALSE)
 	if (!istype(M))
 		to_chat(user, SPAN_WARNING("\The [src] cannot be applied to [M]!"))
 		return TRUE

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -49,3 +49,4 @@
 				user.visible_message(SPAN_NOTICE("\The [user] applies some nanite paste on [user != M ? "[M]'s [S.name]" : "[S]"] with [src]."),\
 				SPAN_NOTICE("You apply some nanite paste on [user == M ? "your" : "[M]'s"] [S.name]."))
 			return TRUE
+	else return FALSE

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -10,8 +10,9 @@
 
 
 /obj/item/stack/nanopaste/attack(mob/living/M as mob, mob/user as mob)
+	. = FALSE
 	if (!istype(M) || !istype(user))
-		return ..()
+		return FALSE
 	if (istype(M,/mob/living/silicon/robot))	//Repairing cyborgs
 		var/mob/living/silicon/robot/R = M
 		if (R.getBruteLoss() || R.getFireLoss() )
@@ -49,4 +50,3 @@
 				user.visible_message(SPAN_NOTICE("\The [user] applies some nanite paste on [user != M ? "[M]'s [S.name]" : "[S]"] with [src]."),\
 				SPAN_NOTICE("You apply some nanite paste on [user == M ? "your" : "[M]'s"] [S.name]."))
 			return TRUE
-	else return FALSE

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -5,12 +5,13 @@
 	icon = 'icons/obj/medical.dmi'
 	icon_state = "nanopaste"
 	origin_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	amount = 10
 
 
 /obj/item/stack/nanopaste/attack(mob/living/M as mob, mob/user as mob)
 	if (!istype(M) || !istype(user))
-		return FALSE
+		return ..()
 	if (istype(M,/mob/living/silicon/robot))	//Repairing cyborgs
 		var/mob/living/silicon/robot/R = M
 		if (R.getBruteLoss() || R.getFireLoss() )
@@ -23,6 +24,7 @@
 				SPAN_NOTICE("You apply some [src] at [R]'s damaged areas."))
 		else
 			to_chat(user, SPAN_NOTICE("All [R]'s systems are nominal."))
+		return TRUE
 
 	if (istype(M,/mob/living/carbon/human))		//Repairing robolimbs
 		var/mob/living/carbon/human/H = M
@@ -30,19 +32,20 @@
 
 		if(!S)
 			to_chat(user, SPAN_WARNING("\The [M] is missing that body part."))
-			return
+			return TRUE
 
 		if(BP_IS_BRITTLE(S))
 			to_chat(user, SPAN_WARNING("\The [M]'s [S.name] is hard and brittle - \the [src] cannot repair it."))
-			return
+			return TRUE
 
 		if(S && BP_IS_ROBOTIC(S) && S.hatch_state == HATCH_OPENED)
-			if(!S.get_damage())
+			if (!S.get_damage())
 				to_chat(user, SPAN_NOTICE("Nothing to fix here."))
-			else if(can_use(1))
+			else if (can_use(1))
 				user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 				S.heal_damage(15, 15, robo_repair = 1)
 				H.updatehealth()
 				use(1)
 				user.visible_message(SPAN_NOTICE("\The [user] applies some nanite paste on [user != M ? "[M]'s [S.name]" : "[S]"] with [src]."),\
 				SPAN_NOTICE("You apply some nanite paste on [user == M ? "your" : "[M]'s"] [S.name]."))
+			return TRUE

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -211,6 +211,7 @@
 
 
 /obj/item/toy/crossbow/attack(mob/M as mob, mob/user as mob)
+	. = FALSE
 	if (istype(M) && M.lying)
 		if (bullets > 0)
 			M.visible_message(
@@ -227,7 +228,6 @@
 			M.visible_message(SPAN_DANGER("\The [user] casually lines up a shot with \the [M]'s head, pulls the trigger, then realizes they are out of ammo and drops to the floor in search of some!"))
 			user.Weaken(5)
 			return TRUE
-	else return ..()
 
 /obj/item/toy/crossbow/examine(mob/user, distance)
 	. = ..()

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -44,9 +44,6 @@
 	create_reagents(10)
 	..()
 
-/obj/item/toy/water_balloon/attack(mob/living/carbon/human/M as mob, mob/user as mob)
-	return
-
 /obj/item/toy/water_balloon/afterattack(atom/A as mob|obj, mob/user as mob, proximity)
 	if(!proximity) return
 	if (istype(A, /obj/structure/reagent_dispensers/watertank) && get_dist(src,A) <= 1)
@@ -149,6 +146,7 @@
 		icon_r_hand = 'icons/mob/onmob/items/righthand_guns.dmi',
 		)
 	w_class = ITEM_SIZE_SMALL
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	attack_verb = list("attacked", "struck", "hit")
 	var/bullets = 5
 
@@ -213,25 +211,23 @@
 
 
 /obj/item/toy/crossbow/attack(mob/M as mob, mob/user as mob)
-	src.add_fingerprint(user)
+	if(istype(M) && M.lying)
+		if (bullets > 0)
+			M.visible_message(
+				SPAN_DANGER("\The [user] casually lines up a shot with \the [M]'s head and pulls the trigger!"),
+				SPAN_WARNING("You hear the sound of foam against skull")
+			)
+			M.visible_message(SPAN_WARNING("\The [M] was hit in the head by the foam dart!"))
 
-// ******* Check
-
-	if (src.bullets > 0 && M.lying)
-
-		M.visible_message(
-			SPAN_DANGER("\The [user] casually lines up a shot with \the [M]'s head and pulls the trigger!"),
-			SPAN_WARNING("You hear the sound of foam against skull")
-		)
-		M.visible_message(SPAN_WARNING("\The [M] was hit in the head by the foam dart!"))
-
-		playsound(user.loc, 'sound/items/syringeproj.ogg', 50, 1)
-		new /obj/item/toy/ammo/crossbow(M.loc)
-		src.bullets--
-	else if (M.lying && src.bullets == 0)
-		M.visible_message(SPAN_DANGER("\The [user] casually lines up a shot with \the [M]'s head, pulls the trigger, then realizes they are out of ammo and drops to the floor in search of some!"))
-		user.Weaken(5)
-	return
+			playsound(user.loc, 'sound/items/syringeproj.ogg', 50, 1)
+			new /obj/item/toy/ammo/crossbow(M.loc)
+			src.bullets--
+			return TRUE
+		if (bullets == 0)
+			M.visible_message(SPAN_DANGER("\The [user] casually lines up a shot with \the [M]'s head, pulls the trigger, then realizes they are out of ammo and drops to the floor in search of some!"))
+			user.Weaken(5)
+			return TRUE
+	else return ..()
 
 /obj/item/toy/crossbow/examine(mob/user, distance)
 	. = ..()

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -211,7 +211,7 @@
 
 
 /obj/item/toy/crossbow/attack(mob/M as mob, mob/user as mob)
-	if(istype(M) && M.lying)
+	if (istype(M) && M.lying)
 		if (bullets > 0)
 			M.visible_message(
 				SPAN_DANGER("\The [user] casually lines up a shot with \the [M]'s head and pulls the trigger!"),

--- a/code/game/objects/items/traitor_plush.dm
+++ b/code/game/objects/items/traitor_plush.dm
@@ -12,9 +12,6 @@
 	. = ..()
 	reagents.add_reagent(/datum/reagent/nutriment/protein, 10)
 
-/obj/item/reagent_containers/food/snacks/dehydrated_carp/attack(mob/M, mob/user, def_zone)
-	return
-
 /obj/item/reagent_containers/food/snacks/dehydrated_carp/attack_self(mob/user)
 	if (user.a_intent == I_HELP)
 		user.visible_message(SPAN_NOTICE("\The [user] hugs [src]!"), SPAN_NOTICE("You hug [src]!"))

--- a/code/game/objects/items/trash.dm
+++ b/code/game/objects/items/trash.dm
@@ -16,11 +16,6 @@
 		age = trash_age
 	SSpersistence.track_value(src, /datum/persistent/filth/trash)
 
-
-/obj/item/trash/attack(mob/living/target, mob/living/user)
-	return
-
-
 /obj/item/trash/raisins
 	name = "\improper 4no raisins"
 	icon_state = "4no_raisins"

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -38,9 +38,6 @@
 		work_modes = h.children
 	work_mode = work_modes[1]
 
-/obj/item/rcd/attack()
-	return 0
-
 /obj/item/rcd/proc/can_use(mob/user,turf/T)
 	return (user.Adjacent(T) && user.get_active_hand() == src && !user.incapacitated())
 

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -46,14 +46,11 @@
 	if (ishuman(A))
 		var/mob/living/carbon/human/H = A
 		var/obj/item/organ/external/head/head = H.organs_by_name[BP_HEAD]
-		to_world("Correctly created head [head].")
 
 		if (!istype(head))
-			to_world("Breaking early to return true.")
 			return TRUE
 
 		if (user.a_intent == I_HELP && user.zone_sel.selecting == BP_HEAD)
-			to_world("NOT A HEAD.")
 			head.write_on(user, name)
 			return TRUE
 

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -39,6 +39,7 @@
 		icon_state = initial(icon_state)
 
 /obj/item/lipstick/attack(atom/A, mob/living/user as mob)
+	. = FALSE
 	if (!open)
 		to_chat(user, SPAN_NOTICE("You need to uncap \the [src] first!"))
 		return TRUE
@@ -80,7 +81,6 @@
 		head.write_on(user, name)
 		return TRUE
 
-	else return ..()
 
 //you can wipe off lipstick with paper! see code/modules/paperwork/paper.dm, paper/attack()
 

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -6,6 +6,7 @@
 	icon_state = "lipstick"
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	var/colour = "red"
 	var/open = 0
 
@@ -37,38 +38,52 @@
 	else
 		icon_state = initial(icon_state)
 
-/obj/item/lipstick/attack(atom/A, mob/user as mob, target_zone)
-	if(!open)	return
+/obj/item/lipstick/attack(atom/A, mob/living/user as mob)
+	if (!open)
+		to_chat(user, SPAN_NOTICE("You need to uncap \the [src] first!"))
+		return TRUE
 
-	if(ishuman(A))
+	if (ishuman(A))
 		var/mob/living/carbon/human/H = A
 		var/obj/item/organ/external/head/head = H.organs_by_name[BP_HEAD]
+		to_world("Correctly created head [head].")
 
-		if(!istype(head))
-			return
+		if (!istype(head))
+			to_world("Breaking early to return true.")
+			return TRUE
 
-		if(user.a_intent == I_HELP && target_zone == BP_HEAD)
-			head.write_on(user, src.name)
-		else if(head.has_lips)
-			if(H.makeup_style)	//if they already have lipstick on
+		if (user.a_intent == I_HELP && user.zone_sel.selecting == BP_HEAD)
+			to_world("NOT A HEAD.")
+			head.write_on(user, name)
+			return TRUE
+
+		if (head.has_lips && user.zone_sel.selecting == BP_MOUTH)
+			if (H.makeup_style)	//if they already have lipstick on
 				to_chat(user, SPAN_NOTICE("You need to wipe off the old lipstick first!"))
-				return
-			if(H == user)
-				user.visible_message(SPAN_NOTICE("[user] does their lips with \the [src]."), \
+				return TRUE
+
+			if (H == user)
+				user.visible_message(SPAN_NOTICE("\The [user] does their lips with \the [src]."), \
 									 SPAN_NOTICE("You take a moment to apply \the [src]. Perfect!"))
 				H.makeup_style = colour
 				H.update_body()
+				return TRUE
 			else
-				user.visible_message(SPAN_WARNING("[user] begins to do [H]'s lips with \the [src]."), \
-									 SPAN_NOTICE("You begin to apply \the [src]."))
-				if(do_after(user, 4 SECONDS, H, DO_EQUIP))
-					user.visible_message(SPAN_NOTICE("[user] does [H]'s lips with \the [src]."), \
-										 SPAN_NOTICE("You apply \the [src]."))
+				user.visible_message(SPAN_WARNING("\The [user] begins to do \the [H]'s lips with \the [src]."), \
+									 SPAN_NOTICE("You begin to apply \the [src] on \the [H]'s lips."))
+				if (do_after(user, 4 SECONDS, H, DO_EQUIP))
+					user.visible_message(SPAN_NOTICE("\The [user] does \the [H]'s lips with \the [src]."), \
+										 SPAN_NOTICE("You apply \the [src] on \the [H]'s lips."))
 					H.makeup_style = colour
 					H.update_body()
-	else if(istype(A, /obj/item/organ/external/head))
+				return TRUE
+
+	if(istype(A, /obj/item/organ/external/head))
 		var/obj/item/organ/external/head/head = A
-		head.write_on(user, src)
+		head.write_on(user, name)
+		return TRUE
+
+	else return ..()
 
 //you can wipe off lipstick with paper! see code/modules/paperwork/paper.dm, paper/attack()
 

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -297,10 +297,11 @@
 /obj/item/shockpaddles/proc/checked_use(charge_amt)
 	return 0
 
-/obj/item/shockpaddles/attack(mob/living/M, mob/living/user, target_zone)
+/obj/item/shockpaddles/attack(mob/living/M, mob/living/user)
+	. = FALSE
 	var/mob/living/carbon/human/H = M
 	if (!istype(H) || user.a_intent != I_HELP)
-		return ..()
+		return FALSE
 
 	if (can_use(user, H))
 		busy = 1

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -300,7 +300,7 @@
 /obj/item/shockpaddles/attack(mob/living/M, mob/living/user, target_zone)
 	var/mob/living/carbon/human/H = M
 	if (!istype(H) || user.a_intent != I_HELP)
-		return ..() //Cycle through the rest of the use_* calls.
+		return ..()
 
 	if (can_use(user, H))
 		busy = 1

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -208,6 +208,7 @@
 	force = 2
 	throwforce = 6
 	w_class = ITEM_SIZE_LARGE
+	item_flags = ITEM_FLAG_TRY_ATTACK
 
 	var/safety = 1 //if you can zap people with the paddles on harm mode
 	var/combat = 0 //If it can be used to revive people wearing thick clothing (e.g. spacesuits)
@@ -298,10 +299,10 @@
 
 /obj/item/shockpaddles/attack(mob/living/M, mob/living/user, target_zone)
 	var/mob/living/carbon/human/H = M
-	if(!istype(H) || user.a_intent == I_HURT)
-		return ..() //Do a regular attack. Harm intent shocking happens as a hit effect
+	if (!istype(H) || user.a_intent == I_HURT)
+		return ..() //Cycle through the rest of the use_* calls.
 
-	if(can_use(user, H))
+	if (can_use(user, H))
 		busy = 1
 		update_icon()
 

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -299,7 +299,7 @@
 
 /obj/item/shockpaddles/attack(mob/living/M, mob/living/user, target_zone)
 	var/mob/living/carbon/human/H = M
-	if (!istype(H) || user.a_intent == I_HURT)
+	if (!istype(H) || user.a_intent != I_HELP)
 		return ..() //Cycle through the rest of the use_* calls.
 
 	if (can_use(user, H))
@@ -310,8 +310,7 @@
 
 		busy = 0
 		update_icon()
-
-	return 1
+	return TRUE
 
 //Since harm-intent now skips the delay for deliberate placement, you have to be able to hit them in combat in order to shock people.
 /obj/item/shockpaddles/apply_hit_effect(mob/living/target, mob/living/user, hit_zone)
@@ -405,7 +404,7 @@
 		return
 
 	//no need to spend time carefully placing the paddles, we're just trying to shock them
-	user.visible_message(SPAN_DANGER("\The [user] slaps [src] onto [H]'s [affecting.name]."), SPAN_DANGER("You overcharge [src] and slap them onto [H]'s [affecting.name]."))
+	user.visible_message(SPAN_DANGER("\The [user] slaps [src] onto [H]'s [affecting.name]. [safety? "However, it fizzles out as the safety indicator flashes.": ""]"), SPAN_DANGER("You overcharge [src] and slap them onto [H]'s [affecting.name]. [safety? "However, it fizzles out as the safety indicator flashes.": ""]"))
 
 	//Just stop at awkwardly slapping electrodes on people if the safety is enabled
 	if(safety)

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -97,6 +97,3 @@
 			playsound(loc, 'sound/items/timer.ogg', 50)
 		T--
 	explode(get_turf(target))
-
-/obj/item/plastique/attack(mob/M as mob, mob/user as mob, def_zone)
-	return

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -64,8 +64,8 @@
 	return
 
 /obj/item/extinguisher/attack(mob/living/M, mob/user)
-	if (user.a_intent == I_HELP)
-		if (safety || (world.time < src.last_use + 20))
+	if (user.a_intent == I_HELP && !safety)
+		if (world.time < last_use + 20)
 			return TRUE
 		if (reagents.total_volume < 1)
 			to_chat(user, SPAN_NOTICE("\The [src] is empty."))
@@ -78,7 +78,7 @@
 		playsound(src.loc, 'sound/effects/extinguish.ogg', 75, 1, -3)
 
 		return TRUE
-	return ..()
+	else return ..()
 
 /obj/item/extinguisher/proc/propel_object(obj/O, mob/user, movementdirection)
 	if(O.anchored) return

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -64,6 +64,7 @@
 	return
 
 /obj/item/extinguisher/attack(mob/living/M, mob/user)
+	. = FALSE
 	if (user.a_intent == I_HELP && !safety)
 		if (world.time < last_use + 20)
 			return TRUE
@@ -78,7 +79,6 @@
 		playsound(src.loc, 'sound/effects/extinguish.ogg', 75, 1, -3)
 
 		return TRUE
-	else return ..()
 
 /obj/item/extinguisher/proc/propel_object(obj/O, mob/user, movementdirection)
 	if(O.anchored) return

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -65,7 +65,7 @@
 
 /obj/item/extinguisher/attack(mob/living/M, mob/user)
 	if (user.a_intent == I_HELP)
-		if (safety || (world.time < src.last_use + 20)) // We still catch help intent to not randomly attack people
+		if (safety || (world.time < src.last_use + 20))
 			return TRUE
 		if (reagents.total_volume < 1)
 			to_chat(user, SPAN_NOTICE("\The [src] is empty."))
@@ -77,7 +77,7 @@
 		user.visible_message(SPAN_NOTICE("\The [user] sprays \the [M] with \the [src]."))
 		playsound(src.loc, 'sound/effects/extinguish.ogg', 75, 1, -3)
 
-		return TRUE // No afterattack
+		return TRUE
 	return ..()
 
 /obj/item/extinguisher/proc/propel_object(obj/O, mob/user, movementdirection)

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -6,6 +6,7 @@
 	item_state = "fire_extinguisher"
 	hitsound = 'sound/weapons/smash.ogg'
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	throwforce = 10
 	w_class = ITEM_SIZE_NORMAL
 	throw_speed = 2
@@ -63,20 +64,20 @@
 	return
 
 /obj/item/extinguisher/attack(mob/living/M, mob/user)
-	if(user.a_intent == I_HELP)
-		if(src.safety || (world.time < src.last_use + 20)) // We still catch help intent to not randomly attack people
-			return
-		if(src.reagents.total_volume < 1)
+	if (user.a_intent == I_HELP)
+		if (safety || (world.time < src.last_use + 20)) // We still catch help intent to not randomly attack people
+			return TRUE
+		if (reagents.total_volume < 1)
 			to_chat(user, SPAN_NOTICE("\The [src] is empty."))
-			return
+			return TRUE
 
-		src.last_use = world.time
+		last_use = world.time
 		reagents.splash(M, min(reagents.total_volume, spray_amount))
 
 		user.visible_message(SPAN_NOTICE("\The [user] sprays \the [M] with \the [src]."))
 		playsound(src.loc, 'sound/effects/extinguish.ogg', 75, 1, -3)
 
-		return 1 // No afterattack
+		return TRUE // No afterattack
 	return ..()
 
 /obj/item/extinguisher/proc/propel_object(obj/O, mob/user, movementdirection)

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -151,6 +151,7 @@
 	icon = 'icons/obj/gifts.dmi'
 	icon_state = "wrap_paper"
 	var/amount = 2.5*BASE_STORAGE_COST(ITEM_SIZE_HUGE)
+	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/wrapping_paper/attackby(obj/item/W as obj, mob/user as mob)
 	..()
@@ -198,9 +199,10 @@
 		to_chat(user, text("There is about [] square units of paper left!", src.amount))
 
 /obj/item/wrapping_paper/attack(mob/target as mob, mob/user as mob)
-	if (!istype(target, /mob/living/carbon/human)) return
-	var/mob/living/carbon/human/H = target
+	if (!istype(target, /mob/living/carbon/human))
+		return ..()
 
+	var/mob/living/carbon/human/H = target
 	if (istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket) || H.stat)
 		if (src.amount > 2)
 			var/obj/effect/spresent/present = new /obj/effect/spresent (H.loc)
@@ -217,3 +219,4 @@
 			to_chat(user, SPAN_WARNING("You need more paper."))
 	else
 		to_chat(user, "They are moving around too much. A straightjacket would help.")
+	return TRUE

--- a/code/game/objects/items/weapons/gift_wrappaper.dm
+++ b/code/game/objects/items/weapons/gift_wrappaper.dm
@@ -199,8 +199,9 @@
 		to_chat(user, text("There is about [] square units of paper left!", src.amount))
 
 /obj/item/wrapping_paper/attack(mob/target as mob, mob/user as mob)
+	. = FALSE
 	if (!istype(target, /mob/living/carbon/human))
-		return ..()
+		return FALSE
 
 	var/mob/living/carbon/human/H = target
 	if (istype(H.wear_suit, /obj/item/clothing/suit/straight_jacket) || H.stat)

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/tools/handcuffs.dmi'
 	icon_state = "handcuff"
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	slot_flags = SLOT_BELT
 	throwforce = 5
 	w_class = ITEM_SIZE_SMALL
@@ -26,31 +27,31 @@
 	return ..()
 
 /obj/item/handcuffs/attack(mob/living/carbon/C, mob/living/user)
-
-	if(!user.IsAdvancedToolUser())
-		return
+	if (!user.IsAdvancedToolUser())
+		return FALSE
 
 	if ((MUTATION_CLUMSY in user.mutations) && prob(50))
 		to_chat(user, SPAN_WARNING("Uh ... how do those things work?!"))
 		place_handcuffs(user, user)
-		return
+		return TRUE
 
 	// only carbons can be handcuffed
-	if(istype(C))
-		if(!C.handcuffed)
+	if (istype(C))
+		if (!C.handcuffed)
 			if (C == user)
 				place_handcuffs(user, user)
-				return
+				return TRUE
 
 			//check for an aggressive grab (or robutts)
-			if(C.has_danger_grab(user))
+			if (C.has_danger_grab(user))
 				place_handcuffs(C, user)
 			else
 				to_chat(user, SPAN_DANGER("You need to have a firm grip on [C] before you can put \the [src] on!"))
 		else
 			to_chat(user, SPAN_WARNING("\The [C] is already handcuffed!"))
+		return TRUE
 	else
-		..()
+		return ..()
 
 /obj/item/handcuffs/proc/can_place(mob/target, mob/user)
 	if(user == target || istype(user, /mob/living/silicon/robot) || istype(user, /mob/living/bot))

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -27,6 +27,7 @@
 	return ..()
 
 /obj/item/handcuffs/attack(mob/living/carbon/C, mob/living/user)
+	. = FALSE
 	if (!user.IsAdvancedToolUser())
 		return FALSE
 
@@ -50,8 +51,6 @@
 		else
 			to_chat(user, SPAN_WARNING("\The [C] is already handcuffed!"))
 		return TRUE
-	else
-		return ..()
 
 /obj/item/handcuffs/proc/can_place(mob/target, mob/user)
 	if(user == target || istype(user, /mob/living/silicon/robot) || istype(user, /mob/living/bot))

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -44,8 +44,9 @@
 		..()
 
 /obj/item/implanter/attack(mob/M as mob, mob/user as mob)
+	. = FALSE
 	if (!istype(M, /mob/living/carbon))
-		return ..()
+		return FALSE
 
 	if (user && imp)
 		M.visible_message(SPAN_WARNING("[user] is attemping to implant [M]."))
@@ -63,4 +64,3 @@
 				src.imp = null
 				update_icon()
 		return TRUE
-	else return ..()

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -6,6 +6,7 @@
 	throw_speed = 1
 	throw_range = 5
 	w_class = ITEM_SIZE_SMALL
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	matter = list(MATERIAL_ALUMINIUM = 1000, MATERIAL_GLASS = 1000)
 	var/obj/item/implant/imp = null
 
@@ -44,22 +45,22 @@
 
 /obj/item/implanter/attack(mob/M as mob, mob/user as mob)
 	if (!istype(M, /mob/living/carbon))
-		return
-	if (user && src.imp)
-		M.visible_message(SPAN_WARNING("[user] is attemping to implant [M]."))
+		return ..()
 
+	if (user && imp)
+		M.visible_message(SPAN_WARNING("[user] is attemping to implant [M]."))
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 		user.do_attack_animation(M)
 
 		var/target_zone = user.zone_sel.selecting
-		if(src.imp.can_implant(M, user, target_zone))
+		if (imp.can_implant(M, user, target_zone))
 			var/imp_name = imp.name
 
-			if(do_after(user, 5 SECONDS, M, DO_EQUIP) && src.imp?.implant_in_mob(M, target_zone))
+			if (do_after(user, 5 SECONDS, M, DO_EQUIP) && src.imp?.implant_in_mob(M, target_zone))
 				M.visible_message(SPAN_WARNING("[M] has been implanted by [user]."))
 				admin_attack_log(user, M, "Implanted using \the [src] ([imp_name])", "Implanted with \the [src] ([imp_name])", "used an implanter, \the [src] ([imp_name]), on")
 
 				src.imp = null
 				update_icon()
-
-	return
+		return TRUE
+	else return ..()

--- a/code/game/objects/items/weapons/implants/implants/compressed.dm
+++ b/code/game/objects/items/weapons/implants/implants/compressed.dm
@@ -51,11 +51,12 @@
 
 /obj/item/implanter/compressed/attack(mob/M as mob, mob/user as mob)
 	var/obj/item/implant/compressed/c = imp
-	if (!c)	return
+	if (!c || !istype(M, /mob/living/carbon))
+		return ..()
 	if (c.scanned == null)
 		to_chat(user, "Please compress an object with the implanter first.")
-		return
-	..()
+		return TRUE
+	else return ..() //Implanting code is under the parent's attack proc.
 
 /obj/item/implanter/compressed/afterattack(obj/item/A, mob/user as mob, proximity)
 	if(!proximity)

--- a/code/game/objects/items/weapons/implants/implants/compressed.dm
+++ b/code/game/objects/items/weapons/implants/implants/compressed.dm
@@ -56,7 +56,7 @@
 	if (c.scanned == null)
 		to_chat(user, "Please compress an object with the implanter first.")
 		return TRUE
-	else return ..() //Implanting code is under the parent's attack proc.
+	else return ..()
 
 /obj/item/implanter/compressed/afterattack(obj/item/A, mob/user as mob, proximity)
 	if(!proximity)

--- a/code/game/objects/items/weapons/implants/implants/compressed.dm
+++ b/code/game/objects/items/weapons/implants/implants/compressed.dm
@@ -52,7 +52,7 @@
 /obj/item/implanter/compressed/attack(mob/M as mob, mob/user as mob)
 	var/obj/item/implant/compressed/c = imp
 	if (!c || !istype(M, /mob/living/carbon))
-		return ..()
+		return FALSE
 	if (c.scanned == null)
 		to_chat(user, "Please compress an object with the implanter first.")
 		return TRUE

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -7,6 +7,7 @@
 	w_class = ITEM_SIZE_TINY
 	throwforce = 4
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	slot_flags = SLOT_BELT
 	attack_verb = list("burnt", "singed")
 	var/max_fuel = 5
@@ -75,20 +76,19 @@
 		AddOverlays(overlay_image(icon, "[bis.base_icon_state]_striker", flags=RESET_COLOR))
 
 /obj/item/flame/lighter/attack(mob/living/M, mob/living/carbon/user)
-	if(!istype(M, /mob))
-		return
+	if (!istype(M))
+		return FALSE
 
-	if(lit)
+	if (lit)
 		M.IgniteMob()
-
-		if(istype(M.wear_mask, /obj/item/clothing/mask/smokable/cigarette) && user.zone_sel.selecting == BP_MOUTH)
+		if (istype(M.wear_mask, /obj/item/clothing/mask/smokable/cigarette) && user.zone_sel.selecting == BP_MOUTH)
 			var/obj/item/clothing/mask/smokable/cigarette/cig = M.wear_mask
-			if(M == user)
+			if (M == user)
 				cig.attackby(src, user)
 			else
 				cig.light(SPAN_NOTICE("[user] holds the [name] out for [M], and lights the [cig.name]."))
-			return
-	..()
+			return TRUE
+	return ..()
 
 /obj/item/flame/lighter/Process()
 	if(!submerged() && reagents.has_reagent(/datum/reagent/fuel))

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -76,6 +76,7 @@
 		AddOverlays(overlay_image(icon, "[bis.base_icon_state]_striker", flags=RESET_COLOR))
 
 /obj/item/flame/lighter/attack(mob/living/M, mob/living/carbon/user)
+	. = FALSE
 	if (!istype(M))
 		return FALSE
 
@@ -88,7 +89,6 @@
 			else
 				cig.light(SPAN_NOTICE("[user] holds the [name] out for [M], and lights the [cig.name]."))
 			return TRUE
-	return ..()
 
 /obj/item/flame/lighter/Process()
 	if(!submerged() && reagents.has_reagent(/datum/reagent/fuel))

--- a/code/game/objects/items/weapons/material/coins.dm
+++ b/code/game/objects/items/weapons/material/coins.dm
@@ -40,7 +40,8 @@
 		ClearOverlays()
 
 
-/obj/item/material/coin/attack(atom/target, mob/living/user, target_zone)
+/obj/item/material/coin/attack(atom/target, mob/living/user)
+	. = FALSE
 	if (target == user)
 		attack_self(user)
 		return TRUE
@@ -66,7 +67,6 @@
 			range = 5
 		)
 		return TRUE
-	else return ..()
 
 
 /obj/item/material/coin/attack_self(mob/living/user)

--- a/code/game/objects/items/weapons/material/coins.dm
+++ b/code/game/objects/items/weapons/material/coins.dm
@@ -66,6 +66,7 @@
 			range = 5
 		)
 		return TRUE
+	else return ..()
 
 
 /obj/item/material/coin/attack_self(mob/living/user)

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -7,6 +7,7 @@
  */
 /obj/item/material/kitchen/utensil
 	w_class = ITEM_SIZE_TINY
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	thrown_force_multiplier = 1
 	origin_tech = list(TECH_MATERIAL = 1)
 	attack_verb = list("attacked", "stabbed", "poked")
@@ -28,10 +29,10 @@
 	return
 
 /obj/item/material/kitchen/utensil/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if(!istype(M))
-		return FALSE
+	if (!istype(M) || user.a_intent != I_HELP)
+		return ..()
 
-	if (user.a_intent == I_HELP && reagents.total_volume > 0)
+	if (reagents.total_volume > 0)
 		if(M == user)
 			if(!M.can_eat(loaded))
 				return TRUE
@@ -50,7 +51,7 @@
 
 		else
 			user.visible_message(SPAN_WARNING("\The [user] begins to feed \the [M]!"))
-			if(!M.can_force_feed(user, loaded) || !do_after(user, 5 SECONDS, M, DO_PUBLIC_UNIQUE))
+			if (!M.can_force_feed(user, loaded) || !do_after(user, 5 SECONDS, M, DO_PUBLIC_UNIQUE))
 				return TRUE
 
 			if (user.get_active_hand() != src)
@@ -60,8 +61,9 @@
 		playsound(M.loc,'sound/items/eatfood.ogg', rand(10,40), 1)
 		ClearOverlays()
 		return TRUE
-	else return FALSE
-
+	else
+		to_chat(user, SPAN_WARNING("You don't have anything on \the [src]."))
+		return TRUE
 
 
 /obj/item/material/kitchen/utensil/fork

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -29,8 +29,9 @@
 	return
 
 /obj/item/material/kitchen/utensil/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+	. = FALSE
 	if (!istype(M) || user.a_intent != I_HELP)
-		return ..()
+		return FALSE
 
 	if (reagents.total_volume > 0)
 		if(M == user)
@@ -136,6 +137,7 @@
 
 
 /obj/item/material/kitchen/rollingpin/attack(mob/living/target, mob/living/user)
+	. = FALSE
 	if ((MUTATION_CLUMSY in user.mutations) && prob(50) && user.unEquip(src))
 		user.visible_message(
 			SPAN_WARNING("\The [user] manages to hit \himself on the head with \the [src]!"),
@@ -145,4 +147,3 @@
 		user.take_organ_damage(10, 0)
 		user.Paralyse(2)
 		return TRUE
-	return ..()

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -124,6 +124,7 @@
 	icon_state = "rolling_pin"
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	default_material = MATERIAL_WOOD
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	max_force = 15
 	force_multiplier = 0.7 // 10 when wielded with weight 15 (wood)
 	thrown_force_multiplier = 1 // as above
@@ -141,5 +142,5 @@
 		)
 		user.take_organ_damage(10, 0)
 		user.Paralyse(2)
-		return
+		return TRUE
 	return ..()

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -15,7 +15,7 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	sharp = TRUE
 	edge = TRUE
-	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES | ITEM_FLAG_TRY_ATTACK
 
 //table knives
 /obj/item/material/knife/table

--- a/code/game/objects/items/weapons/material/stick.dm
+++ b/code/game/objects/items/weapons/material/stick.dm
@@ -28,6 +28,7 @@
 
 
 /obj/item/material/stick/attack(mob/M, mob/user)
+	. = FALSE
 	if(istype(M) && user != M && user.a_intent == I_HELP)
 		//Playful poking is its own thing
 		user.visible_message(SPAN_NOTICE("[user] pokes [M] with [src]."), SPAN_NOTICE("You poke [M] with [src]."))
@@ -35,4 +36,3 @@
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(M)
 		return TRUE
-	else return ..()

--- a/code/game/objects/items/weapons/material/stick.dm
+++ b/code/game/objects/items/weapons/material/stick.dm
@@ -28,11 +28,11 @@
 
 
 /obj/item/material/stick/attack(mob/M, mob/user)
-	if(user != M && user.a_intent == I_HELP)
+	if(istype(M) && user != M && user.a_intent == I_HELP)
 		//Playful poking is its own thing
 		user.visible_message(SPAN_NOTICE("[user] pokes [M] with [src]."), SPAN_NOTICE("You poke [M] with [src]."))
 		//Consider adding a check to see if target is dead
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(M)
 		return TRUE
-	return ..()
+	else return ..()

--- a/code/game/objects/items/weapons/material/stick.dm
+++ b/code/game/objects/items/weapons/material/stick.dm
@@ -8,6 +8,7 @@
 	force_multiplier = 0.1
 	thrown_force_multiplier = 0.1
 	w_class = ITEM_SIZE_NORMAL
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	default_material = MATERIAL_WOOD
 	attack_verb = list("poked", "jabbed")
 
@@ -33,5 +34,5 @@
 		//Consider adding a check to see if target is dead
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(M)
-		return
+		return TRUE
 	return ..()

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/soap.dmi'
 	icon_state = "soap"
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	w_class = ITEM_SIZE_SMALL
 	throwforce = 0
 	throw_speed = 4
@@ -159,13 +160,13 @@
 
 //attack_as_weapon
 /obj/item/soap/attack(mob/living/target, mob/living/user, target_zone)
-	if(target && user && ishuman(target) && ishuman(user) && !target.stat && !user.stat && user.zone_sel &&user.zone_sel.selecting == BP_MOUTH)
+	if (target && user && ishuman(target) && ishuman(user) && !target.stat && !user.stat && user.zone_sel &&user.zone_sel.selecting == BP_MOUTH)
 		user.visible_message(SPAN_DANGER("\The [user] washes \the [target]'s mouth out with soap!"))
-		if(reagents)
+		if (reagents)
 			reagents.trans_to_mob(target, reagents.total_volume / 2, CHEM_INGEST)
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN) //prevent spam
-		return
-	..()
+		return TRUE
+	else return ..()
 
 /obj/item/soap/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/key))

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -159,14 +159,14 @@
 		user.update_personal_goal(/datum/goal/clean, 1)
 
 //attack_as_weapon
-/obj/item/soap/attack(mob/living/target, mob/living/user, target_zone)
-	if (target && user && ishuman(target) && ishuman(user) && !target.stat && !user.stat && user.zone_sel &&user.zone_sel.selecting == BP_MOUTH)
+/obj/item/soap/attack(mob/living/target, mob/living/user)
+	. = FALSE
+	if (target && user && ishuman(target) && ishuman(user) && !target.stat && !user.stat && user.zone_sel.selecting == BP_MOUTH)
 		user.visible_message(SPAN_DANGER("\The [user] washes \the [target]'s mouth out with soap!"))
 		if (reagents)
 			reagents.trans_to_mob(target, reagents.total_volume / 2, CHEM_INGEST)
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN) //prevent spam
 		return TRUE
-	else return ..()
 
 /obj/item/soap/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/key))

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -7,6 +7,7 @@
 	throw_range = 5
 	w_class = ITEM_SIZE_NORMAL
 	max_w_class = ITEM_SIZE_SMALL
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	max_storage_space = 4
 	var/mob/affecting = null
 	var/deity_name = "Christ"
@@ -66,17 +67,18 @@
 	icon_changed = 1
 
 /obj/item/storage/bible/attack(mob/living/carbon/human/M, mob/living/carbon/human/user)
-	if(user == M || !ishuman(user) || !ishuman(M))
-		return
-	if(user.mind && istype(user.mind.assigned_job, /datum/job/chaplain))
+	if (user == M || !ishuman(user) || !ishuman(M))
+		return FALSE
+	if (user.mind && istype(user.mind.assigned_job, /datum/job/chaplain))
 		user.visible_message(SPAN_NOTICE("\The [user] places \the [src] on \the [M]'s forehead, reciting a prayer..."))
-		if(do_after(user, 5 SECONDS, M, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS) && user.Adjacent(M))
+		if (do_after(user, 5 SECONDS, M, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS) && user.Adjacent(M))
 			user.visible_message("\The [user] finishes reciting \his prayer, removing \the [src] from \the [M]'s forehead.", "You finish reciting your prayer, removing \the [src] from \the [M]'s forehead.")
-			if(user.get_cultural_value(TAG_RELIGION) == M.get_cultural_value(TAG_RELIGION))
+			if (user.get_cultural_value(TAG_RELIGION) == M.get_cultural_value(TAG_RELIGION))
 				to_chat(M, SPAN_NOTICE("You feel calm and relaxed, at one with the universe."))
 			else
 				to_chat(M, "Nothing happened.")
-		..()
+		return TRUE
+	else return ..()
 
 /obj/item/storage/bible/afterattack(atom/A, mob/user as mob, proximity)
 	if(!proximity) return

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -67,6 +67,7 @@
 	icon_changed = 1
 
 /obj/item/storage/bible/attack(mob/living/carbon/human/M, mob/living/carbon/human/user)
+	. = FALSE
 	if (user == M || !ishuman(user) || !ishuman(M))
 		return FALSE
 	if (user.mind && istype(user.mind.assigned_job, /datum/job/chaplain))
@@ -78,7 +79,6 @@
 			else
 				to_chat(M, "Nothing happened.")
 		return TRUE
-	else return ..()
 
 /obj/item/storage/bible/afterattack(atom/A, mob/user as mob, proximity)
 	if(!proximity) return

--- a/code/game/objects/items/weapons/storage/fancy/smokable/_smokable.dm
+++ b/code/game/objects/items/weapons/storage/fancy/smokable/_smokable.dm
@@ -42,7 +42,7 @@
 /obj/item/storage/fancy/smokable/attack(mob/living/carbon/target, mob/living/carbon/user)
 	if (user != target || !istype(user) || user.a_intent != I_HELP)
 		return ..()
-	. = TRUE
+
 	if (!opened)
 		opened = !opened
 		playsound(src.loc, src.open_sound, 50, 0, -5)
@@ -50,18 +50,19 @@
 	var/obj/item/clothing/mask/smokable/smokable = locate() in contents
 	if (!smokable)
 		to_chat(user, SPAN_WARNING("\The [src] has nothing smokable left inside."))
-		return
+		return TRUE
 	if (user.wear_mask)
 		to_chat(user, SPAN_WARNING("Your [user.wear_mask.name] is in the way."))
-		return
+		return TRUE
 	if (!smokable.mob_can_equip(user, slot_wear_mask))
-		return
+		return TRUE
 	remove_from_storage(smokable, user.loc)
 	update_icon()
 	if (!user.equip_to_slot_if_possible(smokable, slot_wear_mask))
 		to_chat(user, SPAN_WARNING("\The [smokable] falls from you. Oh no."))
-		return
+		return TRUE
 	to_chat(user, SPAN_NOTICE("You take \a [smokable] from \the [src]."))
+	return TRUE
 
 
 /obj/item/storage/fancy/smokable/proc/UpdateReagents()

--- a/code/game/objects/items/weapons/storage/fancy/smokable/_smokable.dm
+++ b/code/game/objects/items/weapons/storage/fancy/smokable/_smokable.dm
@@ -40,8 +40,9 @@
 
 
 /obj/item/storage/fancy/smokable/attack(mob/living/carbon/target, mob/living/carbon/user)
+	. = FALSE
 	if (user != target || !istype(user) || user.a_intent != I_HELP)
-		return ..()
+		return FALSE
 
 	if (!opened)
 		opened = !opened

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -131,8 +131,9 @@
 		update_icon()
 
 /obj/item/melee/baton/attack(mob/M, mob/user)
+	. = FALSE
 	if (!istype(M))
-		return ..()
+		return FALSE
 	if (status && (MUTATION_CLUMSY in user.mutations) && prob(50))
 		to_chat(user, SPAN_DANGER("You accidentally hit yourself with the [src]!"))
 		user.Weaken(30)
@@ -143,7 +144,6 @@
 		user.do_attack_animation(M)
 		apply_hit_effect(M, user, user.zone_sel? user.zone_sel.selecting : ran_zone())
 		return TRUE
-	else return ..()
 
 /obj/item/melee/baton/apply_hit_effect(mob/living/target, mob/living/user, hit_zone)
 	if(isrobot(target))

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -6,11 +6,12 @@
 	icon_state = "stunbaton"
 	item_state = "baton"
 	slot_flags = SLOT_BELT
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	force = 15
 	throwforce = 7
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_COMBAT = 2)
-	attack_verb = list("beaten")
+	attack_verb = list("beat", "whacked")
 	base_parry_chance = 30
 	attack_ignore_harm_check = TRUE
 	var/stunforce = 0
@@ -130,12 +131,19 @@
 		update_icon()
 
 /obj/item/melee/baton/attack(mob/M, mob/user)
-	if(status && (MUTATION_CLUMSY in user.mutations) && prob(50))
+	if (!istype(M))
+		return ..()
+	if (status && (MUTATION_CLUMSY in user.mutations) && prob(50))
 		to_chat(user, SPAN_DANGER("You accidentally hit yourself with the [src]!"))
 		user.Weaken(30)
 		deductcharge(hitcost)
-		return
-	return ..()
+		return TRUE
+	if (user.a_intent != I_HURT) //If not harm-batonning; bypass use_weapon entirely and just apply stun effect. Set cooldowns since bypassing use_weapon.
+		user.setClickCooldown(user.get_attack_speed(src))
+		user.do_attack_animation(M)
+		apply_hit_effect(M, user,  user.zone_sel.selecting)
+		return TRUE
+	else return ..()
 
 /obj/item/melee/baton/apply_hit_effect(mob/living/target, mob/living/user, hit_zone)
 	if(isrobot(target))
@@ -147,42 +155,40 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		affecting = H.get_organ(hit_zone)
-	var/abuser =  user ? "" : "by [user]"
-	if(user && user.a_intent == I_HURT)
-		. = ..()
-		if(.)
-			return
+	var/abuser =  user ? "" : "by \the [user]"
+	if (user && user.a_intent == I_HURT)
+		if (!..())
+			return FALSE
 
 		//whacking someone causes a much poorer electrical contact than deliberately prodding them.
 		stun *= 0.5
-		if(status)		//Checks to see if the stunbaton is on.
+		if (status)		//Checks to see if the stunbaton is on.
 			agony *= 0.5	//whacking someone causes a much poorer contact than prodding them.
 		else
 			agony = 0	//Shouldn't really stun if it's off, should it?
 		//we can't really extract the actual hit zone from ..(), unfortunately. Just act like they attacked the area they intended to.
-	else if(!status)
-		if(affecting)
-			target.visible_message(SPAN_WARNING("[target] has been prodded in the [affecting.name] with [src][abuser]. Luckily it was off."))
+	else if (!status)
+		if (affecting)
+			target.visible_message(SPAN_WARNING("\The [target] has been prodded in the \the [affecting.name] with \the [src][abuser]. Luckily \the [src] was off."))
 		else
-			target.visible_message(SPAN_WARNING("[target] has been prodded with [src][abuser]. Luckily it was off."))
+			target.visible_message(SPAN_WARNING("\The [target] has been prodded with \the[src][abuser]. Luckily \the [src] was off."))
 	else
-		if(affecting)
-			target.visible_message(SPAN_DANGER("[target] has been prodded in the [affecting.name] with [src]!"))
+		if (affecting)
+			target.visible_message(SPAN_DANGER("\The [target] has been prodded in the \the [affecting.name] with \the [src]!"))
 		else
-			target.visible_message(SPAN_DANGER("[target] has been prodded with [src][abuser]!"))
+			target.visible_message(SPAN_DANGER("\The [target] has been prodded with \the [src][abuser]!"))
 		playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 
 	//stun effects
-	if(status)
+	if (status)
 		target.stun_effect_act(stun, agony, hit_zone, src)
 		msg_admin_attack("[key_name(user)] stunned [key_name(target)] with the [src].")
 		deductcharge(hitcost)
 
-		if(ishuman(target))
+		if (ishuman(target))
 			var/mob/living/carbon/human/H = target
 			H.forcesay(GLOB.hit_appends)
-
-	return 1
+	return TRUE
 
 /obj/item/melee/baton/emp_act(severity)
 	if(bcell)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -141,7 +141,7 @@
 	if (user.a_intent != I_HURT) //If not harm-batonning; bypass use_weapon entirely and just apply stun effect. Set cooldowns since bypassing use_weapon.
 		user.setClickCooldown(user.get_attack_speed(src))
 		user.do_attack_animation(M)
-		apply_hit_effect(M, user,  user.zone_sel.selecting)
+		apply_hit_effect(M, user, user.zone_sel? user.zone_sel.selecting : ran_zone())
 		return TRUE
 	else return ..()
 

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -15,19 +15,20 @@
 	item_state = "classic_baton"
 	base_parry_chance = 30
 	slot_flags = SLOT_BELT
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	force = 10
 
 /obj/item/melee/classic_baton/attack(mob/M as mob, mob/living/user as mob)
 	if ((MUTATION_CLUMSY in user.mutations) && prob(50))
 		to_chat(user, SPAN_WARNING("You club yourself over the head."))
 		user.Weaken(3 * force)
-		if(ishuman(user))
+		if (ishuman(user))
 			var/mob/living/carbon/human/H = user
 			H.apply_damage(2*force, DAMAGE_BRUTE, BP_HEAD)
 		else
 			user.take_organ_damage(2*force, 0)
-		return
-	return ..()
+		return TRUE
+	else return ..()
 
 //Telescopic baton
 /obj/item/melee/telebaton
@@ -38,6 +39,7 @@
 	item_state = "telebaton_0"
 	base_parry_chance = 30
 	slot_flags = SLOT_BELT
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	w_class = ITEM_SIZE_SMALL
 	force = 3
 	var/on = 0
@@ -78,18 +80,13 @@
 		AddOverlays(blood_overlay)
 
 /obj/item/melee/telebaton/attack(mob/target as mob, mob/living/user as mob)
-	if(on)
-		if ((MUTATION_CLUMSY in user.mutations) && prob(50))
-			to_chat(user, SPAN_WARNING("You club yourself over the head."))
-			user.Weaken(3 * force)
-			if(ishuman(user))
-				var/mob/living/carbon/human/H = user
-				H.apply_damage(2*force, DAMAGE_BRUTE, BP_HEAD)
-			else
-				user.take_organ_damage(2*force, 0)
-			return
-		if(..())
-			//playsound(src.loc, "swing_hit", 50, 1, -1)
-			return
-	else
-		return ..()
+	if (on && (MUTATION_CLUMSY in user.mutations) && prob(50))
+		to_chat(user, SPAN_WARNING("You club yourself over the head."))
+		user.Weaken(3 * force)
+		if (ishuman(user))
+			var/mob/living/carbon/human/H = user
+			H.apply_damage(2*force, DAMAGE_BRUTE, BP_HEAD)
+		else
+			user.take_organ_damage(2*force, 0)
+		return TRUE
+	else return ..()

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -19,6 +19,7 @@
 	force = 10
 
 /obj/item/melee/classic_baton/attack(mob/M as mob, mob/living/user as mob)
+	. = FALSE
 	if ((MUTATION_CLUMSY in user.mutations) && prob(50))
 		to_chat(user, SPAN_WARNING("You club yourself over the head."))
 		user.Weaken(3 * force)
@@ -28,7 +29,6 @@
 		else
 			user.take_organ_damage(2*force, 0)
 		return TRUE
-	else return ..()
 
 //Telescopic baton
 /obj/item/melee/telebaton
@@ -80,6 +80,7 @@
 		AddOverlays(blood_overlay)
 
 /obj/item/melee/telebaton/attack(mob/target as mob, mob/living/user as mob)
+	. = FALSE
 	if (on && (MUTATION_CLUMSY in user.mutations) && prob(50))
 		to_chat(user, SPAN_WARNING("You club yourself over the head."))
 		user.Weaken(3 * force)
@@ -89,4 +90,3 @@
 		else
 			user.take_organ_damage(2*force, 0)
 		return TRUE
-	else return ..()

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -7,6 +7,7 @@
 	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/tape_roll/attack(mob/living/carbon/human/H, mob/user)
+	. = FALSE
 	if (istype(H))
 		if (user.zone_sel.selecting == BP_EYES)
 			if (!H.organs_by_name[BP_HEAD])
@@ -75,9 +76,6 @@
 			else
 				to_chat(user, SPAN_WARNING("\The [H] isn't wearing a spacesuit for you to reseal."))
 			return TRUE
-
-		else
-			return FALSE
 
 /obj/item/tape_roll/proc/stick(obj/item/W, mob/user)
 	if(!istype(W, /obj/item/paper) || istype(W, /obj/item/paper/sticky) || !user.unEquip(W))

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -33,6 +33,7 @@
 			playsound(src, 'sound/effects/tape.ogg',25)
 			user.visible_message(SPAN_DANGER("\The [user] has taped up \the [H]'s eyes!"))
 			H.equip_to_slot_or_del(new /obj/item/clothing/glasses/blindfold/tape(H), slot_glasses)
+			return TRUE
 
 		else if (user.zone_sel.selecting == BP_MOUTH || user.zone_sel.selecting == BP_HEAD)
 			if (!H.organs_by_name[BP_HEAD])
@@ -59,22 +60,24 @@
 			playsound(src, 'sound/effects/tape.ogg',25)
 			user.visible_message(SPAN_DANGER("\The [user] has taped up \the [H]'s mouth!"))
 			H.equip_to_slot_or_del(new /obj/item/clothing/mask/muzzle/tape(H), slot_wear_mask)
+			return TRUE
 
 		else if(user.zone_sel.selecting == BP_R_HAND || user.zone_sel.selecting == BP_L_HAND)
 			playsound(src, 'sound/effects/tape.ogg',25)
 			var/obj/item/handcuffs/cable/tape/T = new(user)
 			if (!T.place_handcuffs(H, user))
 				qdel(T)
+			return TRUE
 
 		else if (user.zone_sel.selecting == BP_CHEST)
 			if (H.wear_suit && istype(H.wear_suit, /obj/item/clothing/suit/space))
 				H.wear_suit.attackby(src, user)//everything is handled by attackby
 			else
 				to_chat(user, SPAN_WARNING("\The [H] isn't wearing a spacesuit for you to reseal."))
+			return TRUE
 
 		else
-			return ..()
-		return TRUE //If one of the above conditions met, do not call further use_*. If not; call parent to continue chain.
+			return FALSE
 
 /obj/item/tape_roll/proc/stick(obj/item/W, mob/user)
 	if(!istype(W, /obj/item/paper) || istype(W, /obj/item/paper/sticky) || !user.unEquip(W))

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -4,58 +4,58 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "taperoll"
 	w_class = ITEM_SIZE_SMALL
+	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/tape_roll/attack(mob/living/carbon/human/H, mob/user)
-	if(istype(H))
-		if(user.zone_sel.selecting == BP_EYES)
-
-			if(!H.organs_by_name[BP_HEAD])
+	if (istype(H))
+		if (user.zone_sel.selecting == BP_EYES)
+			if (!H.organs_by_name[BP_HEAD])
 				to_chat(user, SPAN_WARNING("\The [H] doesn't have a head."))
-				return
-			if(!H.has_eyes())
+				return TRUE
+			if (!H.has_eyes())
 				to_chat(user, SPAN_WARNING("\The [H] doesn't have any eyes."))
-				return
-			if(H.glasses)
-				to_chat(user, SPAN_WARNING("\The [H] is already wearing somethign on their eyes."))
-				return
-			if(H.head && (H.head.body_parts_covered & FACE))
+				return TRUE
+			if (H.glasses)
+				to_chat(user, SPAN_WARNING("\The [H] is already wearing something on their eyes."))
+				return TRUE
+			if (H.head && (H.head.body_parts_covered & FACE))
 				to_chat(user, SPAN_WARNING("Remove their [H.head] first."))
-				return
+				return TRUE
 			user.visible_message(SPAN_DANGER("\The [user] begins taping over \the [H]'s eyes!"))
 
-			if(!do_after(user, 3 SECONDS, H, DO_PUBLIC_UNIQUE))
-				return
+			if (!do_after(user, 3 SECONDS, H, DO_PUBLIC_UNIQUE))
+				return TRUE
 
 			// Repeat failure checks.
-			if(!H || !src || !H.organs_by_name[BP_HEAD] || !H.has_eyes() || H.glasses || (H.head && (H.head.body_parts_covered & FACE)))
-				return
+			if (!H || !src || !H.organs_by_name[BP_HEAD] || !H.has_eyes() || H.glasses || (H.head && (H.head.body_parts_covered & FACE)))
+				return TRUE
 
 			playsound(src, 'sound/effects/tape.ogg',25)
 			user.visible_message(SPAN_DANGER("\The [user] has taped up \the [H]'s eyes!"))
 			H.equip_to_slot_or_del(new /obj/item/clothing/glasses/blindfold/tape(H), slot_glasses)
 
-		else if(user.zone_sel.selecting == BP_MOUTH || user.zone_sel.selecting == BP_HEAD)
-			if(!H.organs_by_name[BP_HEAD])
+		else if (user.zone_sel.selecting == BP_MOUTH || user.zone_sel.selecting == BP_HEAD)
+			if (!H.organs_by_name[BP_HEAD])
 				to_chat(user, SPAN_WARNING("\The [H] doesn't have a head."))
-				return
-			if(!H.check_has_mouth())
+				return TRUE
+			if (!H.check_has_mouth())
 				to_chat(user, SPAN_WARNING("\The [H] doesn't have a mouth."))
-				return
-			if(H.wear_mask)
+				return TRUE
+			if (H.wear_mask)
 				to_chat(user, SPAN_WARNING("\The [H] is already wearing a mask."))
-				return
-			if(H.head && (H.head.body_parts_covered & FACE))
+				return TRUE
+			if (H.head && (H.head.body_parts_covered & FACE))
 				to_chat(user, SPAN_WARNING("Remove their [H.head] first."))
-				return
+				return TRUE
 			playsound(src, 'sound/effects/tape.ogg',25)
 			user.visible_message(SPAN_DANGER("\The [user] begins taping up \the [H]'s mouth!"))
 
-			if(!do_after(user, 3 SECONDS, H, DO_PUBLIC_UNIQUE))
-				return
+			if (!do_after(user, 3 SECONDS, H, DO_PUBLIC_UNIQUE))
+				return TRUE
 
 			// Repeat failure checks.
 			if(!H || !src || !H.organs_by_name[BP_HEAD] || !H.check_has_mouth() || H.wear_mask || (H.head && (H.head.body_parts_covered & FACE)))
-				return
+				return TRUE
 			playsound(src, 'sound/effects/tape.ogg',25)
 			user.visible_message(SPAN_DANGER("\The [user] has taped up \the [H]'s mouth!"))
 			H.equip_to_slot_or_del(new /obj/item/clothing/mask/muzzle/tape(H), slot_wear_mask)
@@ -63,18 +63,18 @@
 		else if(user.zone_sel.selecting == BP_R_HAND || user.zone_sel.selecting == BP_L_HAND)
 			playsound(src, 'sound/effects/tape.ogg',25)
 			var/obj/item/handcuffs/cable/tape/T = new(user)
-			if(!T.place_handcuffs(H, user))
+			if (!T.place_handcuffs(H, user))
 				qdel(T)
 
-		else if(user.zone_sel.selecting == BP_CHEST)
-			if(H.wear_suit && istype(H.wear_suit, /obj/item/clothing/suit/space))
+		else if (user.zone_sel.selecting == BP_CHEST)
+			if (H.wear_suit && istype(H.wear_suit, /obj/item/clothing/suit/space))
 				H.wear_suit.attackby(src, user)//everything is handled by attackby
 			else
 				to_chat(user, SPAN_WARNING("\The [H] isn't wearing a spacesuit for you to reseal."))
 
 		else
 			return ..()
-		return 1
+		return TRUE //If one of the above conditions met, do not call further use_*. If not; call parent to continue chain.
 
 /obj/item/tape_roll/proc/stick(obj/item/W, mob/user)
 	if(!istype(W, /obj/item/paper) || istype(W, /obj/item/paper/sticky) || !user.unEquip(W))

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -5,6 +5,7 @@
 	item_state = "welder"
 	desc = "A portable welding gun with a port for attaching fuel tanks."
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	slot_flags = SLOT_BELT
 	center_of_mass = "x=14;y=15"
 	waterproof = FALSE
@@ -280,26 +281,25 @@
 		update_icon()
 
 /obj/item/weldingtool/attack(mob/living/M, mob/living/user, target_zone)
-	if(ishuman(M))
+	if (ishuman(M))
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/S = H.organs_by_name[target_zone]
 
-		if(!S || !BP_IS_ROBOTIC(S) || user.a_intent != I_HELP)
+		if (!S || !BP_IS_ROBOTIC(S) || user.a_intent != I_HELP)
 			return ..()
 
-		if(BP_IS_BRITTLE(S))
+		if (BP_IS_BRITTLE(S))
 			to_chat(user, SPAN_WARNING("\The [M]'s [S.name] is hard and brittle - \the [src]  cannot repair it."))
-			return 1
+			return TRUE
 
-		if(!welding)
+		if (!welding)
 			to_chat(user, SPAN_WARNING("You'll need to turn [src] on to patch the damage on [M]'s [S.name]!"))
-			return 1
+			return TRUE
 
-		if(S.robo_repair(15, DAMAGE_BRUTE, "some dents", src, user))
+		if (S.robo_repair(15, DAMAGE_BRUTE, "some dents", src, user))
 			remove_fuel(1, user)
-
-	else
-		return ..()
+		return TRUE
+	else return ..()
 
 
 /obj/item/weldingtool/IsFlameSource()

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -280,13 +280,15 @@
 		playsound(src, 'sound/items/welderdeactivate.ogg', 10, 1)
 		update_icon()
 
-/obj/item/weldingtool/attack(mob/living/M, mob/living/user, target_zone)
+/obj/item/weldingtool/attack(mob/living/M, mob/living/user)
+	. = FALSE
 	if (ishuman(M))
+		var/target_zone = user.zone_sel.selecting
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/S = H.organs_by_name[target_zone]
 
 		if (!S || !BP_IS_ROBOTIC(S) || user.a_intent != I_HELP)
-			return ..()
+			return FALSE
 
 		if (BP_IS_BRITTLE(S))
 			to_chat(user, SPAN_WARNING("\The [M]'s [S.name] is hard and brittle - \the [src]  cannot repair it."))
@@ -299,7 +301,6 @@
 		if (S.robo_repair(15, DAMAGE_BRUTE, "some dents", src, user))
 			remove_fuel(1, user)
 		return TRUE
-	else return ..()
 
 
 /obj/item/weldingtool/IsFlameSource()

--- a/code/game/objects/items/weapons/tools/wirecutter.dm
+++ b/code/game/objects/items/weapons/tools/wirecutter.dm
@@ -5,6 +5,7 @@
 	icon_state = "cutters_preview"
 	item_state = "cutters"
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	slot_flags = SLOT_BELT
 	force = 3.0
 	throw_speed = 2
@@ -30,14 +31,13 @@
 	. = ..()
 
 /obj/item/wirecutters/attack(mob/living/carbon/C as mob, mob/user as mob)
-	if(istype(C) && user.a_intent == I_HELP && (C.handcuffed) && (istype(C.handcuffed, /obj/item/handcuffs/cable)))
+	if (istype(C) && user.a_intent == I_HELP && (C.handcuffed) && (istype(C.handcuffed, /obj/item/handcuffs/cable)))
 		usr.visible_message("\The [usr] cuts \the [C]'s restraints with \the [src]!",\
 		"You cut \the [C]'s restraints with \the [src]!",\
 		"You hear cable being cut.")
 		C.handcuffed = null
-		if(C.buckled && C.buckled.buckle_require_restraints)
+		if (C.buckled && C.buckled.buckle_require_restraints)
 			C.buckled.unbuckle_mob()
 		C.update_inv_handcuffed()
-		return
-	else
-		..()
+		return TRUE
+	else return ..()

--- a/code/game/objects/items/weapons/tools/wirecutter.dm
+++ b/code/game/objects/items/weapons/tools/wirecutter.dm
@@ -31,6 +31,7 @@
 	. = ..()
 
 /obj/item/wirecutters/attack(mob/living/carbon/C as mob, mob/user as mob)
+	. = FALSE
 	if (istype(C) && user.a_intent == I_HELP && (C.handcuffed) && (istype(C.handcuffed, /obj/item/handcuffs/cable)))
 		usr.visible_message("\The [usr] cuts \the [C]'s restraints with \the [src]!",\
 		"You cut \the [C]'s restraints with \the [src]!",\
@@ -40,4 +41,3 @@
 			C.buckled.unbuckle_mob()
 		C.update_inv_handcuffed()
 		return TRUE
-	else return ..()

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -12,6 +12,7 @@
 	throw_range = 5
 	w_class = ITEM_SIZE_NORMAL
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	matter = list(MATERIAL_ALUMINIUM = 3000)
 	hitsound = "tray_hit"
 	var/bash_cooldown = 0 // You can bash a rolling pin against a tray to make a shield bash sound! Based on world.time
@@ -34,14 +35,15 @@
 // When hitting people with the tray, drop all its items everywhere. You jerk.
 /obj/item/tray/attack(mob/living/M, mob/living/user)
 	if (user.a_intent != I_HURT)
-		return FALSE
-	. = ..()
+		return ..()
+
 	// Drop all the things. All of them.
 	ClearOverlays()
 	for(var/obj/item/I in carrying)
 		I.dropInto(get_turf(M))
 		carrying.Remove(I)
 		step(I, pick(NORTH, SOUTH, EAST, WEST, NORTHWEST, NORTHEAST, SOUTHWEST, SOUTHEAST))
+	return TRUE
 
 
 // Bash a rolling pin against a tray like a true knight!

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -34,8 +34,9 @@
 
 // When hitting people with the tray, drop all its items everywhere. You jerk.
 /obj/item/tray/attack(mob/living/M, mob/living/user)
+	. = FALSE
 	if (user.a_intent != I_HURT)
-		return ..()
+		return FALSE
 
 	// Drop all the things. All of them.
 	ClearOverlays()

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -16,8 +16,9 @@
 	return src
 
 /obj/item/nullrod/attack(mob/M as mob, mob/living/user as mob) //Paste from old-code to decult with a null rod.
+	. = FALSE
 	if (!istype(M) || user.a_intent == I_HELP)
-		return ..()
+		return FALSE
 
 	admin_attack_log(user, M, "Attacked using \a [src]", "Was attacked with \a [src]", "used \a [src] to attack")
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
@@ -43,8 +44,6 @@
 		M.visible_message(SPAN_NOTICE("\The [user] waves \the [src] over \the [M]'s head."))
 		GLOB.cult.offer_uncult(M)
 		return TRUE
-
-	else return ..()
 
 /obj/item/energy_net
 	name = "energy net"

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -5,6 +5,7 @@
 	icon_state = "nullrod"
 	item_state = "nullrod"
 	slot_flags = SLOT_BELT
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	force = 10
 	throw_speed = 1
 	throw_range = 4
@@ -15,35 +16,35 @@
 	return src
 
 /obj/item/nullrod/attack(mob/M as mob, mob/living/user as mob) //Paste from old-code to decult with a null rod.
-	if (user.a_intent == I_HELP)
-		return FALSE
+	if (!istype(M) || user.a_intent == I_HELP)
+		return ..()
 
 	admin_attack_log(user, M, "Attacked using \a [src]", "Was attacked with \a [src]", "used \a [src] to attack")
-
 	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	user.do_attack_animation(M)
 	//if(user != M)
-	if(M.mind && LAZYLEN(M.mind.learned_spells))
-		M.silence_spells(300) //30 seconds
-		to_chat(M, SPAN_DANGER("You've been silenced!"))
-		return
-
 	if (!user.IsAdvancedToolUser())
 		to_chat(user, SPAN_DANGER("You don't have the dexterity to do this!"))
-		return
+		return TRUE
 
 	if ((MUTATION_CLUMSY in user.mutations) && prob(50))
 		to_chat(user, SPAN_DANGER("The rod slips out of your hand and hits your head."))
 		user.take_organ_damage(10, 0)
 		user.Paralyse(20)
-		return
+		return TRUE
+
+	if (M.mind && LAZYLEN(M.mind.learned_spells))
+		M.silence_spells(300) //30 seconds
+		M.visible_message(SPAN_NOTICE("\The [user] waves \the [src] over \the [M]'s head."))
+		to_chat(M, SPAN_DANGER("You've been silenced!"))
+		return TRUE
 
 	if(GLOB.cult && iscultist(M))
 		M.visible_message(SPAN_NOTICE("\The [user] waves \the [src] over \the [M]'s head."))
 		GLOB.cult.offer_uncult(M)
-		return
+		return TRUE
 
-	..()
+	else return ..()
 
 /obj/item/energy_net
 	name = "energy net"

--- a/code/game/objects/structures/ironing_board.dm
+++ b/code/game/objects/structures/ironing_board.dm
@@ -130,7 +130,7 @@
 		var/obj/item/ironing_iron/iron = weapon
 		var/zone = user.zone_sel.selecting
 		if (!iron.iron_enabled)
-			weapon.attack(buckled_mob, user, zone, TRUE)
+			buckled_mob.use_weapon(iron, user)
 			return TRUE
 		var/mob/living/carbon/human/human
 		var/obj/item/organ/external/organ

--- a/code/modules/clothing/clothing_accessories.dm
+++ b/code/modules/clothing/clothing_accessories.dm
@@ -33,14 +33,6 @@
 						return FALSE
 	return TRUE
 
-
-/obj/item/clothing/attackby(obj/item/I, mob/user)
-	if (attempt_attach_accessory(I, user))
-		return
-	if (attempt_store_item(I, user))
-		return
-	..()
-
 /obj/item/clothing/attack_hand(mob/user)
 	//only forward to the attached accessory if the clothing is equipped (not in a storage)
 	if(length(accessories) && src.loc == user)

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -162,13 +162,12 @@
 		text = replacetext(text, "FLAME", "[W.name]")
 		light(text)
 
-/obj/item/clothing/mask/smokable/attack(mob/living/M, mob/living/user, def_zone)
+/obj/item/clothing/mask/smokable/attack(mob/living/M, mob/living/user)
+	. = FALSE
 	if (istype(M) && M.on_fire)
 		user.do_attack_animation(M)
 		light(SPAN_NOTICE("\The [user] coldly lights the \the [src] with the burning body of \the [M]."))
 		return TRUE
-	else
-		return ..()
 
 
 /obj/item/clothing/mask/smokable/IsFlameSource()
@@ -333,7 +332,7 @@
 
 	return
 
-/obj/item/clothing/mask/smokable/cigarette/attack(mob/living/carbon/human/H, mob/user, def_zone)
+/obj/item/clothing/mask/smokable/cigarette/attack(mob/living/carbon/human/H, mob/user)
 	if (lit && H == user && istype(H))
 		var/obj/item/blocked = H.check_mouth_coverage()
 		if (blocked)
@@ -343,7 +342,7 @@
 		smoke(5)
 		add_trace_DNA(H)
 		return TRUE
-	else return ..()
+	return ..()
 
 /obj/item/clothing/mask/smokable/cigarette/afterattack(obj/item/reagent_containers/glass/glass, mob/user, proximity)
 	..()

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -3,7 +3,7 @@
 	desc = "You're not sure what this is. You should probably ahelp it."
 	body_parts_covered = 0
 	waterproof = FALSE
-	item_flags = null
+	item_flags = ITEM_FLAG_TRY_ATTACK
 
 	var/lit = 0
 	var/icon_on
@@ -163,10 +163,10 @@
 		light(text)
 
 /obj/item/clothing/mask/smokable/attack(mob/living/M, mob/living/user, def_zone)
-	if(istype(M) && M.on_fire)
+	if (istype(M) && M.on_fire)
 		user.do_attack_animation(M)
 		light(SPAN_NOTICE("\The [user] coldly lights the \the [src] with the burning body of \the [M]."))
-		return 1
+		return TRUE
 	else
 		return ..()
 
@@ -334,16 +334,16 @@
 	return
 
 /obj/item/clothing/mask/smokable/cigarette/attack(mob/living/carbon/human/H, mob/user, def_zone)
-	if(lit && H == user && istype(H))
+	if (lit && H == user && istype(H))
 		var/obj/item/blocked = H.check_mouth_coverage()
-		if(blocked)
+		if (blocked)
 			to_chat(H, SPAN_WARNING("\The [blocked] is in the way!"))
-			return 1
+			return TRUE
 		to_chat(H, SPAN_NOTICE("You take a drag on your [name]."))
 		smoke(5)
 		add_trace_DNA(H)
-		return 1
-	return ..()
+		return TRUE
+	else return ..()
 
 /obj/item/clothing/mask/smokable/cigarette/afterattack(obj/item/reagent_containers/glass/glass, mob/user, proximity)
 	..()

--- a/code/modules/clothing/under/accessories/_accessory.dm
+++ b/code/modules/clothing/under/accessories/_accessory.dm
@@ -106,6 +106,12 @@
 	else
 		dropInto(loc)
 
+/obj/item/clothing/accessory/use_on(obj/target, mob/user)
+	if (istype(target, /obj/item/clothing))
+		var/obj/item/clothing/clothes = target
+		if (clothes.attempt_attach_accessory(src, user))
+			return TRUE
+	return ..()
 
 //default attackby behaviour
 /obj/item/clothing/accessory/attackby(obj/item/I, mob/user)

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -60,12 +60,12 @@
 
 
 /obj/item/clothing/accessory/badge/attack(mob/living/carbon/human/M, mob/living/user)
+	. = FALSE
 	if (isliving(user))
 		user.visible_message(SPAN_DANGER("[user] invades [M]'s personal space, thrusting \the [src] into their face insistently."),SPAN_DANGER("You invade [M]'s personal space, thrusting \the [src] into their face insistently."))
 		if (stored_name)
 			to_chat(M, SPAN_WARNING("It reads: [stored_name], [badge_string]."))
 		return TRUE
-	else return ..()
 
 
 /obj/item/clothing/accessory/badge/investigator

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -5,6 +5,7 @@
 	slot_flags = SLOT_BELT | SLOT_TIE
 	slot = ACCESSORY_SLOT_INSIGNIA
 	accessory_flags = ACCESSORY_REMOVABLE | ACCESSORY_HIGH_VISIBILITY
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	on_rolled_down = ACCESSORY_ROLLED_NONE
 	var/badge_string = "Detective"
 	var/stored_name
@@ -63,6 +64,8 @@
 		user.visible_message(SPAN_DANGER("[user] invades [M]'s personal space, thrusting \the [src] into their face insistently."),SPAN_DANGER("You invade [M]'s personal space, thrusting \the [src] into their face insistently."))
 		if (stored_name)
 			to_chat(M, SPAN_WARNING("It reads: [stored_name], [badge_string]."))
+		return TRUE
+	else return ..()
 
 
 /obj/item/clothing/accessory/badge/investigator

--- a/code/modules/clothing/under/accessories/stethoscope.dm
+++ b/code/modules/clothing/under/accessories/stethoscope.dm
@@ -7,10 +7,11 @@
 
 
 /obj/item/clothing/accessory/stethoscope/attack(mob/living/target, mob/living/user)
+	. = FALSE
 	if (!ishuman(target) || !istype(user))
-		return ..()
+		return FALSE
 	if (user.a_intent != I_HELP)
-		return ..()
+		return FALSE
 	var/mob/living/carbon/human/H = target
 	var/obj/item/organ/organ = H.get_organ(user.zone_sel.selecting)
 	if (!organ)

--- a/code/modules/clothing/under/accessories/stethoscope.dm
+++ b/code/modules/clothing/under/accessories/stethoscope.dm
@@ -3,18 +3,20 @@
 	desc = "An outdated medical apparatus for listening to the sounds of the human body. It also makes you look like you know what you're doing."
 	icon_state = "stethoscope"
 	accessory_flags = ACCESSORY_REMOVABLE | ACCESSORY_HIGH_VISIBILITY
+	item_flags = ITEM_FLAG_TRY_ATTACK
 
 
 /obj/item/clothing/accessory/stethoscope/attack(mob/living/target, mob/living/user)
 	if (!ishuman(target) || !istype(user))
-		return
+		return ..()
 	if (user.a_intent != I_HELP)
-		return ..(target, user)
+		return ..()
 	var/mob/living/carbon/human/H = target
 	var/obj/item/organ/organ = H.get_organ(user.zone_sel.selecting)
 	if (!organ)
-		return
+		return TRUE
 	user.visible_message(
 		SPAN_ITALIC("\The [user] places \the [src] against \the [target]'s [organ.name]."),
-		SPAN_NOTICE("You place \the [src] against \the [target]'s [organ.name]. You head [english_list(organ.listen())].")
+		SPAN_NOTICE("You place \the [src] against \the [target]'s [organ.name]. You hear [english_list(organ.listen())].")
 	)
+	return TRUE

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -182,7 +182,6 @@
 		if (user.zone_sel.selecting == BP_MOUTH)
 			to_chat(user, SPAN_WARNING("\The [src] is too dry to use on \the [target]!"))
 			return TRUE
-		return ..()
 	else return ..()
 
 /obj/item/reagent_containers/glass/rag/afterattack(atom/A as obj|turf|area, mob/user as mob, proximity)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -115,6 +115,7 @@
 				A.clean_blood()
 
 /obj/item/reagent_containers/glass/rag/attack(atom/target as obj|turf|area, mob/user as mob , flag)
+	. = FALSE
 	if (isliving(target))
 		var/mob/living/M = target
 		if (on_fire)
@@ -182,7 +183,6 @@
 		if (user.zone_sel.selecting == BP_MOUTH)
 			to_chat(user, SPAN_WARNING("\The [src] is too dry to use on \the [target]!"))
 			return TRUE
-	else return ..()
 
 /obj/item/reagent_containers/glass/rag/afterattack(atom/A as obj|turf|area, mob/user as mob, proximity)
 	if(!proximity)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -23,7 +23,7 @@
 	possible_transfer_amounts = "5"
 	volume = 10
 	can_be_placed_into = null
-	item_flags = ITEM_FLAG_NO_BLUDGEON
+	item_flags = ITEM_FLAG_NO_BLUDGEON | ITEM_FLAG_TRY_ATTACK
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	unacidable = FALSE
 
@@ -115,9 +115,9 @@
 				A.clean_blood()
 
 /obj/item/reagent_containers/glass/rag/attack(atom/target as obj|turf|area, mob/user as mob , flag)
-	if(isliving(target))
+	if (isliving(target))
 		var/mob/living/M = target
-		if(on_fire)
+		if (on_fire)
 			if (user.a_intent == I_HELP)
 				return FALSE
 			user.visible_message(
@@ -127,6 +127,7 @@
 			user.do_attack_animation(src)
 			admin_attack_log(user, M, "used \the [src] (ignited) to attack", "was attacked using \the [src] (ignited)", "attacked with \the [src] (ignited)")
 			M.IgniteMob()
+			return TRUE
 		else if (reagents.total_volume)
 			if (iscarbon(target) && user.a_intent == I_HELP && flag == BP_HEAD)
 				var/mob/living/carbon/C = target
@@ -144,12 +145,12 @@
 							user.visible_message(SPAN_NOTICE("\The [user] scrubs the ink off \the [M]'s forehead."), SPAN_NOTICE("You scrub the ink off \the [M]'s forehead."))
 					else
 						to_chat(user, SPAN_WARNING("You need to wet the rag with [wash_amount] units of [initial(R.name)] to get the ink off!"))
-					return
+				return TRUE
 
 			if(user.zone_sel.selecting == BP_MOUTH)
 				if (!M.has_danger_grab(user))
 					to_chat(user, SPAN_WARNING("You need to have a firm grip on \the [target] before you can use \the [src] on them!"))
-					return
+					return TRUE
 
 				user.do_attack_animation(src)
 				user.visible_message(
@@ -161,26 +162,28 @@
 				var/grab_time = 6 SECONDS
 				if (user.skill_check(SKILL_COMBAT, SKILL_TRAINED))
 					grab_time = 3 SECONDS
+				if (!do_after(user, grab_time, target, DO_PUBLIC_UNIQUE))
+					return TRUE
 
-				if (do_after(user, grab_time, target, DO_PUBLIC_UNIQUE))
-					user.visible_message(
-						SPAN_DANGER("\The [user] smothers \the [target] with \the [src]!"),
-						SPAN_DANGER("You smother \the [target] with \the [src]!")
-					)
-					//it's inhaled, so... maybe CHEM_BLOOD doesn't make a whole lot of sense but it's the best we can do for now
-					var/trans_amt = reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_BLOOD)
-					if (reagents.should_admin_log())
-						var/contained_reagents = reagents.get_reagents()
-						admin_inject_log(user, M, src, contained_reagents, trans_amt)
-					update_name()
+				user.visible_message(
+					SPAN_DANGER("\The [user] smothers \the [target] with \the [src]!"),
+					SPAN_DANGER("You smother \the [target] with \the [src]!")
+				)
+				//it's inhaled, so... maybe CHEM_BLOOD doesn't make a whole lot of sense but it's the best we can do for now
+				var/trans_amt = reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_BLOOD)
+				if (reagents.should_admin_log())
+					var/contained_reagents = reagents.get_reagents()
+					admin_inject_log(user, M, src, contained_reagents, trans_amt)
+				update_name()
+				return TRUE
 			else
 				wipe_down(target, user)
-		else if (user.zone_sel.selecting == BP_MOUTH)
+				return TRUE
+		if (user.zone_sel.selecting == BP_MOUTH)
 			to_chat(user, SPAN_WARNING("\The [src] is too dry to use on \the [target]!"))
-			return
-		return
-
-	return ..()
+			return TRUE
+		return ..()
+	else return ..()
 
 /obj/item/reagent_containers/glass/rag/afterattack(atom/A as obj|turf|area, mob/user as mob, proximity)
 	if(!proximity)

--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -76,6 +76,7 @@
 	icon = 'icons/obj/tools/card.dmi'
 	icon_state = "fingerprint0"
 	item_state = "paper"
+	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/sample/print/attack_self(mob/user)
 	if(evidence && length(evidence))
@@ -95,42 +96,42 @@
 
 /obj/item/sample/print/attack(mob/living/M, mob/user)
 
-	if(!ishuman(M))
+	if (!ishuman(M))
 		return ..()
 
-	if(evidence && length(evidence))
-		return 0
+	if (evidence && length(evidence))
+		return FALSE
 
 	var/mob/living/carbon/human/H = M
 
-	if(H.gloves)
+	if (H.gloves)
 		to_chat(user, SPAN_WARNING("\The [H] is wearing gloves."))
-		return 1
+		return TRUE
 
-	if(user != H && H.a_intent != I_HELP && !H.lying)
+	if (user != H && H.a_intent != I_HELP && !H.lying)
 		user.visible_message(SPAN_DANGER("\The [user] tries to take prints from \the [H], but they move away."))
-		return 1
+		return TRUE
 
-	if(user.zone_sel.selecting == BP_R_HAND || user.zone_sel.selecting == BP_L_HAND)
+	if (user.zone_sel.selecting == BP_R_HAND || user.zone_sel.selecting == BP_L_HAND)
 		var/has_hand
 		var/obj/item/organ/external/O = H.organs_by_name[BP_R_HAND]
-		if(istype(O) && !O.is_stump())
+		if (istype(O) && !O.is_stump())
 			has_hand = 1
 		else
 			O = H.organs_by_name[BP_L_HAND]
-			if(istype(O) && !O.is_stump())
+			if (istype(O) && !O.is_stump())
 				has_hand = 1
-		if(!has_hand)
+		if (!has_hand)
 			to_chat(user, SPAN_WARNING("They don't have any hands."))
-			return 1
+			return TRUE
 		user.visible_message("[user] takes a copy of \the [H]'s fingerprints.")
 		var/fullprint = H.get_full_print()
 		evidence[fullprint] = fullprint
 		copy_evidence(src)
 		SetName("[initial(name)] (\the [H])")
 		update_icon()
-		return 1
-	return 0
+		return TRUE
+	else return ..()
 
 /obj/item/sample/print/copy_evidence(atom/supplied)
 	if(supplied.fingerprints && length(supplied.fingerprints))

--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -95,9 +95,9 @@
 	update_icon()
 
 /obj/item/sample/print/attack(mob/living/M, mob/user)
-
+	. = FALSE
 	if (!ishuman(M))
-		return ..()
+		return FALSE
 
 	if (evidence && length(evidence))
 		return FALSE
@@ -131,7 +131,6 @@
 		SetName("[initial(name)] (\the [H])")
 		update_icon()
 		return TRUE
-	else return ..()
 
 /obj/item/sample/print/copy_evidence(atom/supplied)
 	if(supplied.fingerprints && length(supplied.fingerprints))

--- a/code/modules/detectivework/tools/swabs.dm
+++ b/code/modules/detectivework/tools/swabs.dm
@@ -30,9 +30,9 @@
 	return used
 
 /obj/item/forensics/swab/attack(mob/living/M, mob/user)
-
+	. = FALSE
 	if (!ishuman(M))
-		return ..()
+		return FALSE
 
 	if (is_used())
 		to_chat(user, SPAN_WARNING("This swab has already been used."))

--- a/code/modules/detectivework/tools/swabs.dm
+++ b/code/modules/detectivework/tools/swabs.dm
@@ -4,9 +4,6 @@
 	icon = 'icons/obj/forensics.dmi'
 	icon_state = "swab"
 
-/obj/item/swabber/attack()
-	return 0
-
 // This is pretty nasty but is a damn sight easier than trying to make swabs a stack item.
 /obj/item/swabber/afterattack(atom/A, mob/user, proximity, params)
 	if(proximity)
@@ -23,6 +20,7 @@
 	name = "swab"
 	desc = "A sterilized cotton swab and vial used to take forensic samples."
 	icon_state = "swab"
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	var/list/gunshot_residue_sample
 	var/list/dna
 	var/list/trace_dna
@@ -33,58 +31,57 @@
 
 /obj/item/forensics/swab/attack(mob/living/M, mob/user)
 
-	if(!ishuman(M))
+	if (!ishuman(M))
 		return ..()
 
-	if(is_used())
-		return
+	if (is_used())
+		to_chat(user, SPAN_WARNING("This swab has already been used."))
+		return TRUE
 
 	var/mob/living/carbon/human/H = M
 	var/sample_type
 
-	if(H.wear_mask)
-		to_chat(user, SPAN_WARNING("\The [H] is wearing a mask."))
-		return
-
-	if(!H.dna || !H.dna.unique_enzymes)
+	if (!H.dna || !H.dna.unique_enzymes)
 		to_chat(user, SPAN_WARNING("They don't seem to have DNA!"))
-		return
+		return TRUE
 
-	if(user != H && (H.a_intent != I_HELP && !H.lying && !H.incapacitated(INCAPACITATION_DEFAULT)))
+	if (user != H && (H.a_intent != I_HELP && !H.lying && !H.incapacitated(INCAPACITATION_DEFAULT)))
 		user.visible_message(SPAN_DANGER("\The [user] tries to take a swab sample from \the [H], but they move away."))
-		return
+		return TRUE
 
-	if(user.zone_sel.selecting == BP_MOUTH)
-		if(!H.organs_by_name[BP_HEAD])
+	if (user.zone_sel.selecting == BP_MOUTH)
+		if (!H.organs_by_name[BP_HEAD])
 			to_chat(user, SPAN_WARNING("They don't have a head."))
-			return
-		if(!H.check_has_mouth())
+			return TRUE
+		if (!H.check_has_mouth())
 			to_chat(user, SPAN_WARNING("They don't have a mouth."))
-			return
+			return TRUE
+		if (H.wear_mask)
+			to_chat(user, SPAN_WARNING("\The [H] is wearing a mask."))
+			return TRUE
 		user.visible_message("[user] swabs \the [H]'s mouth for a saliva sample.")
 		dna = list(H.dna.unique_enzymes)
 		sample_type = "DNA"
 
 	else
 		var/zone = user.zone_sel.selecting
-		if(!H.has_organ(zone))
+		if (!H.has_organ(zone))
 			to_chat(user, SPAN_WARNING("They don't have that part!"))
-			return
+			return TRUE
 		var/obj/item/organ/external/O = H.get_organ(zone)
-		if(!O.gunshot_residue)
-			return
+		if (!O.gunshot_residue)
+			to_chat(user, SPAN_NOTICE("There is no gunshot residue on \the [O]."))
+			return TRUE
 		var/obj/C = H.get_covering_equipped_item_by_zone(zone)
-		if(C)
+		if (C)
 			afterattack(C, user, 1) //Lazy but this would work
-			return
+			return TRUE
 		user.visible_message("[user] swabs [H]'s [O.name] for a sample.")
 		sample_type = "gunshot_residue"
 		gunshot_residue_sample = O.gunshot_residue.Copy()
-
-	if(sample_type)
+	if (sample_type)
 		set_used(sample_type, H)
-		return
-	return 1
+	return TRUE
 
 /obj/item/forensics/swab/afterattack(atom/A, mob/user, proximity)
 

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -163,6 +163,7 @@
 	throw_speed = 1
 	throw_range = 5
 	w_class = ITEM_SIZE_NORMAL		 //upped to three because books are, y'know, pretty big. (and you could hide them inside eachother recursively forever)
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	attack_verb = list("bashed", "whacked", "educated")
 	var/dat			 // Actual page content
 	var/author		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
@@ -244,11 +245,13 @@
 		..()
 
 /obj/item/book/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if(user.zone_sel.selecting == BP_EYES)
+	if (user.a_intent == I_HELP && user.zone_sel.selecting == BP_EYES)
 		user.visible_message(SPAN_NOTICE("You open up the book and show it to [M]. "), \
 			SPAN_NOTICE(" [user] opens up a book and shows it to [M]. "))
 		show_browser(M, "<i>Author: [author].</i><br><br>" + "[dat]", "window=book;size=1000x550")
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN) //to prevent spam
+		return TRUE
+	else return ..()
 
 /*
  * Manual Base Object

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -245,7 +245,7 @@
 		..()
 
 /obj/item/book/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if (user.a_intent == I_HELP && user.zone_sel.selecting == BP_EYES)
+	if (istype(M) && user.a_intent == I_HELP && user.zone_sel.selecting == BP_EYES)
 		user.visible_message(SPAN_NOTICE("You open up the book and show it to [M]. "), \
 			SPAN_NOTICE(" [user] opens up a book and shows it to [M]. "))
 		show_browser(M, "<i>Author: [author].</i><br><br>" + "[dat]", "window=book;size=1000x550")

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -245,13 +245,13 @@
 		..()
 
 /obj/item/book/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+	. = FALSE
 	if (istype(M) && user.a_intent == I_HELP && user.zone_sel.selecting == BP_EYES)
 		user.visible_message(SPAN_NOTICE("You open up the book and show it to [M]. "), \
 			SPAN_NOTICE(" [user] opens up a book and shows it to [M]. "))
 		show_browser(M, "<i>Author: [author].</i><br><br>" + "[dat]", "window=book;size=1000x550")
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN) //to prevent spam
 		return TRUE
-	else return ..()
 
 /*
  * Manual Base Object

--- a/code/modules/mechs/equipment/_equipment.dm
+++ b/code/modules/mechs/equipment/_equipment.dm
@@ -17,9 +17,6 @@
 	var/require_adjacent = TRUE
 	var/active = FALSE //For gear that has an active state (ie, floodlights)
 
-/obj/item/mech_equipment/attack(mob/living/M, mob/living/user, target_zone) //Generally it's not desired to be able to attack with items
-	return 0
-
 /obj/item/mech_equipment/afterattack(atom/target, mob/living/user, inrange, params)
 	if(require_adjacent)
 		if(!inrange)

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -264,7 +264,7 @@
 			playsound(E, 'sound/mecha/mech_punch_fast.ogg', 35, 1)
 			if (do_after(E, 1.2 SECONDS, get_turf(user), DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS) && E && MC)
 				for (var/mob/living/M in orange(1, E))
-					attack(M, E, E.zone_sel.selecting, FALSE)
+					M.use_weapon(src, E)
 				E.spin(0.65 SECONDS, 0.125 SECONDS)
 				playsound(E, 'sound/mecha/mechstep01.ogg', 40, 1)
 

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -70,7 +70,6 @@
 
 
 /obj/item/grab/resolve_attackby(atom/A, mob/user, click_params)
-	// Relying on BYOND proc ordering isn't working, so go go ugly workaround.
 	if (ishuman(user) && affecting == A)
 		var/mob/living/carbon/human/H = user
 		if (H.check_psi_grab(src))
@@ -84,9 +83,7 @@
 		if (current_grab.downgrade_on_action)
 			downgrade()
 		return TRUE
-	if(current_grab.hit_with_grab(src)) //If there is no use_grab override or if it returns FALSE; then will behave according to intent.
-		return TRUE
-	return ..() //To cover for legacy behavior. Should not reach here normally. Have all grabs be handled by use_grab or hit_with_grab.
+	else return current_grab.hit_with_grab(src)
 
 /obj/item/grab/dropped()
 	..()

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -6,6 +6,7 @@ var/global/list/holder_mob_icon_cache = list()
 	desc = "You shouldn't ever see this."
 	icon = 'icons/obj/ash.dmi'
 	slot_flags = SLOT_HEAD | SLOT_HOLSTER
+	item_flags = ITEM_FLAG_TRY_ATTACK
 
 	sprite_sheets = list(
 		SPECIES_VOX = 'icons/mob/species/vox/onmob_head_vox.dmi'
@@ -92,15 +93,13 @@ var/global/list/holder_mob_icon_cache = list()
 
 /obj/item/holder/attack(mob/target, mob/user)
 	// Devour on click on self with holder
-	if(target == user && istype(user,/mob/living/carbon))
+	if (target == user && istype(user,/mob/living/carbon))
 		var/mob/living/carbon/M = user
-
-		for(var/mob/victim in src.contents)
+		for (var/mob/victim in src.contents)
 			M.devour(victim)
-
 		update_state()
-
-	..()
+		return TRUE
+	else return ..()
 
 /obj/item/holder/proc/sync(mob/living/M)
 	dir = 2

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -92,6 +92,7 @@ var/global/list/holder_mob_icon_cache = list()
 		M.show_inv(usr)
 
 /obj/item/holder/attack(mob/target, mob/user)
+	. = FALSE
 	// Devour on click on self with holder
 	if (target == user && istype(user,/mob/living/carbon))
 		var/mob/living/carbon/M = user
@@ -99,7 +100,6 @@ var/global/list/holder_mob_icon_cache = list()
 			M.devour(victim)
 		update_state()
 		return TRUE
-	else return ..()
 
 /obj/item/holder/proc/sync(mob/living/M)
 	dir = 2

--- a/code/modules/mob/living/bot/secbot.dm
+++ b/code/modules/mob/living/bot/secbot.dm
@@ -238,7 +238,7 @@
 	else
 		a_intent = I_GRAB
 
-	stun_baton.attack(M, src, BP_CHEST) //robots and turrets aim for center of mass
+	stun_baton.resolve_attackby(M, src)
 	flick(attack_state, src)
 
 /mob/living/bot/secbot/explode()

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -18,8 +18,8 @@
 		var/embed_threshold = weapon_sharp? 5*I.w_class : 15*I.w_class
 
 		//Sharp objects will always embed if they do enough damage.
-		if((weapon_sharp && damage > (10*I.w_class)) || (damage > embed_threshold && prob(embed_chance)))
+		if ((weapon_sharp && damage > (10*I.w_class)) || (damage > embed_threshold && prob(embed_chance)))
 			src.embed(I, hit_zone, supplied_wound = created_wound)
 			I.has_embedded()
 
-	return 1
+	return TRUE

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -1,6 +1,6 @@
 
-/mob/living/carbon/standard_weapon_hit_effects(obj/item/I, mob/living/user, effective_force, hit_zone)
-	if(!effective_force)
+/mob/living/carbon/hit_with_weapon(obj/item/I, mob/living/user, effective_force, hit_zone)
+	if (!effective_force)
 		return 0
 
 	//Apply weapon damage

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -159,10 +159,10 @@ meteor_act
 /mob/living/carbon/human/resolve_item_attack(obj/item/I, mob/living/user, target_zone)
 
 	for (var/obj/item/grab/G in grabbed_by)
-		if(G.resolve_item_attack(user, I, target_zone))
+		if (G.resolve_item_attack(user, I, target_zone))
 			return null
 
-	if(user == src) // Attacking yourself can't miss
+	if (user == src)
 		return target_zone
 
 	var/accuracy_penalty = user.melee_accuracy_mods()
@@ -172,11 +172,11 @@ meteor_act
 
 	var/hit_zone = get_zone_with_miss_chance(target_zone, src, accuracy_penalty)
 
-	if(!hit_zone)
+	if (!hit_zone)
 		visible_message(SPAN_DANGER("\The [user] misses [src] with \the [I]!"))
 		return null
 
-	if(check_shields(I.force, I, user, target_zone, "the [I.name]"))
+	if (check_shields(I.force, I, user, hit_zone, "the [I.name]"))
 		return null
 
 	var/obj/item/organ/external/affecting = get_organ(hit_zone)
@@ -188,50 +188,38 @@ meteor_act
 
 /mob/living/carbon/human/hit_with_weapon(obj/item/I, mob/living/user, effective_force, hit_zone)
 	var/obj/item/organ/external/affecting = get_organ(hit_zone)
-	if(!affecting)
-		return //should be prevented by attacked_with_item() but for sanity.
+	if (!affecting)
+		return FALSE
 
-	var/weapon_mention
-	if(I.attack_message_name())
-		weapon_mention = " with [I.attack_message_name()]"
-	visible_message(SPAN_DANGER("\The [src] has been [length(I.attack_verb)? pick(I.attack_verb) : "attacked"] in the [affecting.name][weapon_mention] by \the [user]!"))
-	return standard_weapon_hit_effects(I, user, effective_force, hit_zone)
-
-/mob/living/carbon/human/standard_weapon_hit_effects(obj/item/I, mob/living/user, effective_force, hit_zone)
-	var/obj/item/organ/external/affecting = get_organ(hit_zone)
-	if(!affecting)
-		return 0
-
-	if(user.a_intent == I_DISARM)
+	if (user.a_intent == I_DISARM)
 		effective_force *= 0.66 //reduced effective force...
 
 	var/blocked = get_blocked_ratio(hit_zone, I.damtype, I.damage_flags(), I.armor_penetration, effective_force)
 
 	// Handle striking to cripple.
-	if(user.a_intent == I_DISARM)
-		if(!..(I, user, effective_force, hit_zone))
-			return 0
+	if (user.a_intent == I_DISARM)
+		if (!..(I, user, effective_force, hit_zone))
+			return FALSE
 
 		//set the dislocate mult less than the effective force mult so that
 		//dislocating limbs on disarm is a bit easier than breaking limbs on harm
 		attack_joint(affecting, I, effective_force, 0.5, blocked) //...but can dislocate joints
-	else if(!..())
-		return 0
+	else if (!..())
+		return FALSE
 
 	var/unimpeded_force = (1 - blocked) * effective_force
-	if(effective_force > 10 || effective_force >= 5 && prob(33))
+	if (effective_force > 10 || effective_force >= 5 && prob(33))
 		forcesay(GLOB.hit_appends)	//forcesay checks stat already
 		radio_interrupt_cooldown = world.time + (RADIO_INTERRUPT_DEFAULT * 0.8) //getting beat on can briefly prevent radio use
 	if ((I.damtype == DAMAGE_BRUTE || I.damtype == DAMAGE_PAIN) && prob(25 + (unimpeded_force * 2)))
-		if(!stat)
-			if(!headcheck(hit_zone))
-				if(prob(unimpeded_force + 5))
+		if (!stat)
+			if (!headcheck(hit_zone))
+				if (prob(unimpeded_force + 5))
 					apply_effect(3, EFFECT_WEAKEN, 100 * blocked)
 					visible_message(SPAN_DANGER("[src] has been knocked down!"))
 		//Apply blood
 		attack_bloody(I, user, effective_force, hit_zone)
-
-	return 1
+	return TRUE
 
 /mob/living/carbon/human/proc/attack_bloody(obj/item/W, mob/living/attacker, effective_force, hit_zone)
 	if (W.damtype != DAMAGE_BRUTE)

--- a/code/modules/mob/living/carbon/xenobiological/items.dm
+++ b/code/modules/mob/living/carbon/xenobiological/items.dm
@@ -134,6 +134,7 @@
 	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/slimepotion/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
+	. = FALSE
 	if (!istype(M, /mob/living/carbon/slime))
 		return FALSE
 	if (M.is_adult) //Can't tame adults
@@ -169,6 +170,7 @@
 	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/slimepotion2/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
+	. = FALSE
 	if (!istype(M, /mob/living/carbon/slime))
 		return FALSE
 	if (M.stat)
@@ -201,6 +203,7 @@
 	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/slimesteroid/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
+	. = FALSE
 	if (!istype(M, /mob/living/carbon/slime))
 		return FALSE
 	if (M.is_adult) //Can't tame adults
@@ -247,6 +250,7 @@
 	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/slimepotion3/attack(mob/living/carbon/slime/M, mob/user)
+	. = FALSE
 	if (!istype(M, /mob/living/carbon/slime))
 		return FALSE
 	if (M.is_adult) //Can't revive adults

--- a/code/modules/mob/living/carbon/xenobiological/items.dm
+++ b/code/modules/mob/living/carbon/xenobiological/items.dm
@@ -131,20 +131,22 @@
 	desc = "A potent chemical mix that will nullify a slime's powers, causing it to become docile and tame."
 	icon = 'icons/obj/chemical_storage.dmi'
 	icon_state = "Pinkpotion"
+	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/slimepotion/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
-	if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
+	. = ..()
+	if (!istype(M, /mob/living/carbon/slime))//If target is not a slime.
 		to_chat(user, SPAN_WARNING(" The potion only works on baby slimes!"))
-		return ..()
-	if(M.is_adult) //Can't tame adults
+		return TRUE
+	if (M.is_adult) //Can't tame adults
 		to_chat(user, SPAN_WARNING(" Only baby slimes can be tamed!"))
-		return..()
-	if(M.stat)
+		return TRUE
+	if (M.stat)
 		to_chat(user, SPAN_WARNING(" The slime is dead!"))
-		return..()
-	if(M.mind)
+		return TRUE
+	if (M.mind)
 		to_chat(user, SPAN_WARNING(" The slime resists!"))
-		return ..()
+		return TRUE
 	var/mob/living/simple_animal/slime/pet = new /mob/living/simple_animal/slime(M.loc)
 	pet.icon_state = "[M.colour] baby slime"
 	pet.icon_living = "[M.colour] baby slime"
@@ -159,23 +161,26 @@
 	pet.SetName(newname)
 	pet.real_name = newname
 	qdel(src)
+	return TRUE
 
 /obj/item/slimepotion2
 	name = "advanced docility potion"
 	desc = "A potent chemical mix that will nullify a slime's powers, causing it to become docile and tame. This one is meant for adult slimes."
 	icon = 'icons/obj/chemical_storage.dmi'
 	icon_state = "LPinkpotion"
+	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/slimepotion2/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
-	if(!istype(M, /mob/living/carbon/slime))
+	. = ..()
+	if (!istype(M, /mob/living/carbon/slime))
 		to_chat(user, SPAN_WARNING(" The potion only works on slimes!"))
-		return ..()
-	if(M.stat)
+		return TRUE
+	if (M.stat)
 		to_chat(user, SPAN_WARNING(" The slime is dead!"))
-		return..()
-	if(M.mind)
+		return TRUE
+	if (M.mind)
 		to_chat(user, SPAN_WARNING(" The slime resists!"))
-		return ..()
+		return TRUE
 	var/mob/living/simple_animal/adultslime/pet = new /mob/living/simple_animal/adultslime(M.loc)
 	pet.icon_state = "[M.colour] adult slime"
 	pet.icon_living = "[M.colour] adult slime"
@@ -190,31 +195,34 @@
 	pet.SetName(newname)
 	pet.real_name = newname
 	qdel(src)
-
+	return TRUE
 
 /obj/item/slimesteroid
 	name = "slime steroid"
 	desc = "A potent chemical mix that will cause a slime to generate more extract."
 	icon = 'icons/obj/chemical_storage.dmi'
 	icon_state = "Greenpotion"
+	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/slimesteroid/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
-	if(!istype(M, /mob/living/carbon/slime))//If target is not a slime.
+	. = ..()
+	if (!istype(M, /mob/living/carbon/slime))//If target is not a slime.
 		to_chat(user, SPAN_WARNING(" The steroid only works on baby slimes!"))
-		return ..()
-	if(M.is_adult) //Can't tame adults
+		return TRUE
+	if (M.is_adult) //Can't tame adults
 		to_chat(user, SPAN_WARNING(" Only baby slimes can use the steroid!"))
-		return..()
-	if(M.stat)
+		return TRUE
+	if (M.stat)
 		to_chat(user, SPAN_WARNING(" The slime is dead!"))
-		return..()
-	if(M.cores == 3)
+		return TRUE
+	if (M.cores == 3)
 		to_chat(user, SPAN_WARNING(" The slime already has the maximum amount of extract!"))
-		return..()
+		return TRUE
 
 	to_chat(user, "You feed the slime the steroid. It now has triple the amount of extract.")
 	M.cores = 3
 	qdel(src)
+	return TRUE
 
 /obj/item/slimesteroid2
 	name = "extract enhancer"
@@ -242,27 +250,29 @@
 	desc= "A potent chemical mix that will revitalize a recently dead slime"
 	icon= 'icons/obj/chemical_storage.dmi'
 	icon_state= "Goldpotion"
+	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/slimepotion3/attack(mob/living/carbon/slime/M, mob/user)
-	if(!istype(M)) //If target is not a slime.
+	. = ..()
+	if (!istype(M)) //If target is not a slime.
 		to_chat(user, SPAN_WARNING("\The [src] only works on slimes!"))
-		return..()
-	if(M.is_adult) //Can't revive adults
+		return TRUE
+	if (M.is_adult) //Can't revive adults
 		to_chat(user, SPAN_WARNING("Only baby slimes can use \the [src]!"))
-		return FALSE
-	if(M.cores < 1)
+		return TRUE
+	if (M.cores < 1)
 		to_chat(user, SPAN_WARNING("\The [M] has no cores!"))
-		return FALSE
-	if(M.stat== CONSCIOUS)//need to change this to living?
+		return TRUE
+	if (M.stat== CONSCIOUS)//need to change this to living?
 		to_chat(user, SPAN_WARNING("\The [M] is already alive!"))
-		return FALSE
+		return TRUE
 	user.visible_message(
 		SPAN_NOTICE("The [user] feeds \a [src] to \the [M]. Life floods back into it!"),
 		SPAN_NOTICE("You feed \the [src] to \the [M]. Life floods back into it!")
 		)
 	M.revive()
 	qdel(src)
-
+	return TRUE
 
 /obj/effect/golemrune
 	anchored = TRUE

--- a/code/modules/mob/living/carbon/xenobiological/items.dm
+++ b/code/modules/mob/living/carbon/xenobiological/items.dm
@@ -134,10 +134,8 @@
 	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/slimepotion/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
-	. = ..()
-	if (!istype(M, /mob/living/carbon/slime))//If target is not a slime.
-		to_chat(user, SPAN_WARNING(" The potion only works on baby slimes!"))
-		return TRUE
+	if (!istype(M, /mob/living/carbon/slime))
+		return FALSE
 	if (M.is_adult) //Can't tame adults
 		to_chat(user, SPAN_WARNING(" Only baby slimes can be tamed!"))
 		return TRUE
@@ -171,10 +169,8 @@
 	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/slimepotion2/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
-	. = ..()
 	if (!istype(M, /mob/living/carbon/slime))
-		to_chat(user, SPAN_WARNING(" The potion only works on slimes!"))
-		return TRUE
+		return FALSE
 	if (M.stat)
 		to_chat(user, SPAN_WARNING(" The slime is dead!"))
 		return TRUE
@@ -205,10 +201,8 @@
 	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/slimesteroid/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
-	. = ..()
-	if (!istype(M, /mob/living/carbon/slime))//If target is not a slime.
-		to_chat(user, SPAN_WARNING(" The steroid only works on baby slimes!"))
-		return TRUE
+	if (!istype(M, /mob/living/carbon/slime))
+		return FALSE
 	if (M.is_adult) //Can't tame adults
 		to_chat(user, SPAN_WARNING(" Only baby slimes can use the steroid!"))
 		return TRUE
@@ -253,10 +247,8 @@
 	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/slimepotion3/attack(mob/living/carbon/slime/M, mob/user)
-	. = ..()
-	if (!istype(M)) //If target is not a slime.
-		to_chat(user, SPAN_WARNING("\The [src] only works on slimes!"))
-		return TRUE
+	if (!istype(M, /mob/living/carbon/slime))
+		return FALSE
 	if (M.is_adult) //Can't revive adults
 		to_chat(user, SPAN_WARNING("Only baby slimes can use \the [src]!"))
 		return TRUE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -131,28 +131,14 @@
 /mob/living/proc/resolve_item_attack(obj/item/I, mob/living/user, target_zone)
 	return target_zone
 
-//Called when the mob is hit with an item in combat. Returns the blocked result
+///Called when the mob is hit with an item in combat. Returns the blocked result
 /mob/living/proc/hit_with_weapon(obj/item/I, mob/living/user, effective_force, hit_zone)
-	var/weapon_mention
-	if(I.attack_message_name())
-		weapon_mention = " with [I.attack_message_name()]"
-	visible_message(SPAN_DANGER("\The [src] has been [length(I.attack_verb)? pick(I.attack_verb) : "attacked"][weapon_mention] by \the [user]!"))
-
-	. = standard_weapon_hit_effects(I, user, effective_force, hit_zone)
-
-	if (I.damtype == DAMAGE_BRUTE && prob(33)) // Added blood for whacking non-humans too
-		var/turf/simulated/location = get_turf(src)
-		if(istype(location)) location.add_blood_floor(src)
-
-///returns false if the effects failed to apply for some reason, true otherwise.
-/mob/living/proc/standard_weapon_hit_effects(obj/item/I, mob/living/user, effective_force, hit_zone)
 	if(!effective_force)
 		return FALSE
 
-	//Apply weapon damage
 	var/damage_flags = I.damage_flags()
-
 	return apply_damage(effective_force, I.damtype, hit_zone, damage_flags, used_weapon=I, armor_pen=I.armor_penetration)
+
 
 //this proc handles being hit by a thrown atom
 /mob/living/hitby(atom/movable/AM, datum/thrownthing/TT)

--- a/code/modules/mob/living/living_health.dm
+++ b/code/modules/mob/living/living_health.dm
@@ -57,7 +57,7 @@
 		if (DAMAGE_BRAIN)
 			adjustBrainLoss(damage)
 		else
-			apply_damage(damage, damage_type, def_zone, damage_flags, used_weapon, silent = TRUE)
+			apply_damage(damage, damage_type, def_zone, damage_flags, used_weapon, used_weapon.armor_penetration, TRUE)
 	return prior_death_state != health_dead()
 
 

--- a/code/modules/mob/living/silicon/pai/paiwire.dm
+++ b/code/modules/mob/living/silicon/pai/paiwire.dm
@@ -3,17 +3,17 @@
 	name = "data cable"
 	icon = 'icons/obj/machines/power/power_local.dmi'
 	icon_state = "wire1"
-
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	var/obj/machinery/machine
 
-/obj/item/pai_cable/proc/plugin(obj/machinery/M as obj, mob/user as mob)
-	if(istype(M, /obj/machinery/door) || istype(M, /obj/machinery/camera))
-		if(!user.unEquip(src, M))
-			return
-		user.visible_message("[user] inserts [src] into a data port on [M].", "You insert [src] into a data port on [M].", "You hear the satisfying click of a wire jack fastening into place.")
-		src.machine = M
-	else
-		user.visible_message("[user] dumbly fumbles to find a place on [M] to plug in [src].", "There aren't any ports on [M] that match the jack belonging to [src].")
 
 /obj/item/pai_cable/attack(obj/machinery/M as obj, mob/user as mob)
-	src.plugin(M, user)
+	if (istype(M, /obj/machinery/door) || istype(M, /obj/machinery/camera))
+		if (!user.unEquip(src, M))
+			return TRUE
+		user.visible_message("[user] inserts [src] into a data port on [M].", "You insert [src] into a data port on [M].", "You hear the satisfying click of a wire jack fastening into place.")
+		src.machine = M
+		return TRUE
+	else
+		user.visible_message("[user] dumbly fumbles to find a place on [M] to plug in [src].", "There aren't any ports on [M] that match the jack belonging to [src].")
+		return ..()

--- a/code/modules/mob/living/silicon/pai/paiwire.dm
+++ b/code/modules/mob/living/silicon/pai/paiwire.dm
@@ -8,6 +8,7 @@
 
 
 /obj/item/pai_cable/attack(obj/machinery/M as obj, mob/user as mob)
+	. = FALSE
 	if (istype(M, /obj/machinery/door) || istype(M, /obj/machinery/camera))
 		if (!user.unEquip(src, M))
 			return TRUE
@@ -16,4 +17,4 @@
 		return TRUE
 	else
 		user.visible_message("[user] dumbly fumbles to find a place on [M] to plug in [src].", "There aren't any ports on [M] that match the jack belonging to [src].")
-		return ..()
+		return FALSE

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -9,6 +9,7 @@
 	desc = "A hand-held scanner able to diagnose robotic injuries."
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_BELT
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	throwforce = 3
 	w_class = ITEM_SIZE_SMALL
 	throw_speed = 5
@@ -114,6 +115,7 @@
 	return
 
 /obj/item/device/robotanalyzer/attack(mob/living/M, mob/living/user)
+	. = ..()
 	roboscan(M, user)
-	src.add_fingerprint(user)
-	return
+	add_fingerprint(user)
+	return TRUE

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -115,6 +115,7 @@
 	return
 
 /obj/item/device/robotanalyzer/attack(mob/living/M, mob/living/user)
+	. = FALSE
 	if (!istype(M))
 		return FALSE
 	roboscan(M, user)

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -115,7 +115,8 @@
 	return
 
 /obj/item/device/robotanalyzer/attack(mob/living/M, mob/living/user)
-	. = ..()
+	if (!istype(M))
+		return FALSE
 	roboscan(M, user)
 	add_fingerprint(user)
 	return TRUE

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -211,10 +211,6 @@
 	wrapped = null
 	update_icon()
 
-/obj/item/gripper/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	// Don't fall through and smack people with gripper, instead just no-op
-	return 0
-
 /obj/item/gripper/resolve_attackby(atom/target, mob/living/user, params)
 
 	// Ensure fumbled items are accessible.
@@ -342,9 +338,6 @@
 	var/datum/matter_synth/glass = null
 	var/datum/matter_synth/wood = null
 	var/datum/matter_synth/plastic = null
-
-/obj/item/matter_decompiler/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	return
 
 /obj/item/matter_decompiler/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, proximity, params)
 

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -256,9 +256,6 @@
 	icon_state = "paper_bin1"
 	item_state = "sheet-metal"
 
-/obj/item/form_printer/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	return
-
 /obj/item/form_printer/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, flag, params)
 
 	if(!target || !flag)

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -213,7 +213,7 @@
 		else
 			to_chat(user, SPAN_NOTICE("\The [M] is undamaged."))
 		return TRUE
-	return ..()
+	else return ..()
 
 /////////////////////////////Behemoth/////////////////////////
 

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -206,6 +206,7 @@
 	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/natural_weapon/cult_builder/attack(mob/living/M, mob/living/user)
+	. = FALSE
 	if (istype(M, /mob/living/simple_animal/construct))
 		if (M.health < M.maxHealth)
 			M.adjustBruteLoss(-5)
@@ -213,7 +214,6 @@
 		else
 			to_chat(user, SPAN_NOTICE("\The [M] is undamaged."))
 		return TRUE
-	else return ..()
 
 /////////////////////////////Behemoth/////////////////////////
 

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -206,8 +206,8 @@
 	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/natural_weapon/cult_builder/attack(mob/living/M, mob/living/user)
-	if(istype(M, /mob/living/simple_animal/construct))
-		if(M.health < M.maxHealth)
+	if (istype(M, /mob/living/simple_animal/construct))
+		if (M.health < M.maxHealth)
 			M.adjustBruteLoss(-5)
 			user.visible_message(SPAN_NOTICE("\The [user] mends some of \the [M]'s wounds."))
 		else

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -203,6 +203,7 @@
 	name = "heavy arms"
 	attack_verb = list("rammed")
 	force = 5
+	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/natural_weapon/cult_builder/attack(mob/living/M, mob/living/user)
 	if(istype(M, /mob/living/simple_animal/construct))
@@ -211,7 +212,7 @@
 			user.visible_message(SPAN_NOTICE("\The [user] mends some of \the [M]'s wounds."))
 		else
 			to_chat(user, SPAN_NOTICE("\The [M] is undamaged."))
-		return
+		return TRUE
 	return ..()
 
 /////////////////////////////Behemoth/////////////////////////

--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -107,8 +107,9 @@
 
 
 /obj/item/device/soulstone/attack(mob/living/simple_animal/M, mob/user)
+	. = FALSE
 	if (!istype(M))
-		return ..()
+		return FALSE
 
 	if (M == shade)
 		to_chat(user, SPAN_NOTICE("You recapture \the [M]."))

--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -10,6 +10,7 @@
 	desc = "A strange, ridged chunk of some glassy red material. Achingly cold to the touch."
 	w_class = ITEM_SIZE_SMALL
 	slot_flags = SLOT_BELT
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	origin_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 4)
 
 	var/full = SOULSTONE_EMPTY
@@ -106,20 +107,24 @@
 
 
 /obj/item/device/soulstone/attack(mob/living/simple_animal/M, mob/user)
-	if(M == shade)
+	if (!istype(M))
+		return ..()
+
+	if (M == shade)
 		to_chat(user, SPAN_NOTICE("You recapture \the [M]."))
 		M.forceMove(src)
-		return
-	if(full == SOULSTONE_ESSENCE)
+		return TRUE
+	if (full == SOULSTONE_ESSENCE)
 		to_chat(user, SPAN_NOTICE("\The [src] is already full."))
-		return
-	if(M.stat != DEAD && !M.is_asystole())
+		return TRUE
+	if (M.stat != DEAD && !M.is_asystole())
 		to_chat(user, SPAN_NOTICE("Kill or maim the victim first."))
-		return
-	for(var/obj/item/W in M)
+		return TRUE
+	for (var/obj/item/W in M)
 		M.drop_from_inventory(W)
 	M.dust()
 	set_full(SOULSTONE_ESSENCE)
+	return TRUE
 
 /obj/item/device/soulstone/attack_self(mob/user)
 	if(full != SOULSTONE_ESSENCE) // No essence - no shade

--- a/code/modules/mob/living/simple_animal/defense.dm
+++ b/code/modules/mob/living/simple_animal/defense.dm
@@ -59,6 +59,15 @@
 
 	return
 
+/mob/living/simple_animal/use_weapon(obj/item/weapon, mob/user, list/click_params)
+	// Attempt attack
+	var/result = weapon.attack(src, user, user.zone_sel ? user.zone_sel.selecting : ran_zone())
+	if (result && ai_holder)
+		ai_holder.react_to_attack(user)
+		return TRUE
+
+	return ..()
+
 
 /mob/living/simple_animal/use_tool(obj/item/tool, mob/user, list/click_params)
 	// Butcher's Cleaver - Butcher dead mob
@@ -122,13 +131,13 @@
 
 	return ..()
 
-/mob/living/simple_animal/post_use_item(obj/item/tool, mob/living/user, interaction_handled, use_call, click_params)
+/mob/living/simple_animal/post_use_item(obj/item/tool, mob/living/user, interaction_handled, use_call)
 	if (interaction_handled && ai_holder && (use_call == "attack" || use_call == "weapon"))
 		ai_holder.react_to_attack(user)
 	..()
 
-/mob/living/simple_animal/hit_with_weapon(obj/item/O, mob/living/user, effective_force, hit_zone)
 
+/mob/living/simple_animal/hit_with_weapon(obj/item/O, mob/living/user, effective_force, hit_zone)
 	visible_message(SPAN_DANGER("\The [src] has been attacked with \the [O] by [user]!"))
 	if (O.force <= resistance)
 		to_chat(user, SPAN_DANGER("This weapon is ineffective; it does no damage."))

--- a/code/modules/mob/living/simple_animal/defense.dm
+++ b/code/modules/mob/living/simple_animal/defense.dm
@@ -59,16 +59,6 @@
 
 	return
 
-/mob/living/simple_animal/use_weapon(obj/item/weapon, mob/user, list/click_params)
-	// Attempt attack
-	var/result = weapon.attack(src, user, user.zone_sel ? user.zone_sel.selecting : ran_zone())
-	if (result && ai_holder)
-		ai_holder.react_to_attack(user)
-		return TRUE
-
-	return ..()
-
-
 /mob/living/simple_animal/use_tool(obj/item/tool, mob/user, list/click_params)
 	// Butcher's Cleaver - Butcher dead mob
 	if (istype(tool, /obj/item/material/knife/kitchen/cleaver))
@@ -138,8 +128,7 @@
 
 
 /mob/living/simple_animal/hit_with_weapon(obj/item/O, mob/living/user, effective_force, hit_zone)
-	visible_message(SPAN_DANGER("\The [src] has been attacked with \the [O] by [user]!"))
-	if (O.force <= resistance)
+	if(O.force <= resistance)
 		to_chat(user, SPAN_DANGER("This weapon is ineffective; it does no damage."))
 		return FALSE
 
@@ -154,8 +143,6 @@
 	adjustBruteLoss(damage)
 	if (O.edge || O.sharp)
 		adjustBleedTicks(damage)
-	if (ai_holder)
-		ai_holder.react_to_attack(user)
 	return TRUE
 
 /mob/living/simple_animal/proc/reflect_unarmed_damage(mob/living/carbon/human/attacker, damage_type, description)

--- a/code/modules/mob/living/simple_animal/hostile/faithful_hound.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithful_hound.dm
@@ -39,10 +39,11 @@
 			if((m == src) || (m in allowed_mobs) || m.faction == faction)
 				continue
 			var/new_aggress = 1
+			var/obj/item/weapon = get_natural_weapon()
 			var/mob/living/M = m
 			var/dist = get_dist(M, src)
 			if(dist < 2) //Attack! Attack!
-				M.attackby(get_natural_weapon(), src)
+				weapon.resolve_attackby(M, src)
 				return .
 			else if(dist == 2)
 				new_aggress = 3

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/webslinger.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/webslinger.dm
@@ -183,11 +183,3 @@
 	for (var/obj/aura/web/W in auras)
 		var/tally = W.stacks * 2
 		return . + tally
-
-/mob/living/use_tool(obj/item/tool, mob/user, list/click_params)
-	if (length(auras))
-		for (var/obj/aura/web/web in auras)
-			web.remove_webbing(user)
-			return TRUE
-
-	return ..()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
@@ -127,9 +127,10 @@
 
 /obj/item/natural_weapon/goatking
 	name = "giant horns"
-	attack_verb = list("brutalized")
+	attack_verb = list("brutalized", "impaled", "stabbed")
 	force = 40
 	sharp = TRUE
+	show_in_message = TRUE
 
 /obj/item/natural_weapon/goatking/fire
 	name = "burning horns"
@@ -194,6 +195,7 @@
 	attack_verb = list("impaled", "stabbed")
 	force = 15
 	sharp = TRUE
+	show_in_message = TRUE
 
 /mob/living/simple_animal/hostile/retaliate/goat/guard/master
 	name = "master of the guard"

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -508,7 +508,8 @@
 				return
 
 			//Time for the hurt to begin!
-			L.attackby(get_natural_weapon(), src)
+			var/obj/item/weapon = get_natural_weapon()
+			weapon.resolve_attackby(L, src)
 			return
 
 		//Otherwise, fly towards the mob!

--- a/code/modules/mob/living/simple_animal/hostile/voxslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/voxslug.dm
@@ -76,11 +76,11 @@ Small, little HP, poisonous.
 
 /obj/item/holder/voxslug/attack(mob/target, mob/user)
 	var/mob/living/simple_animal/hostile/voxslug/V = contents[1]
-	if(!V.stat && istype(target, /mob/living/carbon/human))
+	if (!V.stat && istype(target, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = target
-		if(!do_after(user, 3 SECONDS, H, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS))
-			return
+		if (!do_after(user, 3 SECONDS, H, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS))
+			return TRUE
 		V.attach(H)
 		qdel(src)
-		return
-	..()
+		return TRUE
+	else return ..()

--- a/code/modules/mob/living/simple_animal/hostile/voxslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/voxslug.dm
@@ -75,6 +75,7 @@ Small, little HP, poisonous.
 			R.add_reagent(/datum/reagent/drugs/cryptobiolin, 0.5)
 
 /obj/item/holder/voxslug/attack(mob/target, mob/user)
+	. = FALSE
 	var/mob/living/simple_animal/hostile/voxslug/V = contents[1]
 	if (!V.stat && istype(target, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = target
@@ -83,4 +84,3 @@ Small, little HP, poisonous.
 		V.attach(H)
 		qdel(src)
 		return TRUE
-	else return ..()

--- a/code/modules/mob/living/simple_animal/natural_weapons.dm
+++ b/code/modules/mob/living/simple_animal/natural_weapons.dm
@@ -16,14 +16,14 @@
 
 /obj/item/natural_weapon/bite
 	name = "teeth"
-	attack_verb = list("bitten")
+	attack_verb = list("bit")
 	hitsound = 'sound/weapons/bite.ogg'
 	force = 10
 	sharp = TRUE
 
 /obj/item/natural_weapon/bite/weak
 	force = 5
-	attack_verb = list("bitten", "nipped")
+	attack_verb = list("bit", "nipped")
 
 /obj/item/natural_weapon/bite/mouse
 	force = 1

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -5,6 +5,7 @@ var/global/list/organ_cache = list()
 	icon = 'icons/obj/organs.dmi'
 	germ_level = 0
 	w_class = ITEM_SIZE_TINY
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	default_action_type = /datum/action/item_action/organ
 
 	// Strings.
@@ -305,14 +306,14 @@ var/global/list/organ_cache = list()
 
 /obj/item/organ/attack(mob/target, mob/user)
 
-	if(status & ORGAN_ROBOTIC || !istype(target) || !istype(user) || (user != target && user.a_intent == I_HELP))
+	if (status & ORGAN_ROBOTIC || !istype(target) || !istype(user) || (user != target && user.a_intent == I_HELP))
 		return ..()
 
-	if(alert("Do you really want to use this organ as food? It will be useless for anything else afterwards.",,"Ew, no.","Bon appetit!") == "Ew, no.")
+	if (alert("Do you really want to use this organ as food? It will be useless for anything else afterwards.",,"Ew, no.","Bon appetit!") == "Ew, no.")
 		to_chat(user, SPAN_NOTICE("You successfully repress your cannibalistic tendencies."))
-		return
-	if(!user.unEquip(src))
-		return
+		return TRUE
+	if (!user.unEquip(src))
+		return TRUE
 	var/obj/item/reagent_containers/food/snacks/organ/O = new(get_turf(src))
 	O.SetName(name)
 	O.appearance = src
@@ -321,7 +322,8 @@ var/global/list/organ_cache = list()
 	transfer_fingerprints_to(O)
 	user.put_in_active_hand(O)
 	qdel(src)
-	target.attackby(O, user)
+	O.resolve_attackby(target, user)
+	return TRUE
 
 /obj/item/organ/proc/can_feel_pain()
 	return (!BP_IS_ROBOTIC(src) && (!species || !(species.species_flags & SPECIES_FLAG_NO_PAIN)))

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -305,9 +305,9 @@ var/global/list/organ_cache = list()
 	return 1
 
 /obj/item/organ/attack(mob/target, mob/user)
-
+	. = FALSE
 	if (status & ORGAN_ROBOTIC || !istype(target) || !istype(user) || (user != target && user.a_intent == I_HELP))
-		return ..()
+		return FALSE
 
 	if (alert("Do you really want to use this organ as food? It will be useless for anything else afterwards.",,"Ew, no.","Bon appetit!") == "Ew, no.")
 		to_chat(user, SPAN_NOTICE("You successfully repress your cannibalistic tendencies."))

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -26,6 +26,7 @@
 	if (label)
 		target.AddLabel(label, user)
 		return TRUE
+	else return ..()
 
 
 /obj/item/hand_labeler/attack_self(mob/living/user)

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -22,11 +22,11 @@
 	icon_state = "labeler[!isnull(label)]"
 
 
-/obj/item/hand_labeler/attack(atom/target, mob/living/user, target_zone, animate)
+/obj/item/hand_labeler/attack(atom/target, mob/living/user)
+	. = FALSE
 	if (label)
 		target.AddLabel(label, user)
 		return TRUE
-	else return ..()
 
 
 /obj/item/hand_labeler/attack_self(mob/living/user)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -224,6 +224,7 @@
 	show_content(user)
 
 /obj/item/paper/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+	. = FALSE
 	if (!istype(M))
 		return FALSE
 	if (user.zone_sel.selecting == BP_EYES)
@@ -232,7 +233,7 @@
 		examinate(M, src)
 		return TRUE
 
-	else if (user.zone_sel.selecting == BP_MOUTH) // lipstick wiping
+	if (user.zone_sel.selecting == BP_MOUTH) // lipstick wiping
 		if (ishuman(M))
 			var/mob/living/carbon/human/H = M
 			if (H == user)
@@ -250,7 +251,6 @@
 				H.makeup_style = null
 				H.update_body()
 				return TRUE
-	else return ..()
 
 /obj/item/paper/proc/addtofield(id, text, links = 0)
 	var/locid = 0

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -21,6 +21,7 @@
 	randpixel = 8
 	throwforce = 0
 	w_class = ITEM_SIZE_TINY
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	throw_range = 1
 	throw_speed = 1
 	layer = ABOVE_OBJ_LAYER
@@ -223,26 +224,31 @@
 	show_content(user)
 
 /obj/item/paper/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if(user.zone_sel.selecting == BP_EYES)
+	if (user.zone_sel.selecting == BP_EYES)
 		user.visible_message(SPAN_NOTICE("You show the paper to [M]. "), \
 			SPAN_NOTICE(" [user] holds up a paper and shows it to [M]. "))
 		examinate(M, src)
+		return TRUE
 
-	else if(user.zone_sel.selecting == BP_MOUTH) // lipstick wiping
-		if(ishuman(M))
+	else if (user.zone_sel.selecting == BP_MOUTH) // lipstick wiping
+		if (ishuman(M))
 			var/mob/living/carbon/human/H = M
-			if(H == user)
+			if (H == user)
 				to_chat(user, SPAN_NOTICE("You wipe off the lipstick with [src]."))
 				H.makeup_style = null
 				H.update_body()
+				return TRUE
 			else
 				user.visible_message(SPAN_WARNING("[user] begins to wipe [H]'s lipstick off with \the [src]."), \
 								 	 SPAN_NOTICE("You begin to wipe off [H]'s lipstick."))
-				if(do_after(user, 2 SECONDS, H, (DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS) & ~DO_BOTH_CAN_TURN))
-					user.visible_message(SPAN_NOTICE("[user] wipes [H]'s lipstick off with \the [src]."), \
-										 SPAN_NOTICE("You wipe off [H]'s lipstick."))
-					H.makeup_style = null
-					H.update_body()
+				if (!do_after(user, 2 SECONDS, H, (DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS) & ~DO_BOTH_CAN_TURN))
+					return TRUE
+				user.visible_message(SPAN_NOTICE("[user] wipes [H]'s lipstick off with \the [src]."), \
+									 SPAN_NOTICE("You wipe off [H]'s lipstick."))
+				H.makeup_style = null
+				H.update_body()
+				return TRUE
+	else return ..()
 
 /obj/item/paper/proc/addtofield(id, text, links = 0)
 	var/locid = 0

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -224,6 +224,8 @@
 	show_content(user)
 
 /obj/item/paper/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+	if (!istype(M))
+		return FALSE
 	if (user.zone_sel.selecting == BP_EYES)
 		user.visible_message(SPAN_NOTICE("You show the paper to [M]. "), \
 			SPAN_NOTICE(" [user] holds up a paper and shows it to [M]. "))

--- a/code/modules/paperwork/pen/crayon.dm
+++ b/code/modules/paperwork/pen/crayon.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/crayons.dmi'
 	icon_state = "crayonred"
 	w_class = ITEM_SIZE_TINY
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	attack_verb = list("attacked", "coloured")
 	colour = "#ff0000" //RGB
 	color_description = "red crayon"

--- a/code/modules/paperwork/pen/crayon.dm
+++ b/code/modules/paperwork/pen/crayon.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/obj/crayons.dmi'
 	icon_state = "crayonred"
 	w_class = ITEM_SIZE_TINY
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	attack_verb = list("attacked", "coloured")
 	colour = "#ff0000" //RGB
 	color_description = "red crayon"

--- a/code/modules/paperwork/pen/pen.dm
+++ b/code/modules/paperwork/pen/pen.dm
@@ -56,10 +56,11 @@
 			head.write_on(user, color_description)
 			return TRUE
 
-	else if(istype(A, /obj/item/organ/external/head) && user.a_intent != I_HELP) //Not on help intent to not break ghetto surgery.
+	else if (istype(A, /obj/item/organ/external/head) && user.a_intent != I_HELP) //Not on help intent to not break ghetto surgery.
 		var/obj/item/organ/external/head/head = A
 		head.write_on(user, color_description)
 		return TRUE
+
 	else return ..()
 
 /obj/item/pen/proc/toggle()

--- a/code/modules/paperwork/pen/pen.dm
+++ b/code/modules/paperwork/pen/pen.dm
@@ -5,7 +5,9 @@
 	icon_state = "pen"
 	item_state = "pen"
 	slot_flags = SLOT_BELT | SLOT_EARS
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	throwforce = 0
+	force = 2
 	w_class = ITEM_SIZE_TINY
 	force = 2
 	puncture = TRUE
@@ -47,19 +49,18 @@
 	color_description = "transluscent ink"
 
 /obj/item/pen/attack(atom/A, mob/user, target_zone)
-	if(ishuman(A) && user.a_intent == I_HELP && target_zone == BP_HEAD)
+	if (ishuman(A) && user.a_intent == I_HELP && target_zone == BP_HEAD)
 		var/mob/living/carbon/human/H = A
 		var/obj/item/organ/external/head/head = H.organs_by_name[BP_HEAD]
-		if(istype(head))
+		if (istype(head))
 			head.write_on(user, color_description)
 			return TRUE
 
-	if(istype(A, /obj/item/organ/external/head) && user.a_intent != I_HELP) //Not on help intent to not break ghetto surgery.
+	else if(istype(A, /obj/item/organ/external/head) && user.a_intent != I_HELP) //Not on help intent to not break ghetto surgery.
 		var/obj/item/organ/external/head/head = A
 		head.write_on(user, color_description)
 		return TRUE
-
-	else return FALSE
+	else return ..()
 
 /obj/item/pen/proc/toggle()
 	return

--- a/code/modules/paperwork/pen/pen.dm
+++ b/code/modules/paperwork/pen/pen.dm
@@ -48,20 +48,19 @@
 	colour = "white"
 	color_description = "transluscent ink"
 
-/obj/item/pen/attack(atom/A, mob/user, target_zone)
-	if (ishuman(A) && user.a_intent == I_HELP && target_zone == BP_HEAD)
+/obj/item/pen/attack(atom/A, mob/user)
+	. = FALSE
+	if (ishuman(A) && user.a_intent == I_HELP && user.zone_sel.selecting == BP_HEAD)
 		var/mob/living/carbon/human/H = A
 		var/obj/item/organ/external/head/head = H.organs_by_name[BP_HEAD]
 		if (istype(head))
 			head.write_on(user, color_description)
 			return TRUE
 
-	else if (istype(A, /obj/item/organ/external/head) && user.a_intent != I_HELP) //Not on help intent to not break ghetto surgery.
+	if (istype(A, /obj/item/organ/external/head) && user.a_intent != I_HELP) //Not on help intent to not break ghetto surgery.
 		var/obj/item/organ/external/head/head = A
 		head.write_on(user, color_description)
 		return TRUE
-
-	else return ..()
 
 /obj/item/pen/proc/toggle()
 	return

--- a/code/modules/paperwork/pen/reagent_pen.dm
+++ b/code/modules/paperwork/pen/reagent_pen.dm
@@ -7,28 +7,27 @@
 	create_reagents(30)
 
 /obj/item/pen/reagent/attack(mob/living/M, mob/user, target_zone)
-
-	if(!istype(M))
-		return
-
-	. = ..()
+	if (!istype(M))
+		return ..()
 
 	var/allow = M.can_inject(user, target_zone)
-	if(allow)
+	if (allow)
 		if (allow == INJECTION_PORT)
-			if(M != user)
+			if (M != user)
 				to_chat(user, SPAN_WARNING("You begin hunting for an injection port on \the [M]'s suit!"))
 			else
 				to_chat(user, SPAN_NOTICE("You begin hunting for an injection port on your suit."))
-			if(!user.do_skilled(INJECTION_PORT_DELAY, SKILL_MEDICAL, M, do_flags = DO_MEDICAL))
-				return
-		if(reagents.total_volume)
-			if(M.reagents)
+			if (!user.do_skilled(INJECTION_PORT_DELAY, SKILL_MEDICAL, M, do_flags = DO_MEDICAL))
+				return TRUE
+		if (reagents.total_volume)
+			if (M.reagents)
 				var/should_admin_log = reagents.should_admin_log()
 				var/contained_reagents = reagents.get_reagents()
 				var/trans = reagents.trans_to_mob(M, 30, CHEM_BLOOD)
 				if (should_admin_log)
 					admin_inject_log(user, M, src, contained_reagents, trans)
+		return TRUE
+	else return ..()
 
 /*
  * Sleepy Pens

--- a/code/modules/paperwork/pen/reagent_pen.dm
+++ b/code/modules/paperwork/pen/reagent_pen.dm
@@ -6,10 +6,12 @@
 	..()
 	create_reagents(30)
 
-/obj/item/pen/reagent/attack(mob/living/M, mob/user, target_zone)
+/obj/item/pen/reagent/attack(mob/living/M, mob/user)
+	. = FALSE
 	if (!istype(M))
-		return ..()
+		return FALSE
 
+	var/target_zone = user.zone_sel.selecting
 	var/allow = M.can_inject(user, target_zone)
 	if (allow)
 		if (allow == INJECTION_PORT)
@@ -27,7 +29,6 @@
 				if (should_admin_log)
 					admin_inject_log(user, M, src, contained_reagents, trans)
 		return TRUE
-	else return ..()
 
 /*
  * Sleepy Pens

--- a/code/modules/paperwork/pen/retractable_pen.dm
+++ b/code/modules/paperwork/pen/retractable_pen.dm
@@ -32,7 +32,7 @@
 	else
 		icon_state = "[base_state]"
 
-/obj/item/pen/retractable/attack(atom/A, mob/user, target_zone)
+/obj/item/pen/retractable/attack(atom/A, mob/user)
 	if(!active)
 		toggle()
 	return ..()

--- a/code/modules/paperwork/pen/retractable_pen.dm
+++ b/code/modules/paperwork/pen/retractable_pen.dm
@@ -35,7 +35,7 @@
 /obj/item/pen/retractable/attack(atom/A, mob/user, target_zone)
 	if(!active)
 		toggle()
-	..()
+	return ..()
 
 /obj/item/pen/retractable/attack_self(mob/user)
 	toggle()

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -174,9 +174,6 @@ var/global/photo_count = 0
 		size = nsize
 		to_chat(usr, SPAN_NOTICE("Camera will now take [size]x[size] photos."))
 
-/obj/item/device/camera/attack(mob/living/carbon/human/M as mob, mob/user as mob)
-	return
-
 /obj/item/device/camera/attack_self(mob/user as mob)
 	on = !on
 	update_icon()

--- a/code/modules/paperwork/stamps.dm
+++ b/code/modules/paperwork/stamps.dm
@@ -5,11 +5,13 @@
 	icon_state = "stamp-deckchief"
 	item_state = "stamp"
 	throwforce = 0
+	force = 1
 	w_class = ITEM_SIZE_TINY
 	throw_speed = 7
 	throw_range = 15
 	matter = list(MATERIAL_STEEL = 60)
 	attack_verb = list("stamped")
+	hitsound = 'sound/effects/stamp.ogg'
 
 /obj/item/stamp/captain
 	name = "captain's rubber stamp"

--- a/code/modules/power/cable_coil.dm
+++ b/code/modules/power/cable_coil.dm
@@ -35,6 +35,7 @@ GLOBAL_LIST_INIT(cable_default_colors, list(
 	)
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CAN_BE_PAINTED
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	slot_flags = SLOT_BELT
 	item_state = "coil"
 	attack_verb = list("whipped", "lashed", "disciplined", "flogged")
@@ -88,9 +89,7 @@ GLOBAL_LIST_INIT(cable_default_colors, list(
 
 
 /obj/item/stack/cable_coil/attack(mob/living/carbon/human/target, mob/living/user, def_zone)
-	if (user.a_intent != I_HELP)
-		return ..()
-	if (!istype(target))
+	if (user.a_intent != I_HELP || !istype(target))
 		return ..()
 	var/obj/item/organ/external/organ = target.organs_by_name[user.zone_sel.selecting]
 	if (!organ)

--- a/code/modules/power/cable_coil.dm
+++ b/code/modules/power/cable_coil.dm
@@ -88,9 +88,10 @@ GLOBAL_LIST_INIT(cable_default_colors, list(
 			SetName(initial(name))
 
 
-/obj/item/stack/cable_coil/attack(mob/living/carbon/human/target, mob/living/user, def_zone)
+/obj/item/stack/cable_coil/attack(mob/living/carbon/human/target, mob/living/user)
+	. = FALSE
 	if (user.a_intent != I_HELP || !istype(target))
-		return ..()
+		return FALSE
 	var/obj/item/organ/external/organ = target.organs_by_name[user.zone_sel.selecting]
 	if (!organ)
 		to_chat(user, SPAN_WARNING("\The [target] is missing that organ."))

--- a/code/modules/psionics/equipment/psipower.dm
+++ b/code/modules/psionics/equipment/psipower.dm
@@ -29,11 +29,11 @@
 	sound_to(owner, 'sound/effects/psi/power_fail.ogg')
 	user.drop_from_inventory(src)
 
-/obj/item/psychic_power/attack(mob/living/M, mob/living/user, target_zone)
+/obj/item/psychic_power/attack(mob/living/M, mob/living/user)
+	. = FALSE
 	if(M.do_psionics_check(max(force, maintain_cost), user))
 		to_chat(user, SPAN_DANGER("\The [src] flickers violently out of phase!"))
 		return TRUE
-	else return ..()
 
 /obj/item/psychic_power/afterattack(atom/target, mob/living/user, proximity)
 	if(target.do_psionics_check(max(force, maintain_cost), user))

--- a/code/modules/psionics/equipment/psipower.dm
+++ b/code/modules/psionics/equipment/psipower.dm
@@ -2,6 +2,7 @@
 	name = "psychic power"
 	icon = 'icons/obj/psychic_powers.dmi'
 	atom_flags = 0
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	anchored = TRUE
 	var/maintain_cost = 3
 	var/mob/living/owner
@@ -31,8 +32,8 @@
 /obj/item/psychic_power/attack(mob/living/M, mob/living/user, target_zone)
 	if(M.do_psionics_check(max(force, maintain_cost), user))
 		to_chat(user, SPAN_DANGER("\The [src] flickers violently out of phase!"))
-		return 1
-	. = ..()
+		return TRUE
+	else return ..()
 
 /obj/item/psychic_power/afterattack(atom/target, mob/living/user, proximity)
 	if(target.do_psionics_check(max(force, maintain_cost), user))

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -145,11 +145,11 @@
 	var/is_self = target == user
 	if (!target.check_has_mouth())
 		to_chat(user, SPAN_WARNING("[is_self ? "You" : "\The [target]"] can't consume \the [src] - [is_self ? "you" : "they"] don't have a mouth!"))
-		return FALSE
+		return TRUE
 	var/obj/item/blocker = target.check_mouth_coverage()
 	if (blocker)
 		to_chat(user, SPAN_WARNING("[is_self ? "Your" : "\The [target]'s"] [blocker] is in the way!"))
-		return FALSE
+		return TRUE
 	user?.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 	if (is_self)
 		self_feed_message(target)
@@ -157,7 +157,7 @@
 	else
 		other_feed_message_start(user, target)
 		if (!do_after(user, 3 SECONDS, target, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS))
-			return FALSE
+			return TRUE
 		other_feed_message_finish(user, target)
 		add_trace_DNA(target)
 		var/contained = reagentlist()

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -7,6 +7,7 @@
 	amount_per_transfer_from_this = 5
 	volume = 30
 	possible_transfer_amounts = null
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	canremove = FALSE
 
 	/// Numeric index of the synthesizer in use, or 0 if dispensing from an external container
@@ -57,33 +58,34 @@
 	return 1
 
 /obj/item/reagent_containers/borghypo/attack(mob/living/M, mob/user, target_zone)
-	if(!istype(M))
-		return
+	if (!istype(M))
+		return ..()
 
-	if(mode && !reagent_volumes[reagent_ids[mode]])
+	if (mode && !reagent_volumes[reagent_ids[mode]])
 		to_chat(user, SPAN_WARNING("\The [src] is empty."))
-		return
+		return TRUE
 	var/obj/item/reagent_containers/container = null
 	if (!mode)
 		container = dispense.resolve()
 		if (!valid_container(user, container))
 			to_chat(user, SPAN_WARNING("Can't find the container to dispense from."))
-			return
+			return TRUE
 		if (!container.reagents?.total_volume)
 			to_chat(user, SPAN_WARNING("\The [container] is empty."))
+			return TRUE
 
 	var/allow = M.can_inject(user, target_zone)
 	if (allow)
 		if (allow == INJECTION_PORT)
 			user.visible_message(SPAN_WARNING("\The [user] begins hunting for an injection port on \the [M]'s suit!"))
-			if(!user.do_skilled(INJECTION_PORT_DELAY, SKILL_MEDICAL, M, do_flags = DO_MEDICAL))
-				return
+			if (!user.do_skilled(INJECTION_PORT_DELAY, SKILL_MEDICAL, M, do_flags = DO_MEDICAL))
+				return TRUE
 		to_chat(user, SPAN_NOTICE("You inject [M] with the injector."))
-		if(ishuman(M))
+		if (ishuman(M))
 			var/mob/living/carbon/human/H = M
 			H.custom_pain(SPAN_WARNING("You feel a tiny prick!"), 1, TRUE, H.get_organ(user.zone_sel.selecting))
 
-		if(M.reagents)
+		if (M.reagents)
 			if (mode)
 				var/datum/reagent/R = reagent_ids[mode]
 				var/should_admin_log = initial(R.should_admin_log)
@@ -93,6 +95,7 @@
 				if (should_admin_log)
 					admin_inject_log(user, M, src, R, transferred)
 				to_chat(user, SPAN_NOTICE("[transferred] units injected. [reagent_volumes[R]] units remaining."))
+				return TRUE
 			else
 				var/datum/reagents/R = container.reagents
 				var/should_admin_log = R.should_admin_log()
@@ -101,7 +104,8 @@
 				if (should_admin_log)
 					admin_inject_log(user, M, src, contained, transferred)
 				to_chat(user, SPAN_NOTICE("[transferred] units injected. [R.total_volume] units remaining in \the [container]."))
-	return
+				return TRUE
+	else return ..()
 
 /obj/item/reagent_containers/borghypo/attack_self(mob/user as mob)
 	ui_interact(user)
@@ -246,7 +250,7 @@
 		)
 
 /obj/item/reagent_containers/borghypo/service/attack(mob/M, mob/user)
-	return
+	return FALSE //We don't want the service borg to be able to inject alcohol into blood.
 
 /obj/item/reagent_containers/borghypo/service/afterattack(obj/target, mob/user, proximity)
 	if(!proximity)

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -57,9 +57,10 @@
 					reagent_volumes[T] = min(reagent_volumes[T] + 5, volume)
 	return 1
 
-/obj/item/reagent_containers/borghypo/attack(mob/living/M, mob/user, target_zone)
+/obj/item/reagent_containers/borghypo/attack(mob/living/M, mob/user)
+	. = FALSE
 	if (!istype(M))
-		return ..()
+		return FALSE
 
 	if (mode && !reagent_volumes[reagent_ids[mode]])
 		to_chat(user, SPAN_WARNING("\The [src] is empty."))
@@ -74,6 +75,7 @@
 			to_chat(user, SPAN_WARNING("\The [container] is empty."))
 			return TRUE
 
+	var/target_zone = user.zone_sel.selecting
 	var/allow = M.can_inject(user, target_zone)
 	if (allow)
 		if (allow == INJECTION_PORT)
@@ -105,7 +107,6 @@
 					admin_inject_log(user, M, src, contained, transferred)
 				to_chat(user, SPAN_NOTICE("[transferred] units injected. [R.total_volume] units remaining in \the [container]."))
 				return TRUE
-	else return ..()
 
 /obj/item/reagent_containers/borghypo/attack_self(mob/user as mob)
 	ui_interact(user)

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -43,7 +43,9 @@
 	return
 
 /obj/item/reagent_containers/food/condiment/attack(mob/M as mob, mob/user as mob, def_zone)
-	if(standard_feed_mob(user, M))
+	if (!istype(M))
+		return FALSE
+	if (standard_feed_mob(user, M))
 		return TRUE
 	else return ..()
 

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -42,12 +42,12 @@
 /obj/item/reagent_containers/food/condiment/attack_self(mob/user as mob)
 	return
 
-/obj/item/reagent_containers/food/condiment/attack(mob/M as mob, mob/user as mob, def_zone)
+/obj/item/reagent_containers/food/condiment/attack(mob/M as mob, mob/user as mob)
+	. = FALSE
 	if (!istype(M))
 		return FALSE
 	if (standard_feed_mob(user, M))
 		return TRUE
-	else return ..()
 
 /obj/item/reagent_containers/food/condiment/afterattack(obj/target, mob/user, proximity)
 	if(!proximity)

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -11,6 +11,7 @@
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = "emptycondiment"
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	possible_transfer_amounts = "1;5;10"
 	center_of_mass = "x=16;y=6"
 	volume = 50
@@ -43,7 +44,8 @@
 
 /obj/item/reagent_containers/food/condiment/attack(mob/M as mob, mob/user as mob, def_zone)
 	if(standard_feed_mob(user, M))
-		return
+		return TRUE
+	else return ..()
 
 /obj/item/reagent_containers/food/condiment/afterattack(obj/target, mob/user, proximity)
 	if(!proximity)

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -7,6 +7,7 @@
 	icon = 'icons/obj/food/drinks.dmi'
 	icon_state = null
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	amount_per_transfer_from_this = 5
 	volume = 50
 	var/filling_states   // List of percentages full that have icons
@@ -34,9 +35,9 @@
 		return ..()
 
 	if(standard_feed_mob(user, M))
-		return
+		return TRUE
 
-	return 0
+	return ..()
 
 /obj/item/reagent_containers/food/drinks/afterattack(obj/target, mob/user, proximity)
 	if(!proximity) return

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -31,13 +31,15 @@
 	atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 
 /obj/item/reagent_containers/food/drinks/attack(mob/M as mob, mob/user as mob, def_zone)
+	if (!istype(M))
+		return FALSE
 	if(force && !(item_flags & ITEM_FLAG_NO_BLUDGEON) && user.a_intent == I_HURT)
-		return ..()
+		return FALSE
 
 	if(standard_feed_mob(user, M))
 		return TRUE
 
-	return ..()
+	else return ..()
 
 /obj/item/reagent_containers/food/drinks/afterattack(obj/target, mob/user, proximity)
 	if(!proximity) return

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -30,7 +30,8 @@
 	to_chat(user, SPAN_NOTICE("You open \the [src] with an audible pop!"))
 	atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 
-/obj/item/reagent_containers/food/drinks/attack(mob/M as mob, mob/user as mob, def_zone)
+/obj/item/reagent_containers/food/drinks/attack(mob/M as mob, mob/user as mob)
+	. = FALSE
 	if (!istype(M))
 		return FALSE
 	if(force && !(item_flags & ITEM_FLAG_NO_BLUDGEON) && user.a_intent == I_HURT)
@@ -38,8 +39,6 @@
 
 	if(standard_feed_mob(user, M))
 		return TRUE
-
-	else return ..()
 
 /obj/item/reagent_containers/food/drinks/afterattack(obj/target, mob/user, proximity)
 	if(!proximity) return

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -820,11 +820,7 @@
 	throw_speed = 3
 	throw_range = 5
 	item_state = "beer"
+	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("stabbed", "slashed", "attacked")
 	sharp = TRUE
 	var/icon/broken_outline = icon('icons/obj/food/drinks.dmi', "broken")
-
-
-/obj/item/broken_bottle/attack(mob/living/carbon/M, mob/living/carbon/user)
-	playsound(loc, 'sound/weapons/bladeslice.ogg', 50, 1, -1)
-	return ..()

--- a/code/modules/reagents/reagent_containers/food/sandwich.dm
+++ b/code/modules/reagents/reagent_containers/food/sandwich.dm
@@ -102,9 +102,10 @@
 	var/obj/item/O = pick(contents)
 	to_chat(user, SPAN_ITALIC("You think you can see [O.name] in there."))
 
-/obj/item/reagent_containers/food/snacks/csandwich/attack(mob/living/M as mob, mob/user as mob, def_zone)
+/obj/item/reagent_containers/food/snacks/csandwich/attack(mob/living/M as mob, mob/user as mob)
+	. = FALSE
 	if (!istype(M))
-		return ..()
+		return FALSE
 	var/obj/item/shard
 	for (var/obj/item/O in contents)
 		if (istype(O,/obj/item/material/shard))

--- a/code/modules/reagents/reagent_containers/food/sandwich.dm
+++ b/code/modules/reagents/reagent_containers/food/sandwich.dm
@@ -17,6 +17,7 @@
 	var/list/ingredients = list()
 	var/fullname = ""
 	var/renamed = 0
+	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/reagent_containers/food/snacks/csandwich/verb/rename_sandwich()
 	set name = "Rename Sandwich"
@@ -101,19 +102,16 @@
 	var/obj/item/O = pick(contents)
 	to_chat(user, SPAN_ITALIC("You think you can see [O.name] in there."))
 
-/obj/item/reagent_containers/food/snacks/csandwich/attack(mob/M as mob, mob/user as mob, def_zone)
-
+/obj/item/reagent_containers/food/snacks/csandwich/attack(mob/living/M as mob, mob/user as mob, def_zone)
+	if (!istype(M))
+		return ..()
 	var/obj/item/shard
-	for(var/obj/item/O in contents)
-		if(istype(O,/obj/item/material/shard))
+	for (var/obj/item/O in contents)
+		if (istype(O,/obj/item/material/shard))
 			shard = O
 			break
 
-	var/mob/living/H
-	if(istype(M,/mob/living))
-		H = M
-
-	if(H && shard && M == user) //This needs a check for feeding the food to other people, but that could be abusable.
-		to_chat(H, SPAN_WARNING("You lacerate your mouth on a [shard.name] in the sandwich!"))
-		H.adjustBruteLoss(5) //TODO: Target head if human.
-	..()
+	if (shard && M == user)
+		to_chat(M, SPAN_WARNING("You lacerate your mouth on a [shard.name] in the sandwich!"))
+		M.adjustBruteLoss(5) //TODO: Target head if human.
+	return ..()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3,6 +3,7 @@
 	desc = "Yummy!"
 	icon = 'icons/obj/food/food.dmi'
 	center_of_mass = "x=16;y=16"
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	var/bitesize = 1
 	var/bitecount = 0
 	var/slice_path
@@ -56,73 +57,74 @@
 
 
 /obj/item/reagent_containers/food/snacks/attack(mob/M as mob, mob/user as mob, def_zone)
-	if(!reagents || !reagents.total_volume)
+	if (!istype(M, /mob/living/carbon))
+		return ..()
+	if (!reagents || !reagents.total_volume)
 		to_chat(user, SPAN_DANGER("None of [src] left!"))
 		qdel(src)
-		return 0
-	if(!is_open_container())
+		return TRUE
+	if (!is_open_container())
 		to_chat(user, SPAN_NOTICE("\The [src] isn't open!"))
-		return 0
-	if(istype(M, /mob/living/carbon))
-		//TODO: replace with standard_feed_mob() call.
-		var/mob/living/carbon/C = M
-		var/fullness = C.get_fullness()
-		if(C == user)								//If you're eating it yourself
-			if(istype(C,/mob/living/carbon/human))
-				var/mob/living/carbon/human/H = M
-				if(!H.check_has_mouth())
-					to_chat(user, "Where do you intend to put \the [src]? You don't have a mouth!")
-					return
-				var/obj/item/blocked = H.check_mouth_coverage()
-				if(blocked)
-					to_chat(user, SPAN_WARNING("\The [blocked] is in the way!"))
-					return
+		return TRUE
 
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)//puts a limit on how fast people can eat/drink things
-			if (fullness <= 50)
-				to_chat(C, SPAN_DANGER("You hungrily chew out a piece of [src] and gobble it!"))
-			if (fullness > 50 && fullness <= 150)
-				to_chat(C, SPAN_NOTICE("You hungrily begin to eat [src]."))
-			if (fullness > 150 && fullness <= 350)
-				to_chat(C, SPAN_NOTICE("You take a bite of [src]."))
-			if (fullness > 350 && fullness <= 550)
-				to_chat(C, SPAN_NOTICE("You unwillingly chew a bit of [src]."))
-			if (fullness > 550)
-				to_chat(C, SPAN_DANGER("You cannot force any more of [src] to go down your throat."))
-				return 0
+	//TODO: replace with standard_feed_mob() call.
+	var/mob/living/carbon/C = M
+	var/fullness = C.get_fullness()
+	if (C == user)								//If you're eating it yourself
+		if (istype(C,/mob/living/carbon/human))
+			var/mob/living/carbon/human/H = M
+			if (!H.check_has_mouth())
+				to_chat(user, "Where do you intend to put \the [src]? You don't have a mouth!")
+				return TRUE
+			var/obj/item/blocked = H.check_mouth_coverage()
+			if (blocked)
+				to_chat(user, SPAN_WARNING("\The [blocked] is in the way!"))
+				return TRUE
+
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)//puts a limit on how fast people can eat/drink things
+		if (fullness <= 50)
+			to_chat(C, SPAN_DANGER("You hungrily chew out a piece of [src] and gobble it!"))
+		if (fullness > 50 && fullness <= 150)
+			to_chat(C, SPAN_NOTICE("You hungrily begin to eat [src]."))
+		if (fullness > 150 && fullness <= 350)
+			to_chat(C, SPAN_NOTICE("You take a bite of [src]."))
+		if (fullness > 350 && fullness <= 550)
+			to_chat(C, SPAN_NOTICE("You unwillingly chew a bit of [src]."))
+		if (fullness > 550)
+			to_chat(C, SPAN_DANGER("You cannot force any more of [src] to go down your throat."))
+			return TRUE
+	else
+		if(!M.can_force_feed(user, src))
+			return TRUE
+
+		if (fullness <= 550)
+			user.visible_message(SPAN_DANGER("[user] attempts to feed [M] [src]."))
 		else
-			if(!M.can_force_feed(user, src))
-				return
+			user.visible_message(SPAN_DANGER("[user] cannot force anymore of [src] down [M]'s throat."))
+			return TRUE
 
-			if (fullness <= 550)
-				user.visible_message(SPAN_DANGER("[user] attempts to feed [M] [src]."))
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+		if (!do_after(user, 3 SECONDS, M, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS))
+			return TRUE
+
+		if (user.get_active_hand() != src)
+			return TRUE
+
+		var/contained = reagentlist()
+		admin_attack_log(user, M, "Fed the victim with [name] (Reagents: [contained])", "Was fed [src] (Reagents: [contained])", "used [src] (Reagents: [contained]) to feed")
+		user.visible_message(SPAN_DANGER("[user] feeds [M] [src]."))
+
+	if (reagents) //Handle ingestion of the reagent.
+		if (eat_sound)
+			playsound(M, pick(eat_sound), rand(10, 50), 1)
+		if (reagents.total_volume)
+			if (reagents.total_volume > bitesize)
+				reagents.trans_to_mob(M, bitesize, CHEM_INGEST)
 			else
-				user.visible_message(SPAN_DANGER("[user] cannot force anymore of [src] down [M]'s throat."))
-				return 0
-
-			user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-			if(!do_after(user, 3 SECONDS, M, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS)) return
-
-			if (user.get_active_hand() != src)
-				return
-
-			var/contained = reagentlist()
-			admin_attack_log(user, M, "Fed the victim with [name] (Reagents: [contained])", "Was fed [src] (Reagents: [contained])", "used [src] (Reagents: [contained]) to feed")
-			user.visible_message(SPAN_DANGER("[user] feeds [M] [src]."))
-
-		if(reagents) //Handle ingestion of the reagent.
-			if(eat_sound)
-				playsound(M, pick(eat_sound), rand(10, 50), 1)
-			if(reagents.total_volume)
-				if(reagents.total_volume > bitesize)
-					reagents.trans_to_mob(M, bitesize, CHEM_INGEST)
-				else
-					reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
-				bitecount++
-				OnConsume(M, user)
-			return 1
-
-	return 0
+				reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
+			bitecount++
+			OnConsume(M, user)
+	return TRUE
 
 /obj/item/reagent_containers/food/snacks/examine(mob/user, distance)
 	. = ..()

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -56,9 +56,10 @@
 	return
 
 
-/obj/item/reagent_containers/food/snacks/attack(mob/M as mob, mob/user as mob, def_zone)
+/obj/item/reagent_containers/food/snacks/attack(mob/M as mob, mob/user as mob)
+	. = FALSE
 	if (!istype(M, /mob/living/carbon))
-		return ..()
+		return FALSE
 	if (!reagents || !reagents.total_volume)
 		to_chat(user, SPAN_DANGER("None of [src] left!"))
 		qdel(src)

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1496,6 +1496,7 @@
 			W.src_flavor = ""
 		else
 			to_chat(user,"The cube doesn't so much as twitch without a DNA sample.")
+		return TRUE
 	return ..()
 
 

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -67,12 +67,12 @@
 		atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 	update_icon()
 
-/obj/item/reagent_containers/glass/attack(mob/M as mob, mob/user as mob, def_zone)
+/obj/item/reagent_containers/glass/attack(mob/M as mob, mob/user as mob)
+	. = FALSE
 	if (!istype(M))
-		return ..()
+		return FALSE
 	if (standard_feed_mob(user, M))
 		return TRUE
-	else return ..()
 
 /obj/item/reagent_containers/glass/standard_feed_mob(mob/user, mob/target)
 	if(!is_open_container())

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -14,6 +14,7 @@
 	volume = 60
 	w_class = ITEM_SIZE_SMALL
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	unacidable = TRUE
 
 
@@ -67,18 +68,18 @@
 	update_icon()
 
 /obj/item/reagent_containers/glass/attack(mob/M as mob, mob/user as mob, def_zone)
-	if(force && !(item_flags & ITEM_FLAG_NO_BLUDGEON) && user.a_intent == I_HURT)
-		return	..()
-	if(standard_feed_mob(user, M))
-		return
-	return 0
+	if (!istype(M))
+		return ..()
+	if (standard_feed_mob(user, M))
+		return TRUE
+	else return ..()
 
 /obj/item/reagent_containers/glass/standard_feed_mob(mob/user, mob/target)
 	if(!is_open_container())
 		to_chat(user, SPAN_NOTICE("You need to open \the [src] first."))
-		return 1
+		return TRUE
 	if(user.a_intent == I_HURT)
-		return 1
+		return FALSE
 	return ..()
 
 /obj/item/reagent_containers/glass/self_feed_message(mob/user)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -16,6 +16,7 @@
 	possible_transfer_amounts = null
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	slot_flags = SLOT_BELT
+	item_flags = ITEM_FLAG_TRY_ATTACK
 
 	// autoinjectors takes less time than a normal syringe (overriden for hypospray).
 	// This delay is only applied when injecting concious mobs, and is not applied for self-injection
@@ -29,15 +30,15 @@
 	var/single_use = TRUE // autoinjectors are not refillable (overriden for hypospray)
 
 /obj/item/reagent_containers/hypospray/attack(mob/living/M, mob/user)
-	if(!reagents.total_volume)
-		to_chat(user, SPAN_WARNING("[src] is empty."))
-		return
 	if (!istype(M))
-		return
+		return ..()
+	if (!reagents.total_volume)
+		to_chat(user, SPAN_WARNING("[src] is empty."))
+		return TRUE
 
 	var/allow = M.can_inject(user, check_zone(user.zone_sel.selecting))
-	if(!allow)
-		return
+	if (!allow)
+		return TRUE
 
 	if (allow == INJECTION_PORT)
 		if(M != user)
@@ -45,7 +46,7 @@
 		else
 			to_chat(user, SPAN_NOTICE("You begin hunting for an injection port on your suit."))
 		if(!user.do_skilled(INJECTION_PORT_DELAY, SKILL_MEDICAL, M, do_flags = DO_MEDICAL))
-			return
+			return TRUE
 
 	user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 	user.do_attack_animation(M)
@@ -53,10 +54,11 @@
 	if(user != M && !M.incapacitated() && time) // you're injecting someone else who is concious, so apply the device's intrisic delay
 		to_chat(user, SPAN_WARNING("\The [user] is trying to inject \the [M] with \the [name]."))
 		if(!user.do_skilled(time, SKILL_MEDICAL, M, do_flags = DO_MEDICAL))
-			return
+			return TRUE
 
 	if(single_use && reagents.total_volume <= 0) // currently only applies to autoinjectors
 		atom_flags &= ~ATOM_FLAG_OPEN_CONTAINER // Prevents autoinjectors to be refilled.
+		update_icon()
 
 	to_chat(user, SPAN_NOTICE("You inject [M] with [src]."))
 	if(ishuman(M))
@@ -73,8 +75,7 @@
 		if (should_admin_log)
 			admin_inject_log(user, M, src, contained, trans)
 		to_chat(user, SPAN_NOTICE("[trans] units injected. [reagents.total_volume] units remaining in \the [src]."))
-
-	return
+	return TRUE
 
 /obj/item/reagent_containers/hypospray/vial
 	name = "hypospray"
@@ -181,10 +182,6 @@
 		reagents.add_reagent(T, starts_with[T])
 	update_icon()
 	return
-
-/obj/item/reagent_containers/hypospray/autoinjector/attack(mob/M as mob, mob/user as mob)
-	..()
-	update_icon()
 
 /obj/item/reagent_containers/hypospray/autoinjector/on_reagent_change()
 	update_icon()

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -30,8 +30,9 @@
 	var/single_use = TRUE // autoinjectors are not refillable (overriden for hypospray)
 
 /obj/item/reagent_containers/hypospray/attack(mob/living/M, mob/user)
+	. = FALSE
 	if (!istype(M))
-		return ..()
+		return FALSE
 	if (!reagents.total_volume)
 		to_chat(user, SPAN_WARNING("[src] is empty."))
 		return TRUE

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -19,9 +19,10 @@
 	if(!icon_state)
 		icon_state = "pill[rand(1, 5)]" //preset pills only use colour changing or unique icons
 
-/obj/item/reagent_containers/pill/attack(mob/M as mob, mob/user as mob, def_zone)
+/obj/item/reagent_containers/pill/attack(mob/M as mob, mob/user as mob)
+	. = FALSE
 	if (!istype(M))
-		return ..()
+		return FALSE
 
 	if (M == user)
 		if (!M.can_eat(src))
@@ -53,7 +54,6 @@
 			reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
 		qdel(src)
 		return TRUE
-	return ..()
 
 /obj/item/reagent_containers/pill/afterattack(obj/target, mob/user, proximity)
 	if(!proximity) return

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -10,6 +10,7 @@
 	randpixel = 7
 	possible_transfer_amounts = null
 	w_class = ITEM_SIZE_TINY
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	slot_flags = SLOT_EARS
 	volume = 30
 
@@ -19,40 +20,40 @@
 		icon_state = "pill[rand(1, 5)]" //preset pills only use colour changing or unique icons
 
 /obj/item/reagent_containers/pill/attack(mob/M as mob, mob/user as mob, def_zone)
-		//TODO: replace with standard_feed_mob() call.
+	if (!istype(M))
+		return ..()
 
-	if(M == user)
-		if(!M.can_eat(src))
-			return
+	if (M == user)
+		if (!M.can_eat(src))
+			return TRUE
 
 		M.visible_message(SPAN_NOTICE("[M] swallows a pill."), SPAN_NOTICE("You swallow \the [src]."), null, 2)
-		if(reagents.total_volume)
+		if (reagents.total_volume)
 			reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
 		qdel(src)
-		return 1
+		return TRUE
 
-	else if(istype(M, /mob/living/carbon/human))
-		if(!M.can_force_feed(user, src))
-			return
+	if (ishuman(M))
+		if (!M.can_force_feed(user, src))
+			return TRUE
 
 		user.visible_message(SPAN_WARNING("[user] attempts to force [M] to swallow \the [src]."))
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-		if(!do_after(user, 3 SECONDS, M, DO_MEDICAL))
-			return
+		if (!do_after(user, 3 SECONDS, M, DO_MEDICAL))
+			return TRUE
 
 		if (user.get_active_hand() != src)
-			return
+			return TRUE
 
 		user.visible_message(SPAN_WARNING("[user] forces [M] to swallow \the [src]."))
 		var/contained = reagentlist()
 		if (reagents.should_admin_log())
 			admin_attack_log(user, M, "Fed the victim with [name] (Reagents: [contained])", "Was fed [src] (Reagents: [contained])", "used [src] (Reagents: [contained]) to feed")
-		if(reagents.total_volume)
+		if (reagents.total_volume)
 			reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
 		qdel(src)
-		return 1
-
-	return 0
+		return TRUE
+	return ..()
 
 /obj/item/reagent_containers/pill/afterattack(obj/target, mob/user, proximity)
 	if(!proximity) return

--- a/code/modules/spells/hand/hand_item.dm
+++ b/code/modules/spells/hand/hand_item.dm
@@ -24,10 +24,10 @@ Basically: I can use it to target things where I click. I can then pass these ta
 	return ITEM_SIZE_NO_CONTAINER
 
 /obj/item/magic_hand/attack(mob/living/M, mob/living/user)
+	. = FALSE
 	if (hand_spell && hand_spell.valid_target(M, user))
 		fire_spell(M, user)
 		return TRUE
-	return ..()
 
 /obj/item/magic_hand/proc/fire_spell(atom/A, mob/living/user)
 	if(!hand_spell) //no spell? Die.

--- a/code/modules/spells/hand/hand_item.dm
+++ b/code/modules/spells/hand/hand_item.dm
@@ -9,6 +9,7 @@ Basically: I can use it to target things where I click. I can then pass these ta
 	item_flags = 0
 	obj_flags = 0
 	simulated = FALSE
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	icon_state = "spell"
 	var/next_spell_time = 0
 	var/spell/hand/hand_spell
@@ -23,10 +24,10 @@ Basically: I can use it to target things where I click. I can then pass these ta
 	return ITEM_SIZE_NO_CONTAINER
 
 /obj/item/magic_hand/attack(mob/living/M, mob/living/user)
-	if(hand_spell && hand_spell.valid_target(M, user))
+	if (hand_spell && hand_spell.valid_target(M, user))
 		fire_spell(M, user)
-		return 0
-	return 1
+		return TRUE
+	return ..()
 
 /obj/item/magic_hand/proc/fire_spell(atom/A, mob/living/user)
 	if(!hand_spell) //no spell? Die.

--- a/code/modules/xenoarcheaology/tools/ano_device_battery.dm
+++ b/code/modules/xenoarcheaology/tools/ano_device_battery.dm
@@ -204,9 +204,10 @@
 	STOP_PROCESSING(SSobj, src)
 	..()
 
-/obj/item/anodevice/attack(mob/living/M as mob, mob/living/user as mob, def_zone)
+/obj/item/anodevice/attack(mob/living/M as mob, mob/living/user as mob)
+	. = FALSE
 	if (!istype(M))
-		return ..()
+		return FALSE
 
 	if (activated && inserted_battery.battery_effect.effect == EFFECT_TOUCH && !isnull(inserted_battery))
 		inserted_battery.battery_effect.DoEffectTouch(M)

--- a/code/modules/xenoarcheaology/tools/ano_device_battery.dm
+++ b/code/modules/xenoarcheaology/tools/ano_device_battery.dm
@@ -19,6 +19,7 @@
 	name = "Anomaly power utilizer"
 	icon = 'icons/obj/tools/xenoarcheology_anomaly_utilizer.dmi'
 	icon_state = "anodev"
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	var/activated = 0
 	var/duration = 0
 	var/interval = 0
@@ -205,9 +206,9 @@
 
 /obj/item/anodevice/attack(mob/living/M as mob, mob/living/user as mob, def_zone)
 	if (!istype(M))
-		return
+		return ..()
 
-	if(activated && inserted_battery.battery_effect.effect == EFFECT_TOUCH && !isnull(inserted_battery))
+	if (activated && inserted_battery.battery_effect.effect == EFFECT_TOUCH && !isnull(inserted_battery))
 		inserted_battery.battery_effect.DoEffectTouch(M)
 		inserted_battery.use_power(energy_consumed_on_touch)
 		user.visible_message(SPAN_NOTICE("[user] taps [M] with [src], and it shudders on contact."))
@@ -216,3 +217,4 @@
 
 	if(inserted_battery.battery_effect)
 		admin_attack_log(user, M, "Tapped their victim with \a [src] (EFFECT: [inserted_battery.battery_effect.name])", "Was tapped by \a [src] (EFFECT: [inserted_battery.battery_effect.name])", "used \a [src] (EFFECT: [inserted_battery.battery_effect.name]) to tap")
+	return TRUE

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -57,7 +57,7 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 6 "uses of .len" '\.len\b' -P
-exactly 393 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 392 "attackby() override" '\/attackby\((.*)\)'  -P
 exactly 15 "uses of examine()" '[.|\s]examine\(' -P # If this fails it's likely because you used '/atom/proc/examine(mob)' instead of '/proc/examinate(mob, atom)' - Exception: An examine()-proc may call other examine()-procs
 exactly 7 "direct modifications of overlays list" '\boverlays((\s*[|^=+&-])|(\.(Cut)|(Add)|(Copy)|(Remove)|(Remove)))' -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -57,7 +57,7 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 6 "uses of .len" '\.len\b' -P
-exactly 392 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 389 "attackby() override" '\/attackby\((.*)\)'  -P
 exactly 15 "uses of examine()" '[.|\s]examine\(' -P # If this fails it's likely because you used '/atom/proc/examine(mob)' instead of '/proc/examinate(mob, atom)' - Exception: An examine()-proc may call other examine()-procs
 exactly 7 "direct modifications of overlays list" '\boverlays((\s*[|^=+&-])|(\.(Cut)|(Add)|(Copy)|(Remove)|(Remove)))' -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong


### PR DESCRIPTION
No changelog needed. Iirc pulled all the user facing stuff into separate PRs.

So this PR has alot of changes. Briefly; attack() now returns TRUE/FALSE and is part of the use_* chain. Attack() is only called if an item has the ITEM_TRY_TO_ATTACK flag; so if you are planning to create an attack() override you need to consciously enable the flag. Point of an attack() override is if you want special behavior to run before anything else when a mob clicks on another mob with an item, that you don't want all the use_*'s to handle. If attack() returns TRUE; further procs are not called.
**As a result, all attack() overrides should now be returning booleans, as per this PR.** 
If desired, we can just axe the flag completely and always have attack called first. It's a stub returning FALSE for any item without an override.

Another issue prior to this PR is that attack()'s parent called regular melee attack code. Use_weapon also called regular melee attack code. What's more annoying is that each method has features the other does not have. Up until now use_weapon did NOT process special weapon behavior (think a stun baton shocking), armor, miss chance, or even custom verbs. These were all handled by the series of procs called by attack; in order:
- Apply_hit_effect which plays a sound (already handled by use_weapon) and magnifies damage if HULK. 
- Hit_with_weapon which processes custom attack verbs. It also processes simple mobs reacting and random puddle of blood. 
- Standard_weapon_hit_effects which does alot of things, from joint dislocation with an item; sharp/edge/weapon flag processing, to knocking someone down.
- Then reaches apply_damage, a common point with use_weapon. Do note, use_weapon called **none** of the above behavior; resulting in lost functionality.

I did the following: 
1. Apply_hit_effect's sound code was moved to use_weapon. Apply_hit_effect only has the hulk stuff now, and is overrided by items that want special behavior after a successful hit. (Paddles, stun baton, etc.)
2. Moved hit_with_weapon's custom verb functionality to use_weapon's base proc. Moved ai_holder reacting to post_use_item. Axed the random puddle of blood for non-human functionality. 
3. I also moved all of standard_weapon_hit_effect's behavior to hit_with_weapon, since the proc didn't do anything useful anymore. This allows me to completely remove the proc standard_weapon_hit_effects. One less proc in this long chain.
4. Use_weapon **no longer** calls general_health_adjustment but calls apply_hit_effect instead and then goes down the above procs. This is because by calling general health adjustment, it was missing all this other behavior.
5. General health adjustment is no longer called by melee code; but goes straight to apply_damage. Useful functionality from general health adjustment was moved to apply_damage. This is because apply_damage takes armor penetration and damage flags as arguments whereas general health adjustment is more fit to do exactly what its name says: Directly adjust health.

Softly dependent on #33990, #34049 and #33992 since they also turn some attacks() into booleans that I did not do in this PR to ease the suffering, since there is an insane amount of modified files here.


List:
- [x] Go through all attack procs, make sure they now return booleans if processed or not. 
- [x] Go through procs called by attack, make sure their behavior is handled.
- [x] Some simple_animals use target_mob to attack, which is unused. Make them use ai_holder.target and test
- [x] Make holster and accessories use use_on instead of attackby
- [x] Remove non-unique behavior from attack() proc. Moved to use_weapon and simplify.
- [x] Delete airlock code under attackby that lets simple_animals break through doors. This is handled by ai_handler_combat.dm. 
- [ ] Go over show_in_messages var for simple_mobs, make sure everything is set correctly. (Will handle in separate PR)