### PR TITLE
Fixes intercoms and allows you to open the wire hacking menu with an empty hand

### DIFF
--- a/code/game/objects/items/devices/radio/intercom.dm
+++ b/code/game/objects/items/devices/radio/intercom.dm
@@ -254,6 +254,7 @@
 			USE_FEEDBACK_FAILURE("\The [src] has no wiring to expose.")
 			return TRUE
 		wiresexposed = !wiresexposed
+		b_stat = !b_stat
 		update_icon()
 		playsound(src, 'sound/items/Screwdriver.ogg', 50, TRUE)
 		user.visible_message(

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -12,7 +12,8 @@
 	var/traitor_frequency = 0 //tune to frequency to unlock traitor supplies
 	var/canhear_range = 3 // the range which mobs can hear this radio from
 	var/datum/wires/radio/wires = null
-	var/b_stat = 0 // whether or not it is modifiable/attachable
+	/// whether or not it is modifiable/attachable
+	var/b_stat = 0
 	var/broadcasting = FALSE
 	var/listening = TRUE
 	var/list/channels = list() //see communications.dm for full list. First channel is a "default" for :h

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -12,7 +12,7 @@
 	var/traitor_frequency = 0 //tune to frequency to unlock traitor supplies
 	var/canhear_range = 3 // the range which mobs can hear this radio from
 	var/datum/wires/radio/wires = null
-	var/b_stat = 0
+	var/b_stat = 0 // whether or not it is modifiable/attachable
 	var/broadcasting = FALSE
 	var/listening = TRUE
 	var/list/channels = list() //see communications.dm for full list. First channel is a "default" for :h


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl:
bugfix: Fixes intercoms so clicking on them with an empty hand when the wire panel is open will now allow to actually mess with the wires
/:cl:
fixes #34030 
also I added a comment to b_stat cause of the confusion of what in the world is this variable it gave me.