### PR TITLE
RCD rarity

### DIFF
--- a/code/game/machinery/vending/engineering.dm
+++ b/code/game/machinery/vending/engineering.dm
@@ -43,8 +43,7 @@
 		/obj/item/device/radio/intercept = 25
 	)
 	contraband = list(
-		/obj/item/rcd = 1,
-		/obj/item/rcd_ammo = 5
+		/obj/item/rcd_ammo = 3
 	)
 	antag = list(
 		/obj/item/device/encryptionkey/syndicate = 2,

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -16,7 +16,6 @@
 	throw_range = 5
 	w_class = ITEM_SIZE_NORMAL
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 2)
-	matter = list(MATERIAL_STEEL = 50000)
 	var/datum/effect/effect/system/spark_spread/spark_system
 	var/stored_matter = 0
 	var/max_stored_matter = 120

--- a/code/modules/fabrication/designs/general/designs_engineering.dm
+++ b/code/modules/fabrication/designs/general/designs_engineering.dm
@@ -22,7 +22,3 @@
 
 /datum/fabricator_recipe/engineering/camera_assembly
 	path = /obj/item/camera_assembly
-
-/datum/fabricator_recipe/engineering/rcd
-	path = /obj/item/rcd
-	hidden = TRUE

--- a/code/modules/research/designs/designs_tool.dm
+++ b/code/modules/research/designs/designs_tool.dm
@@ -118,3 +118,13 @@
 	materials = list(MATERIAL_STEEL = 6000, MATERIAL_ALUMINIUM = 1000, MATERIAL_PLASTIC = 750)
 	build_path = /obj/item/swapper/jaws_of_life
 	sort_string = "VAGAM"
+
+
+/datum/design/item/tool/rcd
+	name = "rapid construction device"
+	desc = "a gun-shaped device that uses compressed matter to build and dismantle various structures."
+	id = "hand_rcd"
+	req_tech = list(TECH_ENGINEERING = 5, TECH_MATERIAL = 4)
+	materials = list(MATERIAL_STEEL = 25000, MATERIAL_PHORON = 4000, MATERIAL_GOLD = 2000, MATERIAL_SILVER = 2000)
+	build_path = /obj/item/rcd
+	sort_string = "VAGAN"


### PR DESCRIPTION
🆑 Jux
tweak: RCDs can no longer be made or decon'd at autolathes, but can be produced by science.
tweak: The Robco Tool Maker no longer has a contraband RCD, and has two less RCD ammo charges.
/🆑 

Makes them a bit more special by imposing scarcity unless you make use of a hardsuit, mechsuit or robot RCD.