### PR TITLE
Adjust wristwatch and examine code

### DIFF
--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -208,7 +208,7 @@ var/global/list/wireColours = list("red", "blue", "green", "darkred", "orange", 
 						to_chat(L, SPAN_CLASS("error", "You need a remote signaller!"))
 			else if(href_list["examine"])
 				var/colour = href_list["examine"]
-				to_chat(usr, examine(GetIndex(colour), usr))
+				to_chat(usr, ExamineWire(GetIndex(colour), usr))
 
 		// Update Window
 			Interact(usr)
@@ -233,7 +233,7 @@ var/global/list/wireColours = list("red", "blue", "green", "darkred", "orange", 
 /datum/wires/proc/ResetPulsed(index)
 	return
 
-/datum/wires/proc/examine(index, mob/user)
+/datum/wires/proc/ExamineWire(index, mob/user)
 	. = "You aren't sure what this wire does."
 
 	var/datum/wire_description/wd = get_description(index)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -362,13 +362,14 @@
  * **Parameters**:
  * - `user` - The mob performing the examine.
  * - `distance` - The distance in tiles from `user` to `src`.
+ * - `is_adjacent` - Whether `user` is adjacent to `src`.
  * - `infix` String - String that is appended immediately after the atom's name.
  * - `suffix` String - Additional string appended after the atom's name and infix.
  *
  * Returns boolean - The caller always expects TRUE
  *  This is used rather than SHOULD_CALL_PARENT as it enforces that subtypes of a type that explicitly returns still call parent
  */
-/atom/proc/examine(mob/user, distance, infix = "", suffix = "")
+/atom/proc/examine(mob/user, distance, is_adjacent, infix = "", suffix = "")
 	//This reformat names to get a/an properly working on item descriptions when they are bloody
 	var/f_name = "\a [src][infix]."
 	if(blood_color && !istype(src, /obj/effect/decal))
@@ -391,7 +392,7 @@
 	return TRUE
 
 /// Works same as /atom/proc/Examine(), only this output comes immediately after any and all made by /atom/proc/Examine()
-/atom/proc/LateExamine(mob/user, distance)
+/atom/proc/LateExamine(mob/user, distance, is_adjacent)
 	SHOULD_NOT_SLEEP(TRUE)
 
 	user.ForensicsExamination(src, distance)

--- a/code/game/machinery/body_scanner.dm
+++ b/code/game/machinery/body_scanner.dm
@@ -17,9 +17,9 @@
 	machine_name = "body scanner"
 	machine_desc = "A full-body scanning suite that provides a complete health assessment of a patient placed inside. Requires an adjacent console to operate."
 
-/obj/machinery/bodyscanner/examine(mob/user)
+/obj/machinery/bodyscanner/examine(mob/user, distance, is_adjacent)
 	. = ..()
-	if (occupant && user.Adjacent(src))
+	if (occupant && is_adjacent)
 		occupant.examine(arglist(args))
 
 /obj/machinery/bodyscanner/relaymove(mob/user)

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -289,9 +289,9 @@
 
 	return 1
 
-/obj/machinery/cryopod/examine(mob/user)
+/obj/machinery/cryopod/examine(mob/user, distance, is_adjacent)
 	. = ..()
-	if (occupant && user.Adjacent(src))
+	if (occupant && is_adjacent)
 		occupant.examine(arglist(args))
 
 //Lifted from Unity stasis.dm and refactored.

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -172,7 +172,7 @@
 			if (prob(5))
 				qdel(src)
 
-/obj/item/examine(mob/user, distance)
+/obj/item/examine(mob/user, distance, is_adjacent)
 	var/size
 	switch(src.w_class)
 		if(ITEM_SIZE_TINY)
@@ -209,7 +209,7 @@
 			desc_comp += "[SPAN_DANGER("No extractable materials detected.")]<BR>"
 		desc_comp += "*--------*"
 
-	return ..(user, distance, "", desc_comp)
+	return ..(user, distance, is_adjacent, "", desc_comp)
 
 /obj/item/attack_hand(mob/user as mob)
 	if (!user) return

--- a/code/game/objects/items/cryobag.dm
+++ b/code/game/objects/items/cryobag.dm
@@ -96,10 +96,10 @@
 		return airtank
 	..()
 
-/obj/structure/closet/body_bag/cryobag/examine(mob/user)
+/obj/structure/closet/body_bag/cryobag/examine(mob/user, distance, is_adjacent)
 	. = ..()
 	to_chat(user,"The stasis meter shows '[stasis_power]x'.")
-	if(Adjacent(user)) //The bag's rather thick and opaque from a distance.
+	if (is_adjacent) //The bag's rather thick and opaque from a distance.
 		to_chat(user, SPAN_INFO("You peer into \the [src]."))
 		for(var/mob/living/L in contents)
 			L.examine(arglist(args))

--- a/code/game/objects/items/devices/slide_projector.dm
+++ b/code/game/objects/items/devices/slide_projector.dm
@@ -187,7 +187,7 @@
 	if(!istype(slide))
 		qdel(src)
 		return
-	return slide.examine(user, 1)
+	return slide.examine(user, max(distance, 1), FALSE)
 
 /obj/effect/projection/photo
 	alpha = 170

--- a/code/modules/augment/implanter.dm
+++ b/code/modules/augment/implanter.dm
@@ -28,7 +28,7 @@
 		to_chat(user, "It seems to be empty.")
 		return
 	to_chat(user, SPAN_BOLD("It contains:"))
-	augment.examine(user)
+	augment.examine(arglist(args))
 
 
 /obj/item/device/augment_implanter/use_tool(obj/item/tool, mob/user, list/click_params)

--- a/code/modules/clothing/under/accessories/wristwatches.dm
+++ b/code/modules/clothing/under/accessories/wristwatches.dm
@@ -17,18 +17,18 @@
 	icon_state = "wristwatch_fancy"
 
 
-/obj/item/clothing/accessory/wristwatch/examine(mob/user)
+/obj/item/clothing/accessory/wristwatch/examine(mob/user, distance)
 	. = ..()
-	if (in_range(src, user))
-		checktime()
+	if (distance <= 1)
+		CheckTime(user)
 
 
-/obj/item/clothing/accessory/wristwatch/proc/checktime()
-	to_chat(usr, "You check \the [src]. The time is [stationtime2text()] on the [time2text(world.timeofday, "DD")]\th of [time2text(world.timeofday, "Month")], [GLOB.using_map.game_year].")
+/obj/item/clothing/accessory/wristwatch/proc/CheckTime(mob/user)
+	to_chat(user, "You check \the [src]. The time is [stationtime2text()] on the [time2text(world.timeofday, "DD")]\th of [time2text(world.timeofday, "Month")], [GLOB.using_map.game_year].")
 
 
 /obj/item/clothing/accessory/wristwatch/OnTopic(mob/user, list/href_list)
 	if(href_list["check_watch"])
 		if(istype(user))
-			examine(user)
+			examinate(user, src)
 			return TOPIC_HANDLED

--- a/code/modules/mob/examinations.dm
+++ b/code/modules/mob/examinations.dm
@@ -4,7 +4,7 @@
 		to_chat(user, SPAN_NOTICE("Something is there but you can't see it."))
 		return
 	user.face_atom(A)
-	if (!isghost(user))
+	if (user.simulated)
 		if (A.loc != user || user.IsHolding(A))
 			for (var/mob/M in viewers(4, user))
 				if (M == user)
@@ -14,19 +14,22 @@
 						continue
 					to_chat(M, SPAN_SUBTLE("<b>\The [user]</b> looks at \the [A]."))
 	var/distance = INFINITY
+	var/is_adjacent = FALSE
 	if (isghost(user) || user.stat == DEAD)
 		distance = 0
+		is_adjacent = TRUE
 	else
 		var/turf/source_turf = get_turf(user)
 		var/turf/target_turf = get_turf(A)
 		if (source_turf && source_turf.z == target_turf?.z)
 			distance = get_dist(source_turf, target_turf)
-	if (!A.examine(user, distance))
+		is_adjacent = user.Adjacent(A)
+	if (!A.examine(user, distance, is_adjacent))
 		crash_with("Improper /examine() override: [log_info_line(A)]")
-	if (!A.LateExamine(user, distance))
+	if (!A.LateExamine(user, distance, is_adjacent))
 		crash_with("Improper /LateExamine() override: [log_info_line(A)]")
 
-/mob/proc/ForensicsExamination(atom/A, distance)
+/mob/proc/ForensicsExamination(atom/A, distance, is_adjacent)
 	if (!(get_skill_value(SKILL_FORENSICS) >= SKILL_EXPERIENCED && distance <= (get_skill_value(SKILL_FORENSICS) - SKILL_TRAINED)))
 		return
 

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -7,7 +7,7 @@
 
 	selected_image = image(icon('icons/misc/buildmode.dmi'), loc = src, icon_state = "ai_sel")
 
-/mob/living/examine(mob/user, distance, infix, suffix)
+/mob/living/examine(mob/user, distance, is_adjacent, infix, suffix)
 	. = ..()
 	if (admin_paralyzed)
 		to_chat(user, SPAN_DEBUG("OOC: They have been paralyzed by staff. Please avoid interacting with them unless cleared to do so by staff."))

--- a/code/modules/mob/living/silicon/pai/examine.dm
+++ b/code/modules/mob/living/silicon/pai/examine.dm
@@ -1,5 +1,5 @@
-/mob/living/silicon/pai/examine(mob/user, distance)
-	. = ..(user, distance, infix = ", personal AI")
+/mob/living/silicon/pai/examine(mob/user, distance, is_adjacent)
+	. = ..(user, distance, is_adjacent, infix = ", personal AI")
 
 	var/msg = ""
 	switch(src.stat)

--- a/code/modules/mob/living/silicon/robot/examine.dm
+++ b/code/modules/mob/living/silicon/robot/examine.dm
@@ -1,6 +1,6 @@
-/mob/living/silicon/robot/examine(mob/user, distance)
+/mob/living/silicon/robot/examine(mob/user, distance, is_adjacent)
 	var/custom_infix = custom_name ? ", [modtype] [braintype]" : ""
-	. = ..(user, distance, infix = custom_infix)
+	. = ..(user, distance, is_adjacent, infix = custom_infix)
 
 	var/msg = ""
 	var/damage_msg = ""

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -207,9 +207,9 @@
 /atom/movable/openspace/turf_proxy/attack_generic(mob/user as mob)
 	loc.attack_generic(user)
 
-/atom/movable/openspace/turf_proxy/examine(mob/examiner)
+/atom/movable/openspace/turf_proxy/examine(...)
 	SHOULD_CALL_PARENT(FALSE)
-	. = loc.examine(examiner)
+	. = loc.examine(arglist(args))
 
 
 // -- TURF MIMIC --
@@ -235,6 +235,6 @@
 /atom/movable/openspace/turf_mimic/attack_generic(mob/user as mob)
 	to_chat(user, SPAN_NOTICE("You cannot reach \the [src] from here."))
 
-/atom/movable/openspace/turf_mimic/examine(mob/examiner)
+/atom/movable/openspace/turf_mimic/examine(...)
 	SHOULD_CALL_PARENT(FALSE)
-	. = delegate.examine(examiner)
+	. = delegate.examine(arglist(args))

--- a/code/modules/persistence/noticeboards.dm
+++ b/code/modules/persistence/noticeboards.dm
@@ -152,10 +152,10 @@
 
 
 /obj/structure/noticeboard/attack_ai(mob/user)
-	examine(user)
+	examinate(user, src)
 
 /obj/structure/noticeboard/attack_hand(mob/user)
-	examine(user)
+	examinate(user, src)
 
 /obj/structure/noticeboard/examine(mob/user)
 	. = ..()

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -58,6 +58,7 @@ exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 6 "uses of .len" '\.len\b' -P
 exactly 394 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 15 "uses of examine()" '[.|\s]examine\(' -P # If this fails it's likely because you used '/atom/proc/examine(mob)' instead of '/proc/examinate(mob, atom)' - Exception: An examine()-proc may call other examine()-procs
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 num=`find ./html/changelogs -not -name "*.yml" | wc -l`


### PR DESCRIPTION
Have wristwatch examine-proc use the distance var
Have wristwatch CheckTime-proc require a user
Have wristwatch OnTopic-proc use correct examination proc

Also:
Add check to ensure use of correct examination-proc in the future
Clean up various examine-calls
Adds an is_adjacent-var

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->