### PR TITLE
Aghost fix

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1423,6 +1423,7 @@ GLOBAL_VAR_INIT(skip_allow_lists, FALSE)
 	message_admins(SPAN_CLASS("adminnotice", "[key_name_admin(usr)] has put [frommob.ckey] in control of [tomob.name]."))
 	log_admin("[key_name(usr)] stuffed [frommob.ckey] into [tomob.name].")
 	tomob.ckey = frommob.ckey
+	tomob.teleop = null
 	qdel(frommob)
 	return 1
 

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -158,6 +158,8 @@
 	log_and_message_admins("assumed direct control of [M].")
 	var/mob/adminmob = src.mob
 	M.ckey = src.ckey
+	M.teleop = null
+	adminmob.teleop = null
 	if(isghost(adminmob))
 		qdel(adminmob)
 


### PR DESCRIPTION
Hello! My first but not last PR for you ❤️ 

There is a problem for admins. You play in round than for some reason you need to exit in aghost and take direct control over a mob. When you're done - you going back into your old mob. And than if you need for some reason to aghost again - there is "You are already admin-ghosted." And if you dare to delete your mob - blackscreen with only VV exit from it. 

There is a var/teleop that is doing this bug when admins exit and enter new mobs - they old mobs are left with some aethereal ghost that doesn't letting you out in ghosts. 

 Video with working fix:

https://github.com/Baystation12/Baystation12/assets/105150564/63510d47-3bb3-415f-96bb-fe1df8ea9cc9

I hope that admins work will be better!

🆑 cuddleandtea
bugfix: admins can now re-exit their old mobs after entering other mobs and going back
/🆑 