### PR TITLE
Guns no longer ignore safety on harm with good skills

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -234,11 +234,8 @@
 		return
 
 	if(safety())
-		if(user.a_intent == I_HURT && user.skill_check(SKILL_WEAPONS, SKILL_EXPERIENCED))
-			toggle_safety(user)
-		else
-			handle_click_safety(user)
-			return
+		handle_click_safety(user)
+		return
 
 	if(world.time < next_fire_time)
 		if (world.time % 3) //to prevent spam


### PR DESCRIPTION
Exactly what it says on the tin: guns that you have toggled the safety on will no longer turn off their safeties and fire when you're on harm intent if you have experienced+ skill level. This "feature" of high skill isn't actually useful (it's easy to just macro the safety toggle button), and has led to more than a few shelves being shot when trying to put guns away. Safety should trump intent, that's the point of having safeties.

:cl: SingingSpock
tweak: Guns no longer ignore having the safety toggled on when you're on harm intent and click
/:cl: