### PR TITLE
Fixes Dociler and bullpup grenade launcher

### DIFF
--- a/code/game/objects/items/devices/dociler.dm
+++ b/code/game/objects/items/devices/dociler.dm
@@ -2,6 +2,7 @@
 	name = "dociler"
 	desc = "A complex single use recharging injector that spreads a complex neurological serum that makes animals docile and friendly. Somewhat."
 	w_class = ITEM_SIZE_NORMAL
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	origin_tech = list(TECH_BIO = 5, TECH_MATERIAL = 2)
 	icon = 'icons/obj/tools/dociler.dmi'
 	icon_state = "animal_tagger1"
@@ -12,49 +13,54 @@
 	item_state = "gun"
 	force = 1
 	var/loaded = 1
-	var/mode = "completely"
+	var/charge_tick = 0
+	var/recharge_time = 140
+
+/obj/item/device/dociler/Process()
+	if (loaded)
+		return PROCESS_KILL
+	if (++charge_tick < recharge_time)
+		return
+	charge_tick = 0
+	loaded = 1
+	icon_state = "animal_tagger1"
+	update_icon()
+	visible_message("\The [src] beeps, refilling itself.")
+	return PROCESS_KILL
 
 /obj/item/device/dociler/examine(mob/user)
 	. = ..()
-	to_chat(user, SPAN_NOTICE("It is currently set to [mode] docile mode."))
-
-/obj/item/device/dociler/attack_self(mob/user)
-	if(mode == "somewhat")
-		mode = "completely"
-	else
-		mode = "somewhat"
-
-	to_chat(user, "You set \the [src] to [mode] docile mode.")
+	to_chat(user, SPAN_NOTICE("It is currently [loaded? "loaded": "recharging"]."))
 
 /obj/item/device/dociler/attack(mob/living/L, mob/user)
-	if(!istype(L, /mob/living/simple_animal))
-		to_chat(user, SPAN_WARNING("\The [src] cannot not work on \the [L]."))
-		return
+	if (!istype(L))
+		return FALSE
+	if (istype(L, /mob/living/simple_animal))
+		if (!loaded)
+			to_chat(user, SPAN_WARNING("\The [src] isn't loaded!"))
+			return TRUE
 
-	if(!loaded)
-		to_chat(user, SPAN_WARNING("\The [src] isn't loaded!"))
-		return
-
-	user.visible_message("\The [user] thrusts \the [src] deep into \the [L]'s head, injecting something!")
-	to_chat(L, SPAN_NOTICE("You feel pain as \the [user] injects something into you. All of a sudden you feel as if [user] is the friendliest and nicest person you've ever know. You want to be friends with him and all his friends."))
-	if(mode == "somewhat")
+		user.visible_message("\The [user] thrusts \the [src] deep into \the [L]'s head, injecting something!")
+		to_chat(L, SPAN_NOTICE("You feel pain as \the [user] injects something into you. All of a sudden you feel as if \the [user] is the friendliest and nicest person you've ever known. You want to be friends with them and all their friends."))
 		L.faction = user.faction
-	else
-		L.faction = null
-	if(istype(L,/mob/living/simple_animal/hostile))
-		var/mob/living/simple_animal/hostile/H = L
-		H.ai_holder.lose_target()
-		H.attack_same = 0
-		H.friends += weakref(user)
-	L.desc += "<br>[SPAN_NOTICE("It looks especially docile.")]"
-	var/name = input(user, "Would you like to rename \the [L]?", "Dociler", L.name) as text
-	if(length(name))
-		L.real_name = name
-		L.SetName(name)
 
-	loaded = 0
-	icon_state = "animal_tagger0"
-	spawn(1450)
-		loaded = 1
-		icon_state = "animal_tagger1"
-		src.visible_message("\The [src] beeps, refilling itself.")
+		if (istype(L,/mob/living/simple_animal/hostile))
+			var/mob/living/simple_animal/hostile/H = L
+			H.ai_holder.lose_target()
+			H.attack_same = 0
+			H.friends += weakref(user)
+
+		L.desc += "<br>[SPAN_NOTICE("It looks especially docile.")]"
+		var/name = input(user, "Would you like to rename \the [L]?", "Dociler", L.name) as text
+		if (length(name))
+			L.real_name = name
+			L.SetName(name)
+
+		START_PROCESSING(SSobj, src)
+		loaded = 0
+		icon_state = "animal_tagger0"
+		update_icon()
+		return TRUE
+	else
+		to_chat(user, SPAN_WARNING("\The [src] is not compatible with \the [L]"))
+		return TRUE

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -36,35 +36,25 @@
 		power_supply = new cell_type(src)
 	else
 		power_supply = new /obj/item/cell/device/variable(src, max_shots*charge_cost)
-	if(self_recharge)
-		START_PROCESSING(SSobj, src)
 	update_icon()
-
-/obj/item/gun/energy/Destroy()
-	if(self_recharge)
-		STOP_PROCESSING(SSobj, src)
-	return ..()
 
 /obj/item/gun/energy/get_cell()
 	return power_supply
 
 /obj/item/gun/energy/Process()
-	if(self_recharge) //Every [recharge_time] ticks, recharge a shot for the cyborg
-		charge_tick++
-		if(charge_tick < recharge_time) return 0
-		charge_tick = 0
+	if (!power_supply || power_supply.charge >= power_supply.maxcharge)
+		return PROCESS_KILL
+	if (++charge_tick < recharge_time)
+		return
 
-		if(!power_supply || power_supply.charge >= power_supply.maxcharge)
-			return 0 // check if we actually need to recharge
+	var/obj/item/cell/external = get_external_power_supply()
+	charge_tick = 0
+	if (use_external_power && (!external || !external.use(charge_cost))) //Take power from the borg to recharge.
+		return
 
-		if(use_external_power)
-			var/obj/item/cell/external = get_external_power_supply()
-			if(!external || !external.use(charge_cost)) //Take power from the borg...
-				return 0
+	power_supply.give(charge_cost) //... to recharge the shot
+	update_icon()
 
-		power_supply.give(charge_cost) //... to recharge the shot
-		update_icon()
-	return 1
 
 /obj/item/gun/energy/consume_next_projectile()
 	if(!power_supply) return null
@@ -104,3 +94,8 @@
 		else
 			icon_state = "[initial(icon_state)][ratio]"
 		update_held_icon()
+
+/obj/item/gun/energy/handle_post_fire(mob/user, atom/target, pointblank, reflex, obj/projectile)
+	..()
+	if (self_recharge)
+		START_PROCESSING(SSobj, src)

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -200,30 +200,38 @@
 		)
 
 	var/use_launcher = 0
+
+	///Determines if bullpup spawns with launcher, used in Initialize()
+	var/has_launcher = TRUE
 	var/obj/item/gun/launcher/grenade/underslung/launcher
 
 /obj/item/gun/projectile/automatic/bullpup_rifle/Initialize()
 	. = ..()
-	launcher = new(src)
+	if (has_launcher)
+		launcher = new(src)
 
 
 /obj/item/gun/projectile/automatic/bullpup_rifle/use_tool(obj/item/tool, mob/user, list/click_params)
 	// Grenade - Load launcher
-	if (istype(tool, /obj/item/grenade))
+	if (istype(tool, /obj/item/grenade) && launcher)
 		launcher.load(tool, user)
 		return TRUE
 
 	return ..()
 
+/obj/item/gun/projectile/automatic/bullpup_rifle/toggle_safety(mob/user)
+	..()
+	if(launcher)
+		launcher.safety_state = safety_state //Set the launcher's safety to be equivalent to the bullpup's.
 
 /obj/item/gun/projectile/automatic/bullpup_rifle/attack_hand(mob/user)
-	if(user.get_inactive_hand() == src && use_launcher)
+	if(user.get_inactive_hand() == src && launcher && use_launcher)
 		launcher.unload(user)
 	else
 		..()
 
 /obj/item/gun/projectile/automatic/bullpup_rifle/Fire(atom/target, mob/living/user, params, pointblank=0, reflex=0)
-	if(use_launcher)
+	if(launcher && use_launcher)
 		launcher.Fire(target, user, params, pointblank, reflex)
 		if(!launcher.chambered)
 			switch_firemodes() //switch back automatically
@@ -242,6 +250,8 @@
 
 /obj/item/gun/projectile/automatic/bullpup_rifle/examine(mob/user)
 	. = ..()
+	if(!launcher)
+		return
 	if(launcher.chambered)
 		to_chat(user, "\The [launcher] has \a [launcher.chambered] loaded.")
 	else
@@ -255,13 +265,12 @@
 	magazine_type = /obj/item/ammo_magazine/mil_rifle/light
 	one_hand_penalty = 6 //Slightly lighter than the Z8. Still don't try it.
 	bulk = GUN_BULK_LIGHT_RIFLE
+	has_launcher = FALSE
 	wielded_item_state = "z9carbine-wielded"
 	firemodes = list( //Two round bursts. More accurate than the Z8 due to less maximum dispersion. More delay between shots, however, so slower.
 		list(mode_name="semi auto",       burst=1,    fire_delay=null,    move_delay=null, use_launcher=null, one_hand_penalty=6, burst_accuracy=null, dispersion=null),
 		list(mode_name="2-round bursts", burst=2,    fire_delay=null, move_delay=6,    use_launcher=null, one_hand_penalty=7, burst_accuracy=list(0,-1), dispersion=list(0.0, 0.6))
 		)
-
-
 
 /obj/item/gun/projectile/automatic/l6_saw
 	name = "light machine gun"

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -48,7 +48,7 @@ exactly 24 "text2path uses" 'text2path'
 exactly 3 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 5 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 344 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 343 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 0 "anchored = 0/1" 'anchored\s*=\s*\d' -P
 exactly 2 "density = 0/1" 'density\s*=\s*\d' -P


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: Docilers now properly self-recharge
bugfix: Can now properly disable safety on underslung grenade launcher.
bugfix: Light bullpup can no longer be loaded with grenades it can't even fire. It also no longer insists it has a grenade launcher despite best attempts to convince it otherwise.
/🆑 

In this PR, I also made attack() under dociler use booleans and ITEM_TRY_TO_ATTACK in anticipation of my upcoming PR with 60-65 attack() changes. One less to review! This one doesn't call parent attack yet, but it will in the other PR once the attack() and use_weapon() stuff is properly sorted out.

Also made self-charging energy guns stop processing all the time.