### PR TITLE
Drag and drop tables

### DIFF
--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -227,12 +227,6 @@
 	return TRUE
 
 
-/obj/structure/table/MouseDrop_T(obj/item/stack/material/what)
-	if(can_reinforce && isliving(usr) && (!usr.stat) && istype(what) && usr.get_active_hand() == what && Adjacent(usr))
-		reinforce_table(what, usr)
-	else
-		return ..()
-
 /obj/structure/table/proc/reinforce_table(obj/item/stack/material/S, mob/user)
 	if(reinforced)
 		to_chat(user, SPAN_WARNING("\The [src] is already reinforced!"))

--- a/code/modules/tables/tables.dm
+++ b/code/modules/tables/tables.dm
@@ -227,6 +227,17 @@
 	return TRUE
 
 
+/obj/structure/table/MouseDrop_T(atom/dropped, mob/user)
+	// Place held objects on table
+	if (user.IsHolding(dropped))
+		if (!user.use_sanity_check(src, dropped, SANITY_CHECK_DEFAULT | SANITY_CHECK_TOOL_UNEQUIP))
+			return TRUE
+		user.unEquip(dropped, get_turf(src))
+		return TRUE
+
+	return ..()
+
+
 /obj/structure/table/proc/reinforce_table(obj/item/stack/material/S, mob/user)
 	if(reinforced)
 		to_chat(user, SPAN_WARNING("\The [src] is already reinforced!"))


### PR DESCRIPTION
Suggested by sbotkin

## Changelog
:cl: SierraKomodo
rscdel: Click+dragging a stack of metal on a table no longer reinforces the table.
rscadd: Click+dragging held items onto a table now puts that item on the table regardless of intent.
/:cl: