### PR TITLE
Fixes #34153

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -19,16 +19,15 @@ LINEN BINS
 	throw_range = 2
 	w_class = ITEM_SIZE_SMALL
 
-/obj/item/bedsheet/attackby(obj/item/I, mob/user)
-	if(is_sharp(I))
-		user.visible_message(SPAN_NOTICE("\The [user] begins cutting up \the [src] with \a [I]."), SPAN_NOTICE("You begin cutting up \the [src] with \the [I]."))
-		if(do_after(user, 5 SECONDS, src, DO_REPAIR_CONSTRUCT))
+/obj/item/bedsheet/use_tool(obj/item/tool, mob/living/user, list/click_params)
+	if (is_sharp(tool))
+		user.visible_message(SPAN_NOTICE("\The [user] begins cutting up \the [src] with \a [tool]."), SPAN_NOTICE("You begin cutting up \the [src] with \the [tool]."))
+		if (do_after(user, 5 SECONDS, src, DO_REPAIR_CONSTRUCT))
 			to_chat(user, SPAN_NOTICE("You cut \the [src] into pieces!"))
 			for(var/i in 1 to rand(2,5))
 				new /obj/item/reagent_containers/glass/rag(get_turf(src))
 			qdel(src)
-		return
-	..()
+		return TRUE
 
 /obj/item/bedsheet/blue
 	icon_state = "sheetblue"

--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -113,8 +113,8 @@
 		add_padding(padding_type)
 		return TRUE
 
-	// Wirecutters - Remove padding
-	if (isWirecutter(tool))
+	// Sharp items - Remove padding
+	if (is_sharp(tool))
 		if (!padding_material)
 			USE_FEEDBACK_FAILURE("\The [src] has no padding to remove.")
 			return TRUE

--- a/code/game/objects/structures/stool_bed_chair_nest/stools.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/stools.dm
@@ -147,7 +147,7 @@ var/global/list/stool_cache = list() //haha stool
 		to_chat(user, "You add padding to \the [src].")
 		add_padding(padding_type)
 		return
-	else if(isWirecutter(W))
+	else if (is_sharp(W))
 		if(!padding_material)
 			to_chat(user, "\The [src] has no padding to remove.")
 			return

--- a/code/modules/materials/definitions/materials_organic.dm
+++ b/code/modules/materials/definitions/materials_organic.dm
@@ -61,7 +61,7 @@
 	flags = MATERIAL_PADDING
 	brute_armor = 1
 	conductive = 0
-	stack_type = null
+	stack_type = /obj/item/stack/material/cloth
 	hidden_from_codex = TRUE
 	construction_difficulty = MATERIAL_NORMAL_DIY
 
@@ -133,7 +133,7 @@
 	sheet_singular_name = "tile"
 	sheet_plural_name = "tiles"
 	conductive = 0
-	stack_type = null
+	stack_type = /obj/item/stack/tile/carpet
 	construction_difficulty = MATERIAL_NORMAL_DIY
 
 /material/skin

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -57,7 +57,7 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 6 "uses of .len" '\.len\b' -P
-exactly 389 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 388 "attackby() override" '\/attackby\((.*)\)'  -P
 exactly 15 "uses of examine()" '[.|\s]examine\(' -P # If this fails it's likely because you used '/atom/proc/examine(mob)' instead of '/proc/examinate(mob, atom)' - Exception: An examine()-proc may call other examine()-procs
 exactly 7 "direct modifications of overlays list" '\boverlays((\s*[|^=+&-])|(\.(Cut)|(Add)|(Copy)|(Remove)|(Remove)))' -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: Padded beds and brown bar stools now properly drop cloth and carpet respectively when padding is removed.
tweak: Can now remove padding with any sharp item, not only wirecutters.
/🆑

Fixes #34153 

This will conflict with #34157 since they both change attackby count. Whichever one gets merged first, I'll rebase the other.
Down the road, would benefit from allowing different color carpeting also pad unpadded beds/chairs/stools other than brown carpet. Currently uses fabric/cloth for the other colors. Out of the scope of this PR.