### PR TITLE
Make noexcutite actually work

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -866,7 +866,9 @@
 
 /datum/reagent/noexcutite/affect_blood(mob/living/carbon/M, removed)
 	if (IS_METABOLICALLY_INERT(M))
-		M.make_jittery(-50)
+		return
+
+	M.make_jittery(-50)
 
 /datum/reagent/antidexafen
 	name = "Antidexafen"


### PR DESCRIPTION
:cl:
bugfix: Made noexcutite actually prevent jitters like it's supposed to.
/:cl:

#32602 broke noexcutite so that it only worked on the few species that shouldn't actually benefit from it. This PR fixes the IS_METABOLICALLY_INERT check.