### PR TITLE
Remove language when removing changeling

### DIFF
--- a/code/game/antagonist/station/changeling.dm
+++ b/code/game/antagonist/station/changeling.dm
@@ -28,6 +28,7 @@ GLOBAL_DATUM_INIT(changelings, /datum/antagonist/changeling, new)
 	if(. && player && player.current)
 		player.current.remove_changeling_powers()
 		player.current.verbs -= /datum/changeling/proc/EvolutionMenu
+		player.current.remove_language(LANGUAGE_CHANGELING_GLOBAL)
 		QDEL_NULL(player.changeling)
 
 /datum/antagonist/changeling/create_objectives(datum/mind/changeling)


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Mobs no longer keep access to the changeling hivemind when their changeling status is removed.
/:cl:

## Bug Fixes
- Fixes #32441