### PR TITLE
Nabber Kill Grab Fixes

### DIFF
--- a/code/modules/mob/grab/nab/grab_nab.dm
+++ b/code/modules/mob/grab/nab/grab_nab.dm
@@ -34,13 +34,14 @@
 
 	affecting.visible_message(SPAN_DANGER("[assailant] begins crushing [affecting]!"))
 	G.attacking = 1
-	if(do_after(assailant, action_cooldown - 1, affecting, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS))
+	if(do_after(assailant, action_cooldown - 1, affecting, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS) && assailant.use_sanity_check(affecting, G))
 		G.attacking = 0
 		G.action_used()
 		crush(G, crush_damage)
 		return TRUE
 	else
-		G.attacking = 0
+		if (G) // In case the grab was deleted during the timer
+			G.attacking = 0
 		affecting.visible_message(SPAN_NOTICE("[assailant] stops crushing [affecting]!"))
 		return TRUE
 
@@ -53,13 +54,14 @@
 	affecting.visible_message(SPAN_DANGER("[assailant] begins chewing on [affecting]!"))
 	G.attacking = 1
 
-	if(do_after(assailant, action_cooldown - 1, affecting, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS))
+	if(do_after(assailant, action_cooldown - 1, affecting, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS) && assailant.use_sanity_check(affecting, G))
 		G.attacking = 0
 		G.action_used()
 		masticate(G, masticate_damage)
 		return TRUE
 	else
-		G.attacking = 0
+		if (G) // In case the grab was deleted during the timer
+			G.attacking = 0
 		affecting.visible_message(SPAN_NOTICE("[assailant] stops chewing on [affecting]."))
 		return TRUE
 

--- a/code/modules/mob/grab/nab/nab_kill.dm
+++ b/code/modules/mob/grab/nab/nab_kill.dm
@@ -18,6 +18,8 @@
 	process_effect(G)
 
 /datum/grab/nab/kill/process_effect(obj/item/grab/G)
+	if (G.attacking)
+		return
 	var/mob/living/carbon/human/assailant = G.assailant
 	var/mob/living/carbon/human/affecting = G.affecting
 


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Nabber (GAS) kill-grabs no longer repeatedly cancel themselves.
/:cl:

## Bug Fixes
- Fixes #32442

## Other Fixes
- Resolves some runtime errors relating to the grab being dropped or deleted while processing a kill-grab.