### PR TITLE
Exoplanet Gen tweaks

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -259,10 +259,14 @@
 //Lying animation
 #define ANIM_LYING_TIME 2
 
-//Planet habitability class
-#define HABITABILITY_IDEAL  1
-#define HABITABILITY_OKAY  2
-#define HABITABILITY_BAD  3
+
+//Planet habitability weight
+#define HABITABILITY_LOCKED			1
+#define HABITABILITY_TYPICAL		2
+#define HABITABILITY_BAD 			3
+#define HABITABILITY_EXTREME		4
+#define HABITABILITY_RANDOM			5
+
 
 #ifndef WINDOWS_HTTP_POST_DLL_LOCATION
 #define WINDOWS_HTTP_POST_DLL_LOCATION "lib/byhttp.dll"

--- a/code/modules/ZAS/Fire.dm
+++ b/code/modules/ZAS/Fire.dm
@@ -271,7 +271,8 @@ If it gains pressure too slowly, it may leak or just rupture instead of explodin
 			adjust_gas(gas_data.burn_product[g], burned_fuel.gas[g])
 
 		//calculate the energy produced by the reaction and then set the new temperature of the mix
-		temperature = (starting_energy + vsc.fire_fuel_energy_release * (used_gas_fuel)) / heat_capacity()
+		var/energy = starting_energy + vsc.fire_fuel_energy_release * (used_gas_fuel)
+		add_thermal_energy(energy)
 		update_values()
 
 		#ifdef FIREDBG

--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -62,18 +62,8 @@ GLOBAL_VAR(planet_repopulation_disabled)
 	var/list/spawned_features
 
 	//Either a type or a list of types and weights. You must include all types if it's a list
-	var/list/habitability_distribution = list(
-		HABITABILITY_IDEAL = 10,
-		HABITABILITY_OKAY = 40,
-		HABITABILITY_BAD = 50
-	)
-	var/habitability_class
 
-/obj/effect/overmap/visitable/sector/exoplanet/proc/generate_habitability()
-	if (isnum(habitability_distribution))
-		habitability_class = habitability_distribution
-	else
-		habitability_class = pickweight_index(habitability_distribution)
+	var/habitability_weight = HABITABILITY_TYPICAL
 
 /obj/effect/overmap/visitable/sector/exoplanet/New(nloc, max_x, max_y)
 	if (!GLOB.using_map.use_overmap)
@@ -115,14 +105,13 @@ GLOBAL_VAR(planet_repopulation_disabled)
 	..()
 
 /obj/effect/overmap/visitable/sector/exoplanet/proc/build_level()
-	generate_habitability()
 	generate_atmosphere()
 	for (var/datum/exoplanet_theme/T in themes)
 		T.adjust_atmosphere(src)
 	if (atmosphere)
 		//Set up gases for living things
 		if (!length(breathgas))
-			var/list/goodgases = gas_data.gases.Copy()
+			var/list/goodgases = atmosphere.gas.Copy()
 			var/gasnum = min(rand(1,3), length(goodgases))
 			for (var/i = 1 to gasnum)
 				var/gas = pick(goodgases)

--- a/code/modules/overmap/exoplanets/exoplanet_atmosphere.dm
+++ b/code/modules/overmap/exoplanets/exoplanet_atmosphere.dm
@@ -1,9 +1,10 @@
 /obj/effect/overmap/visitable/sector/exoplanet/proc/generate_atmosphere()
 	atmosphere = new
-	if (habitability_class == HABITABILITY_IDEAL)
+	if (habitability_weight == HABITABILITY_LOCKED)
 		atmosphere.adjust_gas(GAS_OXYGEN, MOLES_O2STANDARD, 0)
 		atmosphere.adjust_gas(GAS_NITROGEN, MOLES_N2STANDARD)
 	else //let the fuckery commence
+		var/habitability
 		var/list/newgases = gas_data.gases.Copy()
 		if (prob(90)) //all phoron planet should be rare
 			newgases -= GAS_PHORON
@@ -11,37 +12,50 @@
 			newgases -= GAS_ALIEN
 		newgases -= GAS_STEAM
 
-		var/total_moles = MOLES_CELLSTANDARD * rand(80,120)/100
+		switch(habitability_weight)
+			if (HABITABILITY_TYPICAL)
+				habitability = NORMAL_RAND
+			if (HABITABILITY_BAD)
+				habitability = LINEAR_RAND
+			if (HABITABILITY_EXTREME)
+				habitability = SQUARE_RAND
+			else
+				habitability = UNIFORM_RAND
+
+		var/total_moles = MOLES_CELLSTANDARD * (rand(7, 40) / 10)
+		var/generator/new_moles = generator("num", 0.05 * total_moles, 0.5 * total_moles, habitability)
 		var/badflag = 0
 
-		//Breathable planet
-		if (habitability_class == HABITABILITY_OKAY)
-			atmosphere.gas[GAS_OXYGEN] += MOLES_O2STANDARD
-			total_moles -= MOLES_O2STANDARD
-			badflag = XGM_GAS_FUEL|XGM_GAS_CONTAMINANT
+		var/gasnum = rand(max(habitability_weight - 1, 1), 4)
+		var/i = 0
 
-		var/gasnum = rand(1,4)
-		var/i = 1
-		var/sanity = prob(99.9)
 		while (i <= gasnum && total_moles && length(newgases))
-			if (badflag && sanity)
+			if (badflag)
 				for(var/g in newgases)
 					if (gas_data.flags[g] & badflag)
 						newgases -= g
-			var/ng = pick_n_take(newgases)	//pick a gas
-			if (sanity) //make sure atmosphere is not flammable... always
-				if (gas_data.flags[ng] & XGM_GAS_OXIDIZER)
-					badflag |= XGM_GAS_FUEL
-				if (gas_data.flags[ng] & XGM_GAS_FUEL)
-					badflag |= XGM_GAS_OXIDIZER
-				sanity = 0
 
-			var/part = total_moles * rand(3,80)/100 //allocate percentage to it
+			var/ng = pick_n_take(newgases)	//pick a gas
+
+			if (gas_data.flags[ng] & XGM_GAS_OXIDIZER)
+				badflag |= XGM_GAS_OXIDIZER
+				if (prob(33))
+					badflag |= (XGM_GAS_FUSION_FUEL | XGM_GAS_FUEL)
+
+			if ((gas_data.flags[ng] & XGM_GAS_FUEL) || (gas_data.flags[ng] & XGM_GAS_FUSION_FUEL))
+				badflag |= (XGM_GAS_FUSION_FUEL | XGM_GAS_FUEL)
+				if (prob(33))
+					badflag |= XGM_GAS_OXIDIZER
+
+			var/part = min(0.33 * total_moles, new_moles.Rand()) //allocate percentage to it
 			if (i == gasnum || !length(newgases)) //if it's last gas, let it have all remaining moles
 				part = total_moles
+
 			atmosphere.gas[ng] += part
 			total_moles = max(total_moles - part, 0)
 			i++
+	atmosphere.update_values()
+
 
 /obj/effect/overmap/visitable/sector/exoplanet/proc/get_atmosphere_color()
 	var/list/colors = list()

--- a/code/modules/overmap/exoplanets/planet_types/barren.dm
+++ b/code/modules/overmap/exoplanets/planet_types/barren.dm
@@ -4,23 +4,20 @@
 	color = "#6c6c6c"
 	planetary_area = /area/exoplanet/barren
 	rock_colors = list(COLOR_BEIGE, COLOR_GRAY80, COLOR_BROWN)
-	possible_themes = list(/datum/exoplanet_theme/mountains)
 	map_generators = list(/datum/random_map/noise/exoplanet/barren, /datum/random_map/noise/ore/rich)
 	ruin_tags_blacklist = RUIN_HABITAT|RUIN_WATER
 	features_budget = 6
 	surface_color = "#807d7a"
 	water_color = null
-	habitability_distribution = HABITABILITY_BAD
+	habitability_weight = HABITABILITY_LOCKED
 	has_trees = FALSE
 
 /obj/effect/overmap/visitable/sector/exoplanet/barren/generate_atmosphere()
-	..()
-	atmosphere.remove_ratio(0.9)
+	atmosphere = new
+	return
 
 /obj/effect/overmap/visitable/sector/exoplanet/barren/generate_flora()
-	if(prob(10))
-		flora_diversity = 1
-	..()
+	return
 
 /datum/random_map/noise/exoplanet/barren
 	descriptor = "barren exoplanet"

--- a/code/modules/overmap/exoplanets/planet_types/chlorine.dm
+++ b/code/modules/overmap/exoplanets/planet_types/chlorine.dm
@@ -9,17 +9,19 @@
 	ruin_tags_blacklist = RUIN_HABITAT|RUIN_WATER
 	surface_color = "#a3b879"
 	water_color = COLOR_BOTTLE_GREEN
-	habitability_distribution = HABITABILITY_BAD
+	habitability_weight = HABITABILITY_BAD
 	has_trees = FALSE
 	flora_diversity = 5
 	fauna_types = list(/mob/living/simple_animal/thinbug, /mob/living/simple_animal/hostile/retaliate/beast/samak/alt, /mob/living/simple_animal/yithian, /mob/living/simple_animal/tindalos, /mob/living/simple_animal/hostile/retaliate/jelly)
 	megafauna_types = list(/mob/living/simple_animal/hostile/retaliate/jelly/mega)
 
 /obj/effect/overmap/visitable/sector/exoplanet/chlorine/get_atmosphere_color()
-	return "#e5f2bd"
+	var/air_color = ..()
+	return MixColors("#e5f2bd", air_color)
+
 
 /obj/effect/overmap/visitable/sector/exoplanet/chlorine/generate_map()
-	if(prob(50))
+	if (prob(50))
 		lightlevel = rand(7,10)/10 //It could be night.
 	else
 		lightlevel = 0.1
@@ -27,10 +29,14 @@
 
 /obj/effect/overmap/visitable/sector/exoplanet/chlorine/generate_atmosphere()
 	..()
-	if(atmosphere)
-		atmosphere.adjust_gas(GAS_CHLORINE, MOLES_O2STANDARD)
-		atmosphere.temperature = T100C - rand(0, 100)
-		atmosphere.update_values()
+	var/chlorine = (rand(1, 6) / 10) * (atmosphere.total_moles)
+	atmosphere = atmosphere.remove(chlorine)
+	atmosphere.adjust_gas(GAS_CHLORINE, chlorine)
+
+	var/datum/species/H = all_species[SPECIES_HUMAN]
+	var/generator/new_temp = generator("num", H.cold_level_1 + 40, H.heat_level_1 + 10, UNIFORM_RAND)
+	atmosphere.temperature = new_temp.Rand()
+	atmosphere.update_values()
 
 /datum/random_map/noise/exoplanet/chlorine
 	descriptor = "chlorine exoplanet"

--- a/code/modules/overmap/exoplanets/planet_types/desert.dm
+++ b/code/modules/overmap/exoplanets/planet_types/desert.dm
@@ -8,7 +8,7 @@
 	map_generators = list(/datum/random_map/noise/exoplanet/desert, /datum/random_map/noise/ore/rich)
 	surface_color = "#d6cca4"
 	water_color = null
-	habitability_distribution = list(HABITABILITY_IDEAL = 30, HABITABILITY_OKAY = 50, HABITABILITY_BAD = 10)
+	habitability_weight = HABITABILITY_TYPICAL
 	has_trees = FALSE
 	flora_diversity = 4
 	fauna_types = list(/mob/living/simple_animal/thinbug, /mob/living/simple_animal/tindalos, /mob/living/simple_animal/hostile/voxslug, /mob/living/simple_animal/hostile/retaliate/beast/antlion)
@@ -21,13 +21,10 @@
 
 /obj/effect/overmap/visitable/sector/exoplanet/desert/generate_atmosphere()
 	..()
-	if(atmosphere)
-		var/limit = 1000
-		if(habitability_class <= HABITABILITY_OKAY)
-			var/datum/species/human/H = /datum/species/human
-			limit = initial(H.heat_level_1) - rand(1,10)
-		atmosphere.temperature = min(T20C + rand(20, 100), limit)
-		atmosphere.update_values()
+	var/datum/species/H = all_species[SPECIES_HUMAN]
+	var/generator/new_temp = generator("num", H.heat_level_1, 2 * H.heat_level_1, NORMAL_RAND)
+	atmosphere.temperature = new_temp.Rand()
+	atmosphere.update_values()
 
 /obj/effect/overmap/visitable/sector/exoplanet/desert/adapt_seed(datum/seed/S)
 	..()

--- a/code/modules/overmap/exoplanets/planet_types/grass.dm
+++ b/code/modules/overmap/exoplanets/planet_types/grass.dm
@@ -6,11 +6,18 @@
 	rock_colors = list(COLOR_ASTEROID_ROCK, COLOR_GRAY80, COLOR_BROWN)
 	plant_colors = list("#0e1e14","#1a3e38","#5a7467","#9eab88","#6e7248", "RANDOM")
 	map_generators = list(/datum/random_map/noise/exoplanet/grass)
-	habitability_distribution = list(HABITABILITY_IDEAL = 70, HABITABILITY_OKAY = 20, HABITABILITY_BAD = 5)
+	habitability_weight = HABITABILITY_TYPICAL
 	has_trees = TRUE
 	flora_diversity = 7
-	fauna_types = list(/mob/living/simple_animal/yithian, /mob/living/simple_animal/tindalos, /mob/living/simple_animal/hostile/retaliate/jelly)
-	megafauna_types = list(/mob/living/simple_animal/hostile/retaliate/parrot/space/megafauna, /mob/living/simple_animal/hostile/retaliate/goose/dire)
+	fauna_types = list(
+		/mob/living/simple_animal/yithian,
+		/mob/living/simple_animal/tindalos,
+		/mob/living/simple_animal/hostile/retaliate/jelly
+	)
+	megafauna_types = list(
+		/mob/living/simple_animal/hostile/retaliate/parrot/space/megafauna,
+		/mob/living/simple_animal/hostile/retaliate/goose/dire
+	)
 
 /obj/effect/overmap/visitable/sector/exoplanet/grass/generate_map()
 	if(prob(40))
@@ -19,9 +26,10 @@
 
 /obj/effect/overmap/visitable/sector/exoplanet/grass/generate_atmosphere()
 	..()
-	if(atmosphere)
-		atmosphere.temperature = T20C + rand(10, 30)
-		atmosphere.update_values()
+	var/datum/species/H = all_species[SPECIES_HUMAN]
+	var/generator/new_temp = generator("num", T0C, H.heat_level_1 - 10, UNIFORM_RAND)
+	atmosphere.temperature = new_temp.Rand()
+	atmosphere.update_values()
 
 /obj/effect/overmap/visitable/sector/exoplanet/grass/get_surface_color()
 	return grass_color
@@ -79,8 +87,20 @@
 	lightlevel = 0.5
 	has_trees = TRUE
 	flora_diversity = 8
-	fauna_types = list(/mob/living/simple_animal/passive/cat, /mob/living/simple_animal/passive/chicken, /mob/living/simple_animal/passive/mouse, /mob/living/simple_animal/passive/opossum, /mob/living/simple_animal/hostile/retaliate/goat, /mob/living/simple_animal/hostile/retaliate/goose, /mob/living/simple_animal/passive/cow)
-	megafauna_types = list(/mob/living/simple_animal/hostile/retaliate/parrot/space/megafauna, /mob/living/simple_animal/hostile/retaliate/goose/dire)
+	fauna_types = list(
+		/mob/living/simple_animal/passive/cat,
+		/mob/living/simple_animal/passive/chicken,
+		/mob/living/simple_animal/passive/mouse,
+		/mob/living/simple_animal/passive/opossum,
+		/mob/living/simple_animal/hostile/retaliate/goat,
+		/mob/living/simple_animal/hostile/retaliate/goose,
+		/mob/living/simple_animal/passive/cow
+	)
+	megafauna_types = list(
+		/mob/living/simple_animal/hostile/retaliate/parrot/space/megafauna,
+		/mob/living/simple_animal/hostile/retaliate/goose/dire
+	)
+	habitability_weight = HABITABILITY_LOCKED
 
 	//Animals being named alien creature is a bit odd as these would just be earth transplants
 	species = list( /mob/living/simple_animal/passive/cat 					  = "wild cat",
@@ -91,14 +111,14 @@
 					/mob/living/simple_animal/hostile/retaliate/goose = "goose",
 					/mob/living/simple_animal/passive/cow 					  = "wild cow")
 
-/obj/effect/overmap/visitable/sector/exoplanet/grass/terraformed/generate_habitability()
-	habitability_class = HABITABILITY_IDEAL
 
 /obj/effect/overmap/visitable/sector/exoplanet/grass/terraformed/generate_atmosphere()
 	..()
-	if(atmosphere)
-		atmosphere.temperature = T0C + rand(0, 50)
-		atmosphere.update_values()
+	var/datum/species/H = all_species[SPECIES_HUMAN]
+	var/generator/new_temp = generator("num", T20C, H.heat_level_1 - 15)
+	atmosphere.temperature = new_temp.Rand()
+	to_debug_listeners("[name] temperature set to [atmosphere.temperature]. Alternative value could be [new_temp.Rand()].")
+	atmosphere.update_values()
 
 /obj/effect/overmap/visitable/sector/exoplanet/grass/generate_map()
 	lightlevel = rand(0.7,0.9)/10

--- a/code/modules/overmap/exoplanets/planet_types/shrouded.dm
+++ b/code/modules/overmap/exoplanets/planet_types/shrouded.dm
@@ -12,20 +12,23 @@
 	water_color = "#2b2840"
 	has_trees = TRUE
 	flora_diversity = 4
-	fauna_types = list(/mob/living/simple_animal/hostile/retaliate/royalcrab,
-					   /mob/living/simple_animal/hostile/retaliate/jelly/alt,
-					   /mob/living/simple_animal/hostile/retaliate/beast/shantak/alt,
-					   /mob/living/simple_animal/hostile/leech)
+	fauna_types = list(
+		/mob/living/simple_animal/hostile/retaliate/royalcrab,
+		/mob/living/simple_animal/hostile/retaliate/jelly/alt,
+		/mob/living/simple_animal/hostile/retaliate/beast/shantak/alt,
+		/mob/living/simple_animal/hostile/leech
+	)
 
 
 /obj/effect/overmap/visitable/sector/exoplanet/shrouded/generate_atmosphere()
 	..()
-	if(atmosphere)
-		atmosphere.temperature = T20C - rand(10, 20)
+	if (atmosphere)
+		atmosphere.temperature = rand(T0C, T20C)
 		atmosphere.update_values()
 
 /obj/effect/overmap/visitable/sector/exoplanet/shrouded/get_atmosphere_color()
-	return COLOR_BLACK
+	var/air_color = ..()
+	return MixColors(COLOR_BLACK, air_color)
 
 /datum/random_map/noise/exoplanet/shrouded
 	descriptor = "shrouded exoplanet"
@@ -41,7 +44,7 @@
 /datum/random_map/noise/exoplanet/shrouded/get_additional_spawns(value, turf/T)
 	..()
 
-	if(prob(0.1))
+	if (prob(0.1))
 		new/obj/structure/leech_spawner(T)
 
 /area/exoplanet/shrouded

--- a/code/modules/overmap/exoplanets/planet_types/snow.dm
+++ b/code/modules/overmap/exoplanets/planet_types/snow.dm
@@ -8,21 +8,22 @@
 	map_generators = list(/datum/random_map/noise/exoplanet/snow, /datum/random_map/noise/ore/poor)
 	surface_color = "#e8faff"
 	water_color = "#b5dfeb"
-	habitability_distribution = list(HABITABILITY_IDEAL = 30, HABITABILITY_OKAY = 50, HABITABILITY_BAD = 10)
+	habitability_weight = HABITABILITY_BAD
 	has_trees = TRUE
 	flora_diversity = 4
-	fauna_types = list(/mob/living/simple_animal/hostile/retaliate/beast/samak, /mob/living/simple_animal/hostile/retaliate/beast/diyaab, /mob/living/simple_animal/hostile/retaliate/beast/shantak)
+	fauna_types = list(
+		/mob/living/simple_animal/hostile/retaliate/beast/samak,
+		/mob/living/simple_animal/hostile/retaliate/beast/diyaab,
+		/mob/living/simple_animal/hostile/retaliate/beast/shantak
+	)
 	megafauna_types = list(/mob/living/simple_animal/hostile/retaliate/giant_crab)
 
 /obj/effect/overmap/visitable/sector/exoplanet/snow/generate_atmosphere()
 	..()
-	if(atmosphere)
-		var/limit = 0
-		if(habitability_class <= HABITABILITY_OKAY)
-			var/datum/species/human/H = /datum/species/human
-			limit = initial(H.cold_level_1) + rand(1,10)
-		atmosphere.temperature = max(T0C - rand(10, 100), limit)
-		atmosphere.update_values()
+	var/datum/species/H = all_species[SPECIES_HUMAN]
+	var/generator/new_temp = generator("num", H.cold_level_1 - 50, H.cold_level_3, NORMAL_RAND)
+	atmosphere.temperature = new_temp.Rand()
+	atmosphere.update_values()
 
 /datum/random_map/noise/exoplanet/snow
 	descriptor = "snow exoplanet"

--- a/code/modules/overmap/exoplanets/planet_types/volcanic.dm
+++ b/code/modules/overmap/exoplanets/planet_types/volcanic.dm
@@ -5,25 +5,27 @@
 	planetary_area = /area/exoplanet/volcanic
 	rock_colors = list(COLOR_DARK_GRAY)
 	plant_colors = list("#a23c05","#3f1f0d","#662929","#ba6222","#7a5b3a","#120309")
-	possible_themes = list()
 	map_generators = list(/datum/random_map/automata/cave_system/mountains/volcanic, /datum/random_map/noise/exoplanet/volcanic, /datum/random_map/noise/ore/filthy_rich)
 	ruin_tags_blacklist = RUIN_HABITAT|RUIN_WATER
 	surface_color = "#261e19"
 	water_color = "#c74d00"
-	habitability_distribution = HABITABILITY_BAD
+	habitability_weight = HABITABILITY_EXTREME
 	has_trees = FALSE
 	flora_diversity = 3
 	fauna_types = list(/mob/living/simple_animal/thinbug, /mob/living/simple_animal/hostile/retaliate/beast/shantak/lava, /mob/living/simple_animal/hostile/retaliate/beast/charbaby)
 	megafauna_types = list(/mob/living/simple_animal/hostile/drake)
 
 /obj/effect/overmap/visitable/sector/exoplanet/volcanic/get_atmosphere_color()
-	return COLOR_GRAY20
+	var/air_color = ..()
+	return MixColors(COLOR_GRAY20, air_color)
 
 /obj/effect/overmap/visitable/sector/exoplanet/volcanic/generate_atmosphere()
 	..()
-	if(atmosphere)
-		atmosphere.temperature = T20C + rand(220, 800)
-		atmosphere.update_values()
+	var/datum/species/H = all_species[SPECIES_HUMAN]
+	var/xtreme = H.heat_level_2 + (rand(1,3) *  H.heat_level_2)
+	var/generator/new_temp = generator("num", H.heat_level_2, xtreme, UNIFORM_RAND)
+	atmosphere.temperature = new_temp.Rand()
+	atmosphere.update_values()
 
 /obj/effect/overmap/visitable/sector/exoplanet/volcanic/adapt_seed(datum/seed/S)
 	..()

--- a/code/modules/xgm/xgm_gas_mixture.dm
+++ b/code/modules/xgm/xgm_gas_mixture.dm
@@ -145,15 +145,27 @@
 /datum/gas_mixture/proc/add_thermal_energy(thermal_energy)
 
 	if (total_moles == 0)
-		return 0
+		return FALSE
 
+	var/thermal_mod = 1
 	var/heat_capacity = heat_capacity()
 	if (thermal_energy < 0)
 		if (temperature < TCMB)
-			return 0
-		var/thermal_energy_limit = -(temperature - TCMB)*heat_capacity	//ensure temperature does not go below TCMB
+			return FALSE
+		var/thermal_energy_limit = -(temperature - TCMB) * heat_capacity	//ensure temperature does not go below TCMB
 		thermal_energy = max( thermal_energy, thermal_energy_limit )	//thermal_energy and thermal_energy_limit are negative here.
-	temperature += thermal_energy/heat_capacity
+	else
+		switch (temperature)
+			if (500 to 1000)
+				thermal_mod = 0.8
+			if (1000 to 1500)
+				thermal_mod = 0.6
+			if (1500 to 1750)
+				thermal_mod = 0.4
+			else
+				thermal_mod = 0.2
+
+	temperature += thermal_energy / heat_capacity * thermal_mod
 	return thermal_energy
 
 //Returns the thermal energy change required to get to a new temperature


### PR DESCRIPTION
🆑 Jux
tweak: Exoplanet atmospheres are more varied now, with a wider, but more grounded temperature range and less non-terraformed planets with ideal atmospheres.
tweak: All exoplanet types can now generate with all templates - volcanic cities, for example.
tweak: Thermal energy in gas mixtures is gained significantly slower the hotter the mixture is. 
/🆑 

Should make #33979 more palatable for explorers, offships, any anyone unlucky enough to get drafted for an away mission. The change in atmos fire heat growth should also make hellfires both less common and less painful, if only just.