### PR TITLE
removed glide size config option, all normal AMs have the same glide size

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -247,9 +247,6 @@
 
 	var/static/no_click_cooldown = FALSE
 
-	/// optional runtime configuration of http://www.byond.com/docs/ref/#/atom/movable/var/glide_size
-	var/static/glide_size
-
 	/// Modifier for ticks between moves while running
 	var/static/run_delay = 2
 
@@ -887,8 +884,6 @@
 				walk_delay = value
 			if ("creep_delay")
 				creep_delay = value
-			if ("glide_size")
-				glide_size = value
 			if ("minimum_sprint_cost")
 				minimum_sprint_cost = value
 			if ("skill_sprint_cost_range")

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -129,8 +129,6 @@
 
 
 /atom/movable/Initialize()
-	if (!isnull(config.glide_size))
-		glide_size = config.glide_size
 	. = ..()
 	var/emissive_block = update_emissive_blocker()
 	if(emissive_block)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -1,7 +1,6 @@
 /obj
 	layer = OBJ_LAYER
 	animate_movement = 2
-	glide_size = 3
 
 	var/obj_flags
 


### PR DESCRIPTION
:cl:
tweak: Mobs and objects glide at the same rate again.
/:cl:

I got bored of the bouncy look tbh.