### PR TITLE
Fixes hacker hardsuits runtiming when using a wrench on them

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig_attackby.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_attackby.dm
@@ -104,7 +104,8 @@
 			var/list/current_mounts = list()
 			if(cell) current_mounts   += "cell"
 			if(air_supply) current_mounts += "tank"
-			if (length(chest?.storage?.contents)) current_mounts += "storage"
+			if(istype(chest, /obj/item/clothing/suit/space/rig))
+				if (length(chest?.storage?.contents)) current_mounts += "storage"
 			if(installed_modules && length(installed_modules)) current_mounts += "system module"
 			var/to_remove = input("Which would you like to modify?") as null|anything in current_mounts
 			if(!to_remove)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl:
bugfix: stops hacker hardsuits (and maybe some others) from being unable to remove anything from them with a wrench
/:cl:

fixes #33952 