### PR TITLE
Allow intent-agnostic table frame interactions

### DIFF
--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -143,15 +143,9 @@
 
 	// Material - Plate table
 	if (istype(weapon, /obj/item/stack/material))
-		if (material)
-			reinforce_table(weapon, user)
-			return TRUE
-		material = common_material_add(weapon, user, "plat")
-		if (material)
-			update_connections(TRUE)
-			update_icon()
-			update_desc()
-			update_material()
+		if (!material)
+			return FALSE // Handled by `use_tool()`
+		reinforce_table(weapon, user)
 		return TRUE
 
 	// Welding Tool - Repair damage
@@ -216,10 +210,28 @@
 /obj/structure/table/use_tool(obj/item/tool, mob/user, list/click_params)
 	SHOULD_CALL_PARENT(FALSE)
 
-	// Put things on table
+	// Unfinished table - Construction stuff
 	if (can_plate && !material)
+		// Material - Plate table
+		if (istype(tool, /obj/item/stack/material))
+			material = common_material_add(tool, user, "plat")
+			if (material)
+				update_connections(TRUE)
+				update_icon()
+				update_desc()
+				update_material()
+			return TRUE
+
+		// Wrench - Dismantle
+		if (isWrench(tool))
+			dismantle(tool, user)
+			return TRUE
+
+		// Anything else - Can't put it on an unfinished table
 		USE_FEEDBACK_FAILURE("\The [src] needs to be plated before you can put \the [tool] on it.")
 		return TRUE
+
+	// Put things on table
 	if (!user.unEquip(tool, loc))
 		FEEDBACK_UNEQUIP_FAILURE(user, tool)
 		return TRUE


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Table frames can now be plated or dismantled regardless of user intent.
/:cl: