### PR TITLE
Replace Join Response Team and Join as Actor verb from IC to Ghost tab

### DIFF
--- a/code/game/antagonist/outsider/actors.dm
+++ b/code/game/antagonist/outsider/actors.dm
@@ -35,8 +35,8 @@ GLOBAL_DATUM_INIT(actor, /datum/antagonist/actor, new)
 
 	return 1
 
-/client/verb/join_as_actor()
-	set category = "IC"
+/mob/observer/ghost/verb/join_as_actor()
+	set category = "Ghost"
 	set name = "Join as Actor"
 	set desc = "Join as an Actor to entertain the crew through television!"
 

--- a/code/game/response_team.dm
+++ b/code/game/response_team.dm
@@ -46,10 +46,10 @@ var/global/can_call_ert
 	log_admin("[key_name(usr)] used Dispatch Response Team.")
 	trigger_armed_response_team(1, reason)
 
-/client/verb/JoinResponseTeam()
+/mob/observer/ghost/verb/JoinResponseTeam()
 
 	set name = "Join Response Team"
-	set category = "IC"
+	set category = "Ghost"
 
 	if(!MayRespawn(1))
 		to_chat(usr, SPAN_WARNING("You cannot join the response team at this time."))


### PR DESCRIPTION
:cl: Reishi42
bugfix: It was strange that "Join Response Team" or "Join as Actor" is on the IC tab of living human. 
Moved to the "Ghost" tab, because that looks logical.
/:cl: