### PR TITLE
Fix broken interactions with walls and catwalks

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -148,7 +148,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		return FALSE
 
 
-/turf/can_use_item(obj/item/tool, mob/living/user, click_params)
+/turf/simulated/floor/can_use_item(obj/item/tool, mob/living/user, click_params)
 	. = ..()
 	if (!.)
 		return


### PR DESCRIPTION
It probably shouldn't be possible to build walls on catwalks at all, but that's a lot more complex of a fix that requires touching and reworking underlying code.

## Changelog
:cl: SierraKomodo
bugfix: Catwalks no longer block interactions with walls.
/:cl:

## Bug Fixes
- Fixes #34000