### PR TITLE
Obfuscate OOC Manifest

### DIFF
--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -400,7 +400,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 	var/dat
 	dat += "<h4>Crew Manifest</h4>"
-	dat += html_crew_manifest(OOC = TRUE)
+	dat += html_crew_manifest()
 
 	var/datum/browser/popup = new(src, "Crew Manifest", "Crew Manifest", 370, 420, src)
 	popup.set_content(dat)

--- a/code/modules/modular_computers/file_system/manifest.dm
+++ b/code/modules/modular_computers/file_system/manifest.dm
@@ -34,7 +34,7 @@
 		.manifest tr.alt td {[monochrome?"border-top-width: 2px":"background-color: #373737; color:white"]}
 	</style></head>
 	<table class="manifest" width='350px'>
-	<tr class='head'><th>Name</th><th>Position</th><th>Activity</th></tr>
+	<tr class='head'><th>Name</th><th>Position</th>[OOC ? "" : "<th>Activity</th>"]</tr>
 	"}
 	// sort mobs
 	for(var/datum/computer_file/report/crew_record/CR in GLOB.all_crew_records)
@@ -49,16 +49,7 @@
 			if(branch_obj && rank_obj)
 				mil_ranks[name] = "<abbr title=\"[rank_obj.name], [branch_obj.name]\">[rank_obj.name_short]</abbr> "
 
-		if(OOC)
-			var/active = 0
-			for(var/mob/M in GLOB.player_list)
-				var/mob_real_name = M.real_name
-				if(sanitize(mob_real_name) == CR.get_name() && M.client && M.client.inactivity <= 10 MINUTES)
-					active = 1
-					break
-			isactive[name] = active ? "Active" : "Inactive"
-		else
-			isactive[name] = CR.get_status()
+		isactive[name] = CR.get_status()
 
 		var/datum/job/job = SSjobs.get_by_title(rank)
 		var/found_place = 0
@@ -85,9 +76,11 @@
 	for(var/list/department in dept_data)
 		var/list/names = department["names"]
 		if(length(names) > 0)
-			dat += "<tr><th colspan=3 style=background-color:[department["color"]]>[department["header"]]</th></tr>"
+			var/columns = OOC ? 2 : 3
+			dat += "<tr><th colspan=[columns] style=background-color:[department["color"]]>[department["header"]]</th></tr>"
 			for(var/name in names)
-				dat += "<tr class='candystripe'><td>[mil_ranks[name]][name]</td><td>[names[name]]</td><td>[isactive[name]]</td></tr>"
+				var/status_cell = OOC ? "" : "<td>[isactive[name]]</td>"
+				dat += "<tr class='candystripe'><td>[mil_ranks[name]][name]</td><td>[names[name]]</td>[status_cell]</tr>"
 
 	dat += "</table>"
 	dat = replacetext(dat, "\n", "") // so it can be placed on paper correctly

--- a/code/modules/modular_computers/file_system/manifest.dm
+++ b/code/modules/modular_computers/file_system/manifest.dm
@@ -38,6 +38,9 @@
 	"}
 	// sort mobs
 	for(var/datum/computer_file/report/crew_record/CR in GLOB.all_crew_records)
+		var/status = CR.get_status()
+		if (OOC && status == "Stored")
+			continue
 		var/name = CR.get_formal_name()
 		var/rank = CR.get_job()
 		mil_ranks[name] = ""
@@ -49,7 +52,7 @@
 			if(branch_obj && rank_obj)
 				mil_ranks[name] = "<abbr title=\"[rank_obj.name], [branch_obj.name]\">[rank_obj.name_short]</abbr> "
 
-		isactive[name] = CR.get_status()
+		isactive[name] = status
 
 		var/datum/job/job = SSjobs.get_by_title(rank)
 		var/found_place = 0


### PR DESCRIPTION
Following some feedback from players on the removal of the OOC manifest, this alternative instead attempts to mitigate metagame concerns by removing as much in-round information as possible. This should still keep the utility of the OOC manifest for seeing who's online and what slots are filled.

**NOTE**: This can still be affected by IC actions. If a manifest entry is deleted, added, or modified to have a different job title or department, this will still be reflected in the OOC manifest.

- Closes #33956

### IC Manifest:
![QNeAqimmKu](https://github.com/Baystation12/Baystation12/assets/11140088/f531ad5f-bd5f-44fa-a202-3a7133ea9c2c)

### OOC Manifest:
![DopTPkHGTl](https://github.com/Baystation12/Baystation12/assets/11140088/ce0b6f53-409e-4479-9a5a-a494d1ef6a25)

## Changelog
:cl: SierraKomodo
tweak: The crew manifest displayed to observers and ghosts now uses the IC manifest, reflecting the state of the `Status` field as displayed to people in game.
tweak: The OOC manifest (The one displayed in the player lobby) now hides the Activity column, masking the life and activity status of crew entries.
tweak: Crew manifest entries for crew members listed as `Stored` do not appear on the OOC manifest.
/:cl:
