### PR TITLE
Block merging of PRs flagged for test merge

### DIFF
--- a/.github/workflows/testmerge-blocker.yml
+++ b/.github/workflows/testmerge-blocker.yml
@@ -1,0 +1,17 @@
+name: "Test Merge Blocker"
+
+on:
+  pull_request:
+    types: [synchronize, opened, labeled, unlabeled]
+
+jobs:
+  testmerge-blocker:
+    name: Enforce Test Merge Label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enforce Test Merge Label
+        if: contains(github.event.pull_request.labels.*.name, 'Test Merge') && !contains(github.event.pull_request.labels.*.name, 'Test Merge Passed')
+        run: |
+          echo "Pull request is labeled for Test Merge and has not been flagged as Test Merge Passed."
+          echo "The test merge must pass, or the label removed, before this PR can be merged."
+          exit 1


### PR DESCRIPTION
No user-facing changes.

Adds a github action that (Assuming my research is correct) will block merging of any PR tagged with the `Test Merge` label unless it's also tagged with `Test Merge Passed`. This is to help enforce "Do not merge this because it needs to be tested first" (Because I can and will make that mistake myself one day).