### PR TITLE
fix /hook/startup/proc/set_visibility appearing to error

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -70,6 +70,7 @@ GLOBAL_VAR(href_logfile)
 #ifndef UNIT_TEST
 /hook/startup/proc/set_visibility()
 	world.update_hub_visibility(config.hub_visible)
+	return TRUE
 #endif
 
 /world/New()


### PR DESCRIPTION
it didn't *actually* error, but hook runners expect a TRUE from successful hooks.