### PR TITLE
eliminates new\s*/list style of list definition

### DIFF
--- a/code/_helpers/areas.dm
+++ b/code/_helpers/areas.dm
@@ -14,7 +14,7 @@
 
 /proc/get_area_turfs(area/A, list/predicates)
 	RETURN_TYPE(/list)
-	. = new/list()
+	. = list()
 	A = istype(A) ? A : locate(A)
 	if(!A)
 		return
@@ -24,7 +24,7 @@
 
 /proc/get_subarea_turfs(area/A, list/predicates)
 	RETURN_TYPE(/list)
-	. = new/list()
+	. = list()
 	A = istype(A) ? A.type : A
 	if(!ispath(A))
 		return

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -82,7 +82,7 @@
 	RETURN_TYPE(/list)
 
 	var/turf/centerturf = get_turf(center)
-	var/list/turfs = new/list()
+	var/list/turfs = list()
 	var/rsq = radius * (radius+0.5)
 
 	for(var/atom/T in range(radius, centerturf))
@@ -98,7 +98,7 @@
 	RETURN_TYPE(/list)
 
 	var/turf/centerturf = get_turf(center)
-	var/list/atoms = new/list()
+	var/list/atoms = list()
 	var/rsq = radius * (radius+0.5)
 
 	for(var/atom/A in view(radius, centerturf))
@@ -152,7 +152,7 @@
 	RETURN_TYPE(/list)
 
 	var/turf/centerturf = get_turf(center)
-	var/list/turfs = new/list()
+	var/list/turfs = list()
 	var/rsq = radius * (radius+0.5)
 
 	for(var/turf/T in view(radius, centerturf))
@@ -524,7 +524,7 @@
 
 /proc/getCardinalAirInfo(turf/loc, list/stats=list("temperature"))
 	RETURN_TYPE(/list)
-	var/list/temps = new/list(4)
+	var/list/temps = new(4)
 	for(var/dir in GLOB.cardinal)
 		var/direction
 		switch(dir)
@@ -537,7 +537,7 @@
 			if(WEST)
 				direction = 4
 		var/turf/simulated/T=get_turf(get_step(loc,dir))
-		var/list/rstats = new /list(length(stats))
+		var/list/rstats = new(length(stats))
 		if(T && istype(T) && T.zone)
 			var/datum/gas_mixture/environment = T.return_air()
 			for(var/i=1;i<=length(stats);i++)

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -631,7 +631,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 		var/area/areatemp = areatype
 		areatype = areatemp.type
 
-	var/list/areas = new/list()
+	var/list/areas = list()
 	for(var/area/N in world)
 		if(istype(N, areatype)) areas += N
 	return areas
@@ -648,7 +648,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 	if(!ispath(areatype, /area))
 		return null
 
-	var/list/atoms = new/list()
+	var/list/atoms = list()
 	for(var/area/N in world)
 		if(istype(N, areatype))
 			for(var/atom/A in N)

--- a/code/game/machinery/vitals_monitor.dm
+++ b/code/game/machinery/vitals_monitor.dm
@@ -31,8 +31,8 @@
 
 /obj/machinery/vitals_monitor/Initialize()
 	. = ..()
-	alerts = new /list(3)
-	last_alert = new /list(3)
+	alerts = new(3)
+	last_alert = new(3)
 	for (dir in list(NORTH,EAST,SOUTH,WEST))
 		connected_optable = locate(/obj/machinery/optable, get_step(src, dir))
 		if (connected_optable)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -410,8 +410,8 @@
 	throwforce = 0
 	var/max_capacity = 600
 	var/used_capacity = 0
-	var/list/storedinfo = new/list()
-	var/list/timestamp = new/list()
+	var/list/storedinfo = list()
+	var/list/timestamp = list()
 	var/ruined = 0
 	var/doctored = 0
 

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -11,7 +11,7 @@
 	var/state = 0
 	var/path = 0
 	var/obj/item/device/assembly_holder/detonator = null
-	var/list/beakers = new/list()
+	var/list/beakers = list()
 	var/list/allowed_containers = list(/obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/glass/bottle)
 	var/affected_area = 3
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -9,8 +9,8 @@
 	name = "storage"
 	icon = 'icons/obj/boxes.dmi'
 	w_class = ITEM_SIZE_NORMAL
-	var/list/can_hold = new/list() //List of objects which this item can store (if set, it can't store anything else)
-	var/list/cant_hold = new/list() //List of objects which this item can't store (in effect only if can_hold isn't set)
+	var/list/can_hold = list() //List of objects which this item can store (if set, it can't store anything else)
+	var/list/cant_hold = list() //List of objects which this item can't store (in effect only if can_hold isn't set)
 
 	var/max_w_class = ITEM_SIZE_SMALL //Max size of objects that this object can store (in effect only if can_hold isn't set)
 	var/max_storage_space = null //Total storage cost of items this can hold. Will be autoset based on storage_slots if left null.

--- a/code/game/objects/items/weapons/storage/storage_ui/default.dm
+++ b/code/game/objects/items/weapons/storage/storage_ui/default.dm
@@ -1,5 +1,5 @@
 /datum/storage_ui/default
-	var/list/is_seeing = new/list() //List of mobs which are currently seeing the contents of this item's storage
+	var/list/is_seeing = list() //List of mobs which are currently seeing the contents of this item's storage
 
 	var/obj/screen/storage/boxes
 	var/obj/screen/storage/storage_start //storage UI

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -105,7 +105,7 @@
 /obj/item/clothing/suit/armor/reactive/handle_shield(mob/user, damage, atom/damage_source = null, mob/attacker = null, def_zone = null, attack_text = "the attack")
 	if(prob(50))
 		user.visible_message(SPAN_DANGER("The reactive teleport system flings [user] clear of the attack!"))
-		var/list/turfs = new/list()
+		var/list/turfs = list()
 		for(var/turf/T in orange(6, user))
 			if(istype(T,/turf/space)) continue
 			if(T.density) continue

--- a/code/modules/integrated_electronics/subtypes/smart.dm
+++ b/code/modules/integrated_electronics/subtypes/smart.dm
@@ -125,8 +125,8 @@
 		activate_pin(3)
 		return
 	else
-		var/list/Xn =  new/list(length(P))
-		var/list/Yn =  new/list(length(P))
+		var/list/Xn =  new(length(P))
+		var/list/Yn =  new(length(P))
 		var/turf/T
 		for(var/i =1 to length(P))
 			T=P[i]

--- a/code/modules/modular_computers/file_system/programs/engineering/rcon_console.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/rcon_console.dm
@@ -123,12 +123,12 @@
 // Parameters: None
 // Description: Refreshes local list of known devices.
 /datum/nano_module/rcon/proc/FindDevices()
-	known_SMESs = new /list()
+	known_SMESs = list()
 	for(var/obj/machinery/power/smes/buildable/SMES in SSmachines.machinery)
 		if(AreConnectedZLevels(get_host_z(), get_z(SMES)) && SMES.RCon_tag && (SMES.RCon_tag != "NO_TAG") && SMES.RCon)
 			known_SMESs.Add(SMES)
 
-	known_breakers = new /list()
+	known_breakers = list()
 	for(var/obj/machinery/power/breakerbox/breaker in SSmachines.machinery)
 		if(AreConnectedZLevels(get_host_z(), get_z(breaker)) && breaker.RCon_tag != "NO_TAG")
 			known_breakers.Add(breaker)

--- a/code/modules/overmap/disperser/disperser_console.dm
+++ b/code/modules/overmap/disperser/disperser_console.dm
@@ -1,5 +1,3 @@
-//Amazing disperser from Bxil(tm). Some icons, sounds, and some code shamelessly stolen from ParadiseSS13.
-
 /obj/machinery/computer/ship/disperser
 	name = "obstruction field disperser control"
 	icon = 'icons/obj/machines/computer.dmi'
@@ -26,8 +24,6 @@
 
 	var/accuracy = 0
 
-	/// Number of digits that needs calibration
-	var/caldigit = 4
 	/// What it is
 	var/list/calibration
 	/// what is should be
@@ -41,6 +37,8 @@
 	var/next_shot = 0
 	/// Time to wait between safe shots in deciseconds
 	var/const/coolinterval = 2 MINUTES
+
+	var/const/cal_count = 4
 
 /obj/machinery/computer/ship/disperser/Initialize()
 	. = ..()
@@ -104,8 +102,8 @@
  * Calculating calibration.
  */
 /obj/machinery/computer/ship/disperser/proc/get_calibration()
-	var/list/calresult[caldigit]
-	for(var/i = 1 to caldigit)
+	var/list/calresult = new(cal_count)
+	for(var/i = 1 to cal_count)
 		if(calibration[i] == calexpected[i])
 			calresult[i] = 2
 		else if(calibration[i] in calexpected)
@@ -118,10 +116,10 @@
  * Resetting calibration.
  */
 /obj/machinery/computer/ship/disperser/proc/reset_calibration()
-	calexpected = new /list(caldigit)
-	calibration = new /list(caldigit)
-	for(var/i = 1 to caldigit)
-		calexpected[i] = rand(0,9)
+	calexpected = new(cal_count)
+	calibration = new(cal_count)
+	for(var/i = 1 to cal_count)
+		calexpected[i] = rand(0, 9)
 		calibration[i] = 0
 
 /**
@@ -130,7 +128,7 @@
 /obj/machinery/computer/ship/disperser/proc/cal_accuracy()
 	var/top = 0
 	// Maximum possible value, aka 100% accuracy
-	var/divisor = caldigit * 2
+	var/divisor = cal_count * 2
 	for(var/i in get_calibration())
 		top += i
 	accuracy = round(top * 100 / divisor)
@@ -240,14 +238,12 @@
 
 	if(href_list["calibration"])
 		var/input = input("0-9", "disperser calibration", 0) as num|null
-		// Can be zero so we explicitly check for null
 		if(!isnull(input))
-			var/calnum = sanitize_integer(text2num(href_list["calibration"]), 0, caldigit) // sanitiiiiize
-			// Must add 1 because nanoui indexes from 0
+			var/calnum = sanitize_integer(text2num(href_list["calibration"]), 0, cal_count - 1)
 			calibration[calnum + 1] = sanitize_integer(input, 0, 9, 0)
 
 	if(href_list["skill_calibration"])
-		for(var/i = 1 to min(caldigit, user.get_skill_value(core_skill) - skill_offset))
+		for(var/i = 1 to clamp(user.get_skill_value(core_skill) - skill_offset, 1, cal_count))
 			calibration[i] = calexpected[i]
 
 	if(href_list["strength"])

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -10,7 +10,7 @@
 	throw_range = 7
 	layer = BELOW_OBJ_LAYER
 	var/amount = 30					//How much paper is in the bin.
-	var/list/papers = new/list()	//List of papers put in the bin for reference.
+	var/list/papers = list()	//List of papers put in the bin for reference.
 
 
 /obj/item/paper_bin/MouseDrop(mob/user as mob)

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -361,7 +361,7 @@
 
 /obj/machinery/power/apc/proc/check_updates()
 	if(!update_overlay_chan)
-		update_overlay_chan = new/list()
+		update_overlay_chan = list()
 	var/last_update_state = update_state
 	var/last_update_overlay = update_overlay
 	var/list/last_update_overlay_chan = update_overlay_chan.Copy()

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -416,7 +416,7 @@
 				react_pool -= reactant
 
 		//loop through all the reacting reagents, picking out random reactions for them
-		var/list/produced_reactants = new/list
+		var/list/produced_reactants = list()
 		var/list/p_react_pool = react_pool.Copy()
 		while(length(p_react_pool))
 			//pick one of the unprocessed reacting reagents randomly

--- a/code/modules/power/turbine.dm
+++ b/code/modules/power/turbine.dm
@@ -201,7 +201,7 @@
 	for(var/obj/machinery/compressor/C in SSmachines.machinery)
 		if(id_tag == C.comp_id)
 			compressor = C
-	doors = new /list()
+	doors = list()
 	for(var/obj/machinery/door/blast/P in SSmachines.machinery)
 		if(P.id_tag == id_tag)
 			doors += P

--- a/code/modules/projectiles/guns/launcher/foam_gun.dm
+++ b/code/modules/projectiles/guns/launcher/foam_gun.dm
@@ -17,7 +17,7 @@
 	matter = list(MATERIAL_PLASTIC = 200)
 
 	var/max_darts = 1
-	var/list/darts = new/list()
+	var/list/darts = list()
 
 
 /obj/item/gun/launcher/foam/use_tool(obj/item/tool, mob/user, list/click_params)

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -15,7 +15,7 @@
 	combustion = 1
 
 	var/obj/item/grenade/chambered
-	var/list/grenades = new/list()
+	var/list/grenades = list()
 	var/max_grenades = 5 //holds this + one in the chamber
 	var/whitelisted_grenades = list(
 		/obj/item/grenade/frag/shell)

--- a/code/modules/projectiles/guns/launcher/rocket.dm
+++ b/code/modules/projectiles/guns/launcher/rocket.dm
@@ -16,7 +16,7 @@
 	release_force = 15
 	throw_distance = 30
 	var/max_rockets = 1
-	var/list/rockets = new/list()
+	var/list/rockets = list()
 
 /obj/item/gun/launcher/rocket/examine(mob/user, distance)
 	. = ..()

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -1,5 +1,5 @@
 /datum/reagent/blood
-	data = new/list(
+	data = list(
 		"donor" = null,
 		"species" = SPECIES_HUMAN,
 		"blood_DNA" = null,

--- a/code/procs/AStar.dm
+++ b/code/procs/AStar.dm
@@ -73,7 +73,7 @@ length to avoid portals or something i guess?? Not that they're counted right no
 		var/PathNode/current = open.Dequeue()
 		closed.Add(current.position)
 		if(current.position == end || call(current.position, dist)(end) <= min_target_dist)
-			path = new /list(current.nodes_traversed + 1)
+			path = new (current.nodes_traversed + 1)
 			path[length(path)] = current.position
 			var/index = length(path) - 1
 			while(current.previous_node)

--- a/packs/deepmaint/generator/deepmaint_event.dm
+++ b/packs/deepmaint/generator/deepmaint_event.dm
@@ -6,7 +6,7 @@
 
 /datum/event/deepmaint/start()
 	var/attempts = 5
-	spawned_ladders = new/list()
+	spawned_ladders = list()
 	free_ladders = GLOB.free_deepmaint_ladders.Copy()
 	do
 		if (!length(free_ladders))

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -60,6 +60,7 @@ exactly 7 "uses of .len" '\.len\b' -P
 exactly 388 "attackby() override" '\/attackby\((.*)\)'  -P
 exactly 15 "uses of examine()" '[.|\s]examine\(' -P # If this fails it's likely because you used '/atom/proc/examine(mob)' instead of '/proc/examinate(mob, atom)' - Exception: An examine()-proc may call other examine()-procs
 exactly 7 "direct modifications of overlays list" '\boverlays((\s*[|^=+&-])|(\.(Cut)|(Add)|(Copy)|(Remove)|(Remove)))' -P
+exactly 0 "new/list list instantiations" 'new\s*/list' -P
 # With the potential exception of << if you increase any of these numbers you're probably doing it wrong
 
 num=`find ./html/changelogs -not -name "*.yml" | wc -l`


### PR DESCRIPTION
`new/list` acts like `var/list/blah = new()` but looks at a glance like `var/list/blah = list()`
These differ depending on if there is a numeric parameter - list(3) is [3] but new(3) is [null,null,null].

removed remaining usages, added a test to prevent adds.