### PR TITLE
Apply `use_*` to `/obj/item/holder`

### DIFF
--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -146,9 +146,27 @@ var/global/list/holder_mob_icon_cache = list()
 	origin_tech = list(TECH_BIO = 3, TECH_ENGINEERING = 4)
 	item_state = "poppy"
 
-/obj/item/holder/attackby(obj/item/W as obj, mob/user as mob)
-	for(var/mob/M in src.contents)
-		M.attackby(W,user)
+
+/obj/item/holder/use_grab(obj/item/grab/grab, list/click_params)
+	// Handled by `use_tool()`
+	return FALSE
+
+
+/obj/item/holder/use_weapon(obj/item/weapon, mob/living/user, list/click_params)
+	SHOULD_CALL_PARENT(FALSE)
+
+	// Handled by `use_tool()`
+	return FALSE
+
+
+/obj/item/holder/use_tool(obj/item/tool, mob/living/user, list/click_params)
+	SHOULD_CALL_PARENT(FALSE)
+
+	. = FALSE
+	for (var/mob/held in contents)
+		if (tool.resolve_attackby(held, user, click_params))
+			. = TRUE
+
 
 //Mob procs and vars for scooping up
 /mob/living/var/holder_type

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -57,7 +57,7 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 6 "uses of .len" '\.len\b' -P
-exactly 394 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 393 "attackby() override" '\/attackby\((.*)\)'  -P
 exactly 15 "uses of examine()" '[.|\s]examine\(' -P # If this fails it's likely because you used '/atom/proc/examine(mob)' instead of '/proc/examinate(mob, atom)' - Exception: An examine()-proc may call other examine()-procs
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
rscadd: You can now interact with held mobs using tools, including stabbing that cat you're holding hostage when security tries to bang-rush you.
/:cl: