### PR TITLE
Makes fancy storage use lists for key_items

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy/crackers.dm
+++ b/code/game/objects/items/weapons/storage/fancy/crackers.dm
@@ -6,7 +6,7 @@
 	storage_slots = 6
 	max_w_class = ITEM_SIZE_TINY
 	w_class = ITEM_SIZE_SMALL
-	key_type = /obj/item/reagent_containers/food/snacks/cracker
+	key_type = list(/obj/item/reagent_containers/food/snacks/cracker)
 	can_hold = list(
 		/obj/item/reagent_containers/food/snacks/cracker
 	)

--- a/code/game/objects/items/weapons/storage/fancy/crayons.dm
+++ b/code/game/objects/items/weapons/storage/fancy/crayons.dm
@@ -7,7 +7,7 @@
 	w_class = ITEM_SIZE_SMALL
 	max_w_class = ITEM_SIZE_TINY
 	max_storage_space = 6
-	key_type = /obj/item/pen/crayon
+	key_type = list(/obj/item/pen/crayon)
 	startswith = list(
 		/obj/item/pen/crayon/red,
 		/obj/item/pen/crayon/orange,

--- a/code/game/objects/items/weapons/storage/fancy/egg_box.dm
+++ b/code/game/objects/items/weapons/storage/fancy/egg_box.dm
@@ -6,7 +6,7 @@
 	storage_slots = 12
 	max_w_class = ITEM_SIZE_SMALL
 	w_class = ITEM_SIZE_NORMAL
-	key_type = /obj/item/reagent_containers/food/snacks/egg
+	key_type = list(/obj/item/reagent_containers/food/snacks/egg)
 	can_hold = list(
 		/obj/item/reagent_containers/food/snacks/egg,
 		/obj/item/reagent_containers/food/snacks/boiledegg

--- a/code/game/objects/items/weapons/storage/fancy/matchbox.dm
+++ b/code/game/objects/items/weapons/storage/fancy/matchbox.dm
@@ -8,7 +8,7 @@
 	w_class = ITEM_SIZE_SMALL
 	slot_flags = SLOT_BELT
 	can_hold = list(/obj/item/flame/match)
-	key_type = /obj/item/flame/match
+	key_type = list(/obj/item/flame/match)
 	startswith = list(/obj/item/flame/match = 10)
 	var/sprite_key_type_count = 3
 
@@ -22,7 +22,7 @@
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
 	can_hold = list(/obj/item/flame/match)
-	key_type = /obj/item/flame/match
+	key_type = list(/obj/item/flame/match)
 	startswith = list(/obj/item/flame/match = 3)
 
 

--- a/code/game/objects/items/weapons/storage/fancy/pencilcase.dm
+++ b/code/game/objects/items/weapons/storage/fancy/pencilcase.dm
@@ -7,7 +7,7 @@
 	w_class = ITEM_SIZE_SMALL
 	max_w_class = ITEM_SIZE_TINY
 	max_storage_space = 6 * ITEM_SIZE_TINY
-	key_type = /obj/item/pen
+	key_type = list(/obj/item/pen)
 	startswith = list(
 		/obj/item/pen,
 		/obj/item/pen/blue,

--- a/code/game/objects/items/weapons/storage/fancy/smokable/_smokable.dm
+++ b/code/game/objects/items/weapons/storage/fancy/smokable/_smokable.dm
@@ -10,7 +10,7 @@
 	throwforce = 2
 	slot_flags = SLOT_BELT
 	item_flags = ITEM_FLAG_TRY_ATTACK
-	key_type = /obj/item/clothing/mask/smokable/cigarette
+	key_type = list(/obj/item/clothing/mask/smokable/cigarette)
 	atom_flags = ATOM_FLAG_NO_REACT | ATOM_FLAG_OPEN_CONTAINER
 
 	/// A map? of reagents to add to this container on initialization.

--- a/code/game/objects/items/weapons/storage/fancy/smokable/basic.dm
+++ b/code/game/objects/items/weapons/storage/fancy/smokable/basic.dm
@@ -8,7 +8,7 @@
 	max_storage_space = null
 	sealed = FALSE
 	storage_slots = 6
-	key_type_2 = /obj/item/material/coin
+	key_type = list(/obj/item/clothing/mask/smokable/cigarette, /obj/item/material/coin)
 	startswith = list(
 		/obj/item/clothing/mask/smokable/cigarette = 6
 	)
@@ -19,9 +19,9 @@
 	if (!opened)
 		return
 	for (var/i = 1 to length(contents))
-		if (istype(contents[i], key_type))
+		if (istype(contents[i], /obj/item/clothing/mask/smokable/cigarette))
 			overlays += image(icon, "cig[i]")
-		else if (istype(contents[i], key_type_2))
+		else if (istype(contents[i], /obj/item/material/coin))
 			var/obj/item/material/coin/C = contents[i]
 			var/image/I = image(icon, "colorcoin[i]")
 			if (C.applies_material_colour)
@@ -84,7 +84,6 @@
 	desc = "With a sharp and natural organic menthol flavor, these Temperamentos are a favorite of NDV crews. Hardly anyone knows they make 'em in non-menthol!"
 	icon_state = "TMpacket"
 	item_state = "Dpacket"
-	key_type = /obj/item/clothing/mask/smokable/cigarette/menthol
 	startswith = list(
 		/obj/item/clothing/mask/smokable/cigarette/menthol = 6
 	)
@@ -116,7 +115,6 @@
 	icon_state = "CRpacket"
 	item_state = "Dpacket"
 	max_storage_space = 5
-	key_type = /obj/item/clothing/mask/smokable/cigarette/trident
 	startswith = list(
 		/obj/item/clothing/mask/smokable/cigarette/trident = 5
 	)
@@ -128,7 +126,6 @@
 	icon_state = "CRFpacket"
 	item_state = "Dpacket"
 	max_storage_space = 5
-	key_type = /obj/item/clothing/mask/smokable/cigarette/trident
 	startswith = list(
 		/obj/item/clothing/mask/smokable/cigarette/trident/watermelon,
 		/obj/item/clothing/mask/smokable/cigarette/trident/orange,
@@ -144,7 +141,6 @@
 	icon_state = "CRMpacket"
 	item_state = "Dpacket"
 	max_storage_space = 5
-	key_type = /obj/item/clothing/mask/smokable/cigarette/trident
 	startswith = list(
 		/obj/item/clothing/mask/smokable/cigarette/trident/mint = 5
 	)
@@ -158,7 +154,7 @@
 	max_storage_space = null
 	storage_slots = 7
 	slot_flags = SLOT_BELT
-	key_type = /obj/item/clothing/mask/smokable/cigarette/cigar
+	key_type = list(/obj/item/clothing/mask/smokable/cigarette/cigar)
 	startswith = list(
 		/obj/item/clothing/mask/smokable/cigarette/cigar = 6
 	)

--- a/code/game/objects/items/weapons/storage/fancy/vials.dm
+++ b/code/game/objects/items/weapons/storage/fancy/vials.dm
@@ -7,15 +7,15 @@
 	max_w_class = ITEM_SIZE_TINY
 	storage_slots = 12
 
-	key_type = /obj/item/reagent_containers/glass/beaker/vial
+	key_type = list(/obj/item/reagent_containers/glass/beaker/vial)
 	startswith = list(/obj/item/reagent_containers/glass/beaker/vial = 12)
 
 /obj/item/storage/fancy/vials/Initialize()
 	. = ..()
-	icon_state = "[initial(icon_state)][floor(key_type_count / 2)]"
+	icon_state = "[initial(icon_state)][floor(total_keys / 2)]"
 
 /obj/item/storage/fancy/vials/on_update_icon()
 	overlays.Cut()
 	if (!opened)
 		overlays += image('icons/obj/vialbox.dmi', "cover")
-	icon_state = "[initial(icon_state)][floor(key_type_count / 2)]"
+	icon_state = "[initial(icon_state)][floor(total_keys / 2)]"

--- a/code/modules/reagents/reagent_containers/food/snacks/bugmeat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/bugmeat.dm
@@ -7,7 +7,7 @@
 	storage_slots = 6
 	max_w_class = ITEM_SIZE_SMALL
 	w_class = ITEM_SIZE_NORMAL
-	key_type = /obj/item/reagent_containers/food/snacks/rawcutlet/bugmeat
+	key_type = list(/obj/item/reagent_containers/food/snacks/rawcutlet/bugmeat)
 	can_hold = list(
 		/obj/item/reagent_containers/food/snacks/rawcutlet/bugmeat,
 		/obj/item/reagent_containers/food/snacks/cutlet/bugmeat


### PR DESCRIPTION
No user facing changes.
@Spookerton suggested that using lists for key_items would be neater for fancy storage items instead of duplicating keys. Spook was right!

One change, menthol and trident cigpacks now count any type of cigarette for icon + desc generation. While I understand it was made exclusive to these subtypes because the icon has a green tinted cigarette to indicate menthol, the benefit of having any cigarette change icon/desc means you can actually spike menthol/trident boxes with traitor cigarettes in a believable way.

