### PR TITLE
Installing items using a gripper no longer fails sanity checks

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -217,10 +217,15 @@ avoid code duplication. This includes items that may sometimes act as a standard
 			if (!silent)
 				FEEDBACK_UNEQUIP_FAILURE(src, tool)
 			return FALSE
-		if (HAS_FLAGS(flags, SANITY_CHECK_TOOL_IN_HAND) && get_active_hand() != tool)
-			if (!silent)
-				FEEDBACK_FAILURE(src, "\The [tool] must stay in your active hand.")
-			return FALSE
+		if (HAS_FLAGS(flags, SANITY_CHECK_TOOL_IN_HAND))
+			var/active = get_active_hand()
+			if (istype(active, /obj/item/gripper))
+				var/obj/item/gripper/gripper = active
+				active = gripper.wrapped
+			if (active != tool)
+				if (!silent)
+					FEEDBACK_FAILURE(src, "\The [tool] must stay in your active hand.")
+				return FALSE
 	return TRUE
 
 


### PR DESCRIPTION
:cl:
bugfix: Installing items using a gripper no longer causes errors. This mainly includes airlock electronics.
/:cl:


Since the gripper is the only tool which uses the wrapped item behaviour, I've put it as a condition in the sanity check.

Fixes #34105, fixes #33528