### PR TITLE
Fixes parrying

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -292,20 +292,20 @@ avoid code duplication. This includes items that may sometimes act as a standard
 				SPAN_WARNING("You feel something bounce off you harmlessly.")
 			)
 			return TRUE
-		playsound(src, weapon.hitsound, 75, TRUE)
-		user.visible_message(
-			SPAN_DANGER("\The [user] hits \the [src] with \a [weapon]!"),
-			SPAN_DANGER("You hit \the [src] with \the [weapon]!"),
-			exclude_mobs = list(src)
-		)
-		show_message(
-			SPAN_DANGER("\The [user] hits you with \a [weapon]!"),
-			VISIBLE_MESSAGE,
-			SPAN_DANGER("You feel something hit you!")
-		)
-		general_health_adjustment(weapon.force, weapon.damtype, damage_flags, user.zone_sel?.selecting, weapon)
-		return TRUE
 
+		var/hit_zone = resolve_item_attack(weapon, user, user.zone_sel? user.zone_sel.selecting : ran_zone())
+		if (!hit_zone)
+			return TRUE
+
+		var/datum/attack_result/result = hit_zone
+		if (istype(result))
+			if (result.hit_zone)
+				var/mob/living/victim = result.attackee ? result.attackee : src
+				weapon.apply_hit_effect(victim, user, result.hit_zone)
+				return TRUE
+		if (hit_zone)
+			weapon.apply_hit_effect(src, user, hit_zone)
+		return TRUE
 	return ..()
 
 
@@ -450,7 +450,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
  */
 /obj/item/proc/apply_hit_effect(mob/living/target, mob/living/user, hit_zone)
 	if (hitsound)
-		playsound(loc, hitsound, 50, TRUE, -1)
+		playsound(loc, hitsound, 75, TRUE)
 	var/power = force
 	if (MUTATION_HULK in user.mutations)
 		power *= 2

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -18,6 +18,14 @@
 	if(!damage)
 		return FALSE
 
+	switch (damagetype)
+		if (DAMAGE_EMP, DAMAGE_FIRE)
+			return FALSE // These damages are handled separately by existing legacy code
+		if (DAMAGE_BIO)
+			damagetype = DAMAGE_TOXIN
+		if (DAMAGE_EXPLODE, DAMAGE_PSIONIC)
+			damagetype = DAMAGE_BRUTE
+
 	switch(damagetype)
 		if (DAMAGE_BRUTE)
 			adjustBruteLoss(damage)
@@ -31,12 +39,14 @@
 			adjustOxyLoss(damage)
 		if (DAMAGE_GENETIC)
 			adjustCloneLoss(damage)
-		if (DAMAGE_PAIN)
+		if (DAMAGE_STUN, DAMAGE_PAIN)
 			adjustHalLoss(damage)
 		if (DAMAGE_SHOCK)
 			electrocute_act(damage, used_weapon, 1, def_zone)
 		if (DAMAGE_RADIATION)
 			apply_radiation(damage)
+		if (DAMAGE_BRAIN)
+			adjustBrainLoss(damage)
 
 	updatehealth()
 	return TRUE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -144,9 +144,6 @@
 		var/turf/simulated/location = get_turf(src)
 		if(istype(location)) location.add_blood_floor(src)
 
-	if (ai_holder)
-		ai_holder.react_to_attack(user)
-
 ///returns false if the effects failed to apply for some reason, true otherwise.
 /mob/living/proc/standard_weapon_hit_effects(obj/item/I, mob/living/user, effective_force, hit_zone)
 	if(!effective_force)

--- a/code/modules/mob/living/simple_animal/defense.dm
+++ b/code/modules/mob/living/simple_animal/defense.dm
@@ -60,16 +60,6 @@
 	return
 
 
-/mob/living/simple_animal/use_weapon(obj/item/weapon, mob/user, list/click_params)
-	// Attempt attack
-	var/result = weapon.attack(src, user, user.zone_sel ? user.zone_sel.selecting : ran_zone())
-	if (result && ai_holder)
-		ai_holder.react_to_attack(user)
-		return TRUE
-
-	return ..()
-
-
 /mob/living/simple_animal/use_tool(obj/item/tool, mob/user, list/click_params)
 	// Butcher's Cleaver - Butcher dead mob
 	if (istype(tool, /obj/item/material/knife/kitchen/cleaver))
@@ -132,12 +122,15 @@
 
 	return ..()
 
+/mob/living/simple_animal/post_use_item(obj/item/tool, mob/living/user, interaction_handled, use_call, click_params)
+	if (interaction_handled && ai_holder && (use_call == "attack" || use_call == "weapon"))
+		ai_holder.react_to_attack(user)
+	..()
 
 /mob/living/simple_animal/hit_with_weapon(obj/item/O, mob/living/user, effective_force, hit_zone)
 
 	visible_message(SPAN_DANGER("\The [src] has been attacked with \the [O] by [user]!"))
-
-	if(O.force <= resistance)
+	if (O.force <= resistance)
 		to_chat(user, SPAN_DANGER("This weapon is ineffective; it does no damage."))
 		return FALSE
 
@@ -146,16 +139,14 @@
 		damage = 0
 	if (O.damtype == DAMAGE_STUN)
 		damage = (O.force / 8)
-	if(supernatural && istype(O,/obj/item/nullrod))
+	if (supernatural && istype(O,/obj/item/nullrod))
 		damage *= 2
 		purge = 3
 	adjustBruteLoss(damage)
-	if(O.edge || O.sharp)
+	if (O.edge || O.sharp)
 		adjustBleedTicks(damage)
-
 	if (ai_holder)
 		ai_holder.react_to_attack(user)
-
 	return TRUE
 
 /mob/living/simple_animal/proc/reflect_unarmed_damage(mob/living/carbon/human/attacker, damage_type, description)


### PR DESCRIPTION
🆑 emmanuelbassil, Mucker
bugfix: Restored ability to parry attacks.
bugfix: Restored ability for melee attacks with weapons to miss. 
bugfix: Some melee weapons no longer ignore armor
/🆑 

Moved simple mob's react to attack to post_use_item. A superfluous one has been kept in hit_with_weapon because attacks() still don't feed into the use_* chain. Keeping ai_holder.react under hit_with_weapon remedies that.
In the refactor, where all attacks() are part of the use* chain, post_use_item is sufficient and I can remove this. Superfluous code called by hit_with_weapon and succeeding procs will also be handled in the refactor and not here.

Since melee attacks no longer calls general_health_adjustment; moved relevant code to apply_damage. General_health_adjustment is now only used to directly adjust health using damage_health and restore_health. In the far (far, far, far) future I might explore whether these two can be just be one proc. But I'm tapped out on refactors for the near future.

Proof of concept:
![image](https://github.com/Baystation12/Baystation12/assets/6874235/f3c518db-3f80-429b-9138-22488605e19e)

Also tested human to human and works.
Fixes #33975 
Fixes #33932 