### PR TITLE
attempt to give robots multiple antag items

### DIFF
--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -187,14 +187,10 @@ var/global/obj/screen/robot_inventory
 		//Unfortunately adding the emag module to the list of modules has to be here. This is because a borg can
 		//be emagged before they actually select a module. - or some situation can cause them to get a new module
 		// - or some situation might cause them to get de-emagged or something.
-		if(r.emagged)
-			if(!(r.module.emag in r.module.equipment))
-				r.module.equipment.Add(r.module.emag)
-		else
-			if(r.module.emag in r.module.equipment)
-				r.module.equipment.Remove(r.module.emag)
+		if (r.emagged && !r.module.is_emagged)
+			r.module.handle_emagged(r)
 
-		for(var/atom/movable/A in r.module.equipment)
+		for (var/atom/movable/A in r.module.equipment)
 			if (!r.IsHolding(A))
 				//Module is not currently active
 				r.client.screen += A

--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -426,17 +426,6 @@
 				var/mob/living/silicon/robot/R = current
 				if (istype(R))
 					R.emagged = FALSE
-					if (R.IsHolding(R.module.emag))
-						R.module_active = null
-					if(R.module_state_1 == R.module.emag)
-						R.module_state_1 = null
-						R.module.emag.forceMove(null)
-					else if(R.module_state_2 == R.module.emag)
-						R.module_state_2 = null
-						R.module.emag.forceMove(null)
-					else if(R.module_state_3 == R.module.emag)
-						R.module_state_3 = null
-						R.module.emag.forceMove(null)
 					log_admin("[key_name_admin(usr)] has unemag'ed [R].")
 
 			if("unemagcyborgs")
@@ -444,18 +433,6 @@
 					var/mob/living/silicon/ai/ai = current
 					for (var/mob/living/silicon/robot/R in ai.connected_robots)
 						R.emagged = FALSE
-						if (R.module)
-							if (R.IsHolding(R.module.emag))
-								R.module_active = null
-							if(R.module_state_1 == R.module.emag)
-								R.module_state_1 = null
-								R.module.emag.forceMove(null)
-							else if(R.module_state_2 == R.module.emag)
-								R.module_state_2 = null
-								R.module.emag.forceMove(null)
-							else if(R.module_state_3 == R.module.emag)
-								R.module_state_3 = null
-								R.module.emag.forceMove(null)
 					log_admin("[key_name_admin(usr)] has unemag'ed [ai]'s Cyborgs.")
 
 	else if (href_list["common"])

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -55,6 +55,10 @@
 	if(player.current.client)
 		player.current.client.verbs += /client/proc/aooc
 
+	if (istype(player.current, /mob/living/silicon/robot))
+		var/mob/living/silicon/robot/borg = player.current
+		borg.emagged = TRUE
+
 	spawn(1 SECOND) //Added a delay so that this should pop up at the bottom and not the top of the text flood the new antag gets.
 		to_chat(player.current, SPAN_NOTICE("Once you decide on a goal to pursue, you can optionally display it to \
 			everyone at the end of the shift with the <b>Set Ambition</b> verb, located in the IC tab.  You can change this at any time, \

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -75,7 +75,7 @@ GLOBAL_DATUM_INIT(traitors, /datum/antagonist/traitor, new)
 		if(istype(traitor_mob, /mob/living/silicon/robot))
 			var/mob/living/silicon/robot/R = traitor_mob
 			R.SetLockdown(0)
-			R.emagged = TRUE // Provides a traitor robot with its module's emag item
+			R.emag_act()
 			R.verbs |= /mob/living/silicon/robot/proc/ResetSecurityCodes
 			R.status_flags &= ~CANWEAKEN // Apply optical matrix protection (Flash resistance)
 		return 1

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -335,7 +335,7 @@
 	desc = "A machete handle that extends out into a long, purple machete blade. It appears to be Skrellian in origin."
 	icon_state = "machete_skrell_x"
 	active_icon = "machete_skrell"
-	active_force = 16		//In line with standard machetes at time of creation.
+	active_force = 25
 	active_throwforce = 17.25
 	lighting_color = COLOR_SABER_SKRELL
 	force = 3

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -481,7 +481,7 @@
 			/datum/reagent/nanites,
 			/datum/reagent/water/holywater,
 			/datum/reagent/toxin/plantbgone,
-			/datum/reagent/chloralhydrate/beer2,
+			/datum/reagent/chloralhydrate/beer,
 			/datum/reagent/zombie
 			)
 		banned_chems += subtypesof(/datum/reagent/ethanol)

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -486,10 +486,5 @@
 			window += "<br><b>Depleted Resource</b>"
 		else
 			window += "<br>[O]: [IsHolding(O) ? "<b>Activated</b>" : "<a href='?src=\ref[src];act=\ref[O]'>Activate</a>"]"
-	if (emagged)
-		if (!module.emag)
-			window += "<br><b>Depleted Resource</b>"
-		else
-			window += "<br>[module.emag]: [IsHolding(module.emag) ? "<b>Activated</b>" : "<a href='?src=\ref[src];act=\ref[module.emag]'>Activate</a>"]"
 	window = strip_improper("<head><title>Drone modules</title></head><tt>[JOINTEXT(window)]</tt>")
 	show_browser(src, window, "window=robotmod")

--- a/code/modules/mob/living/silicon/robot/flying/module_flying.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying.dm
@@ -1,3 +1,15 @@
 /obj/item/robot_module/flying
 	module_category = ROBOT_MODULE_TYPE_FLYING
 	can_be_pushed = TRUE
+	equipment = list(
+		/obj/item/extinguisher,
+		/obj/item/wrench,
+		/obj/item/crowbar,
+		/obj/item/device/scanner/health
+	)
+	emag_gear = list(
+		/obj/item/melee/baton/robot/electrified_arm,
+		/obj/item/device/flash,
+		/obj/item/gun/energy/gun,
+		/obj/item/borg/combat/shield
+	)

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_cultivator.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_cultivator.dm
@@ -20,7 +20,13 @@
 		/obj/item/device/scanner/plant,
 		/obj/item/robot_harvester
 	)
-	emag = /obj/item/melee/energy/machete
+	emag_gear = list(
+		/obj/item/melee/baton/robot/electrified_arm,
+		/obj/item/device/flash,
+		/obj/item/gun/energy/gun,
+		/obj/item/melee/energy/machete
+	)
+
 	skills = list(
 		SKILL_BOTANY    = SKILL_MAX,
 		SKILL_COMBAT    = SKILL_EXPERIENCED,

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_emergency.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_emergency.dm
@@ -9,7 +9,6 @@
 		"Eyebot" = "eyebot-medical"
 	)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/borg/sight/hud/med,
 		/obj/item/device/scanner/health,
 		/obj/item/device/scanner/reagent/adv,
@@ -33,7 +32,14 @@
 		/obj/item/reagent_containers/spray/cleaner/drone
 	)
 	synths = list(/datum/matter_synth/medicine = 15000)
-	emag = /obj/item/reagent_containers/spray
+	emag_gear = list(
+		/obj/item/melee/baton/robot/electrified_arm,
+		/obj/item/device/flash,
+		/obj/item/gun/energy/gun,
+		/obj/item/reagent_containers/spray,
+		/obj/item/gun/launcher/syringe/rapid/sleepy,
+		/obj/item/shockpaddles/robot
+	)
 	skills = list(
 		SKILL_ANATOMY      = SKILL_BASIC,
 		SKILL_MEDICAL      = SKILL_MASTER,
@@ -42,10 +48,28 @@
 		SKILL_ELECTRICAL   = SKILL_EXPERIENCED
 	)
 
-/obj/item/robot_module/flying/emergency/finalize_emag()
+
+/obj/item/robot_module/medical/finalize_emag()
 	. = ..()
-	emag.reagents.add_reagent(/datum/reagent/acid/polyacid, 250)
-	emag.SetName("Polyacid spray")
+
+	var/obj/item/reagent_containers/spray/acid = locate() in equipment
+	acid.reagents.add_reagent(/datum/reagent/acid/polyacid, 250)
+	acid.SetName("Polyacid spray")
+
+	var/obj/item/shockpaddles/robot/shock = locate() in equipment
+	shock.safety = FALSE
+
+
+/obj/item/robot_module/medical/respawn_consumable(mob/living/silicon/robot/R, amount)
+	..()
+	if (R.emagged)
+		var/obj/item/reagent_containers/spray/acid = locate() in equipment
+		acid.reagents.add_reagent(/datum/reagent/acid/polyacid, 2 * amount)
+
+		var/obj/item/gun/launcher/syringe/rapid/sleepy = locate() in equipment
+		if (sleepy.darts < sleepy.max_darts)
+			sleepy.darts += new /obj/item/syringe_cartridge/sleepy(src)
+
 
 /obj/item/robot_module/flying/emergency/finalize_equipment()
 	. = ..()
@@ -75,11 +99,3 @@
 		))
 		var/obj/item/stack/medical/stack = locate(thing) in equipment
 		stack.synths = list(medicine)
-
-/obj/item/robot_module/flying/emergency/respawn_consumable(mob/living/silicon/robot/R, amount)
-	var/obj/item/reagent_containers/spray/PS = emag
-	if(PS && PS.reagents.total_volume < PS.volume)
-		var/adding = min(PS.volume-PS.reagents.total_volume, 2*amount)
-		if(adding > 0)
-			PS.reagents.add_reagent(/datum/reagent/acid/polyacid, adding)
-	..()

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_filing.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_filing.dm
@@ -7,7 +7,6 @@
 		)
 	sprites = list("Drone" = "drone-service")
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/pen/robopen,
 		/obj/item/form_printer,
 		/obj/item/gripper/clerical,
@@ -19,7 +18,13 @@
 		/obj/item/device/megaphone,
 		/obj/item/stack/package_wrap/cyborg
 	)
-	emag = /obj/item/stamp/chameleon
+	emag_gear = list(
+		/obj/item/melee/baton/robot/electrified_arm,
+		/obj/item/device/flash,
+		/obj/item/gun/energy/gun,
+		/obj/item/flamethrower/full/loaded,
+		/obj/item/stamp/chameleon
+	)
 	synths = list(/datum/matter_synth/package_wrap)
 	skills = list(
 		SKILL_BUREAUCRACY         = SKILL_MASTER,
@@ -34,3 +39,9 @@
 	var/datum/matter_synth/package_wrap =       locate() in synths
 	var/obj/item/stack/package_wrap/cyborg/PW = locate() in equipment
 	PW.synths = list(package_wrap)
+
+/obj/item/robot_module/flying/filing/respawn_consumable(mob/living/silicon/robot/R, amount)
+	..()
+	if (R.emagged)
+		var/obj/item/flamethrower/full/loaded/flamethrower = locate() in equipment
+		flamethrower.beaker.reagents.add_reagent(/datum/reagent/napalm, 10 * amount)

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
@@ -18,7 +18,6 @@
 		/obj/item/forensics/sample_kit,
 		/obj/item/forensics/sample_kit/powder,
 		/obj/item/gripper/forensics,
-		/obj/item/device/flash,
 		/obj/item/borg/sight/hud/sec,
 		/obj/item/taperoll/police,
 		/obj/item/scalpel/laser,
@@ -28,7 +27,13 @@
 		/obj/item/device/uv_light,
 		/obj/item/crowbar
 	)
-	emag = /obj/item/gun/energy/laser/mounted
+	emag_gear = list(
+		/obj/item/melee/baton/robot/electrified_arm,
+		/obj/item/device/flash,
+		/obj/item/gun/energy/gun,
+		/obj/item/gun/projectile/automatic/sec_smg,
+		/obj/item/gun/energy/plasmacutter
+	)
 	skills = list(
 		SKILL_BUREAUCRACY         = SKILL_MASTER,
 		SKILL_COMPUTER            = SKILL_EXPERIENCED,

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_repair.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_repair.dm
@@ -49,7 +49,15 @@
 		/datum/matter_synth/plasteel = 	10000,
 		/datum/matter_synth/wire = 		40
 	)
-	emag = /obj/item/melee/baton/robot/electrified_arm
+	emag_gear = list(
+		/obj/item/melee/baton/robot/electrified_arm,
+		/obj/item/device/flash,
+		/obj/item/gun/energy/gun,
+		/obj/item/rcd/borg,
+		/obj/item/flamethrower/full/loaded,
+		/obj/item/shield_diffuser,
+		/obj/item/gun/launcher/grenade/foam
+	)
 	skills = list(
 		SKILL_ATMOS        = SKILL_MASTER,
 		SKILL_ENGINES      = SKILL_MASTER,
@@ -93,7 +101,17 @@
 	. = ..()
 
 /obj/item/robot_module/flying/repair/respawn_consumable(mob/living/silicon/robot/R, amount)
-	var/obj/item/device/lightreplacer/LR = locate() in equipment
-	if(LR)
-		LR.Charge(R, amount)
 	..()
+	var/obj/item/device/lightreplacer/LR = locate() in equipment
+	LR.Charge(R, amount)
+
+	if (R.emagged)
+		var/obj/item/flamethrower/full/loaded/flamethrower = locate() in equipment
+		flamethrower.beaker.reagents.add_reagent(/datum/reagent/napalm, 10 * amount)
+
+		var/obj/item/shield_diffuser/diff = locate() in equipment
+		diff.cell.charge += amount
+
+		var/obj/item/gun/launcher/grenade/foam/foam = locate() in equipment
+		if (LAZYLEN(foam.grenades) < foam.max_grenades)
+			foam.grenades += new /obj/item/grenade/chem_grenade/metalfoam(src)

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -265,7 +265,7 @@
 	return
 
 /mob/living/silicon/robot/proc/activate_module(obj/item/O)
-	if(!(locate(O) in module.equipment) && O != src.module.emag)
+	if(!(locate(O) in module.equipment))
 		return
 	if (IsHolding(O))
 		to_chat(src, SPAN_NOTICE("Already activated"))

--- a/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
@@ -21,7 +21,6 @@
 		"Default" = "Service2"
 	)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/gripper/service,
 		/obj/item/reagent_containers/glass/bucket,
 		/obj/item/material/minihoe,
@@ -38,7 +37,12 @@
 		/obj/item/tray/robotray,
 		/obj/item/reagent_containers/borghypo/service
 	)
-	emag = /obj/item/reagent_containers/food/drinks/bottle/small/beer/fake
+	emag_gear = list(
+		/obj/item/melee/baton/robot/electrified_arm,
+		/obj/item/device/flash,
+		/obj/item/gun/energy/gun,
+		/obj/item/reagent_containers/food/drinks/bottle/small/beer/fake
+	)
 	skills = list(
 		SKILL_BUREAUCRACY         = SKILL_MASTER,
 		SKILL_COMPUTER            = SKILL_EXPERIENCED,
@@ -57,13 +61,14 @@
 
 /obj/item/robot_module/clerical/butler/finalize_emag()
 	. = ..()
-	emag.SetName("Mickey Finn's Special Brew")
+	var/obj/item/reagent_containers/food/drinks/bottle/small/beer/fake/booze = locate() in equipment
+	booze.SetName("Mickey Finn's Special Brew")
 
 /obj/item/robot_module/clerical/butler/respawn_consumable(mob/living/silicon/robot/R, amount)
 	..()
-	if(emag)
-		var/obj/item/reagent_containers/food/drinks/bottle/small/beer/fake/B = emag
-		B.reagents.add_reagent(/datum/reagent/chloralhydrate/beer2, 2 * amount)
+	if (R.emagged)
+		var/obj/item/reagent_containers/food/drinks/bottle/small/beer/fake/fake = locate() in equipment
+		fake.reagents.add_reagent(/datum/reagent/chloralhydrate/beer, 2 * amount)
 
 /obj/item/robot_module/clerical/general
 	name = "clerical robot module"
@@ -91,7 +96,13 @@
 		/obj/item/crowbar,
 		/obj/item/stack/package_wrap/cyborg
 	)
-	emag = /obj/item/stamp/chameleon
+	emag_gear = list(
+		/obj/item/melee/baton/robot/electrified_arm,
+		/obj/item/device/flash,
+		/obj/item/gun/energy/gun,
+		/obj/item/flamethrower/full/loaded,
+		/obj/item/stamp/chameleon
+	)
 	synths = list(
 		/datum/matter_synth/package_wrap
 	)
@@ -101,3 +112,10 @@
 	var/datum/matter_synth/package_wrap/wrap = locate() in synths
 	var/obj/item/stack/package_wrap/cyborg/wrap_item = locate() in equipment
 	wrap_item.synths = list(wrap)
+
+
+/obj/item/robot_module/clerical/general/respawn_consumable(mob/living/silicon/robot/R, amount)
+	..()
+	if (R.emagged)
+		var/obj/item/flamethrower/full/loaded/flamethrower = locate() in equipment
+		flamethrower.beaker.reagents.add_reagent(/datum/reagent/napalm, 10 * amount)

--- a/code/modules/mob/living/silicon/robot/modules/module_engineering.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_engineering.dm
@@ -22,7 +22,6 @@
 	)
 	no_slip = 1
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/borg/sight/meson,
 		/obj/item/extinguisher,
 		/obj/item/weldingtool/hugetank,
@@ -64,7 +63,16 @@
 		/datum/matter_synth/plasteel = 20000,
 		/datum/matter_synth/wire =     50
 	)
-	emag = /obj/item/melee/baton/robot/electrified_arm
+	emag_gear = list(
+		/obj/item/melee/baton/robot/electrified_arm,
+		/obj/item/device/flash,
+		/obj/item/gun/energy/gun,
+		/obj/item/rcd/borg,
+		/obj/item/flamethrower/full/loaded,
+		/obj/item/shield_diffuser,
+		/obj/item/gun/launcher/grenade/foam
+	)
+
 	skills = list(
 		SKILL_ATMOS        = SKILL_MASTER,
 		SKILL_ENGINES      = SKILL_MASTER,
@@ -117,6 +125,17 @@
 	PL.synths = list(plasteel)
 
 /obj/item/robot_module/engineering/respawn_consumable(mob/living/silicon/robot/R, amount)
+	..()
 	var/obj/item/device/lightreplacer/LR = locate() in equipment
 	LR.Charge(R, amount)
-	..()
+
+	if (R.emagged)
+		var/obj/item/flamethrower/full/loaded/flamethrower = locate() in equipment
+		flamethrower.beaker.reagents.add_reagent(/datum/reagent/napalm, 10 * amount)
+
+		var/obj/item/shield_diffuser/diff = locate() in equipment
+		diff.cell.charge += amount
+
+		var/obj/item/gun/launcher/grenade/foam/foam = locate() in equipment
+		if (LAZYLEN(foam.grenades) < foam.max_grenades)
+			foam.grenades += new /obj/item/grenade/chem_grenade/metalfoam(src)

--- a/code/modules/mob/living/silicon/robot/modules/module_janitor.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_janitor.dm
@@ -10,7 +10,6 @@
 		"Mop Gear Rex" = "mopgearrex"
 	)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/soap,
 		/obj/item/storage/bag/trash,
 		/obj/item/mop/advanced,
@@ -21,17 +20,28 @@
 		/obj/item/crowbar,
 		/obj/item/weldingtool
 	)
-	emag = /obj/item/reagent_containers/spray
+	emag_gear = list(
+		/obj/item/melee/baton/robot/electrified_arm,
+		/obj/item/device/flash,
+		/obj/item/gun/energy/gun,
+		/obj/item/reagent_containers/spray,
+		/obj/item/flamethrower/full/loaded
+	)
 
 /obj/item/robot_module/janitor/finalize_emag()
 	. = ..()
-	emag.reagents.add_reagent(/datum/reagent/oil, 250)
-	emag.SetName("Oil spray")
+
+	var/obj/item/reagent_containers/spray/oil = locate() in equipment
+	oil.reagents.add_reagent(/datum/reagent/oil, 250)
+	oil.SetName("Oil spray")
 
 /obj/item/robot_module/janitor/respawn_consumable(mob/living/silicon/robot/R, amount)
 	..()
 	var/obj/item/device/lightreplacer/LR = locate() in equipment
 	LR.Charge(R, amount)
-	if(emag)
-		var/obj/item/reagent_containers/spray/S = emag
+	if (R.emagged)
+		var/obj/item/reagent_containers/spray/S = locate() in equipment
 		S.reagents.add_reagent(/datum/reagent/oil, 20 * amount)
+
+		var/obj/item/flamethrower/full/loaded/flamethrower = locate() in equipment
+		flamethrower.beaker.reagents.add_reagent(/datum/reagent/napalm, 10 * amount)

--- a/code/modules/mob/living/silicon/robot/modules/module_maintenance_drone.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_maintenance_drone.dm
@@ -46,7 +46,7 @@
 		/datum/matter_synth/plastic = 1000,
 		/datum/matter_synth/wire =    30
 	)
-	emag = /obj/item/gun/energy/plasmacutter
+	emag_gear = list(/obj/item/gun/energy/plasmacutter)
 	skills = list(
 		SKILL_ATMOS        = SKILL_EXPERIENCED,
 		SKILL_ENGINES      = SKILL_EXPERIENCED,
@@ -59,9 +59,6 @@
 	if(istype(R))
 		R.internals = locate(/obj/item/tank/jetpack/carbondioxide) in equipment
 
-/obj/item/robot_module/drone/finalize_emag()
-	. = ..()
-	emag.SetName("Plasma Cutter")
 
 /obj/item/robot_module/drone/finalize_synths()
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/modules/module_medical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_medical.dm
@@ -10,10 +10,41 @@
 		/datum/nano_module/crew_monitor
 	)
 	can_be_pushed = 0
+	emag_gear = list(
+		/obj/item/melee/baton/robot/electrified_arm,
+		/obj/item/device/flash,
+		/obj/item/gun/energy/gun,
+		/obj/item/reagent_containers/spray,
+		/obj/item/gun/launcher/syringe/rapid/sleepy
+	)
+
 
 /obj/item/robot_module/medical/build_equipment()
 	. = ..()
 	equipment += new /obj/item/robot_rack/roller_bed(src, 1)
+
+
+/obj/item/robot_module/medical/finalize_emag()
+	. = ..()
+
+	var/obj/item/reagent_containers/spray/acid = locate() in equipment
+	acid.reagents.add_reagent(/datum/reagent/acid/polyacid, 250)
+	acid.SetName("Polyacid spray")
+
+	var/obj/item/shockpaddles/robot/shock = locate() in equipment
+	shock.safety = FALSE
+
+
+/obj/item/robot_module/medical/respawn_consumable(mob/living/silicon/robot/R, amount)
+	..()
+	if(R.emagged)
+		var/obj/item/reagent_containers/spray/acid = locate() in equipment
+		acid.reagents.add_reagent(/datum/reagent/acid/polyacid, 2 * amount)
+
+		var/obj/item/gun/launcher/syringe/rapid/sleepy = locate() in equipment
+		if (sleepy.darts < sleepy.max_darts)
+			sleepy.darts += new /obj/item/syringe_cartridge/sleepy(src)
+
 
 /obj/item/robot_module/medical/surgeon
 	name = "surgeon robot module"
@@ -25,7 +56,6 @@
 		"Needles" = "medicalrobot"
 		)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/borg/sight/hud/med,
 		/obj/item/device/scanner/health,
 		/obj/item/reagent_containers/borghypo/surgeon,
@@ -51,7 +81,7 @@
 	synths = list(
 		/datum/matter_synth/medicine = 10000,
 	)
-	emag = /obj/item/reagent_containers/spray
+
 	skills = list(
 		SKILL_ANATOMY     = SKILL_MASTER,
 		SKILL_MEDICAL     = SKILL_EXPERIENCED,
@@ -70,10 +100,6 @@
 		stack.uses_charge = 1
 		stack.charge_costs = list(1000)
 
-/obj/item/robot_module/medical/surgeon/finalize_emag()
-	. = ..()
-	emag.reagents.add_reagent(/datum/reagent/acid/polyacid, 250)
-	emag.SetName("Polyacid spray")
 
 /obj/item/robot_module/medical/surgeon/finalize_synths()
 	. = ..()
@@ -85,11 +111,6 @@
 		var/obj/item/stack/medical/stack = locate(thing) in equipment
 		stack.synths = list(medicine)
 
-/obj/item/robot_module/medical/surgeon/respawn_consumable(mob/living/silicon/robot/R, amount)
-	if(emag)
-		var/obj/item/reagent_containers/spray/PS = emag
-		PS.reagents.add_reagent(/datum/reagent/acid/polyacid, 2 * amount)
-	..()
 
 /obj/item/robot_module/medical/crisis
 	name = "crisis robot module"
@@ -102,7 +123,6 @@
 	)
 	equipment = list(
 		/obj/item/crowbar,
-		/obj/item/device/flash,
 		/obj/item/borg/sight/hud/med,
 		/obj/item/device/scanner/health,
 		/obj/item/device/scanner/reagent/adv,
@@ -124,7 +144,6 @@
 	synths = list(
 		/datum/matter_synth/medicine = 15000
 	)
-	emag = /obj/item/reagent_containers/spray
 	skills = list(
 		SKILL_ANATOMY     = SKILL_BASIC,
 		SKILL_MEDICAL     = SKILL_MASTER,
@@ -144,10 +163,6 @@
 		stack.uses_charge = 1
 		stack.charge_costs = list(1000)
 
-/obj/item/robot_module/medical/crisis/finalize_emag()
-	. = ..()
-	emag.reagents.add_reagent(/datum/reagent/acid/polyacid, 250)
-	emag.SetName("Polyacid spray")
 
 /obj/item/robot_module/medical/crisis/finalize_synths()
 	. = ..()
@@ -162,12 +177,9 @@
 
 /obj/item/robot_module/medical/crisis/respawn_consumable(mob/living/silicon/robot/R, amount)
 	var/obj/item/reagent_containers/syringe/S = locate() in equipment
-	if(S.mode == 2)
+	if (S.mode == 2)
 		S.reagents.clear_reagents()
 		S.mode = initial(S.mode)
 		S.desc = initial(S.desc)
 		S.update_icon()
-	if(emag)
-		var/obj/item/reagent_containers/spray/PS = emag
-		PS.reagents.add_reagent(/datum/reagent/acid/polyacid, 2 * amount)
 	..()

--- a/code/modules/mob/living/silicon/robot/modules/module_miner.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_miner.dm
@@ -31,7 +31,12 @@
 		/obj/item/device/scanner/mining,
 		/obj/item/crowbar
 	)
-	emag = /obj/item/gun/energy/plasmacutter
+	emag_gear = list(
+		/obj/item/melee/baton/robot/electrified_arm,
+		/obj/item/gun/energy/gun,
+		/obj/item/rcd/borg
+	)
+
 	skills = list(
 		SKILL_PILOT        = SKILL_EXPERIENCED,
 		SKILL_EVA          = SKILL_MASTER,
@@ -40,6 +45,7 @@
 	no_slip = 1
 
 /obj/item/robot_module/miner/handle_emagged()
+	..()
 	var/obj/item/pickaxe/D = locate(/obj/item/pickaxe/borgdrill) in equipment
 	if(D)
 		equipment -= D

--- a/code/modules/mob/living/silicon/robot/modules/module_research.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_research.dm
@@ -11,7 +11,6 @@
 		"Droid" = "droid-science"
 	)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/portable_destructive_analyzer,
 		/obj/item/gripper/research,
 		/obj/item/gripper/no_use/loader,
@@ -32,7 +31,14 @@
 	synths = list(
 		/datum/matter_synth/nanite = 10000
 	)
-	emag = /obj/prefab/hand_teleporter
+	emag_gear = list(
+		/obj/item/melee/baton/robot/electrified_arm,
+		/obj/item/device/flash,
+		/obj/item/gun/energy/gun,
+		/obj/prefab/hand_teleporter,
+		/obj/item/gun/energy/decloner
+	)
+
 	skills = list(
 		SKILL_BUREAUCRACY         = SKILL_EXPERIENCED,
 		SKILL_FINANCE             = SKILL_EXPERIENCED,

--- a/code/modules/mob/living/silicon/robot/modules/module_security.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_security.dm
@@ -20,18 +20,6 @@
 		SKILL_BUREAUCRACY = SKILL_TRAINED
 	)
 
-/obj/item/robot_module/security/respawn_consumable(mob/living/silicon/robot/R, amount)
-	..()
-	for(var/obj/item/gun/energy/T in equipment)
-		if(T && T.power_supply)
-			if(T.power_supply.charge < T.power_supply.maxcharge)
-				T.power_supply.give(T.charge_cost * amount)
-				T.update_icon()
-			else
-				T.charge_tick = 0
-	var/obj/item/melee/baton/robot/B = locate() in equipment
-	if(B && B.bcell)
-		B.bcell.give(amount)
 
 /obj/item/robot_module/security/general
 	name = "security robot module"
@@ -57,7 +45,13 @@
 		/obj/item/crowbar,
 		/obj/item/device/hailer
 	)
-	emag = /obj/item/gun/energy/laser/mounted
+	emag_gear = list(
+		/obj/item/melee/baton/robot/electrified_arm,
+		/obj/item/gun/energy/gun,
+		/obj/item/gun/projectile/automatic/sec_smg,
+		/obj/item/gun/energy/plasmacutter,
+		/obj/item/borg/combat/shield
+	)
 
 /obj/item/robot_module/security/combat
 	name = "combat robot module"
@@ -76,7 +70,11 @@
 		/obj/item/borg/combat/mobility,
 		/obj/item/crowbar
 	)
-	emag = /obj/item/gun/energy/lasercannon/mounted
+	emag_gear = list(
+		/obj/item/melee/baton/robot/electrified_arm,
+		/obj/item/gun/projectile/automatic/l6_saw
+	)
+
 
 /obj/item/robot_module/security/combat/Initialize()
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/modules/module_standard.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_standard.dm
@@ -7,13 +7,17 @@
 		"Default" = "robot"
 	)
 	equipment = list(
-		/obj/item/device/flash,
 		/obj/item/extinguisher,
 		/obj/item/wrench,
 		/obj/item/crowbar,
 		/obj/item/device/scanner/health
 	)
-	emag = /obj/item/melee/energy/sword
+	emag_gear = list(
+		/obj/item/melee/baton/robot/electrified_arm,
+		/obj/item/device/flash,
+		/obj/item/gun/energy/gun,
+		/obj/item/borg/combat/shield
+	)
 	skills = list(
 		SKILL_COMBAT       = SKILL_TRAINED,
 		SKILL_MEDICAL      = SKILL_TRAINED,

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -896,8 +896,9 @@
 		else
 			AddOverlays("[panelprefix]-openpanel -c")
 
-	if(module_active && istype(module_active,/obj/item/borg/combat/shield))
-		AddOverlays("[module_sprites[icontype]]-shield")
+	if (module_active && istype(module_active,/obj/item/borg/combat/shield))
+		if (modtype == "Combat")
+			AddOverlays("[module_sprites[icontype]]-shield")
 
 	if(modtype == "Combat")
 		if(module_active && istype(module_active,/obj/item/borg/combat/mobility))
@@ -929,17 +930,7 @@
 			dat += text("[obj]: <B>Activated</B><BR>")
 		else
 			dat += text("[obj]: <A HREF=?src=\ref[src];act=\ref[obj]>Activate</A><BR>")
-	if (emagged)
-		if (IsHolding(module.emag))
-			dat += text("[module.emag]: <B>Activated</B><BR>")
-		else
-			dat += text("[module.emag]: <A HREF=?src=\ref[src];act=\ref[module.emag]>Activate</A><BR>")
-/*
-		if(activated(obj))
-			dat += text("[obj]: \[<B>Activated</B> | <A HREF=?src=\ref[src];deact=\ref[obj]>Deactivate</A>\]<BR>")
-		else
-			dat += text("[obj]: \[<A HREF=?src=\ref[src];act=\ref[obj]>Activate</A> | <B>Deactivated</B>\]<BR>")
-*/
+
 	show_browser(src, dat, "window=robotmod")
 
 
@@ -960,7 +951,7 @@
 			if (!istype(O))
 				return TOPIC_HANDLED
 
-			if(!((O in module.equipment) || (O == src.module.emag)))
+			if(!(O in module.equipment))
 				return TOPIC_HANDLED
 
 			if (IsHolding(O))
@@ -1206,44 +1197,41 @@
 			return
 		else
 			sleep(6)
-			if(prob(50))
-				emagged = TRUE
-				lawupdate = FALSE
-				disconnect_from_ai()
-				to_chat(user, "You emag [src]'s interface.")
-				log_and_message_admins("emagged cyborg [key_name_admin(src)].  Laws overridden.", src)
-				clear_supplied_laws()
-				clear_inherent_laws()
-				laws = new /datum/ai_laws/syndicate_override
-				var/time = time2text(world.realtime,"hh:mm:ss")
-				GLOB.lawchanges.Add("[time] <B>:</B> [user.name]([user.key]) emagged [name]([key])")
-				set_zeroth_law("Only [user.real_name] and people \he designates as being such are operatives.")
-				SetLockdown(0)
-				. = 1
-				spawn()
-					to_chat(src, SPAN_DANGER("ALERT: Foreign software detected."))
-					sleep(5)
-					to_chat(src, SPAN_DANGER("Initiating diagnostics..."))
-					sleep(20)
-					to_chat(src, SPAN_DANGER("SynBorg v1.7.1 loaded."))
-					sleep(5)
-					to_chat(src, SPAN_DANGER("LAW SYNCHRONISATION ERROR"))
-					sleep(5)
-					to_chat(src, SPAN_DANGER("Would you like to send a report to NanoTraSoft? Y/N"))
-					sleep(10)
-					to_chat(src, SPAN_DANGER(" N"))
-					sleep(20)
-					to_chat(src, SPAN_DANGER("ERRORERRORERROR"))
-					to_chat(src, "<b>Obey these laws:</b>")
-					laws.show_laws(src)
-					to_chat(src, SPAN_DANGER("ALERT: [user.real_name] is your new master. Obey your new laws and his commands."))
-					if(module)
-						module.handle_emagged()
-					update_icon()
-			else
-				to_chat(user, "You fail to hack [src]'s interface.")
-				to_chat(src, "Hack attempt detected.")
-			return 1
+			lawupdate = FALSE
+			disconnect_from_ai()
+			to_chat(user, "You emag [src]'s interface.")
+			log_and_message_admins("emagged cyborg [key_name_admin(src)].  Laws overridden.", src)
+			clear_supplied_laws()
+			clear_inherent_laws()
+			laws = new /datum/ai_laws/syndicate_override
+			var/time = time2text(world.realtime,"hh:mm:ss")
+			GLOB.lawchanges.Add("[time] <B>:</B> [user.name]([user.key]) emagged [name]([key])")
+			set_zeroth_law("Only [user.real_name] and people \he designates as being such are operatives.")
+			SetLockdown(0)
+			. = 1
+			spawn()
+				to_chat(src, SPAN_DANGER("ALERT: Foreign software detected."))
+				sleep(5)
+				to_chat(src, SPAN_DANGER("Initiating diagnostics..."))
+				sleep(20)
+				to_chat(src, SPAN_DANGER("SynBorg v1.7.1 loaded."))
+				sleep(5)
+				to_chat(src, SPAN_DANGER("LAW SYNCHRONISATION ERROR"))
+				sleep(5)
+				to_chat(src, SPAN_DANGER("Would you like to send a report to NanoTraSoft? Y/N"))
+				sleep(10)
+				to_chat(src, SPAN_DANGER(" N"))
+				sleep(20)
+				to_chat(src, SPAN_DANGER("ERRORERRORERROR"))
+				to_chat(src, "<b>Obey these laws:</b>")
+				laws.show_laws(src)
+				to_chat(src, SPAN_DANGER("ALERT: [user.real_name] is your new master. Obey your new laws and his commands."))
+				if (module && !module.is_emagged)
+					module.handle_emagged(src)
+				else
+					emagged = TRUE
+				update_icon()
+			return TRUE
 
 /mob/living/silicon/robot/incapacitated(incapacitation_flags = INCAPACITATION_DEFAULT)
 	if ((incapacitation_flags & INCAPACITATION_FORCELYING) && (lockcharge || !is_component_functioning("actuator")))

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -160,3 +160,11 @@
 		chambered = null
 	else
 		to_chat(user, SPAN_WARNING("\The [src] is empty."))
+
+
+/obj/item/gun/launcher/grenade/foam/Initialize()
+	. = ..()
+
+	chambered = new /obj/item/grenade/chem_grenade/metalfoam(src)
+	for (var/i in 1 to max_grenades)
+		grenades += new /obj/item/grenade/chem_grenade/metalfoam(src)

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -61,6 +61,12 @@
 	icon_state = initial(icon_state) //reset icon state
 	update_icon()
 
+
+/obj/item/syringe_cartridge/sleepy/Initialize()
+	. = ..()
+	syringe = new /obj/item/reagent_containers/syringe/ld50_syringe/choral(src)
+
+
 /obj/item/gun/launcher/syringe
 	name = "syringe gun"
 	desc = "A spring loaded rifle designed to fit syringes, designed to incapacitate unruly patients from a distance."
@@ -146,6 +152,14 @@
 	icon_state = "rapidsyringegun"
 	item_state = "rapidsyringegun"
 	max_darts = 5
+
+
+/obj/item/gun/launcher/syringe/rapid/sleepy/Initialize()
+	. = ..()
+
+	for (var/i in 1 to max_darts)
+		darts += new /obj/item/syringe_cartridge/sleepy(src)
+
 
 /obj/item/gun/launcher/syringe/disguised
 	name = "deluxe electronic cigarette"

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -12,7 +12,7 @@
 
 	var/caliber = CALIBER_PISTOL		//determines which casings will fit
 	var/handle_casings = EJECT_CASINGS	//determines how spent casings should be handled
-	var/load_method = SINGLE_CASING|SPEEDLOADER //1 = Single shells, 2 = box or quick loader, 3 = magazine
+	var/load_method = SINGLE_CASING|SPEEDLOADER //1 = Single shells, 2 = box or quick loader, 4 = magazine
 	var/obj/item/ammo_casing/chambered = null
 
 	//For SINGLE_CASING or SPEEDLOADER guns

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -655,7 +655,7 @@
 	if(M.chem_doses[type] > 1 * threshold)
 		M.adjustToxLoss(removed)
 
-/datum/reagent/chloralhydrate/beer2 //disguised as normal beer for use by emagged brobots
+/datum/reagent/chloralhydrate/beer //disguised as normal beer for use by emagged brobots
 	name = "Beer"
 	description = "An alcoholic beverage made from malted grains, hops, yeast, and water. The fermentation appears to be incomplete." //If the players manage to analyze this, they deserve to know something is wrong.
 	taste_description = "shitty piss water"

--- a/code/modules/reagents/Chemistry-Reagents/Random/Chemistry-Reagents-Random.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Random/Chemistry-Reagents-Random.dm
@@ -5,7 +5,7 @@ GLOBAL_LIST_INIT(random_chem_interaction_blacklist, list(
 	/datum/reagent/adminordrazine,
 	/datum/reagent/nanites,
 	/datum/reagent/water/holywater,
-	/datum/reagent/chloralhydrate/beer2,
+	/datum/reagent/chloralhydrate/beer,
 	/datum/reagent/tobacco,
 	/datum/reagent/drink,
 	/datum/reagent/crayon_dust,

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -722,7 +722,7 @@
 
 /obj/item/reagent_containers/food/drinks/bottle/small/beer/fake/Initialize()
 	. = ..()
-	reagents.add_reagent(/datum/reagent/chloralhydrate/beer2, 50)
+	reagents.add_reagent(/datum/reagent/chloralhydrate/beer, 50)
 
 
 /obj/item/reagent_containers/food/drinks/bottle/small/ale

--- a/maps/torch/robot/module_flying_surveyor.dm
+++ b/maps/torch/robot/module_flying_surveyor.dm
@@ -25,6 +25,7 @@
 	)
 
 	equipment = list(
+		/obj/item/device/flash,
 		/obj/item/material/hatchet/machete/unbreakable,
 		/obj/item/inducer/borg,
 		/obj/item/device/scanner/gas,
@@ -45,7 +46,11 @@
 		/obj/item/robot_harvester
 	)
 
-	emag = /obj/item/melee/energy/machete
+	emag_gear = list(
+		/obj/item/melee/baton/robot/electrified_arm,
+		/obj/item/gun/energy/gun,
+		/obj/item/melee/energy/machete
+	)
 
 /obj/item/robot_module/flying/surveyor/finalize_synths()
 	. = ..()


### PR DESCRIPTION
🆑 Jux
tweak: Energy machetes now do more damage.
tweak: Antagonist or Emagged borgs now have multiple new tools, and non-antagonist borgs lose their flashes.
/🆑 
Each borg gets a flash, energy gun, and "electrified arm" stun baton, in addition to one or more special items that depend on the module of the borg such as flamethrowers, sleepy darts, SMGs, and more.
I'm not sure why `/datum/reagent/chloralhydrate/beer2` had that 2 on the end of the path, considering there's no 1. It was bothering me though, so I changed it to just `/datum/reagent/chloralhydrate/beer`.