### PR TITLE
Restores zombies' destructive capabilities, cleans up NPC behaviour

### DIFF
--- a/code/_onclick/other_mobs.dm
+++ b/code/_onclick/other_mobs.dm
@@ -32,6 +32,8 @@
 				SPAN_DANGER("\The [user] smashes through \the [src]!"),
 				SPAN_DANGER("You smash through \the [src]!")
 			)
+			if (MUTATION_FERAL in user.mutations)
+				qdel(src)
 		else
 			user.visible_message(
 				SPAN_DANGER("\The [user] [attack_verb] \the [src]!"),

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -170,7 +170,26 @@
 			do_animate("deny")
 	return
 
+/obj/machinery/door/airlock/attack_generic(mob/user)
+	if (MUTATION_FERAL in user.mutations)
+		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN*2)
+		playsound(loc, damage_hitsound, 50, 1)
+		attack_animation(user)
+
+		if((MACHINE_IS_BROKEN(src)|!arePowerSystemsOn(src)) && density)
+			visible_message(SPAN_DANGER("\The [user] manages to pry \the [src] open!"))
+			open(1)
+		else
+			visible_message(SPAN_DANGER("\The [user] smashes into \the [src]!"))
+			damage_health(10)
+		return
+	..()
+
 /obj/machinery/door/attack_hand(mob/user)
+	if (MUTATION_FERAL in user.mutations)
+		attack_generic(user, 15)
+		return
+
 	..()
 	if (allowed(user) && operable())
 		if (density)

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -114,9 +114,9 @@
 					playsound(src, pick(GLOB.punch_sound), 20)
 				if (MUTATION_FERAL in user.mutations)
 					M.visible_message(SPAN_DANGER("[M.name] slams into \the [src]!"), SPAN_DANGER("You slam into \the [src]!"))
-					playsound(src, pick(GLOB.punch_sound), 45)
-					damage_health(5, DAMAGE_BRUTE)
-					user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN*2) //Additional cooldown
+					playsound(src, 'sound/effects/clang.ogg', 45, 1)
+					damage_health(20, DAMAGE_BRUTE)
+					user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN*5) //Additional cooldown
 					attack_animation(user)
 				else
 					M.visible_message(SPAN_DANGER("[M.name] punches \the [src]!"), SPAN_DANGER("You punch \the [src]!"))

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -555,6 +555,7 @@
 	return
 
 /mob/living/exosuit/attack_generic(mob/user, damage, attack_message = "smashes into")
+	..()
 	if(damage)
 		playsound(loc, body.damage_sound, 40, 1)
 

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -839,7 +839,7 @@
 
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user
-		if(H.species.can_shred(H) || MUTATION_FERAL in H.mutations)
+		if(H.species.can_shred(H) || (MUTATION_FERAL in H.mutations))
 			attack_generic(H, rand(10,20), "slashed")
 			playsound(loc, 'sound/weapons/bite.ogg', 50, 1)
 			if (prob(20))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -839,8 +839,11 @@
 
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/H = user
-		if(H.species.can_shred(H))
-			attack_generic(H, rand(30,50), "slashed")
+		if(H.species.can_shred(H) || MUTATION_FERAL in H.mutations)
+			attack_generic(H, rand(10,20), "slashed")
+			playsound(loc, 'sound/weapons/bite.ogg', 50, 1)
+			if (prob(20))
+				playsound(loc, 'sound/effects/sparks1.ogg', 50, 1)
 			return
 
 	if(opened && !wiresexposed && (!istype(user, /mob/living/silicon)))

--- a/code/modules/species/outsider/zombie.dm
+++ b/code/modules/species/outsider/zombie.dm
@@ -176,24 +176,61 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 
 	addtimer(new Callback(src, .proc/handle_action, H), rand(10, 20))
 
+/datum/species/zombie/proc/is_valid_target(mob/living/T)
+	if (!istype(T, /mob/living/carbon/human)) //Ignore Diona and unconscious non-humans
+		if (istype(T, /mob/living/carbon/alien/diona))
+			return FALSE
+		if (T.stat != CONSCIOUS)
+			return FALSE
+
+	var/mob/living/carbon/human/H = T
+	if (H.is_species(SPECIES_ZOMBIE) || H.is_species(SPECIES_DIONA))
+		return FALSE
+
+	if (H.isSynthetic() && H.stat != CONSCIOUS)
+		return FALSE
+
+	if (istype(T, /mob/living/exosuit))
+		var/mob/living/exosuit/X = T
+		if (!LAZYLEN(X.pilots))
+			return FALSE //Don't attack empty mechs
+
+	return TRUE
+
+/datum/species/zombie/proc/is_consumable(mob/living/T)
+	if (!istype(T, /mob/living/carbon/human))
+		return FALSE
+
+	if (T.isSynthetic())
+		return FALSE
+
+	return is_valid_target(T)
+
+/datum/species/zombie/proc/is_being_consumed(mob/living/T, mob/living/carbon/human/H)
+	//Will exclude consumption candidates if there's another zombie on top of them
+	if (!is_consumable(T))
+		return FALSE
+	for (var/mob/living/carbon/human/M in T.loc.contents)
+		if (M != H && M.stat == CONSCIOUS && M.is_species(SPECIES_ZOMBIE))
+			return TRUE
+	return FALSE
+
 /datum/species/zombie/proc/handle_action(mob/living/carbon/human/H)
 	var/dist = 128
-	for(var/mob/living/M in hearers(H, 15))
-		if ((ishuman(M) || istype(M, /mob/living/exosuit)) && !M.is_species(SPECIES_ZOMBIE) && !M.is_species(SPECIES_DIONA)) //Don't attack fellow zombies, or diona
-			if (istype(M, /mob/living/exosuit))
-				var/mob/living/exosuit/MC = M
-				if (!LAZYLEN(MC.pilots))
-					continue //Don't attack empty mechs
-			if (M.stat == DEAD && target)
+	for (var/mob/living/M in hearers(H, 15))
+		if (is_valid_target(M)) //Don't attack fellow zombies, or diona
+			if (target && M.stat != CONSCIOUS)
 				continue //Only eat corpses when no living (and able) targets are around
+			if (is_being_consumed(M, H))
+				continue //Don't queue up to eat
 			var/D = get_dist(M, H)
 			if (D <= dist * 0.5) //Must be significantly closer to change targets
-				target = M //For closest target
+				target = M //Switch to closest target
 				dist = D
 
 	H.setClickCooldown(DEFAULT_ATTACK_COOLDOWN*2)
 	if (target)
-		if (target.is_species(SPECIES_ZOMBIE))
+		if (!is_valid_target(target) || is_being_consumed(target, H))
 			target = null
 			return
 
@@ -203,24 +240,23 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 				var/obj/obstacle = locate(type) in dir
 				if (obstacle)
 					H.face_atom(obstacle)
-					obstacle.attack_generic(H, 10, "smashes")
+					obstacle.attack_hand(H)
 					break
 
 			walk_to(H, target.loc, 1, H.move_intent.move_delay * 1.25)
 
 		else
-			if (!target.lying) //Subdue meals
-				H.face_atom(target)
+			if ((is_consumable(target) && target.lying)) //Eat the victim
+				walk_to(H, target.loc, 0, H.move_intent.move_delay * 2.5) //Move over them
+				if (H.Adjacent(target)) //Check we're still next to them
+					H.consume()
 
+			else //Otherwise subdue them
+				H.face_atom(target)
 				if (!H.zone_sel)
 					H.zone_sel = new /obj/screen/zone_sel(null)
 				H.zone_sel.selecting = BP_CHEST
 				target.attack_hand(H)
-
-			else //Eat said meals
-				walk_to(H, target.loc, 0, H.move_intent.move_delay * 2.5) //Move over them
-				if (H.Adjacent(target)) //Check we're still next to them
-					H.consume()
 
 		for(var/mob/living/M in hearers(H, 15))
 			if (target == M) //If our target is still nearby
@@ -258,7 +294,7 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 	. = ..()
 	if (!.)
 		return FALSE
-	if (!target || target.is_species(SPECIES_ZOMBIE))
+	if (istype(target, /mob/living/carbon/human) && target.is_species(SPECIES_ZOMBIE))
 		to_chat(usr, SPAN_WARNING("They don't look very appetizing!"))
 		return FALSE
 	return TRUE
@@ -266,7 +302,7 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 /datum/unarmed_attack/bite/sharp/zombie/apply_effects(mob/living/carbon/human/user, mob/living/carbon/human/target, attack_damage, zone)
 	..()
 	admin_attack_log(user, target, "Bit their victim.", "Was bitten.", "bit")
-	if (!(target.species.name in GLOB.zombie_species) || target.is_species(SPECIES_DIONA) || target.isSynthetic()) //No need to check infection for FBPs
+	if (istype(target, /mob/living/carbon/human) || !(target.species.name in GLOB.zombie_species) || target.is_species(SPECIES_DIONA) || target.isSynthetic()) //No need to check infection for FBPs
 		return
 	target.adjustHalLoss(9) //To help bring down targets in voidsuits
 	var/vuln = 1 - target.get_blocked_ratio(zone, DAMAGE_TOXIN, damage_flags = DAMAGE_FLAG_BIO) //Are they protected from bites?
@@ -355,6 +391,13 @@ GLOBAL_LIST_INIT(zombie_species, list(\
 	var/turf/T = get_turf(src)
 	new /obj/effect/decal/cleanable/vomit(T)
 	playsound(T, 'sound/effects/splat.ogg', 20, 1)
+
+	var/obj/item/held_l = get_equipped_item(slot_l_hand)
+	var/obj/item/held_r = get_equipped_item(slot_r_hand)
+	if(held_l)
+		drop_from_inventory(held_l)
+	if(held_r)
+		drop_from_inventory(held_r)
 
 	addtimer(new Callback(src, .proc/transform_zombie), 20)
 


### PR DESCRIPTION
I think a few things may have broken over time, with various damage refactors of objects and such.
Being able to pry open doors should make life a bit easier for infected players.
I've also tried to clean up the NPC behaviour a bit.

:cl:
bugfix: Zombies can now attack borgs and mechs, which were previously invulnerable to their attacks.
bugfix: Mobs now drop any handheld items after zombifying.
tweak: Zombies can once again destroy doors, shutters, and even walls -- albeit very slowly.
tweak: Zombie NPCs are better at prioritizing prey, and will defend themselves against non-human mobs.
/:cl: