### PR TITLE
Repairing arm blade that could be dropped or disarmed

### DIFF
--- a/code/modules/augment/active/armblades.dm
+++ b/code/modules/augment/active/armblades.dm
@@ -65,6 +65,7 @@
 	force_multiplier = 0.2
 	attack_cooldown_modifier = -1
 	default_material = MATERIAL_PLASTEEL
+	canremove = 0
 
 	/// SMALL prevents dismembering limbs - only hands & feet
 	w_class = ITEM_SIZE_SMALL


### PR DESCRIPTION
:cl:Reishi42
bugfix:
The arm blade could simply be released or knocked out of your hands, which is not logical - it’s an implant from your hand, how can you lose it?
I think this fix is quite logical.
/:cl: