### PR TITLE
Expands stabbing eyes to all sharp items

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -901,31 +901,23 @@ GLOBAL_LIST_INIT(duplicate_object_disallowed_vars, list(
 	return 0
 
 
-//For items that can puncture e.g. thick plastic but aren't necessarily sharp
-//Returns 1 if the given item is capable of popping things like balloons, inflatable barriers, or cutting police tape.
+/**
+ * For items that can puncture e.g. thick plastic but aren't necessarily sharp.
+ *
+ * Returns TRUE if the given item is capable of popping things like balloons, inflatable barriers, or cutting police tape. Also used to determine what items can eyestab.
+ */
 /obj/item/proc/can_puncture()
-	return src.sharp
-
-/obj/item/screwdriver/can_puncture()
-	return 1
-
-/obj/item/pen/can_puncture()
-	return 1
+	if(sharp || puncture) return TRUE
+	return FALSE
 
 /obj/item/weldingtool/can_puncture()
-	return 1
-
-/obj/item/screwdriver/can_puncture()
-	return 1
-
-/obj/item/shovel/can_puncture() //includes spades
-	return 1
+	return welding
 
 /obj/item/flame/can_puncture()
-	return src.lit
+	return lit
 
 /obj/item/clothing/mask/smokable/cigarette/can_puncture()
-	return src.lit
+	return lit
 
 //check if mob is lying down on something we can operate him on.
 /proc/can_operate(mob/living/carbon/M, mob/living/carbon/user)

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -13,7 +13,9 @@
 	max_force = 5
 	force_multiplier = 0.1 // 6 when wielded with hardness 60 (steel)
 	thrown_force_multiplier = 0.25 // 5 when thrown with weight 20 (steel)
+	puncture = TRUE
 	default_material = MATERIAL_ALUMINIUM
+	item_flags = ITEM_FLAG_TRY_ATTACK
 
 	var/loaded      //Descriptive string for currently loaded food object.
 	var/scoop_food = 1
@@ -27,20 +29,12 @@
 
 /obj/item/material/kitchen/utensil/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	if(!istype(M))
-		return ..()
+		return FALSE
 
-	if(user.a_intent != I_HELP)
-		if(user.zone_sel.selecting == BP_HEAD || user.zone_sel.selecting == BP_EYES)
-			if((MUTATION_CLUMSY in user.mutations) && prob(50))
-				M = user
-			return eyestab(M,user)
-		else
-			return ..()
-
-	if (reagents.total_volume > 0)
+	if (user.a_intent == I_HELP && reagents.total_volume > 0)
 		if(M == user)
 			if(!M.can_eat(loaded))
-				return
+				return TRUE
 			switch(M.get_fullness())
 				if (0 to 50)
 					to_chat(M, SPAN_DANGER("You ravenously stick \the [src] into your mouth and gobble the food!"))
@@ -52,23 +46,22 @@
 					to_chat(M, SPAN_NOTICE("You unwillingly chew the food on \the [src]."))
 				if (550 to INFINITY)
 					to_chat(M, SPAN_WARNING("You cannot take one more bite from \the [src]!"))
-					return
+					return TRUE
 
 		else
 			user.visible_message(SPAN_WARNING("\The [user] begins to feed \the [M]!"))
 			if(!M.can_force_feed(user, loaded) || !do_after(user, 5 SECONDS, M, DO_PUBLIC_UNIQUE))
-				return
+				return TRUE
 
 			if (user.get_active_hand() != src)
-				return
+				return TRUE
 			M.visible_message(SPAN_NOTICE("\The [user] feeds some [loaded] to \the [M] with \the [src]."))
 		reagents.trans_to_mob(M, reagents.total_volume, CHEM_INGEST)
 		playsound(M.loc,'sound/items/eatfood.ogg', rand(10,40), 1)
 		overlays.Cut()
-		return
-	else
-		to_chat(user, SPAN_WARNING("You don't have anything on \the [src]."))//if we have help intent and no food scooped up DON'T STAB OURSELVES WITH THE FORK
-		return
+		return TRUE
+	else return FALSE
+
 
 
 /obj/item/material/kitchen/utensil/fork

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -17,18 +17,6 @@
 	edge = TRUE
 	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
-/obj/item/material/knife/attack(mob/living/carbon/M, mob/living/carbon/user, target_zone)
-	if(!istype(M))
-		return ..()
-
-	if(user.a_intent != I_HELP)
-		if(target_zone == BP_EYES)
-			if((MUTATION_CLUMSY in user.mutations) && prob(50))
-				M = user
-			return eyestab(M, user)
-
-	return ..()
-
 //table knives
 /obj/item/material/knife/table
 	name = "table knife"

--- a/code/game/objects/items/weapons/material/misc.dm
+++ b/code/game/objects/items/weapons/material/misc.dm
@@ -56,7 +56,6 @@
 	max_force = 15
 	force_multiplier = 0.2 // 12 with hardness 60 (steel)
 	thrown_force_multiplier = 0.75 // 15 with weight 20 (steel)
-	w_class = ITEM_SIZE_SMALL
 	sharp = TRUE
 	edge = TRUE
 	origin_tech = list(TECH_MATERIAL = 2, TECH_COMBAT = 1)
@@ -72,7 +71,7 @@
 	desc = "A long, sturdy blade with a rugged handle. Leading the way to cursed treasures since before space travel."
 	icon = 'icons/obj/weapons/melee_physical.dmi'
 	item_state = "machete"
-	w_class = ITEM_SIZE_NORMAL
+	w_class = ITEM_SIZE_LARGE
 	slot_flags = SLOT_BELT
 	default_material = MATERIAL_TITANIUM
 	base_parry_chance = 50

--- a/code/game/objects/items/weapons/tools/screwdriver.dm
+++ b/code/game/objects/items/weapons/tools/screwdriver.dm
@@ -29,12 +29,3 @@
 	if (prob(75))
 		src.pixel_y = rand(0, 16)
 	. = ..()
-
-/obj/item/screwdriver/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	if(!istype(M) || user.a_intent == "help")
-		return ..()
-	if(user.zone_sel.selecting != BP_EYES && user.zone_sel.selecting != BP_HEAD)
-		return ..()
-	if((MUTATION_CLUMSY in user.mutations) && prob(50))
-		M = user
-	return eyestab(M,user)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -8,8 +8,12 @@
 	var/w_class // Size of the object.
 	var/unacidable = FALSE //universal "unacidabliness" var, here so you can use it in any obj.
 	var/throwforce = 0
-	var/sharp = FALSE		// whether this object cuts
-	var/edge = FALSE		// whether this object is more likely to dismember
+	///// whether this object cuts
+	var/sharp = FALSE
+	///Whether this object is more likely to dismember
+	var/edge = FALSE
+	///For items that can puncture e.g. thick plastic but aren't necessarily sharp. Called in can_puncture()
+	var/puncture = FALSE
 	var/in_use = 0 // If we have a user using us, this will be set on. We will check if the user has stopped using us, and thus stop updating and LAGGING EVERYTHING!
 	var/damtype = DAMAGE_BRUTE
 	var/armor_penetration = 0
@@ -182,8 +186,8 @@
 		. |= DAMAGE_FLAG_EDGE
 	if(is_sharp(src))
 		. |= DAMAGE_FLAG_SHARP
-		if (damtype == DAMAGE_BURN)
-			. |= DAMAGE_FLAG_LASER
+	if (damtype == DAMAGE_BURN)
+		. |= DAMAGE_FLAG_LASER
 
 /obj/attackby(obj/item/O, mob/user)
 	if (isWrench(O) && HAS_FLAGS(obj_flags, OBJ_FLAG_ANCHORABLE))

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -149,6 +149,7 @@
 	matter = list(MATERIAL_STEEL = 50)
 	attack_verb = list("bashed", "bludgeoned", "thrashed", "whacked")
 	edge = TRUE
+	puncture = TRUE
 
 /obj/item/shovel/spade
 	name = "spade"

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -100,6 +100,17 @@
 
 	return
 
+///Processes stabbing eyes with any sharp items. Only works for normal sized or smaller items; if attacking eyes with a large sword will default to parent use_weapon and do a regular attack.
+/mob/living/carbon/use_weapon(obj/item/weapon, mob/living/user, list/click_params)
+	if (user.a_intent == I_HURT && user.zone_sel.selecting == BP_EYES && weapon.can_puncture() && get_max_health() && weapon.w_class <= ITEM_SIZE_NORMAL)
+		var/hit_zone = resolve_item_attack(weapon, user, user.zone_sel.selecting)
+		if (!hit_zone) //Miss message to user is processed in resolve_item_attack.
+			return TRUE
+		if (hit_zone == BP_HEAD || hit_zone == BP_EYES) //Resolve_item_attack on non-self mobs never returns BP_EYES, but changes it to BP_HEAD because of check_zone()
+			return weapon.eyestab(src, user)
+	else return ..()
+
+
 /mob/living/carbon/electrocute_act(shock_damage, obj/source, siemens_coeff = 1.0, def_zone = null)
 	if(status_flags & GODMODE)	return 0	//godmode
 

--- a/code/modules/paperwork/pen/pen.dm
+++ b/code/modules/paperwork/pen/pen.dm
@@ -7,8 +7,11 @@
 	slot_flags = SLOT_BELT | SLOT_EARS
 	throwforce = 0
 	w_class = ITEM_SIZE_TINY
+	force = 2
+	puncture = TRUE
 	throw_speed = 7
 	throw_range = 15
+	item_flags = ITEM_FLAG_TRY_ATTACK
 	matter = list(MATERIAL_PLASTIC = 10)
 	var/colour = "black"	//what colour the ink is!
 	var/color_description = "black ink"
@@ -44,19 +47,19 @@
 	color_description = "transluscent ink"
 
 /obj/item/pen/attack(atom/A, mob/user, target_zone)
-	if(ismob(A))
-		var/mob/M = A
-		if(ishuman(A) && user.a_intent == I_HELP && target_zone == BP_HEAD)
-			var/mob/living/carbon/human/H = M
-			var/obj/item/organ/external/head/head = H.organs_by_name[BP_HEAD]
-			if(istype(head))
-				head.write_on(user, color_description)
-		else
-			to_chat(user, SPAN_WARNING("You stab [M] with \the [src]."))
-			admin_attack_log(user, M, "Stabbed using \a [src]", "Was stabbed with \a [src]", "used \a [src] to stab")
-	else if(istype(A, /obj/item/organ/external/head))
+	if(ishuman(A) && user.a_intent == I_HELP && target_zone == BP_HEAD)
+		var/mob/living/carbon/human/H = A
+		var/obj/item/organ/external/head/head = H.organs_by_name[BP_HEAD]
+		if(istype(head))
+			head.write_on(user, color_description)
+			return TRUE
+
+	if(istype(A, /obj/item/organ/external/head) && user.a_intent != I_HELP) //Not on help intent to not break ghetto surgery.
 		var/obj/item/organ/external/head/head = A
 		head.write_on(user, color_description)
+		return TRUE
+
+	else return FALSE
 
 /obj/item/pen/proc/toggle()
 	return


### PR DESCRIPTION
🆑 emmanuelbassil
tweak: Can now stab eyes with all tiny, small, and normal sized sharp items.
tweak: It is now possible to damage glass/mask items if eye-stabbing with sufficient force. This is affected by CQC skill, making it easier to break glasses with higher skill. It is not possible to break hats that cover eyes (e.g riot helmets) in this way however, no matter the force.
tweak: It is now possible to miss while trying to stab someone's eyes.
/🆑 

Another nice fix I found while doing all my attacks()
Made eyestab properly boolean since it's failure/success now affects whether the code goes onto the next use_*
Removed two attacks() since they're now processed at use_weapon level, made the remaining one boolean.
Added force to pens to match all the other sharp items; slightly weaker than screwdrivers. (Force = 2 instead of 3).
