### PR TITLE
Attack() refactor fixes

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -25,7 +25,6 @@
 	else
 		. = TRUE
 
-///Clickon() with medical stacks will never go past attack() because this proc will never return FALSE. If needed, this is where to change it. Returns TRUE if handled and cannot progress.
 /obj/item/stack/medical/attack(mob/living/carbon/M, mob/user)
 	. = FALSE
 	if (!istype(M))
@@ -179,11 +178,12 @@
 	if (..())
 		return TRUE
 
-	var/list/all_surgeries = GET_SINGLETON_SUBTYPE_MAP(/singleton/surgery_step)
-	for (var/singleton in all_surgeries)
-		var/singleton/surgery_step/S = all_surgeries[singleton]
-		if (S.name && S.tool_quality(src) && S.can_use(user, M, user.zone_sel.selecting, src))
-			return FALSE
+	if (check_possible_surgeries(M, user))
+		return FALSE
+
+	var/turf/T = get_turf(M)
+	if (locate(/obj/machinery/optable, T) && user.a_intent == I_HELP)
+		return FALSE
 
 	if (istype(M, /mob/living/carbon/human))
 		var/mob/living/carbon/human/H = M

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -30,6 +30,8 @@
 	if (istype(M,/mob/living/carbon/human))		//Repairing robolimbs
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/S = H.get_organ(user.zone_sel.selecting)
+		if (check_possible_surgeries(M, user))
+			return FALSE
 
 		if(!S)
 			to_chat(user, SPAN_WARNING("\The [M] is missing that body part."))

--- a/code/game/objects/items/weapons/material/coins.dm
+++ b/code/game/objects/items/weapons/material/coins.dm
@@ -46,6 +46,8 @@
 		attack_self(user)
 		return TRUE
 	if (ismob(target))
+		if (check_possible_surgeries(target, user))
+			return FALSE
 		if (user.a_intent == I_HURT)
 			user.visible_message(
 				SPAN_WARNING("\The [user] menaces \the [target] with \a [src]."),

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -281,13 +281,15 @@
 		update_icon()
 
 /obj/item/weldingtool/attack(mob/living/M, mob/living/user)
-	. = FALSE
 	if (ishuman(M))
 		var/target_zone = user.zone_sel.selecting
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/S = H.organs_by_name[target_zone]
 
 		if (!S || !BP_IS_ROBOTIC(S) || user.a_intent != I_HELP)
+			return FALSE
+
+		if (check_possible_surgeries(M, user))
 			return FALSE
 
 		if (BP_IS_BRITTLE(S))
@@ -300,8 +302,8 @@
 
 		if (S.robo_repair(15, DAMAGE_BRUTE, "some dents", src, user))
 			remove_fuel(1, user)
-		return TRUE
-
+			return TRUE
+	else return FALSE
 
 /obj/item/weldingtool/IsFlameSource()
 	return isOn()

--- a/code/modules/reagents/reagent_containers/glass/bottle.dm
+++ b/code/modules/reagents/reagent_containers/glass/bottle.dm
@@ -9,7 +9,6 @@
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = "5;10;15;25;30;60"
 	w_class = ITEM_SIZE_SMALL
-	item_flags = 0
 	obj_flags = 0
 	volume = 60
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -258,3 +258,10 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 
 /obj/item/stack/handle_post_surgery()
 	use(1)
+
+/obj/item/proc/check_possible_surgeries(mob/living/carbon/M, mob/user)
+	var/list/all_surgeries = GET_SINGLETON_SUBTYPE_MAP(/singleton/surgery_step)
+	for (var/singleton in all_surgeries)
+		var/singleton/surgery_step/S = all_surgeries[singleton]
+		if (S.name && S.tool_quality(src) && S.can_use(user, M, user.zone_sel.selecting, src))
+			return TRUE


### PR DESCRIPTION
🆑 emmanuelbassil
tweak: Bruise kits no longer patch up external damage on mobs placed on optables if on help intent. Need to switch to non-help intent. This is to prevent accidental closures during surgeries. This does not apply to ghetto surgeries.
bugfix: Fixes welders and nano-paste not working during surgeries.
bugfix: Fixes coins not working in ghetto robotic surgeries.
bugfix: Fixes being unable to drink from glass bottles.
/🆑 

Some fixes, pretty self-explanatory. 
Should fix #34162 . Did not test nanopaste; but tested multiple welder surgery steps which now work.