### PR TITLE
Remove extra wrong-direction light from hydroponics

### DIFF
--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -18094,9 +18094,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/thirddeck/aftport)
 "Tm" = (
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/effect/floor_decal/corner/green{
 	dir = 5
 	},


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
matpweak: Removed the extra light in hydroponics that faced the wrong direction.
/:cl:

## Bug Fixes
- Fixes #34173