### PR TITLE
Tweaks grab returns

### DIFF
--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -249,19 +249,19 @@
 
 // What happens when you hit the grabbed person with the grab on help intent.
 /datum/grab/proc/on_hit_help(obj/item/grab/G)
-	return TRUE
+	return FALSE
 
 // What happens when you hit the grabbed person with the grab on disarm intent.
 /datum/grab/proc/on_hit_disarm(obj/item/grab/G)
-	return TRUE
+	return FALSE
 
 // What happens when you hit the grabbed person with the grab on grab intent.
 /datum/grab/proc/on_hit_grab(obj/item/grab/G)
-	return TRUE
+	return FALSE
 
 // What happens when you hit the grabbed person with the grab on harm intent.
 /datum/grab/proc/on_hit_harm(obj/item/grab/G)
-	return TRUE
+	return FALSE
 
 // What happens when you hit the grabbed person with an open hand and you want it
 // to do some special snowflake action based on some other factor such as

--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -38,12 +38,11 @@
 	var/mob/living/carbon/human/affecting = G.affecting
 	var/mob/living/carbon/human/assailant = G.assailant
 
-	if(!G.attacking && !affecting.lying)
-
-		affecting.visible_message(SPAN_NOTICE("[assailant] is trying to pin [affecting] to the ground!"))
+	if (!G.attacking && !affecting.lying)
+		affecting.visible_message(SPAN_NOTICE("\The [assailant] is trying to pin \the [affecting] to the ground!"))
 		G.attacking = 1
 
-		if(do_after(assailant, action_cooldown - 1, affecting, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS))
+		if (do_after(assailant, action_cooldown - 1, affecting, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS) && assailant.use_sanity_check(affecting, G))
 			G.attacking = 0
 			G.action_used()
 			affecting.Weaken(2)
@@ -63,18 +62,18 @@
 	var/mob/living/carbon/human/assailant = G.assailant
 	var/mob/living/carbon/human/affecting = G.affecting
 
-	if(!assailant.skill_check(SKILL_COMBAT, SKILL_TRAINED))
+	if (!assailant.skill_check(SKILL_COMBAT, SKILL_TRAINED))
 		to_chat(assailant, SPAN_NOTICE("You don't know how to do a jointlock!"))
-		return TRUE
+		return FALSE
 
 	if(!O)
 		to_chat(assailant, SPAN_WARNING("[affecting] is missing that body part!"))
-		return TRUE
+		return FALSE
 
-	assailant.visible_message(SPAN_CLASS("danger", "[assailant] begins to [pick("bend", "twist")] [affecting]'s [O.name] into a jointlock!"))
+	assailant.visible_message(SPAN_CLASS("danger", "\The [assailant] begins to [pick("bend", "twist")] \the [affecting]'s [O.name] into a jointlock!"))
 	G.attacking = 1
 
-	if(do_after(assailant, action_cooldown - 1, affecting, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS))
+	if (do_after(assailant, action_cooldown - 1, affecting, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS) && assailant.use_sanity_check(affecting, G))
 		if (!G.has_hold_on_organ(O))
 			to_chat(assailant, SPAN_WARNING("You must keep a hold on your target to jointlock!"))
 			return TRUE
@@ -99,20 +98,20 @@
 	var/mob/living/carbon/human/assailant = G.assailant
 	var/mob/living/carbon/human/affecting = G.affecting
 
-	if(!assailant.skill_check(SKILL_COMBAT, SKILL_TRAINED))
+	if (!assailant.skill_check(SKILL_COMBAT, SKILL_TRAINED))
 		to_chat(assailant, SPAN_NOTICE("You don't know how to dislocate a joint!"))
-		return TRUE
+		return FALSE
 
-	if(!O)
-		to_chat(assailant, SPAN_WARNING("[affecting] is missing that body part!"))
-		return TRUE
+	if (!O)
+		to_chat(assailant, SPAN_WARNING("\The [affecting] is missing that body part!"))
+		return FALSE
 
-	if(!O.dislocated)
+	if (!O.dislocated)
 
-		assailant.visible_message(SPAN_WARNING("[assailant] begins to dislocate [affecting]'s [O.joint]!"))
+		assailant.visible_message(SPAN_WARNING("\The [assailant] begins to dislocate \the [affecting]'s [O.joint]!"))
 		G.attacking = 1
 
-		if(do_after(assailant, action_cooldown - 1, affecting, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS))
+		if (do_after(assailant, action_cooldown - 1, affecting, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS) && assailant.use_sanity_check(affecting, G))
 
 			if (!G.has_hold_on_organ(O))
 				to_chat(assailant, SPAN_WARNING("You must keep a hold on your target to dislocate!"))
@@ -133,10 +132,10 @@
 
 	else if (O.dislocated > 0)
 		to_chat(assailant, SPAN_WARNING("[affecting]'s [O.joint] is already dislocated!"))
-		return TRUE
+		return FALSE
 	else
 		to_chat(assailant, SPAN_WARNING("You can't dislocate [affecting]'s [O.joint]!"))
-		return TRUE
+		return FALSE
 
 /datum/grab/normal/resolve_openhand_attack(obj/item/grab/G)
 	if(G.assailant.a_intent != I_HELP)


### PR DESCRIPTION
Was testing the fixed grabs and noticed that having the conditions return TRUE led to a cooldown triggering, which seems unbalanced and sucks. Now if you're not skilled enough to joint lock or if the organ you want to dislocate is missing, you won't pause for 3 seconds to take a breather. Failed grabs after trying still return TRUE to trigger the cooldown.

While theoretically returning false leads to grab/resolve_attackby to continue and call all the other use_'s, that was how it was behaving before my fix anyways. 

If wanted, we could just have resolve_attackby not return the use_chain at all anyways since there's no conceivable use of a grab needing use_tool, use_weapon, attack(), afterattack() etc. Even post_use_item, which adds fingerprint after any successful use_* is handed by grab's action_used(). Besides, use_grab was not calling post_use_item to start with under current implementation.

Also saw Sierra's sanity check on the nabber grabs and I wanted in on the action.

