### PR TITLE
remove e-machette from borgs

### DIFF
--- a/code/modules/mob/living/silicon/robot/flying/module_flying_cultivator.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_cultivator.dm
@@ -23,8 +23,7 @@
 	emag_gear = list(
 		/obj/item/melee/baton/robot/electrified_arm,
 		/obj/item/device/flash,
-		/obj/item/gun/energy/gun,
-		/obj/item/melee/energy/machete
+		/obj/item/gun/energy/gun
 	)
 
 	skills = list(

--- a/maps/torch/robot/module_flying_surveyor.dm
+++ b/maps/torch/robot/module_flying_surveyor.dm
@@ -48,8 +48,7 @@
 
 	emag_gear = list(
 		/obj/item/melee/baton/robot/electrified_arm,
-		/obj/item/gun/energy/gun,
-		/obj/item/melee/energy/machete
+		/obj/item/gun/energy/gun
 	)
 
 /obj/item/robot_module/flying/surveyor/finalize_synths()


### PR DESCRIPTION
:cl: Mucker
rscdel: Removed the Energy Machette from emagged flying borg's modules.
/:cl:

Found it to be too strong for Borgs due to its high damage and no usage cost.