### PR TITLE
guns ignoring safety on harm intent is a preference

### DIFF
--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -217,6 +217,10 @@ var/global/list/_client_preferences_by_type
 	description = "Draw gun based on intent"
 	key = "HOLSTER_ON_INTENT"
 
+/datum/client_preference/safety_toggle_on_intent
+	description = "Ignore safety on harm intent"
+	key = "SAFETY_ON_INTENT"
+
 /datum/client_preference/show_credits
 	description = "Show End Titles"
 	key = "SHOW_CREDITS"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -234,8 +234,11 @@
 		return
 
 	if(safety())
-		handle_click_safety(user)
-		return
+		if(user.a_intent == I_HURT && user.skill_check(SKILL_WEAPONS, SKILL_EXPERIENCED) && user.client?.get_preference_value(/datum/client_preference/safety_toggle_on_intent) == GLOB.PREF_YES)
+			toggle_safety(user)
+		else
+			handle_click_safety(user)
+			return
 
 	if(world.time < next_fire_time)
 		if (world.time % 3) //to prevent spam


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
pr #34139 is throwing some people off, so I decided to make it a preference so each player can choose

🆑 That0nePerson
tweak: Guns ignoring their safety on harm intent or not is now a preference
/🆑