### PR TITLE
Remove in-game OOC manifest

### DIFF
--- a/code/modules/mob/new_player/new_player.dm
+++ b/code/modules/mob/new_player/new_player.dm
@@ -42,8 +42,6 @@
 		if (config.lore_url)
 			output += "<a href='byond://?src=\ref[src];show_lore=1'>Lore</a>"
 	output += "<hr>"
-	if (GAME_STATE > RUNLEVEL_LOBBY)
-		output += "<a href='byond://?src=\ref[src];manifest=1'>Manifest</a>"
 	output += "<a href='byond://?src=\ref[src];show_preferences=1'>Options</a>"
 	output += "<hr>"
 	output += "<b>Playing As</b><br>"
@@ -179,9 +177,6 @@
 				to_chat(usr, SPAN_WARNING("You must wait [time2text(dsdiff, "mm:ss")] before rejoining."))
 				return
 		LateChoices() //show the latejoin job selection menu
-
-	if(href_list["manifest"])
-		ViewManifest()
 
 	if(href_list["SelectedJob"])
 		var/datum/job/job = SSjobs.get_by_title(href_list["SelectedJob"])
@@ -419,14 +414,6 @@
 
 	new_character.key = key		//Manually transfer the key to log them in
 	return new_character
-
-/mob/new_player/proc/ViewManifest()
-	var/dat = "<div align='center'>"
-	dat += html_crew_manifest(OOC = 1)
-	//show_browser(src, dat, "window=manifest;size=370x420;can_close=1")
-	var/datum/browser/popup = new(src, "Crew Manifest", "Crew Manifest", 370, 420, src)
-	popup.set_content(dat)
-	popup.open()
 
 /mob/new_player/Move()
 	return 0

--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -400,7 +400,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	var/dat
 	dat += "<h4>Crew Manifest</h4>"
-	dat += html_crew_manifest(OOC = TRUE)
+	dat += html_crew_manifest()
 
 	var/datum/browser/popup = new(src, "Crew Manifest", "Crew Manifest", 370, 420, src)
 	popup.set_content(dat)

--- a/code/modules/modular_computers/file_system/manifest.dm
+++ b/code/modules/modular_computers/file_system/manifest.dm
@@ -1,5 +1,5 @@
 // Generates a simple HTML crew manifest for use in various places
-/proc/html_crew_manifest(monochrome, OOC)
+/proc/html_crew_manifest(monochrome)
 	var/list/dept_data = list(
 		list("names" = list(), "header" = "Heads of Staff", "flag" = COM, "color" = MANIFEST_COLOR_COMMAND),
 		list("names" = list(), "header" = "Command Support", "flag" = SPT, "color" = MANIFEST_COLOR_SUPPORT),
@@ -49,16 +49,7 @@
 			if(branch_obj && rank_obj)
 				mil_ranks[name] = "<abbr title=\"[rank_obj.name], [branch_obj.name]\">[rank_obj.name_short]</abbr> "
 
-		if(OOC)
-			var/active = 0
-			for(var/mob/M in GLOB.player_list)
-				var/mob_real_name = M.real_name
-				if(sanitize(mob_real_name) == CR.get_name() && M.client && M.client.inactivity <= 10 MINUTES)
-					active = 1
-					break
-			isactive[name] = active ? "Active" : "Inactive"
-		else
-			isactive[name] = CR.get_status()
+		isactive[name] = CR.get_status()
 
 		var/datum/job/job = SSjobs.get_by_title(rank)
 		var/found_place = 0


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
rscdel: The Manifest button has been removed from the lobby screen.
tweak: The View Manifest button while observing as a ghost now displays the in-character manifest (The one that shows the actual manifest status, instead of Active/Inactive).
/:cl:
