### PR TITLE
faster ssatoms

### DIFF
--- a/code/__defines/__initialization.dm
+++ b/code/__defines/__initialization.dm
@@ -3,9 +3,9 @@
 #define INITIALIZATION_INNEW_MAPLOAD  2	//New should call Initialize(TRUE)
 #define INITIALIZATION_INNEW_REGULAR  3	//New should call Initialize(FALSE)
 
-#define INITIALIZE_HINT_NORMAL   0  //Nothing happens
-#define INITIALIZE_HINT_LATELOAD 1  //Call LateInitialize
-#define INITIALIZE_HINT_QDEL     2  //Call qdel on the atom
+#define INITIALIZE_HINT_NORMAL   1  //Nothing happens
+#define INITIALIZE_HINT_LATELOAD 2  //Call LateInitialize
+#define INITIALIZE_HINT_QDEL     3  //Call qdel on the atom
 
 #define ATOM_FLAG_INITIALIZED FLAG(0) // The atom has been initialized. Also see flags.dm
 

--- a/code/controllers/subsystems/atoms.dm
+++ b/code/controllers/subsystems/atoms.dm
@@ -1,25 +1,24 @@
-#define BAD_INIT_QDEL_BEFORE 1
-#define BAD_INIT_DIDNT_INIT 2
-#define BAD_INIT_SLEPT 4
-#define BAD_INIT_NO_HINT 8
-
-
 SUBSYSTEM_DEF(atoms)
 	name = "Atoms"
 	init_order = SS_INIT_ATOMS
 	flags = SS_NO_FIRE | SS_NEEDS_SHUTDOWN
 
+	var/const/BAD_INIT_QDEL_BEFORE = FLAG(0)
+	var/const/BAD_INIT_DIDNT_INIT = FLAG(1)
+	var/const/BAD_INIT_SLEPT = FLAG(2)
+	var/const/BAD_INIT_NO_HINT = FLAG(3)
+
 	var/static/atom_init_stage = INITIALIZATION_INSSATOMS
 	var/static/old_init_stage
-	var/static/list/late_loaders = list()
-	var/static/list/created_atoms = list()
-	var/static/list/BadInitializeCalls = list()
+	var/static/list/bad_inits = list()
+	var/static/list/init_queue = list()
+	var/static/list/late_init_queue = list()
 
 
 /datum/controller/subsystem/atoms/UpdateStat(time)
 	if (PreventUpdateStat(time))
 		return ..()
-	..("Bad Inits: [length(BadInitializeCalls)]")
+	..("Bad Inits: [length(bad_inits)]")
 
 
 /datum/controller/subsystem/atoms/Shutdown()
@@ -34,8 +33,8 @@ SUBSYSTEM_DEF(atoms)
 
 
 /datum/controller/subsystem/atoms/Recover()
-	created_atoms.Cut()
-	late_loaders.Cut()
+	LIST_RESIZE(init_queue, 0)
+	LIST_RESIZE(late_init_queue, 0)
 	if (atom_init_stage == INITIALIZATION_INNEW_MAPLOAD)
 		InitializeAtoms()
 
@@ -45,59 +44,78 @@ SUBSYSTEM_DEF(atoms)
 		return
 	atom_init_stage = INITIALIZATION_INNEW_MAPLOAD
 	var/list/mapload_arg = list(TRUE)
-	var/count = length(created_atoms)
-	var/atom/created
-	var/list/arguments
-	for (var/i = length(created_atoms) to 1 step -1)
-		created = created_atoms[i]
-		if (!(created.atom_flags & ATOM_FLAG_INITIALIZED))
-			arguments = created_atoms[created] ? mapload_arg + created_atoms[created] : mapload_arg
-			InitAtom(created, arguments)
-			CHECK_TICK
-	created_atoms.Cut()
+	var/atom/atom
+	var/list/params
+	var/count = 0
+	var/time = Uptime()
 	if (!initialized)
-		for (var/atom/A in world)
-			if (!(A.atom_flags & ATOM_FLAG_INITIALIZED))
-				InitAtom(A, mapload_arg)
-				++count
-				CHECK_TICK
-	report_progress("Initialized [count] atom\s")
+		for (atom in world)
+			if (!atom || atom.atom_flags & ATOM_FLAG_INITIALIZED)
+				continue
+			InitAtom(atom, mapload_arg)
+			if (++count % 1000)
+				continue
+			CHECK_TICK
+	for (var/i = 1 to length(init_queue))
+		atom = init_queue[i]
+		if (!atom || atom.atom_flags & ATOM_FLAG_INITIALIZED)
+			continue
+		params = init_queue[atom]
+		if (params)
+			InitAtom(atom, mapload_arg + params)
+		else
+			InitAtom(atom, mapload_arg)
+		if (++count % 50)
+			continue
+		CHECK_TICK
+	LIST_RESIZE(init_queue, 0)
+	time = max((Uptime() - time) * 0.1, 0.1)
+	report_progress("Initialized [count] atom\s in [time]s ([floor(count/time)]/s)")
 	atom_init_stage = INITIALIZATION_INNEW_REGULAR
-	if (!length(late_loaders))
+	if (!length(late_init_queue))
 		return
-	for (var/atom/A as anything in late_loaders)
-		A.LateInitialize(arglist(late_loaders[A]))
-	report_progress("Late initialized [length(late_loaders)] atom\s")
-	late_loaders.Cut()
+	count = 0
+	time = Uptime()
+	for (var/i = 1 to length(late_init_queue))
+		atom = late_init_queue[i]
+		if (!atom)
+			continue
+		atom.LateInitialize(arglist(late_init_queue[atom]))
+		if (++count % 50)
+			continue
+		CHECK_TICK
+	LIST_RESIZE(late_init_queue, 0)
+	time = max((Uptime() - time) * 0.1, 0.1)
+	report_progress("Late initialized [count] atom\s in [time]s ([floor(count/time)]/s)")
 
 
-/datum/controller/subsystem/atoms/proc/InitAtom(atom/A, list/arguments)
-	var/atom_type = A?.type
-	if (QDELING(A))
-		BadInitializeCalls[atom_type] |= BAD_INIT_QDEL_BEFORE
+/datum/controller/subsystem/atoms/proc/InitAtom(atom/atom, list/arguments)
+	var/atom_type = atom.type
+	if (QDELING(atom))
+		bad_inits[atom_type] |= BAD_INIT_QDEL_BEFORE
 		return TRUE
 	var/start_tick = world.time
-	var/result = A.Initialize(arglist(arguments))
-	if(start_tick != world.time)
-		BadInitializeCalls[atom_type] |= BAD_INIT_SLEPT
-	var/qdeleted = FALSE
-	if (result != INITIALIZE_HINT_NORMAL)
-		switch(result)
-			if (INITIALIZE_HINT_LATELOAD)
-				if (arguments[1])	//mapload
-					late_loaders[A] = arguments
-				else
-					A.LateInitialize(arglist(arguments))
-			if (INITIALIZE_HINT_QDEL)
-				qdel(A)
-				qdeleted = TRUE
+	var/hint = atom.Initialize(arglist(arguments))
+	if (start_tick != world.time)
+		bad_inits[atom_type] |= BAD_INIT_SLEPT
+	var/deleted = FALSE
+	switch (hint)
+		if (INITIALIZE_HINT_NORMAL) //noop
+		if (INITIALIZE_HINT_LATELOAD)
+			if (arguments[1])	//mapload
+				late_init_queue[atom] = arguments
 			else
-				BadInitializeCalls[atom_type] |= BAD_INIT_NO_HINT
-	if (!A)	//possible harddel
-		qdeleted = TRUE
-	else if (!(A.atom_flags & ATOM_FLAG_INITIALIZED))
-		BadInitializeCalls[atom_type] |= BAD_INIT_DIDNT_INIT
-	return qdeleted || QDELING(A)
+				atom.LateInitialize(arglist(arguments))
+		if (INITIALIZE_HINT_QDEL)
+			qdel(atom)
+			deleted = TRUE
+		else
+			bad_inits[atom_type] |= BAD_INIT_NO_HINT
+	if (!atom)
+		deleted = TRUE
+	else if (!(atom.atom_flags & ATOM_FLAG_INITIALIZED))
+		bad_inits[atom_type] |= BAD_INIT_DIDNT_INIT
+	return deleted || QDELING(atom)
 
 
 /datum/controller/subsystem/atoms/proc/map_loader_begin()
@@ -111,9 +129,9 @@ SUBSYSTEM_DEF(atoms)
 
 /datum/controller/subsystem/atoms/proc/InitLog()
 	. = ""
-	for (var/path in BadInitializeCalls)
+	for (var/path in bad_inits)
 		. += "Path : [path] \n"
-		var/fails = BadInitializeCalls[path]
+		var/fails = bad_inits[path]
 		if (fails & BAD_INIT_DIDNT_INIT)
 			. += "- Didn't call atom/Initialize()\n"
 		if (fails & BAD_INIT_NO_HINT)
@@ -122,9 +140,3 @@ SUBSYSTEM_DEF(atoms)
 			. += "- Qdel'd in New()\n"
 		if (fails & BAD_INIT_SLEPT)
 			. += "- Slept during Initialize()\n"
-
-
-#undef BAD_INIT_QDEL_BEFORE
-#undef BAD_INIT_DIDNT_INIT
-#undef BAD_INIT_SLEPT
-#undef BAD_INIT_NO_HINT

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -20,26 +20,20 @@ var/global/total_lighting_overlays = 0
 
 	var/needs_update = FALSE
 
-/atom/movable/lighting_overlay/Initialize()
-	// doesn't need special init
-	SHOULD_CALL_PARENT(FALSE)
-	atom_flags |= ATOM_FLAG_INITIALIZED
-	return INITIALIZE_HINT_NORMAL
+/atom/movable/lighting_overlay/Initialize(mapload, no_update)
+	var/turf/turf = loc
+	if (!turf.dynamic_lighting)
+		atom_flags |= ATOM_FLAG_INITIALIZED
+		return INITIALIZE_HINT_QDEL
+	. = ..()
+	verbs.Cut()
+	total_lighting_overlays++
+	turf.lighting_overlay = src
+	turf.luminosity = 0
+	if (no_update)
+		return
+	update_overlay()
 
-/atom/movable/lighting_overlay/New(atom/loc, no_update = FALSE)
-	var/turf/T = loc //If this runtimes atleast we'll know what's creating overlays outside of turfs.
-	if(T.dynamic_lighting)
-		. = ..()
-		verbs.Cut()
-		total_lighting_overlays++
-
-		T.lighting_overlay = src
-		T.luminosity = 0
-		if(no_update)
-			return
-		update_overlay()
-	else
-		qdel(src)
 
 /atom/movable/lighting_overlay/proc/update_overlay()
 	set waitfor = FALSE

--- a/code/unit_tests/subsystem_tests.dm
+++ b/code/unit_tests/subsystem_tests.dm
@@ -2,7 +2,7 @@
 	name = "SUBSYSTEM - ATOMS: Shall have no bad init calls"
 
 /datum/unit_test/subsystem_atom_shall_have_no_bad_init_calls/start_test()
-	if(length(SSatoms.BadInitializeCalls))
+	if(length(SSatoms.bad_inits))
 		log_bad(jointext(SSatoms.InitLog(), null))
 		fail("[SSatoms] had bad initialization calls.")
 	else


### PR DESCRIPTION
We don't really care about tick accuracy during world setup; allows some drift to drastically improve initial initialization performance by hugely reducing how often stoplag() gets run in that phase. This doesn't have a negative impact on feel - network still happens 20~25 times a second depending on hardware.

Also some general rewriting and copy -> index loop edits.

![before](https://cdn.discordapp.com/attachments/256853514624434177/1134870929504223302/dreamseeker_m05dh8YqhT.jpg)

becomes

![after](https://cdn.discordapp.com/attachments/256853514624434177/1134876823960961105/dreamseeker_sjyfAhddQl.jpg)