### PR TITLE
Increase surgeons' chances of repairing robotic organs in organic bodies

### DIFF
--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -375,6 +375,14 @@
 	else
 		return SURGERY_SKILLS_ROBOTIC_ON_MEAT
 
+/singleton/surgery_step/robotics/fix_organ_robotic/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
+	. = ..()
+	if(!target.isSynthetic())
+		if(user.skill_check(SKILL_ANATOMY, SKILL_EXPERIENCED))
+			. += 30
+		if(user.skill_check(SKILL_MEDICAL, SKILL_EXPERIENCED))
+			. += 30
+
 /singleton/surgery_step/robotics/fix_organ_robotic/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected)


### PR DESCRIPTION
#33882 rebalanced robotic surgery so that success chance relied less on tool quality and more on having an experienced complex devices skill. This change affects repairing robotic organs inside of organic bodies, but does not account for the fact that surgeons cannot be experienced in complex devices. With default skills, surgeons only have a 40% chance to repair robotic organs, even when using the best tool.

This PR adds anatomy and medicine as secondary skills for repairing robotic organs, similarly to how engineering skills are used in other robotic surgeries. This way, surgeons with experienced medicine, experienced anatomy, and trained complex devices will have an exact 100% chance of success, provided they are using nanopaste on an organic patient.

:cl:
tweak: Improved surgeons' chances of repairing robotic organs inside of organic bodies.
/:cl: