### PR TITLE
Fixes some hostile mob targeting

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -190,17 +190,16 @@
 	Animals
 */
 /mob/living/simple_animal/UnarmedAttack(atom/A, proximity)
-
-	if(!..())
+	if (!..())
 		return
 	setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
-	if(istype(A,/mob/living))
-		if(!get_natural_weapon() || a_intent == I_HELP)
-			custom_emote(1,"[friendly] [A]!")
+	if (istype(A,/mob/living))
+		if (!get_natural_weapon() || a_intent == I_HELP)
+			custom_emote(VISIBLE_MESSAGE, "[friendly] [A]!")
 			return
-		if(ckey)
+		if (ckey)
 			admin_attack_log(src, A, "Has attacked its victim.", "Has been attacked by its attacker.")
-	if(a_intent == I_HELP)
+	if (a_intent == I_HELP)
 		A.attack_animal(src)
 	else if (get_natural_weapon())
 		A.attackby(get_natural_weapon(), src)

--- a/code/game/atoms_health.dm
+++ b/code/game/atoms_health.dm
@@ -88,8 +88,6 @@
 	SHOULD_CALL_PARENT(TRUE)
 	if (!get_max_health())
 		return FALSE
-	if (health_dead())
-		return FALSE
 	if (!damage || damage < health_min_damage)
 		return FALSE
 	if (is_damage_immune(damage_type))

--- a/code/modules/mob/living/simple_animal/hostile/antlion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/antlion.dm
@@ -50,43 +50,46 @@
 /mob/living/simple_animal/hostile/retaliate/beast/antlion/proc/vanish()
 	visible_message(SPAN_NOTICE("\The [src] burrows into \the [get_turf(src)]!"))
 	set_invisibility(INVISIBILITY_OBSERVER)
+	set_density(FALSE)
 	prep_burrow(TRUE)
 	addtimer(new Callback(src, .proc/diggy), 5 SECONDS)
 
 /mob/living/simple_animal/hostile/retaliate/beast/antlion/proc/diggy()
-	var/list/turf_targets
-	if(target_mob)
-		for(var/turf/T in range(1, get_turf(target_mob)))
-			if(!T.is_floor())
+	var/list/turf_targets = list()
+	if (ai_holder.target)
+		for (var/turf/T in range(2, get_turf(ai_holder.target)))
+			if (!T.is_floor())
 				continue
-			if(!T.z != src.z)
+			if (T.z != src.z)
 				continue
 			turf_targets += T
 	else
-		for(var/turf/T in orange(5, src))
-			if(!T.is_floor())
+		for (var/turf/T in orange(5, src))
+			if (!T.is_floor())
 				continue
-			if(!T.z != src.z)
+			if (T.z != src.z)
 				continue
 			turf_targets += T
-	if(!LAZYLEN(turf_targets)) //oh no
+	if (!LAZYLEN(turf_targets))
 		addtimer(new Callback(src, .proc/emerge, 2 SECONDS))
 		return
 	var/turf/T = pick(turf_targets)
-	if(T && !incapacitated())
+	if (T && !incapacitated())
 		forceMove(T)
 	addtimer(new Callback(src, .proc/emerge, 2 SECONDS))
 
 /mob/living/simple_animal/hostile/retaliate/beast/antlion/proc/emerge()
 	var/turf/T = get_turf(src)
-	if(!T)
+	if (!T)
 		return
 	visible_message(SPAN_WARNING("\The [src] erupts from \the [T]!"))
 	set_invisibility(initial(invisibility))
+	set_density(TRUE)
 	prep_burrow(FALSE)
 	// cooldown_ability(ability_cooldown)
-	for(var/mob/living/carbon/human/H in get_turf(src))
-		H.attackby(natural_weapon, src)
+	for (var/mob/living/carbon/human/H in get_turf(src))
+		var/obj/item/weapon = get_natural_weapon()
+		weapon.resolve_attackby(H, src)
 		visible_message(SPAN_DANGER("\The [src] tears into \the [H] from below!"))
 		H.Weaken(1)
 

--- a/code/modules/mob/living/simple_animal/hostile/leech.dm
+++ b/code/modules/mob/living/simple_animal/hostile/leech.dm
@@ -50,7 +50,7 @@ Tiny, weak, and mostly harmless alone. dangerous in groups.
 	if(!.)
 		return FALSE
 
-	if(target_mob)
+	if(ai_holder.target)
 		belly -= 3
 	else
 		belly -= 1

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/exoplanet.dm
@@ -198,9 +198,8 @@
 
 /datum/ai_holder/simple_animal/melee/charbaby/engage_target()
 	. = ..()
-	var/mob/living/simple_animal/hostile/retaliate/beast/charbaby/C = holder
-	if(isliving(C.target_mob) && prob(25))
-		var/mob/living/L = C.target_mob
+	if(isliving(target) && prob(25))
+		var/mob/living/L = target
 		if(prob(10))
 			L.adjust_fire_stacks(1)
 			L.IgniteMob()

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
@@ -42,8 +42,8 @@
 /datum/ai_holder/simple_animal/goat/king/engage_target()
 	. = ..()
 	var/mob/living/simple_animal/hostile/retaliate/goat/king/G = holder
-	if(isliving(G.target_mob))
-		var/mob/living/L = G.target_mob
+	if(isliving(target))
+		var/mob/living/L = target
 		if(prob(G.stun_chance))
 			L.Weaken(0.5)
 			L.confused += 1

--- a/code/modules/mob/living/simple_animal/hostile/vagrant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vagrant.dm
@@ -62,8 +62,8 @@
 		return PROJECTILE_FORCE_MISS
 	var/oldhealth = health
 	. = ..()
-	if((target_mob != Proj.firer) && health < oldhealth && !incapacitated(INCAPACITATION_KNOCKOUT)) //Respond to being shot at
-		target_mob = Proj.firer
+	if((ai_holder.target != Proj.firer) && health < oldhealth && !incapacitated(INCAPACITATION_KNOCKOUT)) //Respond to being shot at
+		ai_holder.target = Proj.firer
 		turns_per_move = 3
 		ai_holder.walk_to_target()
 


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: Antlions now properly burrow and appear near/on you to ruin your day.
bugfix: King goats have re-learned the lost skill of explorer bowling, and have a chance of running you over.
bugfix: Charbabys now have a 10% chance per attack of setting you on fire again.
/🆑 

Also fixed leeches becoming hungrier if they're pursuing you; fixed vagrants responding to whoever shoots them.
But the hunger feature for leeches isn't really used much (might expand in the future), and vagrants being the OP little weasels that they are aren't in game.
Replaced antlion's attack() by resolve_attackby since I know its specific weapon has no attack() override. Didn't do it for the others simple_mobs as I'm unsure, it's done in the refactor however.