### PR TITLE
Update override references for `/datum/species` vars outside of base definition

### DIFF
--- a/code/modules/emotes/definitions/_species.dm
+++ b/code/modules/emotes/definitions/_species.dm
@@ -8,59 +8,52 @@
 	usable_emotes = sortAssoc(usable_emotes)
 
 // Specific defines follow.
-/datum/species/slime
-	default_emotes = list(
-		/singleton/emote/visible/bounce,
-		/singleton/emote/visible/jiggle,
-		/singleton/emote/visible/lightup,
-		/singleton/emote/visible/vibrate
-		)
+/datum/species/slime/default_emotes = list(
+	/singleton/emote/visible/bounce,
+	/singleton/emote/visible/jiggle,
+	/singleton/emote/visible/lightup,
+	/singleton/emote/visible/vibrate
+)
 
-/datum/species/unathi
-	default_emotes = list(
-		/singleton/emote/human/swish,
-		/singleton/emote/human/wag,
-		/singleton/emote/human/sway,
-		/singleton/emote/human/qwag,
-		/singleton/emote/human/fastsway,
-		/singleton/emote/human/swag,
-		/singleton/emote/human/stopsway,
-		/singleton/emote/audible/lizard_bellow
-		)
+/datum/species/unathi/default_emotes = list(
+	/singleton/emote/human/swish,
+	/singleton/emote/human/wag,
+	/singleton/emote/human/sway,
+	/singleton/emote/human/qwag,
+	/singleton/emote/human/fastsway,
+	/singleton/emote/human/swag,
+	/singleton/emote/human/stopsway,
+	/singleton/emote/audible/lizard_bellow
+)
 
-/datum/species/unathi/yeosa
-	default_emotes = list(
-		/singleton/emote/human/swish,
-		/singleton/emote/human/wag,
-		/singleton/emote/human/sway,
-		/singleton/emote/human/qwag,
-		/singleton/emote/human/fastsway,
-		/singleton/emote/human/swag,
-		/singleton/emote/human/stopsway,
-		/singleton/emote/audible/lizard_bellow,
-		/singleton/emote/audible/lizard_squeal
-		)
+/datum/species/unathi/yeosa/default_emotes = list(
+	/singleton/emote/human/swish,
+	/singleton/emote/human/wag,
+	/singleton/emote/human/sway,
+	/singleton/emote/human/qwag,
+	/singleton/emote/human/fastsway,
+	/singleton/emote/human/swag,
+	/singleton/emote/human/stopsway,
+	/singleton/emote/audible/lizard_bellow,
+	/singleton/emote/audible/lizard_squeal
+)
 
-/datum/species/nabber
-	default_emotes = list(
-		/singleton/emote/audible/bug_hiss,
-		/singleton/emote/audible/bug_buzz,
-		/singleton/emote/audible/bug_chitter
-		)
+/datum/species/nabber/default_emotes = list(
+	/singleton/emote/audible/bug_hiss,
+	/singleton/emote/audible/bug_buzz,
+	/singleton/emote/audible/bug_chitter
+)
 
-/datum/species/adherent
-	default_emotes = list(
-		/singleton/emote/audible/adherent_chime,
-		/singleton/emote/audible/adherent_ding
-	)
+/datum/species/adherent/default_emotes = list(
+	/singleton/emote/audible/adherent_chime,
+	/singleton/emote/audible/adherent_ding
+)
 
-/datum/species/vox
-	default_emotes = list(
-		/singleton/emote/audible/vox_shriek
-	)
+/datum/species/vox/default_emotes = list(
+	/singleton/emote/audible/vox_shriek
+)
 
-/datum/species/diona
-	default_emotes = list(
-		/singleton/emote/audible/chirp,
-		/singleton/emote/audible/multichirp
-	)
+/datum/species/diona/default_emotes = list(
+	/singleton/emote/audible/chirp,
+	/singleton/emote/audible/multichirp
+)

--- a/code/modules/emotes/skrell.dm
+++ b/code/modules/emotes/skrell.dm
@@ -1,18 +1,17 @@
-/datum/species/skrell
-	default_emotes = list(
-		/singleton/emote/audible/skrell_anger,
-		/singleton/emote/audible/skrell_anger1,
-		/singleton/emote/audible/skrell_anger2,
-		/singleton/emote/audible/skrell_laughter,
-		/singleton/emote/audible/skrell_peep,
-		/singleton/emote/audible/skrell_trill,
-		/singleton/emote/audible/skrell_trill1,
-		/singleton/emote/audible/skrell_trill2,
-		/singleton/emote/audible/skrell_warble,
-		/singleton/emote/audible/skrell_warble1,
-		/singleton/emote/audible/skrell_warble2,
-		/singleton/emote/audible/skrell_warble3
-	)
+/datum/species/skrell/default_emotes = list(
+	/singleton/emote/audible/skrell_anger,
+	/singleton/emote/audible/skrell_anger1,
+	/singleton/emote/audible/skrell_anger2,
+	/singleton/emote/audible/skrell_laughter,
+	/singleton/emote/audible/skrell_peep,
+	/singleton/emote/audible/skrell_trill,
+	/singleton/emote/audible/skrell_trill1,
+	/singleton/emote/audible/skrell_trill2,
+	/singleton/emote/audible/skrell_warble,
+	/singleton/emote/audible/skrell_warble1,
+	/singleton/emote/audible/skrell_warble2,
+	/singleton/emote/audible/skrell_warble3
+)
 
 
 /singleton/emote/audible/skrell_anger

--- a/code/modules/mob/living/autohiss.dm
+++ b/code/modules/mob/living/autohiss.dm
@@ -9,22 +9,20 @@
 		return message
 	return species.handle_autohiss(message, L, get_preference_value(/datum/client_preference/autohiss))
 
-/datum/species
-	var/list/autohiss_basic_map = null
-	var/list/autohiss_extra_map = null
-	var/list/autohiss_exempt = null
+/datum/species/var/list/autohiss_basic_map = null
+/datum/species/var/list/autohiss_extra_map = null
+/datum/species/var/list/autohiss_exempt = null
 
-/datum/species/unathi
-	autohiss_basic_map = list(
-			"s" = list("ss", "sss", "ssss")
-		)
-	autohiss_extra_map = list(
-			"x" = list("ks", "kss", "ksss")
-		)
-	autohiss_exempt = list(
-					LANGUAGE_UNATHI_SINTA,
-					LANGUAGE_UNATHI_YEOSA
-	)
+/datum/species/unathi/autohiss_basic_map = list(
+	"s" = list("ss", "sss", "ssss")
+)
+/datum/species/unathi/autohiss_extra_map = list(
+	"x" = list("ks", "kss", "ksss")
+)
+/datum/species/unathi/autohiss_exempt = list(
+	LANGUAGE_UNATHI_SINTA,
+	LANGUAGE_UNATHI_YEOSA
+)
 
 /datum/species/proc/handle_autohiss(message, datum/language/lang, mode)
 	if(!autohiss_basic_map)


### PR DESCRIPTION
## Changelog
No user-facing changes.

## Other Changes
- Updated various var overrides and new var definitions that were performed outside of the base `/datum/species/*` type path definitions to use single-line `/path/to/thing/var/name = blah` instead of the multi-line format, allowing VSC to jump to the correct file when trying to find a definition for a type path.