### PR TITLE
Add a charging station to the GUP

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -13601,9 +13601,6 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/shuttle/petrov/custodial)
 "Ko" = (
-/obj/structure/bed/chair/shuttle/blue{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -13611,6 +13608,7 @@
 	dir = 4;
 	pixel_x = -21
 	},
+/obj/machinery/recharge_station,
 /turf/simulated/floor/tiled/techfloor,
 /area/guppy_hangar/start)
 "Kr" = (


### PR DESCRIPTION
Does the GUP really need FIVE seats?

## Changelog
:cl: SierraKomodo
maptweak: The GUP now has a charging station for IPCs and borgs, replacing one of the many seats it has.
/:cl: