### PR TITLE
deletion starts paused defaults true

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -431,7 +431,7 @@
 
 	var/static/run_empty_levels = FALSE
 
-	var/static/deletion_starts_paused = FALSE
+	var/static/deletion_starts_paused = TRUE
 
 
 /datum/configuration/New()


### PR DESCRIPTION
I don't think this will cause any test oddness at this point, and is the live configuration.