### PR TITLE
Improves parapen feedback

### DIFF
--- a/code/modules/paperwork/pen/reagent_pen.dm
+++ b/code/modules/paperwork/pen/reagent_pen.dm
@@ -7,27 +7,37 @@
 	create_reagents(30)
 
 /obj/item/pen/reagent/attack(mob/living/M, mob/user)
-	. = FALSE
 	if (!istype(M))
+		return FALSE
+	if (!reagents.total_volume)
 		return FALSE
 
 	var/target_zone = user.zone_sel.selecting
 	var/allow = M.can_inject(user, target_zone)
-	if (allow)
-		if (allow == INJECTION_PORT)
-			if (M != user)
-				to_chat(user, SPAN_WARNING("You begin hunting for an injection port on \the [M]'s suit!"))
-			else
-				to_chat(user, SPAN_NOTICE("You begin hunting for an injection port on your suit."))
-			if (!user.do_skilled(INJECTION_PORT_DELAY, SKILL_MEDICAL, M, do_flags = DO_MEDICAL))
-				return TRUE
-		if (reagents.total_volume)
-			if (M.reagents)
-				var/should_admin_log = reagents.should_admin_log()
-				var/contained_reagents = reagents.get_reagents()
-				var/trans = reagents.trans_to_mob(M, 30, CHEM_BLOOD)
-				if (should_admin_log)
-					admin_inject_log(user, M, src, contained_reagents, trans)
+	if (!allow)
+		return TRUE
+
+	if (allow == INJECTION_PORT)
+		if (M != user)
+			to_chat(user, SPAN_WARNING("You begin hunting for an injection port on \the [M]'s suit!"))
+		else
+			to_chat(user, SPAN_NOTICE("You begin hunting for an injection port on your suit."))
+
+		if (!user.do_skilled(INJECTION_PORT_DELAY, SKILL_MEDICAL, M, do_flags = DO_MEDICAL))
+			return TRUE
+
+	if (M.reagents)
+		var/should_admin_log = reagents.should_admin_log()
+		var/contained_reagents = reagents.get_reagents()
+		var/trans = reagents.trans_to_mob(M, 30, CHEM_BLOOD)
+		if (should_admin_log)
+			admin_inject_log(user, M, src, contained_reagents, trans)
+
+	if (user.a_intent == I_HURT && allow != INJECTION_PORT)
+		return M.use_weapon(src, user)
+	else
+		to_chat(user, SPAN_WARNING("You prick \the [M] with \the [src]."))
+		to_chat(M, SPAN_NOTICE("You feel a tiny prick."))
 		return TRUE
 
 /*


### PR DESCRIPTION
A bug was reported that parapens weren't working. Turns out they were working, they just had HORRIBLE feedback. I suspect this is because the old attack() procs that were moved to use_weapon() used to handle feedback.

This was fixed. You now get feedback if you inject someone with any intent. If you inject with harm intent, it will play the regular use_weapon attack animation, sounds, and feedback while also injecting someone. If you inject with any other intent, it will give 'You prick X with the pen'/'you feel a tiny prick' feedback. 

If the reagent pen is empty, the entire attack() proc is skipped and it will go through the rest of resolve_attackby. This fixes not being able to use an empty parapen offensively, in case you want to stab eyes out with it. (Which is a thing since the eyestab overhaul!) 