### PR TITLE
fix character preview not updating

### DIFF
--- a/code/modules/client/preference_setup/general/05_preview.dm
+++ b/code/modules/client/preference_setup/general/05_preview.dm
@@ -67,6 +67,7 @@
 		var/mob/living/carbon/human/dummy/mannequin/mannequin = get_mannequin(client_ckey)
 		mannequin.delete_inventory(TRUE)
 		dress_preview_mob(mannequin)
+		mannequin.ImmediateOverlayUpdate()
 		last_built_icon = icon('icons/effects/128x48.dmi', bgstate)
 		last_built_icon.Scale(48+32, 16+32)
 		mannequin.dir = WEST


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed the character panel preview icon not updating when it should. 
/:cl: