### PR TITLE
Rust output SMES no longer starts fully charged

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -14852,10 +14852,10 @@
 	pixel_x = 25;
 	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
 	},
-/obj/machinery/power/smes/buildable/preset/torch/engine_main{
+/obj/structure/cable,
+/obj/machinery/power/smes/buildable/preset/torch/engine_empty{
 	RCon_tag = "R-UST - Main"
 	},
-/obj/structure/cable,
 /turf/simulated/floor/tiled/monotile,
 /area/vacant/prototype/control)
 "Nm" = (

--- a/maps/torch/torch_presets.dm
+++ b/maps/torch/torch_presets.dm
@@ -109,7 +109,7 @@ var/global/const/NETWORK_FIFTH_DECK  = "Fifth Deck"
 /obj/machinery/power/smes/buildable/preset/torch/substation_full/rust
 	uncreated_component_parts = list(/obj/item/stock_parts/smes_coil/super_io = 2)
 
-// Main Engine output SMES
+// Supermatter output SMES
 /obj/machinery/power/smes/buildable/preset/torch/engine_main
 	uncreated_component_parts = list(
 		/obj/item/stock_parts/smes_coil/super_io = 2,
@@ -119,6 +119,16 @@ var/global/const/NETWORK_FIFTH_DECK  = "Fifth Deck"
 	_input_on = TRUE
 	_output_on = TRUE
 	_fully_charged = TRUE
+
+//RUST Output SMES
+/obj/machinery/power/smes/buildable/preset/torch/engine_empty
+	uncreated_component_parts = list(
+		/obj/item/stock_parts/smes_coil/super_io = 2,
+		/obj/item/stock_parts/smes_coil/super_capacity = 2)
+	_input_maxed = TRUE
+	_output_maxed = TRUE
+	_input_on = TRUE
+	_output_on = TRUE
 
 // Shuttle SMES
 /obj/machinery/power/smes/buildable/preset/torch/shuttle


### PR DESCRIPTION
Unintended side effect of #33914 is that the ship nearly doubled its starting accessible power reserves, since nothing was between the Rust output SMES and the main grid. This makes that SMES just start empty, to return starting power storage to earlier levels.

:cl: SingingSpock
Maptweak: The Rust output SMES no longer has charge in it to start
/:cl: