### PR TITLE
EVA access for scientific personnel

### DIFF
--- a/maps/torch/job/research_jobs.dm
+++ b/maps/torch/job/research_jobs.dm
@@ -26,7 +26,7 @@
 		access_mining_station, access_xenobiology, access_xenoarch, access_nanotrasen, access_solgov_crew,
 		access_expedition_shuttle, access_guppy, access_hangar, access_petrov, access_petrov_helm, access_guppy_helm,
 		access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry, access_petrov_control,
-		access_petrov_maint, access_torch_fax, access_radio_sci, access_radio_exp, access_research_storage
+		access_petrov_maint, access_torch_fax, access_radio_sci, access_radio_exp, access_research_storage, access_eva
 	)
 
 	min_skill = list(   SKILL_BUREAUCRACY = SKILL_BASIC,
@@ -85,7 +85,7 @@
 		access_mining_office, access_mining_station, access_xenobiology, access_guppy_helm,
 		access_xenoarch, access_nanotrasen, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar,
 		access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry, access_petrov_control, access_torch_fax,
-		access_petrov_maint, access_radio_sci, access_radio_exp, access_research_storage
+		access_petrov_maint, access_radio_sci, access_radio_exp, access_research_storage, access_eva
 	)
 	skill_points = 20
 	possible_goals = list(/datum/goal/achievement/notslimefodder)
@@ -128,6 +128,6 @@
 		access_mining_office, access_mining_station, access_xenobiology, access_guppy_helm,
 		access_xenoarch, access_nanotrasen, access_solgov_crew, access_expedition_shuttle, access_guppy, access_hangar,
 		access_petrov_analysis, access_petrov_phoron, access_petrov_toxins, access_petrov_chemistry, access_petrov_control,
-		access_radio_sci, access_radio_exp, access_research_storage
+		access_radio_sci, access_radio_exp, access_research_storage, access_eva
 	)
 	possible_goals = list(/datum/goal/achievement/notslimefodder)


### PR DESCRIPTION
:cl: Sbotkin
tweak: Senior Researcher, Scientist and Research Assistant got EVA access.
/:cl:

As a xenoarcheologist you are expected to work EVA but have no access to EVA gear. Which isn't _that_ bad unless you are an FBP, IPC (no PCU) or if the landing site is in outer space and you need a jetpack.

The research assistant gets it because there is a field assistant sub-role and theoretically they should be helping the xenoarch.

The SR can theoretically go on expeditions too but this is mostly to not leave them the only person in the department without the access. Also because superiors logically should have all the subordinate's access.