### PR TITLE
fix chameleon items not being usable

### DIFF
--- a/code/datums/extensions/chameleon.dm
+++ b/code/datums/extensions/chameleon.dm
@@ -24,6 +24,7 @@
 
 	atom_holder = holder
 	chameleon_verb = /atom/proc/chameleon_appearance
+	atom_holder.verbs += chameleon_verb
 
 /datum/extension/chameleon/Destroy()
 	. = ..()


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed chameleon kit items not working. 
/:cl:

fixed #33871