### PR TITLE
Corporate mining outpost alarms fix

### DIFF
--- a/maps/away/mining/mining_corporate.dm
+++ b/maps/away/mining/mining_corporate.dm
@@ -149,7 +149,6 @@
 /area/outpost/mining
 	name = "Mining Outpost Equipment"
 	icon_state = "outpost_mine_main"
-	area_flags = AREA_FLAG_IS_NOT_PERSISTENT
 	sound_env = STANDARD_STATION
 	base_turf = /turf/simulated/floor/asteroid
 	req_access = list(list(access_mining, access_xenoarch))


### PR DESCRIPTION
No more NanoTrasen facility alarms on my Torch
![image](https://github.com/Baystation12/Baystation12/assets/77477080/8fad8ecc-2f13-4d69-8f42-1e5e504117da)

:cl: LordNest
bugfix: Fixed presence of Corporate mining outpost alarms on Torch monitors.
/:cl: