### PR TITLE
makes cigarette cases start empty, cleans up a bunch of smoking-related descriptions/actions

### DIFF
--- a/code/game/objects/items/weapons/ecigs.dm
+++ b/code/game/objects/items/weapons/ecigs.dm
@@ -46,7 +46,7 @@
 
 /obj/item/clothing/mask/smokable/ecig/util
 	name = "electronic cigarette"
-	desc = "A popular utilitarian model electronic cigarette, the ONI-55. Comes in a variety of colors."
+	desc = "A popular utilitarian model of electronic cigarette, the ONI-55. Comes in a variety of colors."
 	icon_state = "ecigoff1"
 	icon_off = "ecigoff1"
 	icon_empty = "ecigoff1"

--- a/code/game/objects/items/weapons/storage/fancy/smokable/basic.dm
+++ b/code/game/objects/items/weapons/storage/fancy/smokable/basic.dm
@@ -1,6 +1,6 @@
 /obj/item/storage/fancy/smokable/case
 	name = "cigarette case"
-	desc = "A fancy little case for holding cigarettes in it."
+	desc = "A fancy little case for holding cigarettes. It has a spring-loaded click-open mechanism."
 	icon = 'icons/obj/cigarettes.dmi'
 	icon_state = "cigscase"
 	item_state = "syringe_kit"
@@ -9,9 +9,6 @@
 	sealed = FALSE
 	storage_slots = 6
 	key_type = list(/obj/item/clothing/mask/smokable/cigarette, /obj/item/material/coin)
-	startswith = list(
-		/obj/item/clothing/mask/smokable/cigarette = 6
-	)
 
 /obj/item/storage/fancy/smokable/case/on_update_icon()
 	ClearOverlays()
@@ -147,7 +144,7 @@
 
 /obj/item/storage/fancy/smokable/cigar
 	name = "cigar case"
-	desc = "A case for holding your cigars when you are not smoking them."
+	desc = "A case for holding your cigars, in the short interstice before you smoke them."
 	icon_state = "cigarcase"
 	item_state = "cigpacket"
 	max_storage_space = null

--- a/code/game/objects/items/weapons/storage/misc.dm
+++ b/code/game/objects/items/weapons/storage/misc.dm
@@ -51,7 +51,7 @@
 //misc tobacco nonsense
 /obj/item/storage/cigpaper
 	name = "\improper Gen. Eric cigarette paper"
-	desc = "A ubiquitous brand of cigarette paper, allegedly endorsed by 24th century war hero General Eric Osmundsun for rolling your own cigarettes. Osmundsun died in a freak kayak accident. As it ate him alive during his last campaign. It was pretty freaky."
+	desc = "A ubiquitous brand of cigarette rolling-paper endorsed by Commonwealth Civil War General Eric Osmundsun, of the Terran Commonwealth. Osmundsun, known as 'The Aresian Butcher' for his valorant service, died in a freak white-water kayak accident in 2231."
 	icon = 'icons/obj/cigarettes.dmi'
 	icon_state = "cigpaperbook"
 	item_state = "cigpacket"
@@ -69,14 +69,14 @@
 
 /obj/item/storage/cigpaper/fancy
 	name = "\improper Trident cigarette paper"
-	desc = "A fancy brand of Trident cigarette paper, for rolling your own cigarettes. Like a person who appreciates the finer things in life."
+	desc = "A book of Trident-brand cigarette paper, for rolling to impress. Made to cater to individuals who appreciates the finer things in life."
 	icon = 'icons/obj/cigarettes.dmi'
 	icon_state = "fancycigpaperbook"
 	startswith = list(/obj/item/paper/cig/fancy = 10)
 
 /obj/item/storage/cigpaper/filters
 	name = "box of cigarette filters"
-	desc = "A box of generic cigarette filters for those who rolls their own but prefers others to inhale the fumes. Not endorsed by Late General Osmundsun."
+	desc = "A box of generic cigarette filters, for those who roll their own and prefer to reduce the tar concentration in their lungs. Not endorsed by the late General Osmundsun."
 	icon = 'icons/obj/cigarettes.dmi'
 	icon_state = "filterbin"
 	startswith = list(/obj/item/paper/cig/filter = 10)
@@ -101,7 +101,7 @@
 
 /obj/item/storage/chewables/rollable/bad
 	name = "bag of Men at Arms tobacco"
-	desc = "A bag of coarse gritty tobacco marketed towards leather-necks."
+	desc = "A bag of coarse, gritty tobacco, marketed towards leather-necks."
 	startswith = list(/obj/item/reagent_containers/food/snacks/grown/dried_tobacco/bad = 8)
 	icon_state = "rollcoarse"
 
@@ -113,13 +113,13 @@
 
 /obj/item/storage/chewables/rollable/fine
 	name = "bag of Golden Sol tobacco"
-	desc = "A exclusive brand of overpriced tobacco, allegedly grown at a lagrange point station in Sol system."
+	desc = "A exclusive brand of overpriced tobacco, allegedly grown at a hidden lagrange point station somewhere in Sol."
 	startswith = list(/obj/item/reagent_containers/food/snacks/grown/dried_tobacco/fine = 8)
 	icon_state = "rollfine"
 
 /obj/item/storage/chewables/rollable/rollingkit
 	name = "bag of Crewman's First tobacco"
-	desc = "Generic middling quality tobacco for the recently enlisted and cost-conscious smokers. This bag comes with rolling papers and filters!"
+	desc = "Generic, middling quality dried tobacco for the recently enlisted and cost-conscious smokers. This bag comes with rolling papers and filters to kick-start your new habit."
 	startswith = list(
 	/obj/item/reagent_containers/food/snacks/grown/dried_tobacco = 8,
 	/obj/item/storage/cigpaper = 1,
@@ -130,14 +130,14 @@
 //chewing tobacco
 /obj/item/storage/chewables/tobacco
 	name = "tin of Lenny's brand chewing tobacco"
-	desc = "A generic brand of chewing tobacco, for when you can't even be assed to light up."
+	desc = "A dark-brown tin of Lenny's chewing tobacco, favored by the more elder end of Hellshen algae technicians."
 	icon_state = "chew_levi"
 	item_state = "Dpacket"
 	startswith = list(/obj/item/clothing/mask/chewable/tobacco/lenni = 6)
 
 /obj/item/storage/chewables/tobacco2
 	name = "tin of Red Lady chewing tobacco"
-	desc = "A finer grade of chewing tobacco."
+	desc = "A platinum-colored tin filled with high-grade chewing tobacco. The slender, red-haired, red-dressed woman on the front is more recognizable than some religious institutions."
 	icon_state = "chew_redman"
 	item_state = "redlady"
 	startswith = list(/obj/item/clothing/mask/chewable/tobacco/redlady = 6)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -104,7 +104,7 @@
 	if(!opened && src.open_sound)
 		playsound(src.loc, src.open_sound, 50, 0, -5)
 		open_sound_played = TRUE
-		to_chat(user, "You open \the [src]")
+		to_chat(user, "You open \the [src].")
 		queue_icon_update()
 	if (src.use_sound && !open_sound_played)
 		playsound(src.loc, src.use_sound, 50, 0, -5)

--- a/code/modules/clothing/masks/chewable.dm
+++ b/code/modules/clothing/masks/chewable.dm
@@ -58,7 +58,7 @@
 
 /obj/item/clothing/mask/chewable/tobacco
 	name = "wad"
-	desc = "A chewy wad of tobacco. Cut in long strands and treated with syrups so it doesn't taste like a ash-tray when you stuff it into your face."
+	desc = "A chewy wad of tobacco. Cut in long strands and treated with syrups so it doesn't taste like an ashtray when you stuff it into your mouth."
 	throw_speed = 0.5
 	icon_state = "chew"
 	type_butt = /obj/item/trash/cigbutt/spitwad
@@ -89,12 +89,12 @@
 
 /obj/item/clothing/mask/chewable/tobacco/lenni
 	name = "chewing tobacco"
-	desc = "A chewy wad of tobacco. Cut in long strands and treated with syrups so it tastes less like a ash-tray when you stuff it into your face."
+	desc = "A chewy wad of tobacco. Cut in long strands and treated with syrups so it tastes less like an ashtray when you stuff it into your mouth."
 	filling = list(/datum/reagent/tobacco = 2)
 
 /obj/item/clothing/mask/chewable/tobacco/redlady
 	name = "chewing tobacco"
-	desc = "A chewy wad of fine tobacco. Cut in long strands and treated with syrups so it doesn't taste like a ash-tray when you stuff it into your face."
+	desc = "A chewy wad of fine tobacco. Cut in long strands and treated with syrups so it doesn't taste like an ashtray when you stuff it into your mouth."
 	filling = list(/datum/reagent/tobacco/fine = 2)
 
 /obj/item/clothing/mask/chewable/tobacco/nico

--- a/code/modules/clothing/masks/cig_crafting.dm
+++ b/code/modules/clothing/masks/cig_crafting.dm
@@ -1,6 +1,6 @@
 /obj/item/clothing/mask/smokable/cigarette/rolled
 	name = "rolled cigarette"
-	desc = "A hand rolled cigarette using dried plant matter."
+	desc = "A hand-rolled cigarette filled with dried plant matter."
 	icon_state = "cigroll"
 	item_state = "cigoff"
 	type_butt = /obj/item/trash/cigbutt
@@ -12,7 +12,7 @@
 /obj/item/clothing/mask/smokable/cigarette/rolled/examine(mob/user)
 	. = ..()
 	if(filter)
-		to_chat(user, "Capped off one end with a filter.")
+		to_chat(user, "One of the ends is capped off by a filter.")
 
 /obj/item/clothing/mask/smokable/cigarette/rolled/on_update_icon()
 	. = ..()
@@ -31,12 +31,12 @@
 
 /obj/item/paper/cig/fancy
 	name = "\improper Trident rolling paper"
-	desc = "A thin piece of trident branded paper used to make fine smokeables."
+	desc = "A thin piece of Trident-branded paper used to make fine smokeables."
 	icon_state = "cig_paperf"
 
 /obj/item/paper/cig/filter
 	name = "cigarette filter"
-	desc = "A small nub like filter for cigarettes."
+	desc = "A small nub-like filter for cigarettes."
 	icon_state = "cig_filter"
 	w_class = ITEM_SIZE_TINY
 
@@ -65,7 +65,7 @@
 			to_chat(user, SPAN_WARNING("[src] is lit already!"))
 			return
 		if(user.unEquip(I))
-			to_chat(user, SPAN_NOTICE("You stick [I] into \the [src]"))
+			to_chat(user, SPAN_NOTICE("You stick [I] onto \the [src]."))
 			filter = 1
 			SetName("filtered [name]")
 			brand = "[brand] with a filter"
@@ -84,7 +84,7 @@
 			R.chem_volume = reagents.total_volume
 			R.brand = "[src] handrolled in \the [I]."
 			reagents.trans_to_holder(R.reagents, R.chem_volume)
-			to_chat(user, SPAN_NOTICE("You roll \the [src] into \the [I]"))
+			to_chat(user, SPAN_NOTICE("You roll \the [src] into \the [I]."))
 			user.put_in_active_hand(R)
 			qdel(I)
 			qdel(src)


### PR DESCRIPTION
🆑 gy1ta23, joeynosegay
tweak: Some smokeables have better item descriptions.
tweak: Cigarette cases start empty.
/🆑


Now, to start us off, cigarette cases have no real reason to start filled; characters smoke different brands, and it is not enjoyable whatsoever nor conducive to character-building or immersion to spend a good thirty seconds at the start of each round picking out cigarettes from the case and dumping them in disposals. I know this because I do this most every round. Injustices like these need not be lived.

Cigarette hand-rolling. I believe I am one of, quite possibly, around six people in the history of the server to bother to do that, and that includes the guy who ported them from TG and did it once. Do I blame the rest of you for not doing this? Hardly not, it takes a lot of time. At least, I have to hope that most of you aren't hand-rolling somewhere I can't see, because the actions for doing it and the items used in doing it are in a sorry state; the most popular paper isn't even lore-compliant. Joey rewrote most of that, by the way. He gets to be in the changelog because of that. Love you, Joey.

Anyways, I went in, fixed everything I experienced, looked around, fixed everything that I didn't that I saw regardless. I would hope this leads to a better experience for the four other people (the original porter left a while back, I think) who use this mechanic.

Well, at least, I would I say I hope this leads to a better experience if I wasn't a ghost in the wires that lived upon your collective suffering. Ah, but I am, so I am not to be believed. Life will yet carry on, as it tends to do, in this great cathedral of endless sound and sight.

