### PR TITLE
Remove BD probability for denying interaction + increase threshold for denying interaction

### DIFF
--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -238,11 +238,8 @@
 		return TRUE
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
-		if(H.getBrainLoss() >= 55)
+		if(H.getBrainLoss() >= 80)
 			visible_message(SPAN_WARNING("\The [H] stares cluelessly at \the [src]."))
-			return TRUE
-		else if(prob(H.getBrainLoss()))
-			to_chat(user, SPAN_WARNING("You momentarily forget how to use \the [src]."))
 			return TRUE
 	if((. = component_attack_hand(user)))
 		return


### PR DESCRIPTION
:cl:
tweak: Remove probability for the "You momentarily forget ..!" interaction when brain damaged.
tweak: Increase threshold to 80 brain damage for "You look at x cluelessly" interaction.
/:cl:

Brain damage used to prevent you from doing anything useful if you were remotely above 60-70 brain damage (60-70% probability). And above 55 you couldn't do anything at all.

Increases both of that because getting 55+ brain damage but still being functional is a possibility and it's sort of dumb to attribute such a low number to effectively being a goner.