### PR TITLE
Fix multitile doors opacity

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -50,6 +50,8 @@
 
 	/// Integer. Width of the door in tiles.
 	var/width = 1
+	/// List. Player view blocking fillers for multi-tile doors.
+	var/list/fillers
 
 	// Integer. Used for intercepting clicks on our turf. Set 0 to disable click interception. Passed directly to `/datum/extension/turf_hand`.
 	var/turf_hand_priority = 3
@@ -67,14 +69,7 @@
 	else
 		layer = open_layer
 
-
-	if(width > 1)
-		if(dir in list(EAST, WEST))
-			bound_width = width * world.icon_size
-			bound_height = world.icon_size
-		else
-			bound_width = world.icon_size
-			bound_height = width * world.icon_size
+	update_bounds()
 
 	if (turf_hand_priority)
 		set_extension(src, /datum/extension/turf_hand, turf_hand_priority)
@@ -348,13 +343,19 @@
 	do_animate("opening")
 	icon_state = "door0"
 	set_opacity(0)
+	if(width > 1)
+		set_fillers_opacity(0)
 	sleep(3)
 	src.set_density(0)
+	if(width > 1)
+		set_fillers_density(0)
 	update_nearby_tiles()
 	sleep(7)
 	src.layer = open_layer
 	update_icon()
 	set_opacity(0)
+	if(width > 1)
+		set_fillers_opacity(0)
 	operating = DOOR_OPERATING_NO
 
 	if(autoclose)
@@ -374,6 +375,8 @@
 	close_door_at = 0
 	do_animate("closing")
 	src.set_density(1)
+	if(width > 1)
+		set_fillers_density(1)
 	sleep(3)
 	src.layer = closed_layer
 	update_nearby_tiles()
@@ -381,6 +384,8 @@
 	update_icon()
 	if (visible && !glass)
 		set_opacity(1)	//caaaaarn!
+		if(width > 1)
+			set_fillers_opacity(1)
 	operating = DOOR_OPERATING_NO
 
 	//I shall not add a check every x ticks if a door has closed over some fire.
@@ -419,15 +424,9 @@
 
 /obj/machinery/door/Move(new_loc, new_dir)
 	update_nearby_tiles()
+	update_bounds()
 
 	. = ..()
-	if(width > 1)
-		if(dir in list(EAST, WEST))
-			bound_width = width * world.icon_size
-			bound_height = world.icon_size
-		else
-			bound_width = world.icon_size
-			bound_height = width * world.icon_size
 
 	if(.)
 		deconstruct(null, TRUE)
@@ -514,6 +513,67 @@
 	. = ..()
 	if (heat_proof)
 		. += 4000
+
+/**
+ * Checks which way the airlock is facing and adjusts the direction accordingly.
+ * For use with multi-tile airlocks.
+ */
+/obj/machinery/door/proc/get_adjusted_dir(dir)
+	if(dir in list(NORTH, SOUTH))
+		return EAST
+	else
+		return NORTH
+
+/**
+ * Sets the bounds of the airlock. For use with multi-tile airlocks.
+ * If the airlock is multi-tile, it will set the bounds to be the size of the airlock.
+ * If the airlock doesn't already have fillers, it will create them.
+ * If the airlock already has fillers, it will move them to the correct location.
+ */
+/obj/machinery/door/proc/update_bounds()
+	if(width <= 1)
+		return
+
+	if(dir in list(NORTH, SOUTH))
+		bound_width = width * world.icon_size
+		bound_height = world.icon_size
+	else
+		bound_width = world.icon_size
+		bound_height = width * world.icon_size
+
+	LAZYINITLIST(fillers)
+
+	var/adjusted_dir = get_adjusted_dir(dir)
+	var/obj/last_filler = src
+	for (var/i = 1, i < width, i++)
+		var/obj/airlock_filler_object/filler
+
+		if (length(fillers) < i)
+			filler = new
+			filler.pair_airlock(src)
+			fillers.Add(filler)
+		else
+			filler = fillers[i]
+
+		filler.loc = get_step(last_filler, adjusted_dir)
+		filler.density = density
+		filler.set_opacity(opacity)
+
+		last_filler = filler
+
+/obj/machinery/door/proc/set_fillers_density(density)
+	if (!length(fillers))
+		return
+
+	for (var/obj/airlock_filler_object/filler as anything in fillers)
+		filler.density = density
+
+/obj/machinery/door/proc/set_fillers_opacity(opacity)
+	if (!length(fillers))
+		return
+
+	for (var/obj/airlock_filler_object/filler as anything in fillers)
+		filler.set_opacity(opacity)
 
 // Public access
 


### PR DESCRIPTION
It's like in [`tgstation/tgstation /code/game/machinery/doors/door.dm`](https://github.com/tgstation/tgstation/blob/b23b1dd31089d026dfb44d53767c70f2b8ee0514/code/game/machinery/doors/door.dm), but made using `list` - will work not only for 2-tile doors, but also for any `width`.

Fixes #33767

### Changelog
```yml
🆑SuhEugene
bugfix: Fixed multitile doors opacity.
/🆑
```