### PR TITLE
Temp & Pressure resist nerfs

### DIFF
--- a/code/__defines/items_clothing.dm
+++ b/code/__defines/items_clothing.dm
@@ -165,27 +165,23 @@
 #define BODYTEMP_HEAT_DAMAGE_LIMIT 360.15 // The limit the human body can take before it starts taking damage from heat.
 #define BODYTEMP_COLD_DAMAGE_LIMIT 260.15 // The limit the human body can take before it starts taking damage from coldness.
 
-#define SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE 2.0 // What min_cold_protection_temperature is set to for space-helmet quality headwear. MUST NOT BE 0.
-#define   SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE 2.0 // What min_cold_protection_temperature is set to for space-suit quality jumpsuits or suits. MUST NOT BE 0.
-#define       HELMET_MIN_COLD_PROTECTION_TEMPERATURE 160 // For normal helmets.
-#define        ARMOR_MIN_COLD_PROTECTION_TEMPERATURE 160 // For armor.
-#define       GLOVES_MIN_COLD_PROTECTION_TEMPERATURE 2.0 // For some gloves.
-#define         SHOE_MIN_COLD_PROTECTION_TEMPERATURE 2.0 // For shoes.
+#define  SPACE_GEAR_MIN_TEMPERATURE 2.0 // What min_temperature is set to for space-suit quality clothing. MUST NOT BE 0.
+#define  HELMET_MIN_TEMPERATURE 	160 // For normal helmets.
+#define  ARMOR_MIN_TEMPERATURE  	160 // For armor.
+#define  GLOVES_MIN_TEMPERATURE 	2.0 // For some gloves.
+#define  SHOE_MIN_TEMPERATURE 		2.0 // For shoes.
 
-#define  SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE 5000  // These need better heat protect, but not as good heat protect as firesuits.
-#define    FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE 30000 // What max_heat_protection_temperature is set to for firesuit quality headwear. MUST NOT BE 0.
-#define FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE 30000 // For fire-helmet quality items. (Red and white hardhats)
-#define      HELMET_MAX_HEAT_PROTECTION_TEMPERATURE 600   // For normal helmets.
-#define       ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE 600   // For armor.
-#define      GLOVES_MAX_HEAT_PROTECTION_TEMPERATURE 1500  // For some gloves.
-#define        SHOE_MAX_HEAT_PROTECTION_TEMPERATURE 1500  // For shoes.
+#define  SPACE_GEAR_MAX_TEMPERATURE 2000  // These need better heat protect, but not as good heat protect as firesuits.
+#define  ATMOS_GEAR_MAX_TEMPERATURE 4000 // What max_temperature is set to for firesuit quality clothing. MUST NOT BE 0.
+#define  HELMET_MAX_TEMPERATURE		600   // For normal helmets.
+#define  ARMOR_MAX_TEMPERATURE 		600   // For armor.
+#define  GLOVES_MAX_TEMPERATURE 	600  // For some gloves.
+#define  SHOE_MAX_TEMPERATURE 		600  // For shoes.
 
-#define  FIRESUIT_MAX_PRESSURE 		100 * ONE_ATMOSPHERE   // Firesuis and atmos voidsuits
-#define  RIG_MAX_PRESSURE 			50 * ONE_ATMOSPHERE   // Rigs
-#define  LIGHT_RIG_MAX_PRESSURE 	25 * ONE_ATMOSPHERE   // Rigs
-#define  ENG_VOIDSUIT_MAX_PRESSURE 	50 * ONE_ATMOSPHERE 
-#define  VOIDSUIT_MAX_PRESSURE 		25 * ONE_ATMOSPHERE 
-#define  SPACE_SUIT_MAX_PRESSURE 	5 * ONE_ATMOSPHERE
+#define  ATMOS_GEAR_MAX_PRESSURE 	9 * ONE_ATMOSPHERE
+#define  VOIDSUIT_MAX_PRESSURE 		7.5 * ONE_ATMOSPHERE
+#define  SPACE_SUIT_MAX_PRESSURE 	6 * ONE_ATMOSPHERE
+#define  CLOTHING_MAX_PRESSURE		3 * ONE_ATMOSPHERE
 
 // Fire.
 #define FIRE_MIN_STACKS          -20

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -57,7 +57,7 @@
 		bullet = ARMOR_BALLISTIC_SMALL
 	)
 	cold_protection = HEAD
-	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = SPACE_GEAR_MIN_TEMPERATURE
 	siemens_coefficient = 0.8 //That's a pretty cool opening in the hood. Also: Cloth making physical contact to the skull.
 
 /obj/item/clothing/head/culthood/magus

--- a/code/game/gamemodes/wizard/servant_items/overseer.dm
+++ b/code/game/gamemodes/wizard/servant_items/overseer.dm
@@ -10,7 +10,7 @@
 		)
 	icon_state = "necromancer"
 	item_flags = ITEM_FLAG_AIRTIGHT
-	max_pressure_protection = FIRESUIT_MAX_PRESSURE
+	max_pressure_protection = CLOTHING_MAX_PRESSURE
 	min_pressure_protection = 0
 	flags_inv = HIDEEARS | BLOCKHAIR
 
@@ -26,7 +26,7 @@
 		bomb = ARMOR_BOMB_SHIELDED
 		)
 	item_flags = ITEM_FLAG_AIRTIGHT
-	max_pressure_protection = FIRESUIT_MAX_PRESSURE
+	max_pressure_protection = CLOTHING_MAX_PRESSURE
 	min_pressure_protection = 0
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -33,8 +33,8 @@
 
 	var/heat_protection = 0 //flags which determine which body parts are protected from heat. Use the HEAD, UPPER_TORSO, LOWER_TORSO, etc. flags. See setup.dm
 	var/cold_protection = 0 //flags which determine which body parts are protected from cold. Use the HEAD, UPPER_TORSO, LOWER_TORSO, etc. flags. See setup.dm
-	var/max_heat_protection_temperature //Set this variable to determine up to which temperature (IN KELVIN) the item protects against heat damage. Keep at null to disable protection. Only protects areas set by heat_protection flags
-	var/min_cold_protection_temperature //Set this variable to determine down to which temperature (IN KELVIN) the item protects against cold damage. 0 is NOT an acceptable number due to if(varname) tests!! Keep at null to disable protection. Only protects areas set by cold_protection flags
+	var/max_temperature //Set this variable to determine up to which temperature (IN KELVIN) the item protects against heat damage. Keep at null to disable protection. Only protects areas set by heat_protection flags
+	var/min_temperature //Set this variable to determine down to which temperature (IN KELVIN) the item protects against cold damage. 0 is NOT an acceptable number due to if(varname) tests!! Keep at null to disable protection. Only protects areas set by cold_protection flags
 	var/max_pressure_protection // Set this variable if the item protects its wearer against high pressures below an upper bound. Keep at null to disable protection.
 	var/min_pressure_protection // Set this variable if the item protects its wearer against low pressures above a lower bound. Keep at null to disable protection. 0 represents protection against hard vacuum.
 

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -73,8 +73,8 @@
 	var/undeploy_path = null
 	var/taped
 
-	var/max_pressure_diff = RIG_MAX_PRESSURE
-	var/max_temp = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	var/max_pressure_diff = VOIDSUIT_MAX_PRESSURE
+	var/max_temp = SPACE_GEAR_MAX_TEMPERATURE
 
 /obj/structure/inflatable/wall
 	name = "inflatable wall"

--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -374,7 +374,7 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 		if (IsHolding(C))
 			continue
 
-		if( C.max_heat_protection_temperature >= last_temperature )
+		if( C.max_temperature >= last_temperature )
 			if(C.body_parts_covered & HEAD)
 				head_exposure = 0
 			if(C.body_parts_covered & UPPER_TORSO)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -19,6 +19,10 @@
 	item_state = "lgloves"
 	siemens_coefficient = 0
 	permeability_coefficient = 0.05
+	cold_protection = HANDS
+	min_temperature = GLOVES_MIN_TEMPERATURE
+	heat_protection = HANDS
+	max_temperature = GLOVES_MAX_TEMPERATURE
 
 /obj/item/clothing/gloves/insulated/cheap                             //Cheap Chinese Crap
 	desc = "These gloves are cheap copies of the coveted gloves, no way this can end badly."
@@ -39,9 +43,9 @@
 	permeability_coefficient = 0.05
 
 	cold_protection = HANDS
-	min_cold_protection_temperature = GLOVES_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = GLOVES_MIN_TEMPERATURE
 	heat_protection = HANDS
-	max_heat_protection_temperature = GLOVES_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_temperature = GLOVES_MAX_TEMPERATURE
 
 /obj/item/clothing/gloves/thick
 	desc = "These work gloves are thick and fire-resistant."
@@ -53,9 +57,9 @@
 	item_flags = ITEM_FLAG_THICKMATERIAL | ITEM_FLAG_WASHER_ALLOWED
 
 	cold_protection = HANDS
-	min_cold_protection_temperature = GLOVES_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = GLOVES_MIN_TEMPERATURE
 	heat_protection = HANDS
-	max_heat_protection_temperature = GLOVES_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_temperature = GLOVES_MAX_TEMPERATURE
 
 /obj/item/clothing/gloves/thick/modified
 	item_flags = ITEM_FLAG_PREMODIFIED | ITEM_FLAG_WASHER_ALLOWED
@@ -89,9 +93,9 @@
 		bomb = ARMOR_BOMB_RESISTANT,
 		bio = ARMOR_BIO_MINOR)
 	cold_protection = HANDS
-	min_cold_protection_temperature = GLOVES_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = GLOVES_MIN_TEMPERATURE
 	heat_protection = HANDS
-	max_heat_protection_temperature = GLOVES_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_temperature = GLOVES_MAX_TEMPERATURE
 
 /obj/item/clothing/gloves/thick/botany
 	desc = "These leather work gloves protect against thorns, barbs, prickles, spikes and other harmful objects of floral origin."
@@ -180,8 +184,7 @@
 	item_flags = ITEM_FLAG_THICKMATERIAL | ITEM_FLAG_WASHER_ALLOWED
 	body_parts_covered = HANDS
 	cold_protection = HANDS
+	min_temperature = GLOVES_MIN_TEMPERATURE
 	heat_protection = HANDS
-	min_cold_protection_temperature = GLOVES_MIN_COLD_PROTECTION_TEMPERATURE
-	heat_protection = HANDS
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	max_pressure_protection = FIRESUIT_MAX_PRESSURE
+	max_temperature = GLOVES_MAX_TEMPERATURE
+	max_pressure_protection = CLOTHING_MAX_PRESSURE

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -19,8 +19,8 @@
 	flags_inv = 0
 	siemens_coefficient = 0.9
 	heat_protection = HEAD
-	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
-	max_pressure_protection = FIRESUIT_MAX_PRESSURE
+	max_temperature = HELMET_MAX_TEMPERATURE
+	max_pressure_protection = CLOTHING_MAX_PRESSURE
 
 /obj/item/clothing/head/hardhat/orange
 	icon_state = "hardhat0_orange"
@@ -61,7 +61,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
 	cold_protection = HEAD
-	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = SPACE_GEAR_MIN_TEMPERATURE
 	siemens_coefficient = 0.9
 	randpixel = 0
 	species_restricted = list("exclude", SPECIES_NABBER, SPECIES_DIONA)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -19,9 +19,9 @@
 		)
 	flags_inv = HIDEEARS|BLOCKHEADHAIR
 	cold_protection = HEAD
-	min_cold_protection_temperature = HELMET_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = HELMET_MIN_TEMPERATURE
 	heat_protection = HEAD
-	max_heat_protection_temperature = HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_temperature = HELMET_MAX_TEMPERATURE
 	siemens_coefficient = 0.7
 	w_class = ITEM_SIZE_NORMAL
 	species_restricted = list("exclude", SPECIES_NABBER, SPECIES_ADHERENT)
@@ -127,7 +127,7 @@
 		)
 	valid_accessory_slots = null
 	cold_protection = HEAD
-	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = SPACE_GEAR_MIN_TEMPERATURE
 	siemens_coefficient = 0.5
 
 /obj/item/clothing/head/helmet/thunderdome
@@ -143,7 +143,7 @@
 		bomb = ARMOR_BOMB_PADDED
 		)
 	cold_protection = HEAD
-	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = SPACE_GEAR_MIN_TEMPERATURE
 	siemens_coefficient = 1
 
 /obj/item/clothing/head/helmet/gladiator
@@ -170,7 +170,7 @@
 	flags_inv = HIDEEARS|HIDEEYES
 	body_parts_covered = HEAD|EYES|BLOCKHEADHAIR
 	cold_protection = HEAD
-	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = SPACE_GEAR_MIN_TEMPERATURE
 	siemens_coefficient = 0.5
 
 //Non-hardsuit ERT helmets.
@@ -249,8 +249,8 @@
 	flash_protection = FLASH_PROTECTION_MINOR
 	item_flags = ITEM_FLAG_AIRTIGHT
 	min_pressure_protection = 0
-	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
-	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	min_temperature = SPACE_GEAR_MIN_TEMPERATURE
+	max_temperature = SPACE_GEAR_MAX_TEMPERATURE
 	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
 	armor = list(
 		melee = ARMOR_MELEE_VERY_HIGH,

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -161,7 +161,7 @@
 	var/icon_state_up = "ushankaup"
 	flags_inv = HIDEEARS|BLOCKHEADHAIR
 	cold_protection = HEAD
-	min_cold_protection_temperature = HELMET_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = HELMET_MIN_TEMPERATURE
 
 /obj/item/clothing/head/ushanka/attack_self(mob/user as mob)
 	if(icon_state == initial(icon_state))

--- a/code/modules/clothing/shoes/colour.dm
+++ b/code/modules/clothing/shoes/colour.dm
@@ -4,9 +4,9 @@
 	desc = "A pair of black shoes."
 
 	cold_protection = FEET
-	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = SHOE_MIN_TEMPERATURE
 	heat_protection = FEET
-	max_heat_protection_temperature = SHOE_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_temperature = SHOE_MAX_TEMPERATURE
 
 /obj/item/clothing/shoes/brown
 	name = "brown shoes"

--- a/code/modules/clothing/shoes/jobs.dm
+++ b/code/modules/clothing/shoes/jobs.dm
@@ -17,21 +17,16 @@
 	item_state = "jackboots"
 	force = 3
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT, 
-		bullet = ARMOR_BALLISTIC_MINOR, 
-		laser = ARMOR_LASER_MINOR, 
-		energy = ARMOR_ENERGY_MINOR, 
+		melee = ARMOR_MELEE_RESISTANT,
+		bullet = ARMOR_BALLISTIC_MINOR,
+		laser = ARMOR_LASER_MINOR,
+		energy = ARMOR_ENERGY_MINOR,
 		bomb = ARMOR_BOMB_PADDED
 		)
 	siemens_coefficient = 0.7
 	gas_transfer_coefficient = 0.90
 	permeability_coefficient = 0.50
-	cold_protection = FEET
 	body_parts_covered = FEET
-	heat_protection = FEET
-	min_cold_protection_temperature = HELMET_MIN_COLD_PROTECTION_TEMPERATURE
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	max_pressure_protection = FIRESUIT_MAX_PRESSURE
 
 /obj/item/clothing/shoes/jackboots/unathi
 	name = "toe-less jackboots"
@@ -46,18 +41,15 @@
 	icon_state = "workboots"
 	item_state = "workboots"
 	armor = list(
-		melee = ARMOR_MELEE_RESISTANT, 
-		laser = ARMOR_LASER_MINOR, 
-		energy = ARMOR_ENERGY_SMALL, 
+		melee = ARMOR_MELEE_RESISTANT,
+		laser = ARMOR_LASER_MINOR,
+		energy = ARMOR_ENERGY_SMALL,
 		bomb = ARMOR_BOMB_PADDED
 		)
 	siemens_coefficient = 0.7
 	gas_transfer_coefficient = 0.90
 	permeability_coefficient = 0.50
 	body_parts_covered = FEET
-	heat_protection = FEET
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	max_pressure_protection = FIRESUIT_MAX_PRESSURE
 
 /obj/item/clothing/shoes/workboots/toeless
 	name = "toe-less workboots"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -48,9 +48,9 @@
 	siemens_coefficient = 0.6
 
 	cold_protection = FEET
-	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = SHOE_MIN_TEMPERATURE
 	heat_protection = FEET
-	max_heat_protection_temperature = SHOE_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_temperature = SHOE_MAX_TEMPERATURE
 
 
 /obj/item/clothing/shoes/dutyboots
@@ -67,9 +67,6 @@
 	gas_transfer_coefficient = 0.90
 	permeability_coefficient = 0.50
 	body_parts_covered = FEET
-	heat_protection = FEET
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	max_pressure_protection = FIRESUIT_MAX_PRESSURE
 
 /obj/item/clothing/shoes/tactical
 	name = "tactical boots"
@@ -145,9 +142,9 @@
 	siemens_coefficient = 0.7
 
 	cold_protection = FEET
-	min_cold_protection_temperature = SHOE_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = SHOE_MIN_TEMPERATURE
 	heat_protection = FEET
-	max_heat_protection_temperature = SHOE_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_temperature = SHOE_MAX_TEMPERATURE
 	species_restricted = null
 
 /obj/item/clothing/shoes/cyborg

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -16,7 +16,7 @@
 		)
 	siemens_coefficient = 0.6
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
-	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_temperature = SPACE_GEAR_MAX_TEMPERATURE
 	species_restricted = list(SPECIES_VOX)
 	flags_inv = HIDEJUMPSUIT
 	item_flags = ITEM_FLAG_THICKMATERIAL | ITEM_FLAG_INVALID_FOR_CHAMELEON

--- a/code/modules/clothing/spacesuits/captain.dm
+++ b/code/modules/clothing/spacesuits/captain.dm
@@ -57,7 +57,7 @@
 		)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = SPACE_GEAR_MIN_TEMPERATURE
 	siemens_coefficient = 0.7
 
 /obj/item/clothing/suit/armor/captain/Initialize()

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -16,8 +16,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT
 	)
-	max_pressure_protection = FIRESUIT_MAX_PRESSURE
-	min_pressure_protection = 0
 	flags_inv = BLOCKHAIR
 	siemens_coefficient = 0.6
 

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -25,9 +25,9 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR
 		)
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
-	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	max_pressure_protection = RIG_MAX_PRESSURE
+	min_temperature = SPACE_GEAR_MIN_TEMPERATURE
+	max_temperature = SPACE_GEAR_MAX_TEMPERATURE
+	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
 	min_pressure_protection = 0
 
 	siemens_coefficient = 0.2
@@ -220,8 +220,8 @@
 		piece.SetName("[suit_type] [initial(piece.name)]")
 		piece.desc = "It seems to be part of a [src.name]."
 		piece.icon_state = "[initial(icon_state)]"
-		piece.min_cold_protection_temperature = min_cold_protection_temperature
-		piece.max_heat_protection_temperature = max_heat_protection_temperature
+		piece.min_temperature = min_temperature
+		piece.max_temperature = max_temperature
 		if(piece.siemens_coefficient > siemens_coefficient) //So that insulated gloves keep their insulation.
 			piece.siemens_coefficient = siemens_coefficient
 		piece.permeability_coefficient = permeability_coefficient

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -17,7 +17,7 @@
 	offline_slowdown = 1
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	offline_vision_restriction = TINT_NONE
-	max_pressure_protection = LIGHT_RIG_MAX_PRESSURE
+	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
 	min_pressure_protection = 0
 
 	chest_type = /obj/item/clothing/suit/space/rig/light

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -97,7 +97,7 @@
 		)
 	online_slowdown = 2
 	offline_slowdown = 4
-	max_pressure_protection = FIRESUIT_MAX_PRESSURE
+	max_pressure_protection = ATMOS_GEAR_MAX_PRESSURE
 
 	chest_type = /obj/item/clothing/suit/space/rig/merc/heavy
 	helm_type = /obj/item/clothing/head/helmet/space/rig/merc/heavy

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -55,7 +55,7 @@
 	offline_slowdown = 4
 	vision_restriction = TINT_MODERATE
 	offline_vision_restriction = TINT_BLIND
-	max_pressure_protection = FIRESUIT_MAX_PRESSURE
+	max_pressure_protection = ATMOS_GEAR_MAX_PRESSURE
 	min_pressure_protection = 0
 
 	chest_type = /obj/item/clothing/suit/space/rig/industrial
@@ -194,14 +194,14 @@
 	)
 	online_slowdown = 0.75
 	offline_vision_restriction = TINT_HEAVY
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE // this is passed to the rig suit components when deployed, including the helmet.
+	max_temperature = ATMOS_GEAR_MAX_TEMPERATURE // this is passed to the rig suit components when deployed, including the helmet.
 
 	chest_type = /obj/item/clothing/suit/space/rig/ce
 	helm_type = /obj/item/clothing/head/helmet/space/rig/ce
 	glove_type = /obj/item/clothing/gloves/rig/ce
 
 	req_access = list(access_ce)
-	max_pressure_protection = FIRESUIT_MAX_PRESSURE
+	max_pressure_protection = ATMOS_GEAR_MAX_PRESSURE
 	min_pressure_protection = 0
 
 /obj/item/rig/ce/equipped

--- a/code/modules/clothing/spacesuits/rig/suits/vox.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/vox.dm
@@ -12,8 +12,8 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 		)
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	max_pressure_protection = FIRESUIT_MAX_PRESSURE
+	max_temperature = ATMOS_GEAR_MAX_TEMPERATURE
+	max_pressure_protection = ATMOS_GEAR_MAX_PRESSURE
 
 	chest_type = /obj/item/clothing/suit/space/rig/vox_rig
 	helm_type = /obj/item/clothing/head/helmet/space/rig/vox_rig

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -21,7 +21,7 @@
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|BLOCKHAIR
 	body_parts_covered = HEAD|FACE|EYES
 	cold_protection = HEAD
-	min_cold_protection_temperature = SPACE_HELMET_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = SPACE_GEAR_MIN_TEMPERATURE
 	min_pressure_protection = 0
 	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
 	siemens_coefficient = 0.9
@@ -134,7 +134,7 @@
 		)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT|HIDETAIL
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = SPACE_GEAR_MIN_TEMPERATURE
 	min_pressure_protection = 0
 	max_pressure_protection = SPACE_SUIT_MAX_PRESSURE
 	siemens_coefficient = 0.9

--- a/code/modules/clothing/spacesuits/void/misc.dm
+++ b/code/modules/clothing/spacesuits/void/misc.dm
@@ -30,7 +30,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 		)
-	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_temperature = SPACE_GEAR_MAX_TEMPERATURE
 	species_restricted = list(SPECIES_SKRELL,SPECIES_HUMAN)
 
 /obj/item/clothing/head/helmet/space/void/skrell/white
@@ -53,7 +53,7 @@
 		)
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/storage/ore,/obj/item/device/t_scanner,/obj/item/pickaxe,/obj/item/rcd,/obj/item/rpd)
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
-	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_temperature = SPACE_GEAR_MAX_TEMPERATURE
 	species_restricted = list(SPECIES_SKRELL,SPECIES_HUMAN)
 
 /obj/item/clothing/suit/space/void/skrell/white

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -18,7 +18,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT
 		)
-	max_pressure_protection = ENG_VOIDSUIT_MAX_PRESSURE
 	siemens_coefficient = 0.3
 
 /obj/item/clothing/suit/space/void/engineering
@@ -29,7 +28,6 @@
 		slot_l_hand_str = "eng_voidsuit",
 		slot_r_hand_str = "eng_voidsuit",
 	)
-	max_pressure_protection = ENG_VOIDSUIT_MAX_PRESSURE
 	siemens_coefficient = 0.3
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT,
@@ -65,7 +63,6 @@
 		rad = ARMOR_RAD_MINOR
 		)
 	light_overlay = "helmet_light_dual_alt"
-	max_pressure_protection = ENG_VOIDSUIT_MAX_PRESSURE
 
 /obj/item/clothing/suit/space/void/mining
 	icon_state = "rig-mining"
@@ -83,7 +80,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR
 		)
-	max_pressure_protection = ENG_VOIDSUIT_MAX_PRESSURE
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/stack/flag,/obj/item/device/suit_cooling_unit,/obj/item/storage/ore,/obj/item/device/t_scanner,/obj/item/pickaxe, /obj/item/rcd,/obj/item/rpd)
 
 /obj/item/clothing/suit/space/void/mining/prepared
@@ -193,9 +189,9 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SMALL
 		)
-	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_temperature = ATMOS_GEAR_MAX_TEMPERATURE
 	light_overlay = "helmet_light_dual"
-	max_pressure_protection = FIRESUIT_MAX_PRESSURE
+	max_pressure_protection = ATMOS_GEAR_MAX_PRESSURE
 
 /obj/item/clothing/suit/space/void/atmos
 	desc = "A durable voidsuit with advanced temperature-regulation systems as well as minor radiation protection. Well worth the price."
@@ -213,8 +209,8 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SMALL
 		)
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	max_pressure_protection = FIRESUIT_MAX_PRESSURE
+	max_temperature = ATMOS_GEAR_MAX_TEMPERATURE
+	max_pressure_protection = ATMOS_GEAR_MAX_PRESSURE
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/rcd,/obj/item/rpd)
 
 /obj/item/clothing/suit/space/void/atmos/prepared

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -14,7 +14,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR
 		)
-	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_temperature = SPACE_GEAR_MAX_TEMPERATURE
 	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
 	min_pressure_protection = 0
 	siemens_coefficient = 0.4
@@ -49,7 +49,7 @@
 	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit)
 	flags_inv = HIDEGLOVES | HIDESHOES | HIDEJUMPSUIT | HIDETAIL | CLOTHING_BULKY
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
-	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_temperature = SPACE_GEAR_MAX_TEMPERATURE
 	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
 	siemens_coefficient = 0.4
 

--- a/code/modules/clothing/spacesuits/void/wizard.dm
+++ b/code/modules/clothing/spacesuits/void/wizard.dm
@@ -51,7 +51,7 @@
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	body_parts_covered = HANDS
 	cold_protection =    HANDS
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = SPACE_GEAR_MIN_TEMPERATURE
 	species_restricted = null
 	gender = PLURAL
 	gas_transfer_coefficient = 0.01

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -5,9 +5,9 @@
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	flags_inv = CLOTHING_BULKY
 	cold_protection = UPPER_TORSO|LOWER_TORSO
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = ARMOR_MIN_TEMPERATURE
 	heat_protection = UPPER_TORSO|LOWER_TORSO
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_temperature = ARMOR_MAX_TEMPERATURE
 	siemens_coefficient = 0.6
 	equip_delay = 2 SECONDS
 
@@ -227,9 +227,9 @@
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	cold_protection = UPPER_TORSO|LOWER_TORSO
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = ARMOR_MIN_TEMPERATURE
 	heat_protection = UPPER_TORSO|LOWER_TORSO
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_temperature = ARMOR_MAX_TEMPERATURE
 	siemens_coefficient = 0.6
 
 /obj/item/clothing/suit/storage/vest/nt
@@ -477,7 +477,7 @@
 	)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = SPACE_GEAR_MIN_TEMPERATURE
 	siemens_coefficient = 0
 
 /obj/item/clothing/suit/armor/heavy

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -313,7 +313,7 @@
 	icon_state = "bomber"
 	body_parts_covered = UPPER_TORSO|ARMS
 	cold_protection = UPPER_TORSO|ARMS
-	min_cold_protection_temperature = T0C - 20
+	min_temperature = T0C - 20
 	siemens_coefficient = 0.7
 
 /obj/item/clothing/suit/storage/leather_jacket
@@ -356,7 +356,7 @@
 	name = "hoodie"
 	desc = "A warm sweatshirt."
 	icon_state = "hoodie"
-	min_cold_protection_temperature = T0C - 20
+	min_temperature = T0C - 20
 	cold_protection = UPPER_TORSO|LOWER_TORSO|ARMS
 
 /obj/item/clothing/suit/storage/toggle/hoodie/cti

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -70,7 +70,7 @@
 	icon_state = "coatwinter"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	cold_protection = UPPER_TORSO|LOWER_TORSO|ARMS
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = ARMOR_MIN_TEMPERATURE
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
 	armor = list(
 		bio = ARMOR_BIO_MINOR
@@ -88,7 +88,7 @@
 	cold_protection = HEAD
 	flags_inv = HIDEEARS | BLOCKHAIR
 	item_flags = ITEM_FLAG_WASHER_ALLOWED | ITEM_FLAG_INVALID_FOR_CHAMELEON
-	min_cold_protection_temperature = ARMOR_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = ARMOR_MIN_TEMPERATURE
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/captain
 	name = "captain's winter coat"
@@ -166,7 +166,7 @@
 	name = "hoodie"
 	desc = "A warm sweatshirt."
 	icon_state = "hoodie"
-	min_cold_protection_temperature = T0C - 20
+	min_temperature = T0C - 20
 	cold_protection = UPPER_TORSO|LOWER_TORSO|ARMS
 	action_button_name = "Toggle Hood"
 	hoodtype = /obj/item/clothing/head/hoodiehood
@@ -177,7 +177,7 @@
 	desc = "A hood attached to a warm sweatshirt."
 	icon_state = "generic_hood"
 	body_parts_covered = HEAD
-	min_cold_protection_temperature = T0C - 20
+	min_temperature = T0C - 20
 	cold_protection = HEAD
 	flags_inv = HIDEEARS | BLOCKHAIR
 	item_flags = ITEM_FLAG_WASHER_ALLOWED | ITEM_FLAG_INVALID_FOR_CHAMELEON

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -36,8 +36,8 @@
 	heat_protection = UPPER_TORSO | LOWER_TORSO | ARMS
 	cold_protection = UPPER_TORSO | LOWER_TORSO | ARMS
 
-	max_pressure_protection = FIRESUIT_MAX_PRESSURE
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_pressure_protection = CLOTHING_MAX_PRESSURE
+	max_temperature = ARMOR_MAX_TEMPERATURE
 
 /obj/item/clothing/suit/fire/Initialize()
 	. = ..()
@@ -99,7 +99,7 @@
 	flags_inv = HIDEJUMPSUIT|HIDETAIL
 	heat_protection = UPPER_TORSO|LOWER_TORSO
 	item_flags = null
-	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
+	max_temperature = ARMOR_MAX_TEMPERATURE
 	siemens_coefficient = 0
 
 /obj/item/clothing/suit/bomb_suit/Initialize()

--- a/code/modules/clothing/under/accessories/fire_overpants.dm
+++ b/code/modules/clothing/under/accessories/fire_overpants.dm
@@ -13,5 +13,5 @@
 	heat_protection = LOWER_TORSO | LEGS
 	cold_protection = LOWER_TORSO | LEGS
 
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
-	max_pressure_protection = FIRESUIT_MAX_PRESSURE
+	max_temperature = ARMOR_MAX_TEMPERATURE
+	max_pressure_protection = CLOTHING_MAX_PRESSURE

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -113,7 +113,7 @@
 	permeability_coefficient = 0.02
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | ARMS //Needs gloves and shoes with cold protection to be fully protected.
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = SPACE_GEAR_MIN_TEMPERATURE
 
 /obj/item/clothing/under/acj
 	name = "administrative cybernetic jumpsuit"
@@ -134,7 +134,7 @@
 		rad = ARMOR_RAD_SHIELDED
 		)
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
-	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE
+	min_temperature = SPACE_GEAR_MIN_TEMPERATURE
 	siemens_coefficient = 0
 
 /obj/item/clothing/under/owl
@@ -700,7 +700,6 @@
 		energy = ARMOR_ENERGY_SMALL,
 		rad = ARMOR_RAD_MINOR
 		)
-	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 
 /obj/item/clothing/under/sterile
 	name = "sterile jumpsuit"

--- a/code/modules/codex/entries/clothing.dm
+++ b/code/modules/codex/entries/clothing.dm
@@ -50,12 +50,12 @@
 	if(item_flags & ITEM_FLAG_THICKMATERIAL)
 		armor_strings += "The material is exceptionally thick."
 
-	if(max_heat_protection_temperature >= FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE)
+	if(max_temperature >= ATMOS_GEAR_MAX_TEMPERATURE)
 		armor_strings += "You could probably safely skydive into the Sun wearing this."
-	else if(max_heat_protection_temperature >= SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE)
+	else if(max_temperature >= SPACE_GEAR_MAX_TEMPERATURE)
 		armor_strings += "It provides good protection against fire and heat."
 
-	if(!isnull(min_cold_protection_temperature) && min_cold_protection_temperature <= SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE)
+	if(!isnull(min_temperature) && min_temperature <= SPACE_GEAR_MIN_TEMPERATURE)
 		armor_strings += "It provides very good protection against very cold temperatures."
 
 	var/list/covers = list()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -479,11 +479,11 @@
 	//Handle normal clothing
 	for(var/obj/item/clothing/C in list(head,wear_suit,w_uniform,shoes,gloves,wear_mask))
 		if(C)
-			if(C.max_heat_protection_temperature && C.max_heat_protection_temperature >= temperature)
+			if(C.max_temperature && C.max_temperature >= temperature)
 				. |= C.heat_protection
 			if(length(C.accessories))
 				for(var/obj/item/clothing/accessory/A in C.accessories)
-					if(A.max_heat_protection_temperature && A.max_heat_protection_temperature >= temperature)
+					if(A.max_temperature && A.max_temperature >= temperature)
 						. |= A.heat_protection
 
 //See proc/get_heat_protection_flags(temperature) for the description of this proc.
@@ -492,11 +492,11 @@
 	//Handle normal clothing
 	for(var/obj/item/clothing/C in list(head,wear_suit,w_uniform,shoes,gloves,wear_mask))
 		if(C)
-			if(C.min_cold_protection_temperature && C.min_cold_protection_temperature <= temperature)
+			if(C.min_temperature && C.min_temperature <= temperature)
 				. |= C.cold_protection
 			if(length(C.accessories))
 				for(var/obj/item/clothing/accessory/A in C.accessories)
-					if(A.min_cold_protection_temperature && A.min_cold_protection_temperature <= temperature)
+					if(A.min_temperature && A.min_temperature <= temperature)
 						. |= A.cold_protection
 
 

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -314,7 +314,7 @@
 
 	//Scale quadratically so that single digit numbers of fire stacks don't burn ridiculously hot.
 	//lower limit of 700 K, same as matches and roughly the temperature of a cool flame.
-	return max(2.25*round(FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE*(fire_stacks/FIRE_MAX_FIRESUIT_STACKS)**2), 700)
+	return max(2.25*round(ATMOS_GEAR_MAX_TEMPERATURE*(fire_stacks/FIRE_MAX_FIRESUIT_STACKS)**2), 700)
 
 /mob/living/proc/reagent_permeability()
 	return TRUE

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -530,8 +530,8 @@
 		if(istype(H))
 			if(H.gloves)
 				var/obj/item/clothing/gloves/G = H.gloves
-				if(G.max_heat_protection_temperature)
-					if(G.max_heat_protection_temperature > LIGHT_BULB_TEMPERATURE)
+				if(G.max_temperature)
+					if(G.max_temperature > LIGHT_BULB_TEMPERATURE)
 						prot = TRUE
 		else
 			prot = TRUE


### PR DESCRIPTION
🆑 Jux
tweak: All fire suits, space suits, voidsuits and hardsuits have had their temperature resistances dropped dramatically, and all but softsuits get the same treatment in pressure resist.
tweak: Inflatables have had their temperature and pressure resistance dropped dramatically.
tweak: Insulated gloves can be used to safely remove lightbulbs.
bugfix: Various boots that shouldn't have had firesuit-level protections, but did anyways, have been fixed.
/🆑 

Atmos suits can now only handle 4000 kelvin, other space gear 2000, except for some hardsuits which are 4000 with the atmos gear. Firesuits got a HEAVY drop, since they're, well, not space equipment, down to 600 kelvin temp resist.

Pressure is even more extreme, with atmos suits going from 100 atmospheres to 9, voidsuits from 25-50 atmospehres to 7.5, but softsuits from 5 actually get a buff to 6. Fire equipment goes from 100 down to 3, which is still too high imo but might still be an excessive nerf.