### PR TITLE
allow examining of items people are wearing

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -868,6 +868,8 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	var/ID = GetIdCard()
 	if(ID)
 		. += "  <a href='?src=\ref[ID];look_at_id=1'>\[Look at ID\]</a>"
+	else
+		. += "  <a href='?src=\ref[src];examine=1'>\[?\]</a>"
 
 /obj/item/proc/on_active_hand(mob/M)
 
@@ -934,3 +936,10 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 /// Virtual for behavior to do after successful do_after if equip_delay is set
 /obj/item/proc/equip_delay_after(mob/user, slot, equip_flags)
 	return
+
+/obj/item/OnTopic(href, href_list, datum/topic_state/state)
+	. = ..()
+
+	if (href_list["examine"])
+		examinate(usr, src)
+		return TOPIC_HANDLED

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -188,13 +188,15 @@
 		return STATUS_INTERACTIVE
 
 /obj/item/clothing/OnTopic(user, list/href_list, datum/topic_state/state)
+	. = ..()
+
 	if(href_list["list_ungabunga"])
 		var/list/visible = get_visible_accessories()
 		if (length(visible))
 			var/list/display = list()
 			for (var/obj/item/clothing/accessory/A in visible)
 				if (!(A.accessory_flags & ACCESSORY_HIDDEN))
-					display += "[icon2html(A, user)] \a [A]"
+					display += "[icon2html(A, user)] \a [A]<a href='?src=\ref[A];examine=1'>\[?\]</a>"
 			to_chat(user, "Attached to \the [src] are [english_list(display)].")
 		return TOPIC_HANDLED
 	if(href_list["list_armor_damage"])


### PR DESCRIPTION
:cl: Mucker
rscadd: You can now examine items people are wearing by clicking the '?' next to items listed when examine a person.
/:cl:

![image](https://github.com/Baystation12/Baystation12/assets/1161516/456ccb40-fa52-4702-9054-e0e4f0d22d88)
![image](https://github.com/Baystation12/Baystation12/assets/1161516/e14fb0ff-fdde-47c6-8997-8df15ea26534)
