### PR TITLE
robot item fixes

### DIFF
--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -23,6 +23,21 @@
 	var/range = 4
 	var/max_beaker = ITEM_SIZE_SMALL
 
+
+/obj/item/flamethrower/examine(mob/user)
+	. = ..()
+	if (beaker)
+		if (beaker.reagents)
+			to_chat(user, SPAN_NOTICE("The loaded [beaker.name] has about [beaker.reagents.total_volume] unit\s left."))
+		else
+			to_chat(user, SPAN_NOTICE("The loaded [beaker.name] is empty."))
+	else
+		to_chat(user, SPAN_NOTICE("\The [src] has no fuel container loaded!."))
+
+	if (lit)
+		to_chat(user, SPAN_WARNING("\The [src] is lit!"))
+
+
 /obj/item/flamethrower/Destroy()
 	QDEL_NULL(weldtool)
 	QDEL_NULL(igniter)
@@ -33,6 +48,13 @@
 	if(!lit)
 		STOP_PROCESSING(SSobj, src)
 		return null
+	else if (!beaker || beaker.reagents.total_volume == 0)
+		visible_message(SPAN_WARNING("\The [src] sputters and goes out!"))
+		playsound(loc, 'sound/items/welderdeactivate.ogg', 50, TRUE)
+		STOP_PROCESSING(SSobj,src)
+		set_light(0)
+		lit = FALSE
+		update_icon()
 	var/turf/location = loc
 	if(ismob(location))
 		var/mob/M = location
@@ -125,8 +147,8 @@
 	toggle_igniter(user)
 
 /obj/item/flamethrower/proc/toggle_igniter(mob/user)
-	if(!beaker)
-		to_chat(user, SPAN_NOTICE("Attach a fuel container first!"))
+	if(!beaker || beaker.reagents.total_volume == 0)
+		to_chat(user, SPAN_NOTICE("There isn't enough fuel!"))
 		return
 	if(!status)
 		to_chat(user,SPAN_NOTICE("Secure the igniter first!"))
@@ -173,7 +195,7 @@
 			fire_colour = R.fire_colour
 
 	if(power < REQUIRED_POWER_TO_FIRE_FLAMETHROWER)
-		audible_message(SPAN_DANGER("The [src] sputters."))
+		audible_message(SPAN_DANGER("\The [src] sputters."))
 		playsound(src, 'sound/weapons/guns/flamethrower_empty.ogg', 50, TRUE, -3)
 		return
 	playsound(src, pick('sound/weapons/guns/flamethrower1.ogg','sound/weapons/guns/flamethrower2.ogg','sound/weapons/guns/flamethrower3.ogg' ), 50, TRUE, -3)

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_filing.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_filing.dm
@@ -44,4 +44,5 @@
 	..()
 	if (R.emagged)
 		var/obj/item/flamethrower/full/loaded/flamethrower = locate() in equipment
-		flamethrower.beaker.reagents.add_reagent(/datum/reagent/napalm, 10 * amount)
+		if (flamethrower)
+			flamethrower.beaker.reagents.add_reagent(/datum/reagent/napalm, 30 * amount)

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_forensics.dm
@@ -44,6 +44,7 @@
 	)
 
 /obj/item/robot_module/flying/forensics/respawn_consumable(mob/living/silicon/robot/R, amount)
+	..()
 	var/obj/item/reagent_containers/spray/luminol/luminol = locate() in equipment
 	if(!luminol)
 		luminol = new(src)
@@ -52,4 +53,3 @@
 		var/adding = min(luminol.volume-luminol.reagents.total_volume, 2*amount)
 		if(adding > 0)
 			luminol.reagents.add_reagent(/datum/reagent/luminol, adding)
-	..()

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_repair.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_repair.dm
@@ -103,15 +103,18 @@
 /obj/item/robot_module/flying/repair/respawn_consumable(mob/living/silicon/robot/R, amount)
 	..()
 	var/obj/item/device/lightreplacer/LR = locate() in equipment
-	LR.Charge(R, amount)
+	if (LR)
+		LR.Charge(R, amount)
 
 	if (R.emagged)
 		var/obj/item/flamethrower/full/loaded/flamethrower = locate() in equipment
-		flamethrower.beaker.reagents.add_reagent(/datum/reagent/napalm, 10 * amount)
+		if (flamethrower)
+			flamethrower.beaker.reagents.add_reagent(/datum/reagent/napalm, 30 * amount)
 
 		var/obj/item/shield_diffuser/diff = locate() in equipment
-		diff.cell.charge += amount
+		if (diff)
+			diff.cell.charge += 10 * amount
 
 		var/obj/item/gun/launcher/grenade/foam/foam = locate() in equipment
-		if (LAZYLEN(foam.grenades) < foam.max_grenades)
+		if (foam?.max_grenades > length(foam?.grenades))
 			foam.grenades += new /obj/item/grenade/chem_grenade/metalfoam(src)

--- a/code/modules/mob/living/silicon/robot/modules/_module.dm
+++ b/code/modules/mob/living/silicon/robot/modules/_module.dm
@@ -178,28 +178,35 @@
 			F.icon_state = "flash"
 		else if(F.times_used)
 			F.times_used--
-	if(!synths || !length(synths))
-		return
-	for(var/datum/matter_synth/T in synths)
-		T.add_charge(T.recharge_rate * rate)
 
-	for (var/obj/item/gun/energy/T in equipment)
-		if (T && T.power_supply)
-			if (T.self_recharge)
-				return
-			if (T.power_supply.charge < T.power_supply.maxcharge)
-				T.power_supply.give(T.charge_cost * rate)
-				T.update_icon()
-			else
-				T.charge_tick = 0
+	if(length(synths))
+		for(var/datum/matter_synth/T in synths)
+			T.add_charge(T.recharge_rate * rate)
 
-	for (var/obj/item/gun/projectile/P in equipment)
+	var/obj/item/reagent_containers/spray/cleaner/drone/SC = locate() in equipment
+	if (SC)
+		SC.reagents.add_reagent(/datum/reagent/space_cleaner, 8 * rate)
+
+	var/obj/item/gun/energy/E = locate() in equipment
+	if (E?.power_supply)
+		if (E.self_recharge)
+			return
+		if (E.power_supply.charge < E.power_supply.maxcharge)
+			E.power_supply.give(E.charge_cost * 2)
+
+	var/obj/item/gun/projectile/P = locate() in equipment
+	if (P)
 		if (P.load_method == MAGAZINE)
-			if (P.ammo_magazine == null || P.ammo_magazine.stored_ammo == 0)
+			var/obj/item/ammo_magazine/mag = P.ammo_magazine
+			if (!mag || length(mag.stored_ammo) <= mag.max_ammo * 0.25)
 				P.ammo_magazine = new P.magazine_type(src)
+				qdel(mag)
 		else
 			if (length(P.loaded) <= P.max_shells)
 				P.loaded += new P.ammo_type(src)
+
+	for (var/obj/gear in equipment)
+		gear.update_icon()
 
 
 /obj/item/robot_module/proc/add_languages(mob/living/silicon/robot/R)

--- a/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_clerical.dm
@@ -68,7 +68,7 @@
 	..()
 	if (R.emagged)
 		var/obj/item/reagent_containers/food/drinks/bottle/small/beer/fake/fake = locate() in equipment
-		fake.reagents.add_reagent(/datum/reagent/chloralhydrate/beer, 2 * amount)
+		fake.reagents.add_reagent(/datum/reagent/chloralhydrate/beer, 10 * amount)
 
 /obj/item/robot_module/clerical/general
 	name = "clerical robot module"
@@ -118,4 +118,5 @@
 	..()
 	if (R.emagged)
 		var/obj/item/flamethrower/full/loaded/flamethrower = locate() in equipment
-		flamethrower.beaker.reagents.add_reagent(/datum/reagent/napalm, 10 * amount)
+		if (flamethrower)
+			flamethrower.beaker.reagents.add_reagent(/datum/reagent/napalm, 30 * amount)

--- a/code/modules/mob/living/silicon/robot/modules/module_engineering.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_engineering.dm
@@ -127,15 +127,18 @@
 /obj/item/robot_module/engineering/respawn_consumable(mob/living/silicon/robot/R, amount)
 	..()
 	var/obj/item/device/lightreplacer/LR = locate() in equipment
-	LR.Charge(R, amount)
+	if (LR)
+		LR.Charge(R, amount)
 
 	if (R.emagged)
 		var/obj/item/flamethrower/full/loaded/flamethrower = locate() in equipment
-		flamethrower.beaker.reagents.add_reagent(/datum/reagent/napalm, 10 * amount)
+		if (flamethrower)
+			flamethrower.beaker.reagents.add_reagent(/datum/reagent/napalm, 10 * amount)
 
 		var/obj/item/shield_diffuser/diff = locate() in equipment
-		diff.cell.charge += amount
+		if (diff)
+			diff.cell.charge += amount
 
 		var/obj/item/gun/launcher/grenade/foam/foam = locate() in equipment
-		if (LAZYLEN(foam.grenades) < foam.max_grenades)
+		if (foam?.max_grenades > length(foam?.grenades))
 			foam.grenades += new /obj/item/grenade/chem_grenade/metalfoam(src)

--- a/code/modules/mob/living/silicon/robot/modules/module_janitor.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_janitor.dm
@@ -31,17 +31,21 @@
 /obj/item/robot_module/janitor/finalize_emag()
 	. = ..()
 
-	var/obj/item/reagent_containers/spray/oil = locate() in equipment
-	oil.reagents.add_reagent(/datum/reagent/oil, 250)
-	oil.SetName("Oil spray")
+	var/obj/item/reagent_containers/spray/fuel = locate() in equipment
+	fuel.reagents.add_reagent(/datum/reagent/fuel, 250)
+	fuel.SetName("Fuel spray")
 
 /obj/item/robot_module/janitor/respawn_consumable(mob/living/silicon/robot/R, amount)
 	..()
 	var/obj/item/device/lightreplacer/LR = locate() in equipment
-	LR.Charge(R, amount)
+	if (LR)
+		LR.Charge(R, amount)
+
 	if (R.emagged)
 		var/obj/item/reagent_containers/spray/S = locate() in equipment
-		S.reagents.add_reagent(/datum/reagent/oil, 20 * amount)
+		if (S)
+			S.reagents.add_reagent(/datum/reagent/fuel, 30 * amount)
 
 		var/obj/item/flamethrower/full/loaded/flamethrower = locate() in equipment
-		flamethrower.beaker.reagents.add_reagent(/datum/reagent/napalm, 10 * amount)
+		if (flamethrower)
+			flamethrower.beaker.reagents.add_reagent(/datum/reagent/napalm, 30 * amount)

--- a/code/modules/mob/living/silicon/robot/modules/module_maintenance_drone.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_maintenance_drone.dm
@@ -104,10 +104,6 @@
 	var/obj/item/stack/material/cyborg/plastic/P = locate() in equipment
 	P.synths = list(plastic)
 
-/obj/item/robot_module/drone/respawn_consumable(mob/living/silicon/robot/R, amount)
-	..()
-	var/obj/item/reagent_containers/spray/cleaner/drone/SC = locate() in equipment
-	SC.reagents.add_reagent(/datum/reagent/space_cleaner, 8 * amount)
 
 /obj/item/robot_module/drone/construction
 	name = "construction drone module"
@@ -118,6 +114,7 @@
 	. = ..()
 
 /obj/item/robot_module/drone/respawn_consumable(mob/living/silicon/robot/R, amount)
-	var/obj/item/device/lightreplacer/LR = locate() in equipment
-	LR.Charge(R, amount)
 	..()
+	var/obj/item/device/lightreplacer/LR = locate() in equipment
+	if (LR)
+		LR.Charge(R, amount)

--- a/code/modules/mob/living/silicon/robot/modules/module_medical.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_medical.dm
@@ -14,7 +14,7 @@
 		/obj/item/melee/baton/robot/electrified_arm,
 		/obj/item/device/flash,
 		/obj/item/gun/energy/gun,
-		/obj/item/reagent_containers/spray,
+		/obj/item/reagent_containers/spray/chemsprayer,
 		/obj/item/gun/launcher/syringe/rapid/sleepy
 	)
 
@@ -27,22 +27,25 @@
 /obj/item/robot_module/medical/finalize_emag()
 	. = ..()
 
-	var/obj/item/reagent_containers/spray/acid = locate() in equipment
-	acid.reagents.add_reagent(/datum/reagent/acid/polyacid, 250)
-	acid.SetName("Polyacid spray")
+	var/obj/item/reagent_containers/spray/chemsprayer/acid = locate() in equipment
+	if (acid)
+		acid.reagents.add_reagent(/datum/reagent/acid/polyacid, 250)
+		acid.SetName("Polyacid Spray")
 
 	var/obj/item/shockpaddles/robot/shock = locate() in equipment
-	shock.safety = FALSE
+	if (shock)
+		shock.safety = FALSE
 
 
 /obj/item/robot_module/medical/respawn_consumable(mob/living/silicon/robot/R, amount)
 	..()
-	if(R.emagged)
-		var/obj/item/reagent_containers/spray/acid = locate() in equipment
-		acid.reagents.add_reagent(/datum/reagent/acid/polyacid, 2 * amount)
+	if (R.emagged)
+		var/obj/item/reagent_containers/spray/chemsprayer/acid = locate() in equipment
+		if (acid)
+			acid.reagents.add_reagent(/datum/reagent/acid/polyacid, 40 * amount)
 
 		var/obj/item/gun/launcher/syringe/rapid/sleepy = locate() in equipment
-		if (sleepy.darts < sleepy.max_darts)
+		if (sleepy?.max_darts > length(sleepy?.darts))
 			sleepy.darts += new /obj/item/syringe_cartridge/sleepy(src)
 
 
@@ -112,6 +115,13 @@
 		stack.synths = list(medicine)
 
 
+/obj/item/robot_module/medical/surgeon/respawn_consumable(mob/living/silicon/robot/R, amount)
+	..()
+	var/obj/item/reagent_containers/spray/sterilizine/S = locate() in equipment
+	if (S)
+		S.reagents.add_reagent(/datum/reagent/sterilizine, 10 * amount)
+
+
 /obj/item/robot_module/medical/crisis
 	name = "crisis robot module"
 	display_name = "Crisis"
@@ -176,10 +186,10 @@
 		stack.synths = list(medicine)
 
 /obj/item/robot_module/medical/crisis/respawn_consumable(mob/living/silicon/robot/R, amount)
+	..()
 	var/obj/item/reagent_containers/syringe/S = locate() in equipment
 	if (S.mode == 2)
 		S.reagents.clear_reagents()
 		S.mode = initial(S.mode)
 		S.desc = initial(S.desc)
 		S.update_icon()
-	..()

--- a/code/modules/projectiles/guns/launcher/syringe_gun.dm
+++ b/code/modules/projectiles/guns/launcher/syringe_gun.dm
@@ -88,6 +88,15 @@
 	var/max_darts = 1
 	var/obj/item/syringe_cartridge/next
 
+
+/obj/item/gun/launcher/syringe/examine(mob/user, distance)
+	. = ..()
+	to_chat(user, SPAN_NOTICE("\The [src] has [length(darts)] dart\s left!"))
+
+	if (next)
+		to_chat(user, SPAN_WARNING("\The [src] is ready to fire!"))
+
+
 /obj/item/gun/launcher/syringe/consume_next_projectile()
 	if(next)
 		next.prime()


### PR DESCRIPTION
Closes #34106 

I think this is all of them, plus some QoL for flamethrowers and syringe guns.

🆑 Jux
bugfix: Borg antag items that recharge (guns, various reagent items) now recharge properly,  Borg modules that used the drone space cleaner without ever recharging it now recharge it, and Surgeon borgs recharge their sterilizine. All rechargable borg antag items recharge at a more reasonable speed.
bugfix: Borg item icons now update when recharging, making it less of a guessing game for if your tools are charged.
tweak: Flamethrowers and syringe guns both now give feedback on their ammo and ready status when examined. Flamethrowers require fuel to ignite, and go out when they run out of fuel.
/🆑 