### PR TITLE
Delay gun recharging if recently fired

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -98,4 +98,5 @@
 /obj/item/gun/energy/handle_post_fire(mob/user, atom/target, pointblank, reflex, obj/projectile)
 	..()
 	if (self_recharge)
+		charge_tick = 0
 		START_PROCESSING(SSobj, src)


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
balance: Self-recharging guns such as the Advanced Energy Gun and energy based borg and mech weapons now delay recharging when they are fired. This is to prevent guns from self-charging in the middle of mag-dumping the gun and force more tactical consideration of when to fall back to "recharge" the weapon.
/:cl: