### PR TITLE
Remove age-based skill bonuses

### DIFF
--- a/code/modules/client/preference_setup/occupation/skill_selection.dm
+++ b/code/modules/client/preference_setup/occupation/skill_selection.dm
@@ -110,7 +110,7 @@
 
 		points_by_job[job] = job.skill_points							//We compute how many points we had.
 		if(!job.no_skill_buffs)
-			points_by_job[job] += S.skills_from_age(age)				//Applies the species-appropriate age modifier.
+			points_by_job[job] += 8 // Base skill buff
 			points_by_job[job] += S.job_skill_buffs[job.type]			//Applies the per-job species modifier, if any.
 
 		if((points_by_job[job] >= sum) && sum)				//we didn't overspend, so use sanitized imported data

--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -140,9 +140,6 @@
 	var/datum/pronouns/P = H.choose_from_pronouns()
 	return "[SPAN_DANGER("[P.His] beak-segments are cracked and chipped! [P.He] [P.is] not even recognizable.")]\n"
 
-/datum/species/vox/skills_from_age(age)
-	. = 8
-
 /obj/item/vox_changer
 	name = "mouldy mirror"
 	desc = "Something seems strange about this old, dirty mirror. Your reflection doesn't look like you remember it."

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -835,13 +835,6 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 
 	show_browser(src, species.get_description(), "window=species;size=700x400")
 
-/datum/species/proc/skills_from_age(age)	//Converts an age into a skill point allocation modifier. Can be used to give skill point bonuses/penalities not depending on job.
-	switch(age)
-		if(0 to 22) 	. = 0
-		if(23 to 30) 	. = 3
-		if(31 to 45)	. = 6
-		else			. = 8
-
 /datum/species/proc/post_organ_rejuvenate(obj/item/organ/org, mob/living/carbon/human/H)
 	return
 

--- a/code/modules/species/station/adherent.dm
+++ b/code/modules/species/station/adherent.dm
@@ -156,13 +156,6 @@
 /datum/species/adherent/get_blood_name()
 	return "coolant"
 
-/datum/species/adherent/skills_from_age(age)
-	switch(age)
-		if(0 to 1000)    . = -4
-		if(1000 to 2000) . =  0
-		if(2000 to 8000) . =  4
-		else             . =  8
-
 /datum/species/adherent/get_additional_examine_text(mob/living/carbon/human/H)
 	if(can_overcome_gravity(H)) return "\nThey are floating on a cloud of shimmering distortion."
 

--- a/code/modules/species/station/nabber.dm
+++ b/code/modules/species/station/nabber.dm
@@ -402,10 +402,3 @@
 /datum/species/nabber/check_background(datum/job/job, datum/preferences/prefs)
 	var/singleton/cultural_info/culture/nabber/grade = SSculture.get_culture(prefs.cultural_info[TAG_CULTURE])
 	. = istype(grade) ? (job.type in grade.valid_jobs) : ..()
-
-/datum/species/nabber/skills_from_age(age)	//Converts an age into a skill point allocation modifier. Can be used to give skill point bonuses/penalities not depending on job.
-	switch(age)
-		if(0 to 18) 	. = 8
-		if(19 to 27) 	. = 2
-		if(28 to 40)	. = -2
-		else			. = -4

--- a/code/modules/species/station/station.dm
+++ b/code/modules/species/station/station.dm
@@ -412,12 +412,6 @@
 	else
 		H.equip_to_slot_or_del(new /obj/item/device/flashlight/flare(H), slot_r_hand)
 
-/datum/species/diona/skills_from_age(age)
-	switch(age)
-		if(101 to 200)	. = 12 // age bracket before this is 46 to 100 . = 8 making this +4
-		if(201 to 300)	. = 16 // + 8
-		else			. = ..()
-
 // Dionaea spawned by hand or by joining will not have any
 // nymphs passed to them. This should take care of that.
 /datum/species/diona/handle_post_spawn(mob/living/carbon/human/H)


### PR DESCRIPTION
Age-based skill bonuses encourage people to roll higher aged characters to get more skill points, and punishes people that want to play younger characters. I'm not really seeing any benefits to tying character age to skill points, so here we are.

## Changelog
:cl: SierraKomodo
tweak: Skill point bonuses are no longer affected by character age. This has been replaced by a flat 8-point skill bonus.
/:cl: