### PR TITLE
Hide stored entries in Topic manifest

### DIFF
--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -202,6 +202,8 @@ GLOBAL_VAR_INIT(world_topic_last, world.timeofday)
 			if(length(dept_list) > 0)
 				positions[dept] = list()
 				for(var/list/person in dept_list)
+					if (person["status"] == "Stored")
+						continue
 					positions[dept][person["name"]] = person["rank"]
 
 		for(var/k in positions)


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
tweak: External bots no longer receive stored characters when requesting the manifest.
/:cl: