### PR TITLE
Makes the /collapse emote not knock out the user

### DIFF
--- a/code/modules/emotes/definitions/visible.dm
+++ b/code/modules/emotes/definitions/visible.dm
@@ -55,7 +55,7 @@
 
 /singleton/emote/visible/collapse/do_extra(mob/user)
 	if(istype(user))
-		user.Paralyse(2)
+		user.Weaken(2)
 
 /singleton/emote/visible/flash
 	key = "flash"


### PR DESCRIPTION
See title. Replaces the `/collase` emote's `user.Paralyse` with `User.Weaken`, making the user not pass out in the process.

:cl: Ctr-Truescreen
bugfix: Using the /collapse emote floors you instead of making you unconscious.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->