### PR TITLE
Makes "prison break" event more impactful

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -1395,11 +1395,11 @@ About the new airlock wires panel:
 		electrified_until = 0
 
 /obj/machinery/door/airlock/proc/prison_open()
-	if(arePowerSystemsOn())
-		src.unlock()
-		src.open()
-		src.lock()
-	return
+	if (!arePowerSystemsOn())
+		return
+	unlock(TRUE)
+	open(TRUE)
+	lock(TRUE)
 
 /obj/machinery/door/airlock/get_material_melting_point()
 	. = ..()

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -1,8 +1,9 @@
 /datum/event/prison_break
-	startWhen		= 5
-	announceWhen	= 75
+	startWhen = 5
+	announceWhen = 75
+	endWhen = 60
+	var/warning = 0.5
 
-	var/releaseWhen = 60
 	var/list/area/areas = list()		//List of areas to affect. Filled by start()
 
 	var/eventDept = "Security"			//Department name in announcement
@@ -12,14 +13,13 @@
 
 /datum/event/prison_break/setup()
 	announceWhen = rand(75, 105)
-	releaseWhen = rand(60, 90)
-
-	src.endWhen = src.releaseWhen+2
+	endWhen = announceWhen + rand(5, 25)
+	warning = rand(5, 10) / 10
 
 
 /datum/event/prison_break/announce()
-	if(areas && length(areas) > 0)
-		command_announcement.Announce("[pick("Gr3yT1d3 virus","Malignant trojan",)] detected in [location_name()] [(eventDept == "Security")? "imprisonment":"containment"] subroutines. Secure any compromised areas immediately.", "[location_name()] Anti-Virus Alert", zlevels = affecting_z)
+	if (areas && length(areas) > 0)
+		command_announcement.Announce("[pick("Gr3yT1d3 virus","Malignant trojan",)] detected in [location_name()] [eventDept] subroutines. Secure any compromised areas immediately.", "[location_name()] Anti-Virus Alert", zlevels = affecting_z)
 
 
 /datum/event/prison_break/start()
@@ -42,14 +42,13 @@
 
 
 /datum/event/prison_break/tick()
-	if(activeFor == releaseWhen)
-		if(areas && length(areas) > 0)
+	if (activeFor >= warning * endWhen)
+		if (areas && length(areas) > 0)
 			var/obj/machinery/power/apc/theAPC = null
-			for(var/area/A in areas)
+			for (var/area/A in areas)
 				theAPC = A.get_apc()
-				if(theAPC && theAPC.operating)	//If the apc's off, it's a little hard to overload the lights.
-					for(var/obj/machinery/light/L in A)
-						L.flicker(10)
+				if (theAPC && theAPC.operating)
+					theAPC.flicker_lighting()
 
 
 /datum/event/prison_break/end()

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -1111,6 +1111,14 @@
 					L.broken()
 				sleep(1)
 
+
+/obj/machinery/power/apc/proc/flicker_lighting(amount = 10)
+	if (!operating || shorted)
+		return
+	for (var/obj/machinery/light/L in area)
+		L.flicker(amount)
+
+
 /obj/machinery/power/apc/proc/setsubsystem(val)
 	switch(val)
 		if(2)

--- a/maps/torch/torch_events.dm
+++ b/maps/torch/torch_events.dm
@@ -15,7 +15,7 @@
 	areaNotType = list(/area/rnd/xenobiology/xenoflora, /area/rnd/xenobiology/xenoflora_storage)
 
 /datum/event/prison_break/station
-	eventDept = "Local"
+	eventDept = "Vessel"
 	areaName = list("Brig","Supply Warehouse","Xenobiology","Engineering Hard Storage")
 	areaType = list(/area/security/prison, /area/security/brig, /area/quartermaster/storage, /area/rnd/xenobiology, /area/engineering/hardstorage)
 	areaNotType = list(/area/rnd/xenobiology/xenoflora, /area/rnd/xenobiology/xenoflora_storage, /area/quartermaster/storage/upper)
@@ -34,14 +34,14 @@
 /datum/event/prison_break/armory
 	eventDept = "Security"
 	areaName = list("Emergency Armory")
-	areaType = list(/area/command/armoury)
-	areaNotType = list(/area/command/armoury/tactical)
+	areaType = list(/area/command/armoury, /area/command/armoury/tactical)
+
 
 /datum/event_container/moderate/torch
 	available_events = list(
 		new/datum/event_meta(EVENT_LEVEL_MODERATE, "Xenobiology Breach",					/datum/event/prison_break/xenobiology,	0,		list(ASSIGNMENT_SCIENCE = 100)),
 		new/datum/event_meta(EVENT_LEVEL_MODERATE, "Warehouse Breach",						/datum/event/prison_break/warehouse,	0,		list(ASSIGNMENT_SUPPLY = 100)),
-		new/datum/event_meta(EVENT_LEVEL_MODERATE, "Hard Storage Breach",					/datum/event/prison_break/hardstorage,	0,		list(ASSIGNMENT_ENGINEER = 100)),		
+		new/datum/event_meta(EVENT_LEVEL_MODERATE, "Hard Storage Breach",					/datum/event/prison_break/hardstorage,	0,		list(ASSIGNMENT_ENGINEER = 100)),
 		new/datum/event_meta(EVENT_LEVEL_MODERATE, "Armory Breach",						/datum/event/prison_break/armory,		0,		list(ASSIGNMENT_SECURITY = 100))
 		)
 


### PR DESCRIPTION
🆑 Jux
bugfix: The prison break event now bolts open doors like it used to.
tweak: The prison break event will now always announce itself before it ends, and can target both the tac-arm and xenobio cells.
/🆑 
