### PR TITLE
Fixes runtime error and storing guns on harm

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -102,7 +102,7 @@
 
 ///Processes stabbing eyes with any sharp items. Only works for normal sized or smaller items; if attacking eyes with a large sword will default to parent use_weapon and do a regular attack.
 /mob/living/carbon/use_weapon(obj/item/weapon, mob/living/user, list/click_params)
-	if (user.a_intent == I_HURT && user.zone_sel.selecting == BP_EYES && weapon.can_puncture() && get_max_health() && weapon.w_class <= ITEM_SIZE_NORMAL)
+	if (iscarbon(user) && user.a_intent == I_HURT && user.zone_sel.selecting == BP_EYES && weapon.can_puncture() && get_max_health() && weapon.w_class <= ITEM_SIZE_NORMAL)
 		var/hit_zone = resolve_item_attack(weapon, user, user.zone_sel.selecting)
 		if (!hit_zone) //Miss message to user is processed in resolve_item_attack.
 			return TRUE

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -213,7 +213,7 @@
 			else
 				Fire(atom, user, pointblank = TRUE)
 		return TRUE
-	if (user.a_intent == I_HURT) //point blank shooting
+	if (user.a_intent == I_HURT && !user.isEquipped(atom)) //point blank shooting
 		Fire(atom, user, pointblank = TRUE)
 		return TRUE
 	return ..()


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: You are now able to store guns in your inventory objects while on harm intent
/🆑 

During the test merge, two bugs got reported that were actually on live. One is a bug resulting from my eyestab PR, the other I have no idea where it's from. The runtimes were called by simplemobs attacking a carbon mob.