### PR TITLE
Prevents smearing of blood and oil on the floor on creep intent

### DIFF
--- a/code/game/objects/effects/decals/Cleanable/humans.dm
+++ b/code/game/objects/effects/decals/Cleanable/humans.dm
@@ -101,6 +101,8 @@ var/global/list/image/splatter_cache=list()
 		return
 	if(amount < 1)
 		return
+	if(MOVING_DELIBERATELY(perp))
+		return
 
 	var/obj/item/organ/external/l_foot = perp.get_organ(BP_L_FOOT)
 	var/obj/item/organ/external/r_foot = perp.get_organ(BP_R_FOOT)


### PR DESCRIPTION
:cl:
tweak: Carefully stepping (creep intent) on spilled liquids prevents from smearing it.
/:cl: