### PR TITLE
More randomized vendor stock

### DIFF
--- a/code/game/machinery/vending/_vending.dm
+++ b/code/game/machinery/vending/_vending.dm
@@ -545,6 +545,8 @@
 		return FALSE
 	var/obj/item/throw_item
 	for (var/datum/stored_items/vending_products/product in shuffle(product_records))
+		if (product.category == VENDOR_CATEGORY_ANTAG)
+			continue
 		throw_item = product.get_product(loc)
 		if (throw_item)
 			break

--- a/code/game/machinery/vending/boda.dm
+++ b/code/game/machinery/vending/boda.dm
@@ -26,16 +26,20 @@
 		100% less additives and preservatives than our SCG competitors.\
 	"}
 	products = list(
-		/obj/item/reagent_containers/food/drinks/cans/syndicola = 10,
-		/obj/item/reagent_containers/food/drinks/cans/syndicolax = 10,
-		/obj/item/reagent_containers/food/drinks/cans/artbru = 10,
-		/obj/item/reagent_containers/food/drinks/glass2/square/boda = 10,
-		/obj/item/reagent_containers/food/drinks/glass2/square/bodaplus = 10
+		/obj/item/reagent_containers/food/drinks/cans/syndicola = 0,
+		/obj/item/reagent_containers/food/drinks/cans/syndicolax = 0,
+		/obj/item/reagent_containers/food/drinks/cans/artbru = 0,
+		/obj/item/reagent_containers/food/drinks/glass2/square/boda = 0,
+		/obj/item/reagent_containers/food/drinks/glass2/square/bodaplus = 0,
+		/obj/item/reagent_containers/food/drinks/bottle/space_up = 0
 	)
 	contraband = list(
-		/obj/item/reagent_containers/food/drinks/bottle/space_up = 5
+		/obj/item/clothing/under/soviet = 1,
+		/obj/item/clothing/suit/hgpirate = 1
+
 	)
 	rare_products = list(
+		/obj/item/reagent_containers/food/drinks/bottle/space_up = 50,
 		/obj/item/card/id/syndicate = 25,
 		/obj/item/storage/box/syndie_kit/spy = 50
 	)

--- a/code/game/machinery/vending/coffee.dm
+++ b/code/game/machinery/vending/coffee.dm
@@ -5,6 +5,7 @@
 	icon_vend = "coffee-vend"
 	icon_deny = "coffee-deny"
 	base_type = /obj/machinery/vending/coffee
+	maxrandom = 20
 	idle_power_usage = 200
 	vend_power_usage = 40000
 	product_ads = {"\
@@ -45,19 +46,19 @@
 		/obj/item/reagent_containers/food/drinks/ice = 5
 	)
 	products = list(
-		/obj/item/reagent_containers/food/drinks/coffee = 15,
-		/obj/item/reagent_containers/food/drinks/decafcoffee = 15,
-		/obj/item/reagent_containers/food/drinks/tea/black = 15,
-		/obj/item/reagent_containers/food/drinks/tea/green = 15,
-		/obj/item/reagent_containers/food/drinks/tea/chai = 15,
-		/obj/item/reagent_containers/food/drinks/tea/decaf = 15,
-		/obj/item/reagent_containers/food/drinks/h_chocolate = 15,
-		/obj/item/reagent_containers/food/condiment/small/packet/sugar = 25,
-		/obj/item/reagent_containers/pill/pod/cream = 25,
-		/obj/item/reagent_containers/pill/pod/cream_soy = 25,
-		/obj/item/reagent_containers/pill/pod/orange = 10,
-		/obj/item/reagent_containers/pill/pod/mint = 10,
-		/obj/item/reagent_containers/food/drinks/ice = 10
+		/obj/item/reagent_containers/food/drinks/coffee = 0,
+		/obj/item/reagent_containers/food/drinks/decafcoffee = 0,
+		/obj/item/reagent_containers/food/drinks/tea/black = 0,
+		/obj/item/reagent_containers/food/drinks/tea/green = 0,
+		/obj/item/reagent_containers/food/drinks/tea/chai = 0,
+		/obj/item/reagent_containers/food/drinks/tea/decaf = 0,
+		/obj/item/reagent_containers/food/drinks/h_chocolate = 0,
+		/obj/item/reagent_containers/food/condiment/small/packet/sugar = 0,
+		/obj/item/reagent_containers/pill/pod/cream = 0,
+		/obj/item/reagent_containers/pill/pod/cream_soy = 0,
+		/obj/item/reagent_containers/pill/pod/orange = 0,
+		/obj/item/reagent_containers/pill/pod/mint = 0,
+		/obj/item/reagent_containers/food/drinks/ice = 0
 	)
 	rare_products = list(
 		/obj/item/reagent_containers/hypospray/autoinjector/combatstim = 70

--- a/code/game/machinery/vending/cola.dm
+++ b/code/game/machinery/vending/cola.dm
@@ -32,7 +32,6 @@
 		/obj/item/reagent_containers/food/drinks/cans/space_up = 1,
 		/obj/item/reagent_containers/food/drinks/cans/iced_tea = 1,
 		/obj/item/reagent_containers/food/drinks/cans/grape_juice = 1,
-		/obj/item/reagent_containers/food/drinks/cans/cola_pork = 10,
 		/obj/item/reagent_containers/food/drinks/cans/syndicola = 5
 	)
 	products = list(
@@ -44,11 +43,9 @@
 		/obj/item/reagent_containers/food/drinks/cans/space_up = 0,
 		/obj/item/reagent_containers/food/drinks/cans/iced_tea = 0,
 		/obj/item/reagent_containers/food/drinks/cans/grape_juice = 0,
-		/obj/item/reagent_containers/food/drinks/cans/cola_pork = 0,
 		/obj/item/reagent_containers/food/drinks/cans/syndicola = 0
 	)
 	rare_products = list(
-		/obj/item/reagent_containers/food/drinks/cans/cola_pork = 75,
 		/obj/item/reagent_containers/food/drinks/cans/syndicola = 30,
 		/obj/item/pen/reagent/sleepy = 35
 	)

--- a/code/game/machinery/vending/fitness.dm
+++ b/code/game/machinery/vending/fitness.dm
@@ -5,6 +5,7 @@
 	icon_vend = "fitness-vend"
 	icon_deny = "fitness-deny"
 	base_type = /obj/machinery/vending/fitness
+	maxrandom = 8
 	product_slogans = {"\
 		SweatMAX, get robust!\
 	"}
@@ -31,20 +32,23 @@
 		/obj/item/reagent_containers/food/snacks/proteinbar = 5,
 		/obj/item/reagent_containers/food/snacks/meatcube = 10,
 		/obj/item/reagent_containers/pill/diet = 25,
-		/obj/item/towel/random = 40
+		/obj/item/towel/random = 40,
+		/obj/item/reagent_containers/food/condiment/small/packet/protein = 100
 	)
 	products = list(
-		/obj/item/reagent_containers/food/drinks/small_milk = 8,
-		/obj/item/reagent_containers/food/drinks/small_milk_choc = 8,
-		/obj/item/reagent_containers/food/drinks/cans/waterbottle = 8,
-		/obj/item/reagent_containers/food/drinks/glass2/fitnessflask/proteinshake = 8,
-		/obj/item/reagent_containers/food/drinks/glass2/fitnessflask = 8,
-		/obj/item/reagent_containers/food/snacks/proteinbar = 8,
-		/obj/item/reagent_containers/food/snacks/meatcube = 8,
-		/obj/item/reagent_containers/pill/diet = 8,
-		/obj/item/towel/random = 8
+		/obj/item/reagent_containers/food/drinks/small_milk = 0,
+		/obj/item/reagent_containers/food/drinks/small_milk_choc = 0,
+		/obj/item/reagent_containers/food/drinks/cans/waterbottle = 0,
+		/obj/item/reagent_containers/food/drinks/glass2/fitnessflask/proteinshake = 0,
+		/obj/item/reagent_containers/food/drinks/glass2/fitnessflask = 0,
+		/obj/item/reagent_containers/food/snacks/proteinbar = 0,
+		/obj/item/reagent_containers/food/snacks/meatcube = 0,
+		/obj/item/reagent_containers/pill/diet = 0,
+		/obj/item/towel/random = 0,
+		/obj/item/reagent_containers/food/condiment/small/packet/protein = 0
 	)
 	rare_products = list(
+		/obj/item/reagent_containers/food/condiment/small/packet/protein = 30,
 		/obj/item/device/augment_implanter/iatric_monitor = 50,
 		/obj/item/device/augment_implanter/internal_air_system = 25
 	)

--- a/code/game/machinery/vending/games.dm
+++ b/code/game/machinery/vending/games.dm
@@ -5,6 +5,7 @@
 	icon_deny = "games-deny"
 	icon_vend = "games-vend"
 	base_type = /obj/machinery/vending/games
+	maxrandom = 5
 	product_slogans = {"
 		Escape to a fantasy world!;\
 		Fuel your gambling addiction!;\
@@ -34,30 +35,36 @@
 		/obj/item/storage/box/checkers/chess/red = 10,
 		/obj/item/storage/box/checkers/chess = 10,
 		/obj/item/board = 2,
-		/obj/item/storage/fancy/crayons = 3
+		/obj/item/storage/fancy/crayons = 3,
+		/obj/item/reagent_containers/spray/waterflower = 10,
+		/obj/item/storage/box/snappops = 15
 	)
 	products = list(
-		/obj/item/toy/blink = 5,
-		/obj/item/toy/eightball = 8,
-		/obj/item/deck/cards = 5,
-		/obj/item/deck/tarot = 5,
-		/obj/item/pack/cardemon = 6,
-		/obj/item/pack/spaceball = 6,
-		/obj/item/storage/pill_bottle/dice_nerd = 5,
-		/obj/item/storage/pill_bottle/dice = 5,
-		/obj/item/storage/box/checkers = 2,
-		/obj/item/storage/box/checkers/chess/red = 2,
-		/obj/item/storage/box/checkers/chess = 2,
-		/obj/item/board = 2,
-		/obj/item/storage/fancy/crayons = 3
+		/obj/item/toy/blink = 0,
+		/obj/item/toy/eightball = 0,
+		/obj/item/deck/cards = 0,
+		/obj/item/deck/tarot = 0,
+		/obj/item/pack/cardemon = 0,
+		/obj/item/pack/spaceball = 0,
+		/obj/item/storage/pill_bottle/dice_nerd = 0,
+		/obj/item/storage/pill_bottle/dice = 0,
+		/obj/item/storage/box/checkers = 0,
+		/obj/item/storage/box/checkers/chess/red = 0,
+		/obj/item/storage/box/checkers/chess = 0,
+		/obj/item/board = 0,
+		/obj/item/storage/fancy/crayons = 0,
+		/obj/item/reagent_containers/spray/waterflower = 0,
+		/obj/item/storage/box/snappops = 0
 	)
 	rare_products = list(
+		/obj/item/reagent_containers/spray/waterflower = 30,
+		/obj/item/storage/box/snappops = 30,
 		/obj/item/storage/box/large/foam_gun/revolver/tampered = 20,
 		/obj/item/toy/balloon = 5
 	)
 	contraband = list(
-		/obj/item/reagent_containers/spray/waterflower = 2,
-		/obj/item/storage/box/snappops = 3,
+		/obj/item/toy/crossbow = 1,
+		/obj/item/toy/ammo/crossbow = 4,
 		/obj/item/toy/sword = 3,
 		/obj/item/toy/katana = 3,
 		/obj/item/gun/projectile/revolver/capgun = 1,

--- a/code/game/machinery/vending/snack.dm
+++ b/code/game/machinery/vending/snack.dm
@@ -41,17 +41,17 @@
 		/obj/item/reagent_containers/food/snacks/tastybread = 2
 	)
 	products = list(
-		/obj/item/clothing/mask/chewable/candy/lolli = 8,
-		/obj/item/storage/chewables/candy/gum = 4,
-		/obj/item/storage/chewables/candy/cookies = 4,
-		/obj/item/reagent_containers/food/snacks/candy = 6,
-		/obj/item/reagent_containers/food/drinks/dry_ramen = 6,
-		/obj/item/reagent_containers/food/snacks/chips = 6,
-		/obj/item/reagent_containers/food/snacks/sosjerky = 6,
-		/obj/item/reagent_containers/food/snacks/no_raisin = 6,
-		/obj/item/reagent_containers/food/snacks/spacetwinkie = 6,
-		/obj/item/reagent_containers/food/snacks/cheesiehonkers = 6,
-		/obj/item/reagent_containers/food/snacks/tastybread = 6
+		/obj/item/clothing/mask/chewable/candy/lolli = 0,
+		/obj/item/storage/chewables/candy/gum = 0,
+		/obj/item/storage/chewables/candy/cookies = 0,
+		/obj/item/reagent_containers/food/snacks/candy = 0,
+		/obj/item/reagent_containers/food/drinks/dry_ramen = 0,
+		/obj/item/reagent_containers/food/snacks/chips = 0,
+		/obj/item/reagent_containers/food/snacks/sosjerky = 0,
+		/obj/item/reagent_containers/food/snacks/no_raisin = 0,
+		/obj/item/reagent_containers/food/snacks/spacetwinkie = 0,
+		/obj/item/reagent_containers/food/snacks/cheesiehonkers = 0,
+		/obj/item/reagent_containers/food/snacks/tastybread = 0
 	)
 	rare_products = list(
 		/obj/item/storage/box/syndie_kit/shuriken = 70

--- a/code/game/machinery/vending/soda.dm
+++ b/code/game/machinery/vending/soda.dm
@@ -14,18 +14,23 @@
 		/obj/item/reagent_containers/food/drinks/cans/waterbottle = 1,
 		/obj/item/reagent_containers/food/drinks/cans/cola_grape = 1,
 		/obj/item/reagent_containers/food/drinks/cans/cola_lemonlime = 1,
-		/obj/item/reagent_containers/food/drinks/cans/cola_strawberry = 1
+		/obj/item/reagent_containers/food/drinks/cans/cola_strawberry = 1,
+		/obj/item/reagent_containers/food/drinks/cans/cola_pork = 5
 	)
 	products = list(
-		/obj/item/reagent_containers/food/drinks/cans/cola_diet = 10,
-		/obj/item/reagent_containers/food/drinks/cans/rootbeer = 10,
-		/obj/item/reagent_containers/food/drinks/cans/cola_apple = 10,
-		/obj/item/reagent_containers/food/drinks/cans/cola_orange = 10,
-		/obj/item/reagent_containers/food/drinks/cans/waterbottle = 10,
-		/obj/item/reagent_containers/food/drinks/cans/cola_grape = 10,
-		/obj/item/reagent_containers/food/drinks/cans/cola_lemonlime = 10,
-		/obj/item/reagent_containers/food/drinks/cans/cola_strawberry = 10
+		/obj/item/reagent_containers/food/drinks/cans/cola_diet = 0,
+		/obj/item/reagent_containers/food/drinks/cans/rootbeer = 0,
+		/obj/item/reagent_containers/food/drinks/cans/cola_apple = 0,
+		/obj/item/reagent_containers/food/drinks/cans/cola_orange = 0,
+		/obj/item/reagent_containers/food/drinks/cans/waterbottle = 0,
+		/obj/item/reagent_containers/food/drinks/cans/cola_grape = 0,
+		/obj/item/reagent_containers/food/drinks/cans/cola_lemonlime = 0,
+		/obj/item/reagent_containers/food/drinks/cans/cola_strawberry = 0,
+		/obj/item/reagent_containers/food/drinks/cans/cola_pork = 0
+	)
+	rare_products = list(
+		/obj/item/reagent_containers/food/drinks/cans/cola_pork = 30
 	)
 	contraband = list(
-		/obj/item/reagent_containers/food/drinks/cans/cola_pork = 10
+		/obj/item/reagent_containers/food/drinks/cans/space_mountain_wind = 3
 	)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drinks.dm
@@ -244,7 +244,7 @@
 	color = "#baeece"
 	glass_name = "th'oom juice"
 	glass_desc = "sweet and savory goodness!"
-	sugar_amount = 50
+	sugar_amount = 0.5
 	nutrition = 4
 	hydration = 3
 


### PR DESCRIPTION
🆑 emmanuelbassil
tweak: Adds 'rare items' to sovietsoda, fitness, and games vendor.
bugfix: Fixes oversight allowing hacked vending machines to hurl traitor coin items at people.
/🆑 

I only did this for 'public' non-job essential vendors; I don't expect shortages to ever pop up this is only so the stock is less uniform which feels weird for vendors 'everyone' frequents. I did not do this for job essential vendors nor will I do it, randomness there is silly, I feel.

Also added rare items to the boda, fitness, games, and soda (this one not mapped currently) vendors. Moved out some contraband items --> rare in the boda and games, added new contraband to compensate that's more interesting. Also after some thought, will not add 'rare items' to any of the job essential vendors. Randomness on that front also seems silly. I feel it's important to make a few other vendors have 'rare' items and not only the existing soda one.

