### PR TITLE
Replace attack() with use_before()

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -52,7 +52,6 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define ITEM_FLAG_NOCUFFS                   FLAG(13) // Gloves that have this flag prevent cuffs being applied
 #define ITEM_FLAG_CAN_HIDE_IN_SHOES         FLAG(14) // Items that can be hidden in shoes that permit it
 #define ITEM_FLAG_WASHER_ALLOWED            FLAG(15) // Items that can be washed in washing machines
-#define ITEM_FLAG_TRY_ATTACK                FLAG(16) // Use the item's attack() when set before trying the receiver's resolve_attackby()
 
 // Flags for pass_flags.
 #define PASS_FLAG_TABLE     FLAG(0)

--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -384,7 +384,7 @@
 // Aura type options for `/mob/living/proc/aura_check()`.
 /// Aura checks for projectile impacts. Generally called by `/obj/item/projectile/proc/attack_mob()`. Results in `/obj/aura/proc/aura_check_bullet()`.
 #define AURA_TYPE_BULLET "Bullet"
-/// Aura checks for physical weapon attacks. Generally called by `/obj/item/proc/attack()`. Results in `/obj/aura/proc/aura_check_weapon()`.
+/// Aura checks for physical weapon attacks. Generally called by `/obj/item/proc/use_weapon()`. Results in `/obj/aura/proc/aura_check_weapon()`.
 #define AURA_TYPE_WEAPON "Weapon"
 /// Aura checks for thrown atom impacts. Generally called by `/mob/living/hitby()`. Results in `/obj/aura/proc/aura_check_thrown()`.
 #define AURA_TYPE_THROWN "Thrown"

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -432,6 +432,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 /**
  * Called when a mob is clicked while the item is in the active hand. This is usually called first by the mob's `resolve_attackby()` proc.
  * Use this to set item-level overrides that you want running first. If you have an override you don't want running before use_tool and use_weapon, put it in use_after().
+ * You will need to use type checks on atom/target on overrides; or else this will be called on anything you click.
  * If returns FALSE, the rest of the resolve_attackby() chain is called.
  *
  * **Parameters**:

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -51,7 +51,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	atom.pre_use_item(src, user, click_params)
 	var/use_call
 
-	use_call = "before"
+	use_call = "use"
 	. = use_before(atom, user, click_params)
 	if (!. && user.a_intent == I_HURT)
 		use_call = "weapon"
@@ -63,7 +63,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		use_call = "attackby"
 		. = atom.attackby(src, user, click_params)
 	if (!.)
-		use_call = "after"
+		use_call = "use"
 		. = use_after(atom, user, click_params)
 	if (!.)
 		use_call = null

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -7,13 +7,12 @@
 	edge = TRUE
 	sharp = TRUE
 	w_class = ITEM_SIZE_LARGE
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	force = 30
 	throwforce = 10
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "tore", "ripped", "diced", "cut")
 
-/obj/item/melee/cultblade/attack(mob/living/M, mob/living/user)
+/obj/item/melee/cultblade/use_before(mob/living/M, mob/living/user)
 	. = FALSE
 	if (iscultist(user))
 		return FALSE

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -21,7 +21,7 @@
 	else
 		to_chat(user, "The scriptures of Nar-Sie, The One Who Sees, The Geometer of Blood. Contains the details of every ritual his followers could think of. Most of these are useless, though.")
 
-/obj/item/book/tome/attack(mob/living/M, mob/living/user)
+/obj/item/book/tome/use_before(mob/living/M, mob/living/user)
 	. = FALSE
 	if (!istype(M))
 		return FALSE

--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -39,14 +39,15 @@
 		user.setClickCooldown(DEFAULT_QUICK_COOLDOWN)
 		return TRUE
 
-/obj/item/book/tome/afterattack(atom/A, mob/user, proximity)
-	if(!proximity || !iscultist(user))
-		return
+/obj/item/book/tome/use_after(atom/A, mob/user)
+	if(!iscultist(user))
+		return FALSE
 	if(A.reagents && A.reagents.has_reagent(/datum/reagent/water/holywater))
 		to_chat(user, SPAN_NOTICE("You unbless \the [A]."))
 		var/holy2water = A.reagents.get_reagent_amount(/datum/reagent/water/holywater)
 		A.reagents.del_reagent(/datum/reagent/water/holywater)
 		A.reagents.add_reagent(/datum/reagent/water, holy2water)
+		return TRUE
 
 /mob/proc/make_rune(rune, cost = 5, tome_required = 0)
 	var/has_tome = !!IsHolding(/obj/item/book/tome)

--- a/code/game/gamemodes/events/holidays/Christmas.dm
+++ b/code/game/gamemodes/events/holidays/Christmas.dm
@@ -4,12 +4,11 @@
 	icon_state = "cracker"
 	desc = "Directions for use: Requires two people, one to pull each end."
 	var/cracked = 0
-	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/toy/xmas_cracker/New()
 	..()
 
-/obj/item/toy/xmas_cracker/attack(mob/target, mob/user)
+/obj/item/toy/xmas_cracker/use_before(mob/target, mob/user)
 	. = FALSE
 	if (!cracked && istype(target,/mob/living/carbon/human) && (target.stat == CONSCIOUS) && !target.get_active_hand() )
 		target.visible_message(SPAN_NOTICE("[user] and [target] pop \an [src]! *pop*"), SPAN_NOTICE("You pull \an [src] with [target]! *pop*"), SPAN_NOTICE("You hear a *pop*."))

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -121,7 +121,6 @@
 				to_chat(M, SPAN_WARNING("You ate your crayon!"))
 				qdel(src)
 		return TRUE
-	return ..()
 
 
 /obj/random/crayon

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -110,7 +110,7 @@
 					qdel(src)
 	return
 
-/obj/item/pen/crayon/attack(mob/living/carbon/M as mob, mob/user as mob)
+/obj/item/pen/crayon/use_before(mob/living/carbon/M as mob, mob/user as mob)
 	if(istype(M) && M == user)
 		to_chat(M, "You take a bite of the crayon and swallow it.")
 		M.adjust_nutrition(1)

--- a/code/game/objects/items/devices/auto_cpr.dm
+++ b/code/game/objects/items/devices/auto_cpr.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/obj/auto_cpr.dmi'
 	icon_state = "pumper"
 	w_class = ITEM_SIZE_NORMAL
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	origin_tech = list(TECH_MAGNET = 2, TECH_BIO = 2)
 	slot_flags = SLOT_OCLOTHING
 	var/last_pump
@@ -19,7 +18,7 @@
 	else
 		return FALSE
 
-/obj/item/auto_cpr/attack(mob/living/carbon/human/M, mob/living/user)
+/obj/item/auto_cpr/use_before(mob/living/carbon/human/M, mob/living/user)
 	. = FALSE
 	if (istype(M) && user.a_intent == I_HELP)
 		if (M.wear_suit)

--- a/code/game/objects/items/devices/dna_sampler.dm
+++ b/code/game/objects/items/devices/dna_sampler.dm
@@ -2,7 +2,6 @@
 	name = "dna sampler"
 	desc = "An all in one DNA sampling and sequencing device which can be used to deliver a genetic payload to a mimic cube. Requires a DNA sample from the target."
 	w_class = ITEM_SIZE_SMALL
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	origin_tech = list(TECH_BIO = 5, TECH_MATERIAL = 2)
 	icon = 'icons/obj/tools/implanter.dmi'
 	icon_state = "dnainjector0"
@@ -35,7 +34,7 @@
 		src_species = ""
 		src_flavor = ""
 
-/obj/item/device/dna_sampler/attack(mob/living/carbon/human/L, mob/user)
+/obj/item/device/dna_sampler/use_before(mob/living/carbon/human/L, mob/user)
 	. = FALSE
 	if (istype(L) && L.can_inject(user, check_zone(user.zone_sel.selecting)))
 		if (loaded)

--- a/code/game/objects/items/devices/dociler.dm
+++ b/code/game/objects/items/devices/dociler.dm
@@ -2,7 +2,6 @@
 	name = "dociler"
 	desc = "A complex single use recharging injector that spreads a complex neurological serum that makes animals docile and friendly. Somewhat."
 	w_class = ITEM_SIZE_NORMAL
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	origin_tech = list(TECH_BIO = 5, TECH_MATERIAL = 2)
 	icon = 'icons/obj/tools/dociler.dmi'
 	icon_state = "animal_tagger1"
@@ -32,7 +31,7 @@
 	. = ..()
 	to_chat(user, SPAN_NOTICE("It is currently [loaded? "loaded": "recharging"]."))
 
-/obj/item/device/dociler/attack(mob/living/L, mob/user)
+/obj/item/device/dociler/use_before(mob/living/L, mob/user)
 	. = FALSE
 	if (!istype(L))
 		return FALSE

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -9,7 +9,6 @@
 	throw_speed = 4
 	throw_range = 10
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	origin_tech = list(TECH_MAGNET = 2, TECH_COMBAT = 1)
 
 	var/times_used = 0 //Number of times it's been used.
@@ -36,7 +35,7 @@
 	times_used = max(0,round(times_used)) //sanity
 
 //attack_as_weapon
-/obj/item/device/flash/attack(mob/living/M, mob/living/user)
+/obj/item/device/flash/use_before(mob/living/M, mob/living/user)
 	. = FALSE
 	if (!istype(M))
 		return FALSE

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -90,11 +90,9 @@
 		set_dir(new_dir)
 		update_light()
 
-/obj/item/device/flashlight/attack(mob/living/M as mob, mob/living/user as mob)
-	. = FALSE
+/obj/item/device/flashlight/use_after(mob/living/M as mob, mob/living/user as mob)
 	if (istype(M) && on && user.zone_sel.selecting == BP_EYES)
-
-		if((MUTATION_CLUMSY in user.mutations) && prob(50) || user.a_intent == I_HURT)
+		if((MUTATION_CLUMSY in user.mutations) && prob(50))
 			return M.use_weapon(src, user)
 
 		var/mob/living/carbon/human/H = M

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -10,7 +10,6 @@
 	item_state = "flashlight"
 	w_class = ITEM_SIZE_SMALL
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	slot_flags = SLOT_BELT
 
 	matter = list(MATERIAL_PLASTIC = 50, MATERIAL_GLASS = 20)

--- a/code/game/objects/items/devices/holowarrant.dm
+++ b/code/game/objects/items/devices/holowarrant.dm
@@ -9,7 +9,6 @@
 	throw_speed = 4
 	throw_range = 10
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	slot_flags = SLOT_BELT
 	req_access = list(list(access_heads, access_security))
 	var/datum/computer_file/data/warrant/active
@@ -82,7 +81,7 @@
 
 
 //hit other people with it
-/obj/item/device/holowarrant/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/device/holowarrant/use_before(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	. = FALSE
 	if(istype(M))
 		user.visible_message(SPAN_NOTICE("[user] holds up a warrant projector and shows the contents to [M]."), \

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -24,9 +24,7 @@
 	else
 		. = TRUE
 
-///Clickon() with medical stacks will never go past attack() because this proc will never return FALSE. If needed, this is where to change it. Returns TRUE if handled and cannot progress.
-/obj/item/stack/medical/use_before(mob/living/carbon/M, mob/user)
-	. = FALSE
+/obj/item/stack/medical/use_after(mob/living/carbon/M, mob/user)
 	if (!istype(M))
 		return FALSE
 
@@ -77,8 +75,7 @@
 	apply_sounds = list('sound/effects/rip1.ogg','sound/effects/rip2.ogg')
 	amount = 10
 
-/obj/item/stack/medical/bruise_pack/use_before(mob/living/carbon/M, mob/user)
-	. = FALSE
+/obj/item/stack/medical/bruise_pack/use_after(mob/living/carbon/M, mob/user)
 	if (..())
 		return TRUE
 
@@ -137,8 +134,7 @@
 	animal_heal = 4
 	apply_sounds = list('sound/effects/ointment.ogg')
 
-/obj/item/stack/medical/ointment/use_before(mob/living/carbon/M, mob/user)
-	. = FALSE
+/obj/item/stack/medical/ointment/use_after(mob/living/carbon/M, mob/user)
 	if (..())
 		return TRUE
 
@@ -173,13 +169,9 @@
 	apply_sounds = list('sound/effects/rip1.ogg','sound/effects/rip2.ogg','sound/effects/tape.ogg')
 	amount = 10
 
-/obj/item/stack/medical/advanced/bruise_pack/use_before(mob/living/carbon/M, mob/user)
-	. = FALSE
+/obj/item/stack/medical/advanced/bruise_pack/use_after(mob/living/carbon/M, mob/user)
 	if (..())
 		return TRUE
-
-	if (check_possible_surgeries(M, user))
-		return FALSE
 
 	var/turf/T = get_turf(M)
 	if (locate(/obj/machinery/optable, T) && user.a_intent == I_HELP)
@@ -239,8 +231,7 @@
 	apply_sounds = list('sound/effects/ointment.ogg')
 
 
-/obj/item/stack/medical/advanced/ointment/use_before(mob/living/carbon/M, mob/user)
-	. = FALSE
+/obj/item/stack/medical/advanced/ointment/use_after(mob/living/carbon/M, mob/user)
 	if (..())
 		return TRUE
 
@@ -278,8 +269,7 @@
 	can_treat_robots = TRUE
 	var/list/splintable_organs = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG, BP_L_HAND, BP_R_HAND, BP_L_FOOT, BP_R_FOOT)	//List of organs you can splint, natch.
 
-/obj/item/stack/medical/splint/use_before(mob/living/carbon/M, mob/user)
-	. = FALSE
+/obj/item/stack/medical/splint/use_after(mob/living/carbon/M, mob/user)
 	if (..())
 		return TRUE
 
@@ -360,8 +350,7 @@
 	return TRUE
 
 
-/obj/item/stack/medical/resin/use_before(mob/living/carbon/M, mob/user)
-	. = FALSE
+/obj/item/stack/medical/resin/use_after(mob/living/carbon/M, mob/user)
 	if (..())
 		return TRUE
 

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -6,7 +6,6 @@
 	amount = 5
 	max_amount = 5
 	w_class = ITEM_SIZE_SMALL
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	throw_speed = 4
 	throw_range = 20
 
@@ -25,7 +24,8 @@
 	else
 		. = TRUE
 
-/obj/item/stack/medical/attack(mob/living/carbon/M, mob/user)
+///Clickon() with medical stacks will never go past attack() because this proc will never return FALSE. If needed, this is where to change it. Returns TRUE if handled and cannot progress.
+/obj/item/stack/medical/use_before(mob/living/carbon/M, mob/user)
 	. = FALSE
 	if (!istype(M))
 		return FALSE
@@ -77,7 +77,7 @@
 	apply_sounds = list('sound/effects/rip1.ogg','sound/effects/rip2.ogg')
 	amount = 10
 
-/obj/item/stack/medical/bruise_pack/attack(mob/living/carbon/M, mob/user)
+/obj/item/stack/medical/bruise_pack/use_before(mob/living/carbon/M, mob/user)
 	. = FALSE
 	if (..())
 		return TRUE
@@ -137,7 +137,7 @@
 	animal_heal = 4
 	apply_sounds = list('sound/effects/ointment.ogg')
 
-/obj/item/stack/medical/ointment/attack(mob/living/carbon/M, mob/user)
+/obj/item/stack/medical/ointment/use_before(mob/living/carbon/M, mob/user)
 	. = FALSE
 	if (..())
 		return TRUE
@@ -173,7 +173,7 @@
 	apply_sounds = list('sound/effects/rip1.ogg','sound/effects/rip2.ogg','sound/effects/tape.ogg')
 	amount = 10
 
-/obj/item/stack/medical/advanced/bruise_pack/attack(mob/living/carbon/M, mob/user)
+/obj/item/stack/medical/advanced/bruise_pack/use_before(mob/living/carbon/M, mob/user)
 	. = FALSE
 	if (..())
 		return TRUE
@@ -239,7 +239,7 @@
 	apply_sounds = list('sound/effects/ointment.ogg')
 
 
-/obj/item/stack/medical/advanced/ointment/attack(mob/living/carbon/M, mob/user)
+/obj/item/stack/medical/advanced/ointment/use_before(mob/living/carbon/M, mob/user)
 	. = FALSE
 	if (..())
 		return TRUE
@@ -278,7 +278,7 @@
 	can_treat_robots = TRUE
 	var/list/splintable_organs = list(BP_L_ARM, BP_R_ARM, BP_L_LEG, BP_R_LEG, BP_L_HAND, BP_R_HAND, BP_L_FOOT, BP_R_FOOT)	//List of organs you can splint, natch.
 
-/obj/item/stack/medical/splint/attack(mob/living/carbon/M, mob/user)
+/obj/item/stack/medical/splint/use_before(mob/living/carbon/M, mob/user)
 	. = FALSE
 	if (..())
 		return TRUE
@@ -360,7 +360,7 @@
 	return TRUE
 
 
-/obj/item/stack/medical/resin/attack(mob/living/carbon/M, mob/user)
+/obj/item/stack/medical/resin/use_before(mob/living/carbon/M, mob/user)
 	. = FALSE
 	if (..())
 		return TRUE

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -8,8 +8,7 @@
 	amount = 10
 
 
-/obj/item/stack/nanopaste/use_before(mob/living/M as mob, mob/user as mob)
-	. = FALSE
+/obj/item/stack/nanopaste/use_after(mob/living/M as mob, mob/user as mob)
 	if (!istype(M) || !istype(user))
 		return FALSE
 	if (istype(M,/mob/living/silicon/robot))	//Repairing cyborgs
@@ -29,8 +28,6 @@
 	if (istype(M,/mob/living/carbon/human))		//Repairing robolimbs
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/S = H.get_organ(user.zone_sel.selecting)
-		if (check_possible_surgeries(M, user))
-			return FALSE
 
 		if(!S)
 			to_chat(user, SPAN_WARNING("\The [M] is missing that body part."))

--- a/code/game/objects/items/stacks/nanopaste.dm
+++ b/code/game/objects/items/stacks/nanopaste.dm
@@ -5,11 +5,10 @@
 	icon = 'icons/obj/medical.dmi'
 	icon_state = "nanopaste"
 	origin_tech = list(TECH_MATERIAL = 4, TECH_ENGINEERING = 3)
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	amount = 10
 
 
-/obj/item/stack/nanopaste/attack(mob/living/M as mob, mob/user as mob)
+/obj/item/stack/nanopaste/use_before(mob/living/M as mob, mob/user as mob)
 	. = FALSE
 	if (!istype(M) || !istype(user))
 		return FALSE

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -330,19 +330,17 @@
 		..()
 	return
 
-/obj/item/stack/attackby(obj/item/W as obj, mob/user as mob)
-	if (istype(W, /obj/item/stack))
-		var/obj/item/stack/S = W
-		src.transfer_to(S)
+/obj/item/stack/use_tool(obj/item/tool, mob/living/user, list/click_params)
+	if (istype(tool, /obj/item/stack))
+		var/obj/item/stack/new_stack = tool
+		transfer_to(new_stack)
 
 		spawn(0) //give the stacks a chance to delete themselves if necessary
-			if (S && usr.machine==S)
-				S.interact(usr)
-			if (src && usr.machine==src)
-				src.interact(usr)
-	else
-		return ..()
-
+			if (new_stack && user.machine == new_stack)
+				new_stack.interact(usr)
+			if (src && user.machine == src)
+				interact(user)
+		return TRUE
 
 /**
  * Returns a string forming a basic name of the stack. By default, this is `name`.

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -146,7 +146,6 @@
 		icon_r_hand = 'icons/mob/onmob/items/righthand_guns.dmi',
 		)
 	w_class = ITEM_SIZE_SMALL
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	attack_verb = list("attacked", "struck", "hit")
 	var/bullets = 5
 
@@ -210,7 +209,7 @@
 			O.show_message(SPAN_WARNING("\The [user] realized they were out of ammo and starting scrounging for some!"), 1)
 
 
-/obj/item/toy/crossbow/attack(mob/M as mob, mob/user as mob)
+/obj/item/toy/crossbow/use_before(mob/M as mob, mob/user as mob)
 	. = FALSE
 	if (istype(M) && M.lying)
 		if (bullets > 0)

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -50,7 +50,7 @@
 		if (!istype(head))
 			return TRUE
 
-		if (user.a_intent == I_HELP && user.zone_sel.selecting == BP_HEAD)
+		if (user.zone_sel.selecting == BP_HEAD)
 			head.write_on(user, name)
 			return TRUE
 

--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -6,7 +6,6 @@
 	icon_state = "lipstick"
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	var/colour = "red"
 	var/open = 0
 
@@ -38,7 +37,7 @@
 	else
 		icon_state = initial(icon_state)
 
-/obj/item/lipstick/attack(atom/A, mob/living/user as mob)
+/obj/item/lipstick/use_before(atom/A, mob/living/user as mob)
 	. = FALSE
 	if (!open)
 		to_chat(user, SPAN_NOTICE("You need to uncap \the [src] first!"))
@@ -82,7 +81,7 @@
 		return TRUE
 
 
-//you can wipe off lipstick with paper! see code/modules/paperwork/paper.dm, paper/attack()
+//you can wipe off lipstick with paper! see code/modules/paperwork/paper.dm, paper/use_before()
 
 
 /obj/item/haircomb //sparklysheep's comb

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -15,7 +15,6 @@
 	origin_tech = list(TECH_BIO = 4, TECH_POWER = 2)
 	matter = list(MATERIAL_STEEL = 5000, MATERIAL_PLASTIC = 2000, MATERIAL_GLASS = 1500, MATERIAL_ALUMINIUM = 1000)
 	action_button_name = "Remove/Replace Paddles"
-
 	var/obj/item/shockpaddles/linked/paddles
 	var/obj/item/cell/bcell = null
 
@@ -208,7 +207,7 @@
 	force = 2
 	throwforce = 6
 	w_class = ITEM_SIZE_LARGE
-	item_flags = ITEM_FLAG_TRY_ATTACK
+
 
 	var/safety = 1 //if you can zap people with the paddles on harm mode
 	var/combat = 0 //If it can be used to revive people wearing thick clothing (e.g. spacesuits)
@@ -297,7 +296,7 @@
 /obj/item/shockpaddles/proc/checked_use(charge_amt)
 	return 0
 
-/obj/item/shockpaddles/attack(mob/living/M, mob/living/user)
+/obj/item/shockpaddles/use_before(mob/living/M, mob/living/user)
 	. = FALSE
 	var/mob/living/carbon/human/H = M
 	if (!istype(H) || user.a_intent != I_HELP)

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -6,7 +6,6 @@
 	item_state = "fire_extinguisher"
 	hitsound = 'sound/weapons/smash.ogg'
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	throwforce = 10
 	w_class = ITEM_SIZE_NORMAL
 	throw_speed = 2
@@ -63,7 +62,7 @@
 	to_chat(user, "The safety is [safety ? "on" : "off"].")
 	return
 
-/obj/item/extinguisher/attack(mob/living/M, mob/user)
+/obj/item/extinguisher/use_before(mob/living/M, mob/user)
 	. = FALSE
 	if (user.a_intent == I_HELP && !safety)
 		if (world.time < last_use + 20)

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -5,7 +5,6 @@
 	icon = 'icons/obj/tools/handcuffs.dmi'
 	icon_state = "handcuff"
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	slot_flags = SLOT_BELT
 	throwforce = 5
 	w_class = ITEM_SIZE_SMALL
@@ -26,7 +25,7 @@
 		return "legcuff1"
 	return ..()
 
-/obj/item/handcuffs/attack(mob/living/carbon/C, mob/living/user)
+/obj/item/handcuffs/use_before(mob/living/carbon/C, mob/living/user)
 	. = FALSE
 	if (!user.IsAdvancedToolUser())
 		return FALSE

--- a/code/game/objects/items/weapons/implants/implanter.dm
+++ b/code/game/objects/items/weapons/implants/implanter.dm
@@ -6,7 +6,6 @@
 	throw_speed = 1
 	throw_range = 5
 	w_class = ITEM_SIZE_SMALL
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	matter = list(MATERIAL_ALUMINIUM = 1000, MATERIAL_GLASS = 1000)
 	var/obj/item/implant/imp = null
 
@@ -43,7 +42,7 @@
 	else
 		..()
 
-/obj/item/implanter/attack(mob/M as mob, mob/user as mob)
+/obj/item/implanter/use_before(mob/M as mob, mob/user as mob)
 	. = FALSE
 	if (!istype(M, /mob/living/carbon))
 		return FALSE

--- a/code/game/objects/items/weapons/implants/implants/compressed.dm
+++ b/code/game/objects/items/weapons/implants/implants/compressed.dm
@@ -49,7 +49,7 @@
 		icon_state = "cimplanter0"
 	return
 
-/obj/item/implanter/compressed/attack(mob/M as mob, mob/user as mob)
+/obj/item/implanter/compressed/use_before(mob/M as mob, mob/user as mob)
 	var/obj/item/implant/compressed/c = imp
 	if (!c || !istype(M, /mob/living/carbon))
 		return FALSE

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -7,7 +7,6 @@
 	w_class = ITEM_SIZE_TINY
 	throwforce = 4
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	slot_flags = SLOT_BELT
 	attack_verb = list("burnt", "singed")
 	var/max_fuel = 5
@@ -75,7 +74,7 @@
 	else
 		AddOverlays(overlay_image(icon, "[bis.base_icon_state]_striker", flags=RESET_COLOR))
 
-/obj/item/flame/lighter/attack(mob/living/M, mob/living/carbon/user)
+/obj/item/flame/lighter/use_before(mob/living/M, mob/living/carbon/user)
 	. = FALSE
 	if (!istype(M))
 		return FALSE

--- a/code/game/objects/items/weapons/material/coins.dm
+++ b/code/game/objects/items/weapons/material/coins.dm
@@ -11,7 +11,6 @@
 	thrown_force_multiplier = 0.1
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
-	item_flags = ITEM_FLAG_TRY_ATTACK
 
 	/// The smallest interval allowed between coin flips.
 	var/const/FLIP_COOLDOWN = 5 SECONDS
@@ -40,7 +39,7 @@
 		ClearOverlays()
 
 
-/obj/item/material/coin/attack(atom/target, mob/living/user)
+/obj/item/material/coin/use_before(atom/target, mob/living/user)
 	. = FALSE
 	if (target == user)
 		attack_self(user)

--- a/code/game/objects/items/weapons/material/coins.dm
+++ b/code/game/objects/items/weapons/material/coins.dm
@@ -4,7 +4,6 @@
 	icon_state = "coin1"
 	applies_material_colour = TRUE
 	randpixel = 8
-	force = 1
 	throwforce = 1
 	max_force = 5
 	force_multiplier = 0.1
@@ -39,14 +38,12 @@
 		ClearOverlays()
 
 
-/obj/item/material/coin/use_before(atom/target, mob/living/user)
-	. = FALSE
+/obj/item/material/coin/use_after(atom/target, mob/living/user)
+
 	if (target == user)
 		attack_self(user)
 		return TRUE
 	if (ismob(target))
-		if (check_possible_surgeries(target, user))
-			return FALSE
 		if (user.a_intent == I_HURT)
 			user.visible_message(
 				SPAN_WARNING("\The [user] menaces \the [target] with \a [src]."),

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -7,7 +7,6 @@
  */
 /obj/item/material/kitchen/utensil
 	w_class = ITEM_SIZE_TINY
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	thrown_force_multiplier = 1
 	origin_tech = list(TECH_MATERIAL = 1)
 	attack_verb = list("attacked", "stabbed", "poked")
@@ -16,7 +15,6 @@
 	thrown_force_multiplier = 0.25 // 5 when thrown with weight 20 (steel)
 	puncture = TRUE
 	default_material = MATERIAL_ALUMINIUM
-	item_flags = ITEM_FLAG_TRY_ATTACK
 
 	var/loaded      //Descriptive string for currently loaded food object.
 	var/scoop_food = 1
@@ -28,7 +26,7 @@
 	create_reagents(5)
 	return
 
-/obj/item/material/kitchen/utensil/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/material/kitchen/utensil/use_before(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	. = FALSE
 	if (!istype(M) || user.a_intent != I_HELP)
 		return FALSE
@@ -127,7 +125,6 @@
 	icon_state = "rolling_pin"
 	attack_verb = list("bashed", "battered", "bludgeoned", "thrashed", "whacked")
 	default_material = MATERIAL_WOOD
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	max_force = 15
 	force_multiplier = 0.7 // 10 when wielded with weight 15 (wood)
 	thrown_force_multiplier = 1 // as above
@@ -136,7 +133,7 @@
 /obj/item/material/kitchen/rollingpin/aluminium/default_material = MATERIAL_ALUMINIUM
 
 
-/obj/item/material/kitchen/rollingpin/attack(mob/living/target, mob/living/user)
+/obj/item/material/kitchen/rollingpin/use_before(mob/living/target, mob/living/user)
 	. = FALSE
 	if ((MUTATION_CLUMSY in user.mutations) && prob(50) && user.unEquip(src))
 		user.visible_message(

--- a/code/game/objects/items/weapons/material/kitchen.dm
+++ b/code/game/objects/items/weapons/material/kitchen.dm
@@ -26,9 +26,8 @@
 	create_reagents(5)
 	return
 
-/obj/item/material/kitchen/utensil/use_before(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
-	. = FALSE
-	if (!istype(M) || user.a_intent != I_HELP)
+/obj/item/material/kitchen/utensil/use_after(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+	if (!istype(M))
 		return FALSE
 
 	if (reagents.total_volume > 0)

--- a/code/game/objects/items/weapons/material/knives.dm
+++ b/code/game/objects/items/weapons/material/knives.dm
@@ -15,7 +15,7 @@
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	sharp = TRUE
 	edge = TRUE
-	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES | ITEM_FLAG_TRY_ATTACK
+	item_flags = ITEM_FLAG_CAN_HIDE_IN_SHOES
 
 //table knives
 /obj/item/material/knife/table

--- a/code/game/objects/items/weapons/material/stick.dm
+++ b/code/game/objects/items/weapons/material/stick.dm
@@ -8,7 +8,6 @@
 	force_multiplier = 0.1
 	thrown_force_multiplier = 0.1
 	w_class = ITEM_SIZE_NORMAL
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	default_material = MATERIAL_WOOD
 	attack_verb = list("poked", "jabbed")
 
@@ -27,7 +26,7 @@
 	return ..()
 
 
-/obj/item/material/stick/attack(mob/M, mob/user)
+/obj/item/material/stick/use_before(mob/M, mob/user)
 	. = FALSE
 	if(istype(M) && user != M && user.a_intent == I_HELP)
 		//Playful poking is its own thing

--- a/code/game/objects/items/weapons/material/stick.dm
+++ b/code/game/objects/items/weapons/material/stick.dm
@@ -26,12 +26,9 @@
 	return ..()
 
 
-/obj/item/material/stick/use_before(mob/M, mob/user)
-	. = FALSE
+/obj/item/material/stick/use_after(mob/M, mob/user)
 	if(istype(M) && user != M && user.a_intent == I_HELP)
-		//Playful poking is its own thing
 		user.visible_message(SPAN_NOTICE("[user] pokes [M] with [src]."), SPAN_NOTICE("You poke [M] with [src]."))
-		//Consider adding a check to see if target is dead
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		user.do_attack_animation(M)
 		return TRUE

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -5,7 +5,6 @@
 	icon = 'icons/obj/soap.dmi'
 	icon_state = "soap"
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	w_class = ITEM_SIZE_SMALL
 	throwforce = 0
 	throw_speed = 4
@@ -159,7 +158,7 @@
 		user.update_personal_goal(/datum/goal/clean, 1)
 
 //attack_as_weapon
-/obj/item/soap/attack(mob/living/target, mob/living/user)
+/obj/item/soap/use_before(mob/living/target, mob/living/user)
 	. = FALSE
 	if (target && user && ishuman(target) && ishuman(user) && !target.stat && !user.stat && user.zone_sel.selecting == BP_MOUTH)
 		user.visible_message(SPAN_DANGER("\The [user] washes \the [target]'s mouth out with soap!"))

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -7,7 +7,6 @@
 	throw_range = 5
 	w_class = ITEM_SIZE_NORMAL
 	max_w_class = ITEM_SIZE_SMALL
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	max_storage_space = 4
 	var/mob/affecting = null
 	var/deity_name = "Christ"
@@ -66,7 +65,7 @@
 	renamed = 1
 	icon_changed = 1
 
-/obj/item/storage/bible/attack(mob/living/carbon/human/M, mob/living/carbon/human/user)
+/obj/item/storage/bible/use_before(mob/living/carbon/human/M, mob/living/carbon/human/user)
 	. = FALSE
 	if (user == M || !ishuman(user) || !ishuman(M))
 		return FALSE

--- a/code/game/objects/items/weapons/storage/fancy/smokable/_smokable.dm
+++ b/code/game/objects/items/weapons/storage/fancy/smokable/_smokable.dm
@@ -9,7 +9,6 @@
 	max_storage_space = 6
 	throwforce = 2
 	slot_flags = SLOT_BELT
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	key_type = list(/obj/item/clothing/mask/smokable/cigarette)
 	atom_flags = ATOM_FLAG_NO_REACT | ATOM_FLAG_OPEN_CONTAINER
 
@@ -39,7 +38,7 @@
 		UpdateReagents()
 
 
-/obj/item/storage/fancy/smokable/attack(mob/living/carbon/target, mob/living/carbon/user)
+/obj/item/storage/fancy/smokable/use_before(mob/living/carbon/target, mob/living/carbon/user)
 	. = FALSE
 	if (user != target || !istype(user) || user.a_intent != I_HELP)
 		return FALSE

--- a/code/game/objects/items/weapons/storage/fancy/smokable/_smokable.dm
+++ b/code/game/objects/items/weapons/storage/fancy/smokable/_smokable.dm
@@ -38,9 +38,8 @@
 		UpdateReagents()
 
 
-/obj/item/storage/fancy/smokable/use_before(mob/living/carbon/target, mob/living/carbon/user)
-	. = FALSE
-	if (user != target || !istype(user) || user.a_intent != I_HELP)
+/obj/item/storage/fancy/smokable/use_after(mob/living/carbon/target, mob/living/carbon/user)
+	if (user != target || !istype(user))
 		return FALSE
 
 	if (!opened)

--- a/code/game/objects/items/weapons/storage/pill_bottle.dm
+++ b/code/game/objects/items/weapons/storage/pill_bottle.dm
@@ -16,38 +16,32 @@
 	var/label
 
 
-/obj/item/storage/pill_bottle/afterattack(mob/living/target, mob/living/user, proximity_flag)
-	if(!proximity_flag || !istype(target) || target != user)
-		return 1
-	if(!length(contents))
+/obj/item/storage/pill_bottle/use_after(atom/target, mob/living/user)
+	if (!length(contents))
 		to_chat(user, SPAN_WARNING("It's empty!"))
-		return 1
-	var/zone = user.zone_sel.selecting
-	if(zone == BP_MOUTH && target.can_eat())
+		return TRUE
+
+	if (istype(user) && target == user && user.can_eat())
 		user.visible_message(SPAN_NOTICE("[user] pops a pill from \the [src]."))
 		playsound(get_turf(src), 'sound/effects/peelz.ogg', 50)
 		var/list/peelz = filter_list(contents,/obj/item/reagent_containers/pill)
-		if(length(peelz))
+		if (length(peelz))
 			var/obj/item/reagent_containers/pill/P = pick(peelz)
 			remove_from_storage(P)
-			P.attack(target,user)
-			return 1
+			P.resolve_attackby(target ,user)
+			return TRUE
 
-
-/obj/item/storage/pill_bottle/afterattack(obj/target, mob/living/user, proximity)
-	if(!proximity)
-		return
-	if(target.is_open_container() && target.reagents)
-		if(!target.reagents.total_volume)
+	if (isobj(target) && target.is_open_container() && target.reagents)
+		if (!target.reagents.total_volume)
 			to_chat(user, SPAN_NOTICE("[target] is empty. Can't dissolve a pill."))
-			return
+			return TRUE
 
 		var/list/peelz = filter_list(contents,/obj/item/reagent_containers/pill)
-		if(length(peelz))
+		if (length(peelz))
 			var/obj/item/reagent_containers/pill/P = pick(peelz)
 			remove_from_storage(P)
-			P.afterattack(target, user, proximity)
-	return
+			P.afterattack(target, user, TRUE)
+			return TRUE
 
 
 /obj/item/storage/pill_bottle/attack_self(mob/living/user)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -6,7 +6,6 @@
 	icon_state = "stunbaton"
 	item_state = "baton"
 	slot_flags = SLOT_BELT
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	force = 15
 	throwforce = 7
 	w_class = ITEM_SIZE_NORMAL
@@ -130,7 +129,7 @@
 		status = s
 		update_icon()
 
-/obj/item/melee/baton/attack(mob/M, mob/user)
+/obj/item/melee/baton/use_before(mob/M, mob/user)
 	. = FALSE
 	if (!istype(M))
 		return FALSE

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -15,10 +15,9 @@
 	item_state = "classic_baton"
 	base_parry_chance = 30
 	slot_flags = SLOT_BELT
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	force = 10
 
-/obj/item/melee/classic_baton/attack(mob/M as mob, mob/living/user as mob)
+/obj/item/melee/classic_baton/use_before(mob/M as mob, mob/living/user as mob)
 	. = FALSE
 	if ((MUTATION_CLUMSY in user.mutations) && prob(50))
 		to_chat(user, SPAN_WARNING("You club yourself over the head."))
@@ -39,7 +38,6 @@
 	item_state = "telebaton_0"
 	base_parry_chance = 30
 	slot_flags = SLOT_BELT
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	w_class = ITEM_SIZE_SMALL
 	force = 3
 	var/on = 0
@@ -79,7 +77,7 @@
 		ClearOverlays()
 		AddOverlays(blood_overlay)
 
-/obj/item/melee/telebaton/attack(mob/target as mob, mob/living/user as mob)
+/obj/item/melee/telebaton/use_before(mob/target as mob, mob/living/user as mob)
 	. = FALSE
 	if (on && (MUTATION_CLUMSY in user.mutations) && prob(50))
 		to_chat(user, SPAN_WARNING("You club yourself over the head."))

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -4,9 +4,8 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "taperoll"
 	w_class = ITEM_SIZE_SMALL
-	item_flags = ITEM_FLAG_TRY_ATTACK
 
-/obj/item/tape_roll/attack(mob/living/carbon/human/H, mob/user)
+/obj/item/tape_roll/use_before(mob/living/carbon/human/H, mob/user)
 	. = FALSE
 	if (istype(H))
 		if (user.zone_sel.selecting == BP_EYES)

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -279,17 +279,13 @@
 		playsound(src, 'sound/items/welderdeactivate.ogg', 10, 1)
 		update_icon()
 
-/obj/item/weldingtool/use_before(mob/living/M, mob/living/user)
-	. = FALSE
+/obj/item/weldingtool/use_after(mob/living/M, mob/living/user)
 	if (ishuman(M))
 		var/target_zone = user.zone_sel.selecting
 		var/mob/living/carbon/human/H = M
 		var/obj/item/organ/external/S = H.organs_by_name[target_zone]
 
 		if (!S || !BP_IS_ROBOTIC(S) || user.a_intent != I_HELP)
-			return FALSE
-
-		if (check_possible_surgeries(M, user))
 			return FALSE
 
 		if (BP_IS_BRITTLE(S))

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -5,7 +5,6 @@
 	item_state = "welder"
 	desc = "A portable welding gun with a port for attaching fuel tanks."
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	slot_flags = SLOT_BELT
 	center_of_mass = "x=14;y=15"
 	waterproof = FALSE
@@ -280,7 +279,8 @@
 		playsound(src, 'sound/items/welderdeactivate.ogg', 10, 1)
 		update_icon()
 
-/obj/item/weldingtool/attack(mob/living/M, mob/living/user)
+/obj/item/weldingtool/use_before(mob/living/M, mob/living/user)
+	. = FALSE
 	if (ishuman(M))
 		var/target_zone = user.zone_sel.selecting
 		var/mob/living/carbon/human/H = M

--- a/code/game/objects/items/weapons/tools/wirecutter.dm
+++ b/code/game/objects/items/weapons/tools/wirecutter.dm
@@ -29,9 +29,9 @@
 		AddOverlays(overlay_image(icon, "[hardware_icon]", flags=RESET_COLOR))
 	. = ..()
 
-/obj/item/wirecutters/use_before(mob/living/carbon/C as mob, mob/user as mob)
+/obj/item/wirecutters/use_after(mob/living/carbon/C as mob, mob/user as mob)
 	. = FALSE
-	if (istype(C) && user.a_intent == I_HELP && (C.handcuffed) && (istype(C.handcuffed, /obj/item/handcuffs/cable)))
+	if (istype(C) && (C.handcuffed) && (istype(C.handcuffed, /obj/item/handcuffs/cable)))
 		usr.visible_message("\The [usr] cuts \the [C]'s restraints with \the [src]!",\
 		"You cut \the [C]'s restraints with \the [src]!",\
 		"You hear cable being cut.")

--- a/code/game/objects/items/weapons/tools/wirecutter.dm
+++ b/code/game/objects/items/weapons/tools/wirecutter.dm
@@ -5,7 +5,6 @@
 	icon_state = "cutters_preview"
 	item_state = "cutters"
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	slot_flags = SLOT_BELT
 	force = 3.0
 	throw_speed = 2
@@ -30,7 +29,7 @@
 		AddOverlays(overlay_image(icon, "[hardware_icon]", flags=RESET_COLOR))
 	. = ..()
 
-/obj/item/wirecutters/attack(mob/living/carbon/C as mob, mob/user as mob)
+/obj/item/wirecutters/use_before(mob/living/carbon/C as mob, mob/user as mob)
 	. = FALSE
 	if (istype(C) && user.a_intent == I_HELP && (C.handcuffed) && (istype(C.handcuffed, /obj/item/handcuffs/cable)))
 		usr.visible_message("\The [usr] cuts \the [C]'s restraints with \the [src]!",\

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -12,7 +12,6 @@
 	throw_range = 5
 	w_class = ITEM_SIZE_NORMAL
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	matter = list(MATERIAL_ALUMINIUM = 3000)
 	hitsound = "tray_hit"
 	var/bash_cooldown = 0 // You can bash a rolling pin against a tray to make a shield bash sound! Based on world.time
@@ -33,7 +32,7 @@
 	. = ..()
 
 // When hitting people with the tray, drop all its items everywhere. You jerk.
-/obj/item/tray/attack(mob/living/M, mob/living/user)
+/obj/item/tray/use_before(mob/living/M, mob/living/user)
 	. = FALSE
 	if (user.a_intent != I_HURT)
 		return FALSE

--- a/code/game/objects/items/weapons/weaponry.dm
+++ b/code/game/objects/items/weapons/weaponry.dm
@@ -5,7 +5,6 @@
 	icon_state = "nullrod"
 	item_state = "nullrod"
 	slot_flags = SLOT_BELT
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	force = 10
 	throw_speed = 1
 	throw_range = 4
@@ -15,7 +14,7 @@
 /obj/item/nullrod/disrupts_psionics()
 	return src
 
-/obj/item/nullrod/attack(mob/M as mob, mob/living/user as mob) //Paste from old-code to decult with a null rod.
+/obj/item/nullrod/use_before(mob/M as mob, mob/living/user as mob) //Paste from old-code to decult with a null rod.
 	. = FALSE
 	if (!istype(M) || user.a_intent == I_HELP)
 		return FALSE

--- a/code/game/objects/items/weapons/wrapping_paper.dm
+++ b/code/game/objects/items/weapons/wrapping_paper.dm
@@ -8,7 +8,6 @@
 	singular_name = "sheet"
 	amount = 25
 	max_amount = 25
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	icon = 'icons/obj/parcels.dmi'
 	var/package_type
 
@@ -70,8 +69,8 @@
 	return
 
 
-/obj/item/stack/package_wrap/use_on(obj/object, mob/user)
-	if (!isobj(object) || istype(object, src))
+/obj/item/stack/package_wrap/use_after(obj/object, mob/user)
+	if (!isobj(object))
 		return FALSE
 	if (istype(object, /obj/item/smallDelivery) || istype(object,/obj/structure/bigDelivery) || istype(object, /obj/item/evidencebag))
 		to_chat(user, SPAN_WARNING("\The [object] is already wrapped."))
@@ -111,8 +110,6 @@
 	if (istype(object, /obj/structure/closet/crate) || istype(object, /obj/structure/closet))
 		var/item_size
 		var/obj/structure/closet/target = object
-		if (target.opened)
-			return FALSE
 		if (istype(object, /obj/structure/closet/crate))
 			item_size = BASE_STORAGE_COST(ITEM_SIZE_NORMAL)
 		else
@@ -129,7 +126,7 @@
 		wrap_item(package_type, target, user)
 		return TRUE
 
-/obj/item/stack/package_wrap/attack(mob/living/target, mob/living/user)
+/obj/item/stack/package_wrap/use_before(mob/living/target, mob/living/user)
 	if (!istype(target, /mob/living/carbon/human))
 		return FALSE
 	var/mob/living/carbon/human/H = target

--- a/code/game/objects/structures/ironing_board.dm
+++ b/code/game/objects/structures/ironing_board.dm
@@ -261,7 +261,6 @@
 	icon_state = "iron"
 	item_state = "ironingiron"
 	slot_flags = SLOT_BELT
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	throwforce = 10
 	throw_range = 6
 	force = 8
@@ -277,7 +276,7 @@
 		range = 3
 	)
 
-/obj/item/ironing_iron/attack(mob/living/subject, mob/living/user, click_parameters)
+/obj/item/ironing_iron/use_before(mob/living/subject, mob/living/user, click_parameters)
 	if (!istype(subject) || !istype(user))
 		return
 	if (iron_enabled && subject.incapacitated())

--- a/code/game/objects/structures/roller_bed.dm
+++ b/code/game/objects/structures/roller_bed.dm
@@ -393,7 +393,6 @@
 	icon_state = "item"
 	object_type = /obj/item/roller_bed
 	interact_type = /obj/structure/roller_bed
-	item_flags = ITEM_FLAG_TRY_ATTACK
 
 
 /obj/item/robot_rack/roller_bed/resolve_attackby(atom/target, mob/living/user, click_params)

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -3,7 +3,6 @@
 	desc = "You're not sure what this is. You should probably ahelp it."
 	body_parts_covered = 0
 	waterproof = FALSE
-	item_flags = ITEM_FLAG_TRY_ATTACK
 
 	var/lit = 0
 	var/icon_on
@@ -162,7 +161,7 @@
 		text = replacetext(text, "FLAME", "[W.name]")
 		light(text)
 
-/obj/item/clothing/mask/smokable/attack(mob/living/M, mob/living/user)
+/obj/item/clothing/mask/smokable/use_before(mob/living/M, mob/living/user)
 	. = FALSE
 	if (istype(M) && M.on_fire)
 		user.do_attack_animation(M)
@@ -332,7 +331,7 @@
 
 	return
 
-/obj/item/clothing/mask/smokable/cigarette/attack(mob/living/carbon/human/H, mob/user)
+/obj/item/clothing/mask/smokable/cigarette/use_before(mob/living/carbon/human/H, mob/user)
 	if (lit && H == user && istype(H))
 		var/obj/item/blocked = H.check_mouth_coverage()
 		if (blocked)

--- a/code/modules/clothing/under/accessories/badges.dm
+++ b/code/modules/clothing/under/accessories/badges.dm
@@ -5,7 +5,6 @@
 	slot_flags = SLOT_BELT | SLOT_TIE
 	slot = ACCESSORY_SLOT_INSIGNIA
 	accessory_flags = ACCESSORY_REMOVABLE | ACCESSORY_HIGH_VISIBILITY
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	on_rolled_down = ACCESSORY_ROLLED_NONE
 	var/badge_string = "Detective"
 	var/stored_name
@@ -59,7 +58,7 @@
 			user.visible_message(SPAN_NOTICE("[user] displays their [src.name].\nIt reads: [badge_string]."),SPAN_NOTICE("You display your [src.name]. It reads: [badge_string]."))
 
 
-/obj/item/clothing/accessory/badge/attack(mob/living/carbon/human/M, mob/living/user)
+/obj/item/clothing/accessory/badge/use_before(mob/living/carbon/human/M, mob/living/user)
 	. = FALSE
 	if (isliving(user) && istype(M))
 		user.visible_message(SPAN_DANGER("[user] invades [M]'s personal space, thrusting \the [src] into their face insistently."),SPAN_DANGER("You invade [M]'s personal space, thrusting \the [src] into their face insistently."))

--- a/code/modules/clothing/under/accessories/stethoscope.dm
+++ b/code/modules/clothing/under/accessories/stethoscope.dm
@@ -3,10 +3,8 @@
 	desc = "An outdated medical apparatus for listening to the sounds of the human body. It also makes you look like you know what you're doing."
 	icon_state = "stethoscope"
 	accessory_flags = ACCESSORY_REMOVABLE | ACCESSORY_HIGH_VISIBILITY
-	item_flags = ITEM_FLAG_TRY_ATTACK
 
-
-/obj/item/clothing/accessory/stethoscope/attack(mob/living/target, mob/living/user)
+/obj/item/clothing/accessory/stethoscope/use_before(mob/living/target, mob/living/user)
 	. = FALSE
 	if (!ishuman(target) || !istype(user))
 		return FALSE

--- a/code/modules/clothing/under/accessories/stethoscope.dm
+++ b/code/modules/clothing/under/accessories/stethoscope.dm
@@ -4,11 +4,8 @@
 	icon_state = "stethoscope"
 	accessory_flags = ACCESSORY_REMOVABLE | ACCESSORY_HIGH_VISIBILITY
 
-/obj/item/clothing/accessory/stethoscope/use_before(mob/living/target, mob/living/user)
-	. = FALSE
+/obj/item/clothing/accessory/stethoscope/use_after(mob/living/target, mob/living/user)
 	if (!ishuman(target) || !istype(user))
-		return FALSE
-	if (user.a_intent != I_HELP)
 		return FALSE
 	var/mob/living/carbon/human/H = target
 	var/obj/item/organ/organ = H.get_organ(user.zone_sel.selecting)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -114,75 +114,76 @@
 			else
 				A.clean_blood()
 
-/obj/item/reagent_containers/glass/rag/use_before(atom/target as obj|turf|area, mob/user as mob , flag)
-	. = FALSE
-	if (isliving(target))
-		var/mob/living/M = target
-		if (on_fire)
-			if (user.a_intent == I_HELP)
-				return FALSE
-			user.visible_message(
-				SPAN_DANGER("\The [user] hits \the [target] with \the [src]!"),
-				SPAN_DANGER("You hit \the [target] with \the [src]!")
-			)
-			user.do_attack_animation(src)
-			admin_attack_log(user, M, "used \the [src] (ignited) to attack", "was attacked using \the [src] (ignited)", "attacked with \the [src] (ignited)")
-			M.IgniteMob()
-			return TRUE
-		else if (reagents.total_volume)
-			if (iscarbon(target) && user.a_intent == I_HELP && flag == BP_HEAD)
-				var/mob/living/carbon/C = target
-				var/obj/item/organ/external/head/H = C.organs_by_name[BP_HEAD]
-				if (istype(H) && H.forehead_graffiti)
-					var/datum/reagent/R = /datum/reagent/acetone
-					var/wash_amount = 5
-					if (reagents.has_reagent(R, wash_amount))
-						H.forehead_graffiti = null
-						reagents.remove_reagent(R, wash_amount)
-						if (user == target)
-							var/datum/pronouns/P = M.choose_from_pronouns()
-							user.visible_message(SPAN_NOTICE("\The [user] scrubs the ink off [P.his] forehead."), SPAN_NOTICE("You scrub the ink off your forehead."))
-						else
-							user.visible_message(SPAN_NOTICE("\The [user] scrubs the ink off \the [M]'s forehead."), SPAN_NOTICE("You scrub the ink off \the [M]'s forehead."))
+/obj/item/reagent_containers/glass/rag/use_before(mob/living/target, mob/user as mob , flag)
+	if (!istype(target))
+		return FALSE
+
+	var/mob/living/M = target
+	if (on_fire)
+		if (user.a_intent == I_HELP)
+			return FALSE
+		user.visible_message(
+			SPAN_DANGER("\The [user] hits \the [target] with \the [src]!"),
+			SPAN_DANGER("You hit \the [target] with \the [src]!")
+		)
+		user.do_attack_animation(src)
+		admin_attack_log(user, M, "used \the [src] (ignited) to attack", "was attacked using \the [src] (ignited)", "attacked with \the [src] (ignited)")
+		M.IgniteMob()
+		return TRUE
+	else if (reagents.total_volume)
+		if (iscarbon(target) && user.a_intent == I_HELP && flag == BP_HEAD)
+			var/mob/living/carbon/C = target
+			var/obj/item/organ/external/head/H = C.organs_by_name[BP_HEAD]
+			if (istype(H) && H.forehead_graffiti)
+				var/datum/reagent/R = /datum/reagent/acetone
+				var/wash_amount = 5
+				if (reagents.has_reagent(R, wash_amount))
+					H.forehead_graffiti = null
+					reagents.remove_reagent(R, wash_amount)
+					if (user == target)
+						var/datum/pronouns/P = M.choose_from_pronouns()
+						user.visible_message(SPAN_NOTICE("\The [user] scrubs the ink off [P.his] forehead."), SPAN_NOTICE("You scrub the ink off your forehead."))
 					else
-						to_chat(user, SPAN_WARNING("You need to wet the rag with [wash_amount] units of [initial(R.name)] to get the ink off!"))
-				return TRUE
-
-			if(user.zone_sel.selecting == BP_MOUTH)
-				if (!M.has_danger_grab(user))
-					to_chat(user, SPAN_WARNING("You need to have a firm grip on \the [target] before you can use \the [src] on them!"))
-					return TRUE
-
-				user.do_attack_animation(src)
-				user.visible_message(
-					SPAN_DANGER("\The [user] brings \the [src] up to \the [target]'s mouth!"),
-					SPAN_DANGER("You bring \the [src] up to \the [target]'s mouth!"),
-					SPAN_WARNING("You hear some struggling and muffled cries of surprise")
-				)
-
-				var/grab_time = 6 SECONDS
-				if (user.skill_check(SKILL_COMBAT, SKILL_TRAINED))
-					grab_time = 3 SECONDS
-				if (!do_after(user, grab_time, target, DO_PUBLIC_UNIQUE))
-					return TRUE
-
-				user.visible_message(
-					SPAN_DANGER("\The [user] smothers \the [target] with \the [src]!"),
-					SPAN_DANGER("You smother \the [target] with \the [src]!")
-				)
-				//it's inhaled, so... maybe CHEM_BLOOD doesn't make a whole lot of sense but it's the best we can do for now
-				var/trans_amt = reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_BLOOD)
-				if (reagents.should_admin_log())
-					var/contained_reagents = reagents.get_reagents()
-					admin_inject_log(user, M, src, contained_reagents, trans_amt)
-				update_name()
-				return TRUE
-			else
-				wipe_down(target, user)
-				return TRUE
-		if (user.zone_sel.selecting == BP_MOUTH)
-			to_chat(user, SPAN_WARNING("\The [src] is too dry to use on \the [target]!"))
+						user.visible_message(SPAN_NOTICE("\The [user] scrubs the ink off \the [M]'s forehead."), SPAN_NOTICE("You scrub the ink off \the [M]'s forehead."))
+				else
+					to_chat(user, SPAN_WARNING("You need to wet the rag with [wash_amount] units of [initial(R.name)] to get the ink off!"))
 			return TRUE
+
+		if (user.zone_sel.selecting == BP_MOUTH)
+			if (!M.has_danger_grab(user))
+				to_chat(user, SPAN_WARNING("You need to have a firm grip on \the [target] before you can use \the [src] on them!"))
+				return TRUE
+
+			user.do_attack_animation(src)
+			user.visible_message(
+				SPAN_DANGER("\The [user] brings \the [src] up to \the [target]'s mouth!"),
+				SPAN_DANGER("You bring \the [src] up to \the [target]'s mouth!"),
+				SPAN_WARNING("You hear some struggling and muffled cries of surprise")
+			)
+
+			var/grab_time = 6 SECONDS
+			if (user.skill_check(SKILL_COMBAT, SKILL_TRAINED))
+				grab_time = 3 SECONDS
+			if (!do_after(user, grab_time, target, DO_PUBLIC_UNIQUE))
+				return TRUE
+
+			user.visible_message(
+				SPAN_DANGER("\The [user] smothers \the [target] with \the [src]!"),
+				SPAN_DANGER("You smother \the [target] with \the [src]!")
+			)
+			//it's inhaled, so... maybe CHEM_BLOOD doesn't make a whole lot of sense but it's the best we can do for now
+			var/trans_amt = reagents.trans_to_mob(target, amount_per_transfer_from_this, CHEM_BLOOD)
+			if (reagents.should_admin_log())
+				var/contained_reagents = reagents.get_reagents()
+				admin_inject_log(user, M, src, contained_reagents, trans_amt)
+			update_name()
+			return TRUE
+		else
+			wipe_down(target, user)
+			return TRUE
+	if (user.zone_sel.selecting == BP_MOUTH)
+		to_chat(user, SPAN_WARNING("\The [src] is too dry to use on \the [target]!"))
+		return TRUE
 
 /obj/item/reagent_containers/glass/rag/afterattack(atom/A as obj|turf|area, mob/user as mob, proximity)
 	if(!proximity)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -23,7 +23,7 @@
 	possible_transfer_amounts = "5"
 	volume = 10
 	can_be_placed_into = null
-	item_flags = ITEM_FLAG_NO_BLUDGEON | ITEM_FLAG_TRY_ATTACK
+	item_flags = ITEM_FLAG_NO_BLUDGEON
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	unacidable = FALSE
 
@@ -114,7 +114,7 @@
 			else
 				A.clean_blood()
 
-/obj/item/reagent_containers/glass/rag/attack(atom/target as obj|turf|area, mob/user as mob , flag)
+/obj/item/reagent_containers/glass/rag/use_before(atom/target as obj|turf|area, mob/user as mob , flag)
 	. = FALSE
 	if (isliving(target))
 		var/mob/living/M = target

--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -76,7 +76,6 @@
 	icon = 'icons/obj/tools/card.dmi'
 	icon_state = "fingerprint0"
 	item_state = "paper"
-	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/sample/print/attack_self(mob/user)
 	if(evidence && length(evidence))
@@ -94,7 +93,7 @@
 	SetName("[initial(name)] (\the [H])")
 	update_icon()
 
-/obj/item/sample/print/attack(mob/living/M, mob/user)
+/obj/item/sample/print/use_before(mob/living/M, mob/user)
 	. = FALSE
 	if (!ishuman(M))
 		return FALSE

--- a/code/modules/detectivework/tools/swabs.dm
+++ b/code/modules/detectivework/tools/swabs.dm
@@ -20,7 +20,6 @@
 	name = "swab"
 	desc = "A sterilized cotton swab and vial used to take forensic samples."
 	icon_state = "swab"
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	var/list/gunshot_residue_sample
 	var/list/dna
 	var/list/trace_dna
@@ -29,7 +28,7 @@
 /obj/item/forensics/swab/proc/is_used()
 	return used
 
-/obj/item/forensics/swab/attack(mob/living/M, mob/user)
+/obj/item/forensics/swab/use_before(mob/living/M, mob/user)
 	. = FALSE
 	if (!ishuman(M))
 		return FALSE

--- a/code/modules/library/lib_items.dm
+++ b/code/modules/library/lib_items.dm
@@ -163,7 +163,6 @@
 	throw_speed = 1
 	throw_range = 5
 	w_class = ITEM_SIZE_NORMAL		 //upped to three because books are, y'know, pretty big. (and you could hide them inside eachother recursively forever)
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	attack_verb = list("bashed", "whacked", "educated")
 	var/dat			 // Actual page content
 	var/author		 // Who wrote the thing, can be changed by pen or PC. It is not automatically assigned
@@ -244,7 +243,7 @@
 	else
 		..()
 
-/obj/item/book/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/book/use_before(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	. = FALSE
 	if (istype(M) && user.a_intent == I_HELP && user.zone_sel.selecting == BP_EYES)
 		user.visible_message(SPAN_NOTICE("You open up the book and show it to [M]. "), \

--- a/code/modules/mob/holder.dm
+++ b/code/modules/mob/holder.dm
@@ -6,7 +6,6 @@ var/global/list/holder_mob_icon_cache = list()
 	desc = "You shouldn't ever see this."
 	icon = 'icons/obj/ash.dmi'
 	slot_flags = SLOT_HEAD | SLOT_HOLSTER
-	item_flags = ITEM_FLAG_TRY_ATTACK
 
 	sprite_sheets = list(
 		SPECIES_VOX = 'icons/mob/species/vox/onmob_head_vox.dmi'
@@ -91,7 +90,7 @@ var/global/list/holder_mob_icon_cache = list()
 	for(var/mob/M in contents)
 		M.show_inv(usr)
 
-/obj/item/holder/attack(mob/target, mob/user)
+/obj/item/holder/use_before(mob/target, mob/user)
 	. = FALSE
 	// Devour on click on self with holder
 	if (target == user && istype(user,/mob/living/carbon))

--- a/code/modules/mob/living/carbon/brain/MMI.dm
+++ b/code/modules/mob/living/carbon/brain/MMI.dm
@@ -95,14 +95,6 @@
 
 	return ..()
 
-
-/obj/item/device/mmi/use_weapon(obj/item/weapon, mob/user, list/click_params)
-	if (brainmob && weapon.attack(brainmob, user))
-		return TRUE
-
-	return ..()
-
-
 	//TODO: ORGAN REMOVAL UPDATE. Make the brain remain in the MMI so it doesn't lose organ data.
 /obj/item/device/mmi/attack_self(mob/user as mob)
 	if(!brainmob)

--- a/code/modules/mob/living/carbon/xenobiological/items.dm
+++ b/code/modules/mob/living/carbon/xenobiological/items.dm
@@ -131,9 +131,8 @@
 	desc = "A potent chemical mix that will nullify a slime's powers, causing it to become docile and tame."
 	icon = 'icons/obj/chemical_storage.dmi'
 	icon_state = "Pinkpotion"
-	item_flags = ITEM_FLAG_TRY_ATTACK
 
-/obj/item/slimepotion/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
+/obj/item/slimepotion/use_before(mob/living/carbon/slime/M as mob, mob/user as mob)
 	. = FALSE
 	if (!istype(M, /mob/living/carbon/slime))
 		return FALSE
@@ -167,9 +166,8 @@
 	desc = "A potent chemical mix that will nullify a slime's powers, causing it to become docile and tame. This one is meant for adult slimes."
 	icon = 'icons/obj/chemical_storage.dmi'
 	icon_state = "LPinkpotion"
-	item_flags = ITEM_FLAG_TRY_ATTACK
 
-/obj/item/slimepotion2/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
+/obj/item/slimepotion2/use_before(mob/living/carbon/slime/M as mob, mob/user as mob)
 	. = FALSE
 	if (!istype(M, /mob/living/carbon/slime))
 		return FALSE
@@ -200,9 +198,8 @@
 	desc = "A potent chemical mix that will cause a slime to generate more extract."
 	icon = 'icons/obj/chemical_storage.dmi'
 	icon_state = "Greenpotion"
-	item_flags = ITEM_FLAG_TRY_ATTACK
 
-/obj/item/slimesteroid/attack(mob/living/carbon/slime/M as mob, mob/user as mob)
+/obj/item/slimesteroid/use_before(mob/living/carbon/slime/M as mob, mob/user as mob)
 	. = FALSE
 	if (!istype(M, /mob/living/carbon/slime))
 		return FALSE
@@ -247,9 +244,8 @@
 	desc= "A potent chemical mix that will revitalize a recently dead slime"
 	icon= 'icons/obj/chemical_storage.dmi'
 	icon_state= "Goldpotion"
-	item_flags = ITEM_FLAG_TRY_ATTACK
 
-/obj/item/slimepotion3/attack(mob/living/carbon/slime/M, mob/user)
+/obj/item/slimepotion3/use_before(mob/living/carbon/slime/M, mob/user)
 	. = FALSE
 	if (!istype(M, /mob/living/carbon/slime))
 		return FALSE

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -140,7 +140,7 @@
 	return apply_damage(effective_force, I.damtype, hit_zone, damage_flags, used_weapon=I, armor_pen=I.armor_penetration)
 
 /mob/living/post_use_item(obj/item/tool, mob/living/user, interaction_handled, use_call)
-	if (interaction_handled && ai_holder && (use_call == "attack" || use_call == "weapon"))
+	if (interaction_handled && ai_holder && (use_call == "use" || use_call == "weapon"))
 		ai_holder.react_to_attack(user)
 	..()
 

--- a/code/modules/mob/living/silicon/pai/paiwire.dm
+++ b/code/modules/mob/living/silicon/pai/paiwire.dm
@@ -3,11 +3,9 @@
 	name = "data cable"
 	icon = 'icons/obj/machines/power/power_local.dmi'
 	icon_state = "wire1"
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	var/obj/machinery/machine
 
-
-/obj/item/pai_cable/attack(obj/machinery/M as obj, mob/user as mob)
+/obj/item/pai_cable/use_before(obj/machinery/M as obj, mob/user as mob)
 	. = FALSE
 	if (istype(M, /obj/machinery/door) || istype(M, /obj/machinery/camera))
 		if (!user.unEquip(src, M))

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -9,7 +9,6 @@
 	desc = "A hand-held scanner able to diagnose robotic injuries."
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_BELT
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	throwforce = 3
 	w_class = ITEM_SIZE_SMALL
 	throw_speed = 5
@@ -114,7 +113,7 @@
 	playsound(user,'sound/effects/scanbeep.ogg', 30)
 	return
 
-/obj/item/device/robotanalyzer/attack(mob/living/M, mob/living/user)
+/obj/item/device/robotanalyzer/use_before(mob/living/M, mob/living/user)
 	. = FALSE
 	if (!istype(M))
 		return FALSE

--- a/code/modules/mob/living/simple_animal/constructs/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs/constructs.dm
@@ -203,9 +203,8 @@
 	name = "heavy arms"
 	attack_verb = list("rammed")
 	force = 5
-	item_flags = ITEM_FLAG_TRY_ATTACK
 
-/obj/item/natural_weapon/cult_builder/attack(mob/living/M, mob/living/user)
+/obj/item/natural_weapon/cult_builder/use_before(mob/living/M, mob/living/user)
 	. = FALSE
 	if (istype(M, /mob/living/simple_animal/construct))
 		if (M.health < M.maxHealth)

--- a/code/modules/mob/living/simple_animal/constructs/soulstone.dm
+++ b/code/modules/mob/living/simple_animal/constructs/soulstone.dm
@@ -10,7 +10,6 @@
 	desc = "A strange, ridged chunk of some glassy red material. Achingly cold to the touch."
 	w_class = ITEM_SIZE_SMALL
 	slot_flags = SLOT_BELT
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	origin_tech = list(TECH_BLUESPACE = 4, TECH_MATERIAL = 4)
 
 	var/full = SOULSTONE_EMPTY
@@ -106,7 +105,7 @@
 	return ..()
 
 
-/obj/item/device/soulstone/attack(mob/living/simple_animal/M, mob/user)
+/obj/item/device/soulstone/use_before(mob/living/simple_animal/M, mob/user)
 	. = FALSE
 	if (!istype(M))
 		return FALSE

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -262,7 +262,7 @@
 	..()
 
 	// React to being hit
-	if ((use_call == "weapon" || use_call == "attackby") && !stat && !client)
+	if ((use_call == "weapon" || use_call == "use") && !stat && !client)
 		if (parrot_state == PARROT_PERCH)
 			parrot_sleep_dur = parrot_sleep_max //Reset it's sleep timer if it was perched
 

--- a/code/modules/mob/living/simple_animal/hostile/voxslug.dm
+++ b/code/modules/mob/living/simple_animal/hostile/voxslug.dm
@@ -74,7 +74,7 @@ Small, little HP, poisonous.
 			var/datum/reagents/R = L.reagents
 			R.add_reagent(/datum/reagent/drugs/cryptobiolin, 0.5)
 
-/obj/item/holder/voxslug/attack(mob/target, mob/user)
+/obj/item/holder/voxslug/use_before(mob/target, mob/user)
 	. = FALSE
 	var/mob/living/simple_animal/hostile/voxslug/V = contents[1]
 	if (!V.stat && istype(target, /mob/living/carbon/human))

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -5,7 +5,6 @@ var/global/list/organ_cache = list()
 	icon = 'icons/obj/organs.dmi'
 	germ_level = 0
 	w_class = ITEM_SIZE_TINY
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	default_action_type = /datum/action/item_action/organ
 
 	// Strings.
@@ -304,7 +303,7 @@ var/global/list/organ_cache = list()
 		set_dna(owner.dna)
 	return 1
 
-/obj/item/organ/attack(mob/target, mob/user)
+/obj/item/organ/use_before(mob/target, mob/user)
 	. = FALSE
 	if (status & ORGAN_ROBOTIC || !istype(target) || !istype(user) || (user != target && user.a_intent == I_HELP))
 		return FALSE

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -3,7 +3,6 @@
 	icon = 'icons/obj/bureaucracy.dmi'
 	icon_state = "labeler0"
 	item_state = "flight"
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	matter = list(MATERIAL_PLASTIC = 100)
 
 	/// If set, the label text this will apply.
@@ -22,7 +21,7 @@
 	icon_state = "labeler[!isnull(label)]"
 
 
-/obj/item/hand_labeler/attack(atom/target, mob/living/user)
+/obj/item/hand_labeler/use_before(atom/target, mob/living/user)
 	. = FALSE
 	if (label)
 		target.AddLabel(label, user)

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -21,7 +21,6 @@
 	randpixel = 8
 	throwforce = 0
 	w_class = ITEM_SIZE_TINY
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	throw_range = 1
 	throw_speed = 1
 	layer = ABOVE_OBJ_LAYER
@@ -223,7 +222,7 @@
 /obj/item/paper/attack_ai(mob/living/silicon/ai/user)
 	show_content(user)
 
-/obj/item/paper/attack(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
+/obj/item/paper/use_before(mob/living/carbon/M as mob, mob/living/carbon/user as mob)
 	. = FALSE
 	if (!istype(M))
 		return FALSE

--- a/code/modules/paperwork/pen/pen.dm
+++ b/code/modules/paperwork/pen/pen.dm
@@ -55,7 +55,7 @@
 			head.write_on(user, color_description)
 			return TRUE
 
-	if (istype(A, /obj/item/organ/external/head) && user.a_intent != I_HELP) //Not on help intent to not break ghetto surgery.
+	if (istype(A, /obj/item/organ/external/head))
 		var/obj/item/organ/external/head/head = A
 		head.write_on(user, color_description)
 		return TRUE

--- a/code/modules/paperwork/pen/pen.dm
+++ b/code/modules/paperwork/pen/pen.dm
@@ -5,7 +5,6 @@
 	icon_state = "pen"
 	item_state = "pen"
 	slot_flags = SLOT_BELT | SLOT_EARS
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	throwforce = 0
 	force = 2
 	w_class = ITEM_SIZE_TINY
@@ -13,7 +12,6 @@
 	puncture = TRUE
 	throw_speed = 7
 	throw_range = 15
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	matter = list(MATERIAL_PLASTIC = 10)
 	var/colour = "black"	//what colour the ink is!
 	var/color_description = "black ink"
@@ -48,7 +46,7 @@
 	colour = "white"
 	color_description = "transluscent ink"
 
-/obj/item/pen/attack(atom/A, mob/user)
+/obj/item/pen/use_after(atom/A, mob/user)
 	. = FALSE
 	if (ishuman(A) && user.a_intent == I_HELP && user.zone_sel.selecting == BP_HEAD)
 		var/mob/living/carbon/human/H = A

--- a/code/modules/paperwork/pen/reagent_pen.dm
+++ b/code/modules/paperwork/pen/reagent_pen.dm
@@ -6,7 +6,8 @@
 	..()
 	create_reagents(30)
 
-/obj/item/pen/reagent/attack(mob/living/M, mob/user)
+/obj/item/pen/reagent/use_before(mob/living/M, mob/user)
+	. = FALSE
 	if (!istype(M))
 		return FALSE
 	if (!reagents.total_volume)

--- a/code/modules/paperwork/pen/retractable_pen.dm
+++ b/code/modules/paperwork/pen/retractable_pen.dm
@@ -32,7 +32,7 @@
 	else
 		icon_state = "[base_state]"
 
-/obj/item/pen/retractable/attack(atom/A, mob/user)
+/obj/item/pen/retractable/use_before(atom/A, mob/user)
 	if(!active)
 		toggle()
 	return ..()

--- a/code/modules/power/cable_coil.dm
+++ b/code/modules/power/cable_coil.dm
@@ -87,16 +87,16 @@ GLOBAL_LIST_INIT(cable_default_colors, list(
 			SetName(initial(name))
 
 
-/obj/item/stack/cable_coil/use_before(mob/living/carbon/human/target, mob/living/user)
-	. = FALSE
-	if (user.a_intent != I_HELP || !istype(target))
+/obj/item/stack/cable_coil/use_after(mob/living/carbon/human/target, mob/living/user)
+	if (!istype(target))
 		return FALSE
 	var/obj/item/organ/external/organ = target.organs_by_name[user.zone_sel.selecting]
 	if (!organ)
 		to_chat(user, SPAN_WARNING("\The [target] is missing that organ."))
 		return TRUE
 	if (!BP_IS_ROBOTIC(organ))
-		return ..()
+		to_chat(user, SPAN_WARNING("\The [target]'s [organ.name] is not robotic. \The [src] is useless."))
+		return TRUE
 	if (BP_IS_BRITTLE(organ))
 		to_chat(user, SPAN_WARNING("\The [target]'s [organ.name] is hard and brittle - \the [src] cannot repair it."))
 		return TRUE
@@ -104,9 +104,10 @@ GLOBAL_LIST_INIT(cable_default_colors, list(
 	if (!can_use(use_amount))
 		to_chat(user, SPAN_WARNING("You don't have enough of \the [src] left to repair \the [target]'s [organ.name]."))
 		return TRUE
+
 	if (organ.robo_repair(3 * use_amount, DAMAGE_BURN, "some damaged wiring", src, user))
 		use(use_amount)
-	return TRUE
+		return TRUE
 
 
 /obj/item/stack/cable_coil/transfer_to(obj/item/stack/cable_coil/coil)

--- a/code/modules/power/cable_coil.dm
+++ b/code/modules/power/cable_coil.dm
@@ -35,7 +35,6 @@ GLOBAL_LIST_INIT(cable_default_colors, list(
 	)
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CAN_BE_PAINTED
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	slot_flags = SLOT_BELT
 	item_state = "coil"
 	attack_verb = list("whipped", "lashed", "disciplined", "flogged")
@@ -88,7 +87,7 @@ GLOBAL_LIST_INIT(cable_default_colors, list(
 			SetName(initial(name))
 
 
-/obj/item/stack/cable_coil/attack(mob/living/carbon/human/target, mob/living/user)
+/obj/item/stack/cable_coil/use_before(mob/living/carbon/human/target, mob/living/user)
 	. = FALSE
 	if (user.a_intent != I_HELP || !istype(target))
 		return FALSE

--- a/code/modules/psionics/equipment/psipower.dm
+++ b/code/modules/psionics/equipment/psipower.dm
@@ -2,7 +2,6 @@
 	name = "psychic power"
 	icon = 'icons/obj/psychic_powers.dmi'
 	atom_flags = 0
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	anchored = TRUE
 	var/maintain_cost = 3
 	var/mob/living/owner
@@ -29,7 +28,7 @@
 	sound_to(owner, 'sound/effects/psi/power_fail.ogg')
 	user.drop_from_inventory(src)
 
-/obj/item/psychic_power/attack(mob/living/M, mob/living/user)
+/obj/item/psychic_power/use_before(mob/living/M, mob/living/user)
 	. = FALSE
 	if(M.do_psionics_check(max(force, maintain_cost), user))
 		to_chat(user, SPAN_DANGER("\The [src] flickers violently out of phase!"))

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -7,7 +7,6 @@
 	amount_per_transfer_from_this = 5
 	volume = 30
 	possible_transfer_amounts = null
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	canremove = FALSE
 
 	/// Numeric index of the synthesizer in use, or 0 if dispensing from an external container
@@ -57,7 +56,7 @@
 					reagent_volumes[T] = min(reagent_volumes[T] + 5, volume)
 	return 1
 
-/obj/item/reagent_containers/borghypo/attack(mob/living/M, mob/user)
+/obj/item/reagent_containers/borghypo/use_before(mob/living/M, mob/user)
 	. = FALSE
 	if (!istype(M))
 		return FALSE
@@ -250,7 +249,7 @@
 		/datum/reagent/ethanol/coffee/kahlua
 		)
 
-/obj/item/reagent_containers/borghypo/service/attack(mob/M, mob/user)
+/obj/item/reagent_containers/borghypo/service/use_before(mob/M, mob/user)
 	return FALSE //We don't want the service borg to be able to inject alcohol into blood.
 
 /obj/item/reagent_containers/borghypo/service/afterattack(obj/target, mob/user, proximity)

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -11,7 +11,6 @@
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = "emptycondiment"
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	possible_transfer_amounts = "1;5;10"
 	center_of_mass = "x=16;y=6"
 	volume = 50
@@ -42,7 +41,7 @@
 /obj/item/reagent_containers/food/condiment/attack_self(mob/user as mob)
 	return
 
-/obj/item/reagent_containers/food/condiment/attack(mob/M as mob, mob/user as mob)
+/obj/item/reagent_containers/food/condiment/use_before(mob/M as mob, mob/user as mob)
 	. = FALSE
 	if (!istype(M))
 		return FALSE

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -7,7 +7,6 @@
 	icon = 'icons/obj/food/drinks.dmi'
 	icon_state = null
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	amount_per_transfer_from_this = 5
 	volume = 50
 	var/filling_states   // List of percentages full that have icons
@@ -30,7 +29,7 @@
 	to_chat(user, SPAN_NOTICE("You open \the [src] with an audible pop!"))
 	atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 
-/obj/item/reagent_containers/food/drinks/attack(mob/M as mob, mob/user as mob)
+/obj/item/reagent_containers/food/drinks/use_before(mob/M as mob, mob/user as mob)
 	. = FALSE
 	if (!istype(M))
 		return FALSE

--- a/code/modules/reagents/reagent_containers/food/sandwich.dm
+++ b/code/modules/reagents/reagent_containers/food/sandwich.dm
@@ -17,7 +17,6 @@
 	var/list/ingredients = list()
 	var/fullname = ""
 	var/renamed = 0
-	item_flags = ITEM_FLAG_TRY_ATTACK
 
 /obj/item/reagent_containers/food/snacks/csandwich/verb/rename_sandwich()
 	set name = "Rename Sandwich"
@@ -102,7 +101,7 @@
 	var/obj/item/O = pick(contents)
 	to_chat(user, SPAN_ITALIC("You think you can see [O.name] in there."))
 
-/obj/item/reagent_containers/food/snacks/csandwich/attack(mob/living/M as mob, mob/user as mob)
+/obj/item/reagent_containers/food/snacks/csandwich/use_before(mob/living/M as mob, mob/user as mob)
 	. = FALSE
 	if (!istype(M))
 		return FALSE

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3,7 +3,6 @@
 	desc = "Yummy!"
 	icon = 'icons/obj/food/food.dmi'
 	center_of_mass = "x=16;y=16"
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	var/bitesize = 1
 	var/bitecount = 0
 	var/slice_path
@@ -56,7 +55,7 @@
 	return
 
 
-/obj/item/reagent_containers/food/snacks/attack(mob/M as mob, mob/user as mob)
+/obj/item/reagent_containers/food/snacks/use_before(mob/M as mob, mob/user as mob)
 	. = FALSE
 	if (!istype(M, /mob/living/carbon))
 		return FALSE

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -14,7 +14,6 @@
 	volume = 60
 	w_class = ITEM_SIZE_SMALL
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	unacidable = TRUE
 
 
@@ -67,7 +66,7 @@
 		atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 	update_icon()
 
-/obj/item/reagent_containers/glass/attack(mob/M as mob, mob/user as mob)
+/obj/item/reagent_containers/glass/use_before(mob/M as mob, mob/user as mob)
 	. = FALSE
 	if (!istype(M))
 		return FALSE

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -16,7 +16,6 @@
 	possible_transfer_amounts = null
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	slot_flags = SLOT_BELT
-	item_flags = ITEM_FLAG_TRY_ATTACK
 
 	// autoinjectors takes less time than a normal syringe (overriden for hypospray).
 	// This delay is only applied when injecting concious mobs, and is not applied for self-injection
@@ -29,7 +28,7 @@
 	var/time = (1 SECONDS) / 1.9
 	var/single_use = TRUE // autoinjectors are not refillable (overriden for hypospray)
 
-/obj/item/reagent_containers/hypospray/attack(mob/living/M, mob/user)
+/obj/item/reagent_containers/hypospray/use_before(mob/living/M, mob/user)
 	. = FALSE
 	if (!istype(M))
 		return FALSE

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -10,7 +10,6 @@
 	randpixel = 7
 	possible_transfer_amounts = null
 	w_class = ITEM_SIZE_TINY
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	slot_flags = SLOT_EARS
 	volume = 30
 
@@ -19,7 +18,7 @@
 	if(!icon_state)
 		icon_state = "pill[rand(1, 5)]" //preset pills only use colour changing or unique icons
 
-/obj/item/reagent_containers/pill/attack(mob/M as mob, mob/user as mob)
+/obj/item/reagent_containers/pill/use_before(mob/M as mob, mob/user as mob)
 	. = FALSE
 	if (!istype(M))
 		return FALSE

--- a/code/modules/spells/hand/hand_item.dm
+++ b/code/modules/spells/hand/hand_item.dm
@@ -9,7 +9,6 @@ Basically: I can use it to target things where I click. I can then pass these ta
 	item_flags = 0
 	obj_flags = 0
 	simulated = FALSE
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	icon_state = "spell"
 	var/next_spell_time = 0
 	var/spell/hand/hand_spell
@@ -23,7 +22,7 @@ Basically: I can use it to target things where I click. I can then pass these ta
 /obj/item/magic_hand/get_storage_cost()
 	return ITEM_SIZE_NO_CONTAINER
 
-/obj/item/magic_hand/attack(mob/living/M, mob/living/user)
+/obj/item/magic_hand/use_before(mob/living/M, mob/living/user)
 	. = FALSE
 	if (hand_spell && hand_spell.valid_target(M, user))
 		fire_spell(M, user)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -258,10 +258,3 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 
 /obj/item/stack/handle_post_surgery()
 	use(1)
-
-/obj/item/proc/check_possible_surgeries(mob/living/carbon/M, mob/user)
-	var/list/all_surgeries = GET_SINGLETON_SUBTYPE_MAP(/singleton/surgery_step)
-	for (var/singleton in all_surgeries)
-		var/singleton/surgery_step/S = all_surgeries[singleton]
-		if (S.name && S.tool_quality(src) && S.can_use(user, M, user.zone_sel.selecting, src))
-			return TRUE

--- a/code/modules/xenoarcheaology/tools/ano_device_battery.dm
+++ b/code/modules/xenoarcheaology/tools/ano_device_battery.dm
@@ -19,7 +19,6 @@
 	name = "Anomaly power utilizer"
 	icon = 'icons/obj/tools/xenoarcheology_anomaly_utilizer.dmi'
 	icon_state = "anodev"
-	item_flags = ITEM_FLAG_TRY_ATTACK
 	var/activated = 0
 	var/duration = 0
 	var/interval = 0
@@ -204,7 +203,7 @@
 	STOP_PROCESSING(SSobj, src)
 	..()
 
-/obj/item/anodevice/attack(mob/living/M as mob, mob/living/user as mob)
+/obj/item/anodevice/use_before(mob/living/M as mob, mob/living/user as mob)
 	. = FALSE
 	if (!istype(M))
 		return FALSE

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -57,7 +57,7 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 7 "uses of .len" '\.len\b' -P
-exactly 385 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 384 "attackby() override" '\/attackby\((.*)\)'  -P
 exactly 15 "uses of examine()" '[.|\s]examine\(' -P # If this fails it's likely because you used '/atom/proc/examine(mob)' instead of '/proc/examinate(mob, atom)' - Exception: An examine()-proc may call other examine()-procs
 exactly 7 "direct modifications of overlays list" '\boverlays((\s*[|^=+&-])|(\.(Cut)|(Add)|(Copy)|(Remove)|(Remove)))' -P
 exactly 0 "new/list list instantiations" 'new\s*/list' -P


### PR DESCRIPTION
🆑 emmanuelbassil
tweak: Clicking on yourself with a pill bottle no matter the targeted area consumes a pill. Previous behavior required targeting mouth.
/🆑 

Depends on #34157.
Replaced attack() with use_before() and use_on() with use_after(). Removed the attack override flag and incorporated both of these in the resolve_attackby() chain.

While testing, noticed pill_bottle had two separate afterattacks() defined, so the pill popping behavior was not working. Also noticed they're a good candidate to be switched to use_after, and did so. The only afterattacks() I will have trouble switching to use_after are those few that act in a RANGED way.

