### PR TITLE
restrict robot access to their relevant departments

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -467,7 +467,7 @@ var/global/const/NO_EMAG_ACT = -50
 	detail_color = COLOR_AMBER
 
 /obj/item/card/id/synthetic/New()
-	access = get_all_station_access() + access_synth
+	access = GLOB.using_map.synth_access.Copy()
 	..()
 
 /obj/item/card/id/centcom

--- a/code/modules/mob/living/silicon/robot/flying/module_flying_emergency.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying_emergency.dm
@@ -48,7 +48,6 @@
 		SKILL_ELECTRICAL   = SKILL_EXPERIENCED
 	)
 
-
 /obj/item/robot_module/medical/finalize_emag()
 	. = ..()
 

--- a/code/modules/mob/living/silicon/robot/modules/_module.dm
+++ b/code/modules/mob/living/silicon/robot/modules/_module.dm
@@ -51,6 +51,13 @@
 	var/is_emagged = FALSE
 	var/list/emag_gear = list()
 
+	/// Access flags that this module grants. Overwrites all existing access flags.
+	var/list/access = list()
+	/// Whether or not to include the map's defined `synth_access` list.
+	var/use_map_synth_access = TRUE
+	/// Whether or not to apply get_all_station_access() to the access flags.
+	var/use_all_station_access = FALSE
+
 
 /obj/item/robot_module/Initialize()
 
@@ -65,6 +72,8 @@
 	grant_skills(R)
 	add_languages(R)
 	add_subsystems(R)
+	set_map_specific_access()
+	set_access(R)
 	apply_status_flags(R)
 
 	if(R.silicon_radio)
@@ -245,3 +254,15 @@
 /obj/item/robot_module/proc/reset_skills(mob/living/silicon/robot/R)
 	for(var/datum/skill_buff/buff in R.fetch_buffs_of_type(/datum/skill_buff/robot))
 		buff.remove()
+
+/// Updates the robot's access flags with the module's access
+/obj/item/robot_module/proc/set_access(mob/living/silicon/robot/R)
+	R.idcard.access.Cut()
+	R.idcard.access = access.Copy()
+	if (use_map_synth_access)
+		R.idcard.access |= GLOB.using_map.synth_access.Copy()
+	if (use_all_station_access)
+		R.idcard.access |= get_all_station_access()
+
+/obj/item/robot_module/proc/set_map_specific_access()
+	return

--- a/code/modules/mob/living/silicon/robot/modules/module_illegal.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_illegal.dm
@@ -15,6 +15,10 @@
 		/obj/item/tank/jetpack/carbondioxide
 	)
 	var/id
+	access = list(
+		access_syndicate
+	)
+	use_map_synth_access = FALSE
 
 /obj/item/robot_module/syndicate/Initialize()
 	for(var/singleton/hierarchy/skill/skill in GLOB.skills)

--- a/code/modules/mob/living/silicon/robot/modules/module_maintenance_drone.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_maintenance_drone.dm
@@ -53,6 +53,7 @@
 		SKILL_CONSTRUCTION = SKILL_EXPERIENCED,
 		SKILL_ELECTRICAL   = SKILL_EXPERIENCED
 	)
+	use_all_station_access = TRUE
 
 /obj/item/robot_module/drone/finalize_equipment(mob/living/silicon/robot/R)
 	. = ..()

--- a/code/modules/mob/living/silicon/robot/modules/module_research.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_research.dm
@@ -50,6 +50,7 @@
 		SKILL_BOTANY              = SKILL_EXPERIENCED,
 		SKILL_ELECTRICAL          = SKILL_EXPERIENCED
 	)
+
 /obj/item/robot_module/research/finalize_equipment()
 	. = ..()
 	var/obj/item/stack/nanopaste/N = locate() in equipment

--- a/code/modules/mob/living/silicon/robot/modules/module_security.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_security.dm
@@ -20,7 +20,6 @@
 		SKILL_BUREAUCRACY = SKILL_TRAINED
 	)
 
-
 /obj/item/robot_module/security/general
 	name = "security robot module"
 	display_name = "Security"
@@ -74,7 +73,8 @@
 		/obj/item/melee/baton/robot/electrified_arm,
 		/obj/item/gun/projectile/automatic/l6_saw
 	)
-
+	use_map_synth_access = FALSE
+	use_all_station_access = TRUE
 
 /obj/item/robot_module/security/combat/Initialize()
 	. = ..()

--- a/maps/mapsystem/maps_jobs.dm
+++ b/maps/mapsystem/maps_jobs.dm
@@ -7,6 +7,14 @@
 
 	var/default_assistant_title = "Assistant"
 
+	/// List of default access flags provided to all robots on top of their module's flags
+	var/list/synth_access = list(
+		access_synth,
+		access_maint_tunnels,
+		access_teleporter
+	)
+
+
 // The white, and blacklist are type specific, any subtypes (of both species and jobs) have to be added explicitly
 /datum/map/proc/is_species_job_restricted(datum/species/S, datum/job/J)
 	if(!istype(S) || !istype(J))

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -8,6 +8,12 @@
 		/datum/species/vox = list(/datum/job/ai, /datum/job/cyborg),
 		/datum/species/human/mule = list(/datum/job/ai, /datum/job/cyborg, /datum/job/merchant)
 	)
+	synth_access = list(
+		access_synth,
+		access_maint_tunnels,
+		access_teleporter,
+		access_solgov_crew
+	)
 
 #define HUMAN_ONLY_JOBS /datum/job/captain, /datum/job/hop, /datum/job/cmo, /datum/job/chief_engineer, /datum/job/hos, /datum/job/representative, /datum/job/sea, /datum/job/pathfinder, /datum/job/rd
 	species_to_job_blacklist = list(

--- a/maps/torch/robot/_robot_access.dm
+++ b/maps/torch/robot/_robot_access.dm
@@ -1,0 +1,173 @@
+/obj/item/robot_module/clerical/set_map_specific_access()
+	access += list(
+		access_emergency_storage,
+		access_cargo,
+		access_cargo_bot,
+		access_commissary,
+		access_hangar,
+		access_mailsorting,
+		access_radio_serv,
+		access_radio_sup
+	)
+
+/obj/item/robot_module/clerical/butler/set_map_specific_access()
+	access = list(
+		access_commissary,
+		access_hydroponics,
+		access_kitchen,
+		access_radio_serv
+	)
+
+/obj/item/robot_module/medical/set_map_specific_access()
+	access += list(
+		access_chemistry,
+		access_crematorium,
+		access_emergency_storage,
+		access_eva,
+		access_external_airlocks,
+		access_hangar,
+		access_medical,
+		access_medical_equip,
+		access_morgue,
+		access_senmed,
+		access_surgery,
+		access_virology,
+		access_radio_med
+	)
+
+/obj/item/robot_module/engineering/set_map_specific_access()
+	access = list(
+		access_atmospherics,
+		access_construction,
+		access_emergency_storage,
+		access_engine,
+		access_engine_equip,
+		access_eva,
+		access_external_airlocks,
+		access_hangar,
+		access_network,
+		access_robotics,
+		access_seneng,
+		access_tcomsat,
+		access_tech_storage,
+		access_radio_eng
+	)
+
+/obj/item/robot_module/janitor/set_map_specific_access()
+	access = list(
+		access_emergency_storage,
+		access_janitor,
+		access_radio_serv
+	)
+
+/obj/item/robot_module/miner/set_map_specific_access()
+	access = list(
+		access_eva,
+		access_expedition_shuttle,
+		access_guppy,
+		access_hangar,
+		access_mining,
+		access_mining_office,
+		access_mining_station,
+		access_radio_exp,
+		access_radio_sup
+	)
+
+/obj/item/robot_module/research/set_map_specific_access()
+	access = list(
+		access_expedition_shuttle,
+		access_hangar,
+		access_mining_office,
+		access_mining_station,
+		access_petrov,
+		access_petrov_analysis,
+		access_petrov_chemistry,
+		access_petrov_maint,
+		access_petrov_phoron,
+		access_petrov_toxins,
+		access_research,
+		access_tox,
+		access_tox_storage,
+		access_xenoarch,
+		access_xenobiology,
+		access_radio_exp,
+		access_radio_sci
+	)
+
+/obj/item/robot_module/flying/cultivator/set_map_specific_access()
+	access = list(
+		access_hydroponics,
+		access_kitchen,
+		access_research,
+		access_radio_sci,
+		access_radio_serv
+	)
+
+/obj/item/robot_module/flying/emergency/set_map_specific_access()
+	access = list(
+		access_chemistry,
+		access_crematorium,
+		access_emergency_storage,
+		access_eva,
+		access_external_airlocks,
+		access_hangar,
+		access_medical,
+		access_medical_equip,
+		access_morgue,
+		access_senmed,
+		access_surgery,
+		access_virology,
+		access_radio_med
+	)
+
+/obj/item/robot_module/flying/filing/set_map_specific_access()
+	access = list(
+		access_emergency_storage,
+		access_cargo,
+		access_cargo_bot,
+		access_commissary,
+		access_hangar,
+		access_mailsorting,
+		access_radio_serv,
+		access_radio_sup
+	)
+
+/obj/item/robot_module/flying/forensics/set_map_specific_access()
+	access = list(
+		access_brig,
+		access_emergency_storage,
+		access_forensics_lockers,
+		access_morgue,
+		access_sec_doors,
+		access_security,
+		access_radio_sec
+	)
+
+/obj/item/robot_module/flying/repair/set_map_specific_access()
+	access = list(
+		access_atmospherics,
+		access_construction,
+		access_emergency_storage,
+		access_engine,
+		access_engine_equip,
+		access_eva,
+		access_external_airlocks,
+		access_hangar,
+		access_network,
+		access_robotics,
+		access_seneng,
+		access_tcomsat,
+		access_tech_storage,
+		access_radio_eng
+	)
+
+/obj/item/robot_module/security/set_map_specific_access()
+	access = list(
+		access_brig,
+		access_emergency_storage,
+		access_eva,
+		access_external_airlocks,
+		access_sec_doors,
+		access_security,
+		access_radio_sec
+	)

--- a/maps/torch/robot/module_flying_surveyor.dm
+++ b/maps/torch/robot/module_flying_surveyor.dm
@@ -51,6 +51,18 @@
 		/obj/item/gun/energy/gun,
 		/obj/item/melee/energy/machete
 	)
+	access = list(
+		access_emergency_storage,
+		access_eva,
+		access_expedition_shuttle,
+		access_explorer,
+		access_guppy,
+		access_hangar,
+		access_petrov,
+		access_research,
+		access_radio_exp,
+		access_radio_sci
+	)
 
 /obj/item/robot_module/flying/surveyor/finalize_synths()
 	. = ..()

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -122,6 +122,7 @@
 
 	#include "outfits/scgec.dm"
 
+	#include "robot/_robot_access.dm"
 	#include "robot/module_flying_surveyor.dm"
 
 	#include "structures/signs.dm"

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -1589,7 +1589,7 @@
 
 /area/assembly/robotics/laboratory
 	name = "\improper Robotics Laboratory"
-	req_access = list(list(access_medical,access_robotics))
+	req_access = list(list(access_medical,access_robotics, access_synth))
 
 /area/assembly/robotics/office
 	name = "\improper Robotics Office"


### PR DESCRIPTION
:cl: Mucker
balance: Robots no longer have all access, and can only access their relevant department doors. By default, all robots have access to the teleporter and maintenance tunnels, as well as robotics.
/:cl:

Basically a direct copy-paste of the last attempt to do this. I think it's well overdue.