### PR TITLE
Limit and update confusion updating logic

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -506,3 +506,6 @@
 #define PRONOUNS_SHE_THEY	"she/they"
 
 #define PRONOUNS_ALL list(PRONOUNS_THEY_THEM, PRONOUNS_HE_HIM, PRONOUNS_SHE_HER, PRONOUNS_HE_THEY, PRONOUNS_SHE_THEY, PRONOUNS_IT_ITS)
+
+/// Integer (~ticks * SSMobs/wait fire rate). The default maximum value a mob's confused var can be set to.
+#define CONFUSED_MAX 15

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -324,7 +324,7 @@
 
 /mob/proc/AdjustMovementDirection(direction)
 	. = direction
-	if(!confused)
+	if(!is_confused())
 		return
 
 	var/stability = MOVING_DELIBERATELY(src) ? 75 : 25

--- a/code/game/gamemodes/endgame/bluespace_jump/bluespace_jump.dm
+++ b/code/game/gamemodes/endgame/bluespace_jump/bluespace_jump.dm
@@ -68,7 +68,7 @@
 	if(M.client)
 		to_chat(M,SPAN_NOTICE("You feel oddly light, and somewhat disoriented as everything around you shimmers and warps ever so slightly."))
 		M.overlay_fullscreen("bluespace", /obj/screen/fullscreen/bluespace_overlay)
-	M.confused = 20
+	M.set_confused(20)
 	bluegoasts += new/obj/effect/bluegoast/(get_turf(M),M)
 
 
@@ -76,7 +76,6 @@
 	if(M.client)
 		to_chat(M,SPAN_NOTICE("You feel rooted in material world again."))
 		M.clear_fullscreen("bluespace")
-	M.confused = 0
 	for(var/mob/goast in GLOB.ghost_mobs)
 		goast.mouse_opacity = initial(goast.mouse_opacity)
 		goast.set_invisibility(initial(goast.invisibility))

--- a/code/game/machinery/bluespace_drive.dm
+++ b/code/game/machinery/bluespace_drive.dm
@@ -154,7 +154,7 @@
 			to_chat(living, SPAN_DANGER(FONT_LARGE("The Drive's field cracks open briefly, emitting a blinding flash of blue light and a deafenening screech!")))
 		living.flash_eyes(FLASH_PROTECTION_MAJOR)
 		living.Stun(3)
-		living.confused += 15
+		living.mod_confused(15)
 		living.ear_damage += rand(0, 5)
 		living.ear_deaf = max(living.ear_deaf, 15)
 	if (!change_turf)

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -89,7 +89,7 @@
 /obj/machinery/flasher/proc/do_flash(mob/living/victim, flash_time)
 	victim.flash_eyes()
 	victim.eye_blurry += flash_time
-	victim.confused += (flash_time + 2)
+	victim.mod_confused(flash_time + 2)
 	victim.Stun(flash_time / 2)
 	victim.Weaken(3)
 

--- a/code/game/objects/items/devices/flash.dm
+++ b/code/game/objects/items/devices/flash.dm
@@ -117,7 +117,7 @@
 					M.flash_eyes(FLASH_PROTECTION_MODERATE - safety)
 					M.Stun(flash_strength / 2)
 					M.eye_blurry = max(M.eye_blurry, flash_strength)
-					M.confused = max(M.confused, (flash_strength + 2))
+					M.set_confused(flash_strength + 2)
 					if(flash_strength > 3)
 						M.drop_l_hand()
 						M.drop_r_hand()
@@ -130,11 +130,11 @@
 		var/mob/living/simple_animal/SA = M
 		var/safety = SA.eyecheck()
 		if(safety < FLASH_PROTECTION_MAJOR)
-			SA.confused = max(SA.confused, (flash_strength * 0.5))
+			SA.set_confused(flash_strength * 0.5)
 			if(safety < FLASH_PROTECTION_MODERATE)
 				SA.flash_eyes(2)
 				SA.eye_blurry = max(SA.eye_blurry, flash_strength)
-				SA.confused = max(SA.confused, (flash_strength))
+				SA.set_confused(flash_strength)
 		else
 			return TRUE
 

--- a/code/game/objects/items/weapons/grenades/flashbang.dm
+++ b/code/game/objects/items/weapons/grenades/flashbang.dm
@@ -46,29 +46,29 @@
 	M.flash_eyes(FLASH_PROTECTION_MODERATE)
 	if(eye_safety < FLASH_PROTECTION_MODERATE)
 		M.Stun(2)
-		M.confused += 5
+		M.mod_confused(5)
 
 	//Now applying sound
 	if(ear_safety)
 		if(ear_safety < 2 && get_dist(M, T) <= 2)
 			M.Stun(1)
-			M.confused += 3
+			M.mod_confused(3)
 
 	else if(get_dist(M, T) <= 2)
 		M.Stun(3)
-		M.confused += 8
+		M.mod_confused(8)
 		M.ear_damage += rand(0, 5)
 		M.ear_deaf = max(M.ear_deaf,15)
 
 	else if(get_dist(M, T) <= 5)
 		M.Stun(2)
-		M.confused += 5
+		M.mod_confused(5)
 		M.ear_damage += rand(0, 3)
 		M.ear_deaf = max(M.ear_deaf,10)
 
 	else
 		M.Stun(1)
-		M.confused += 3
+		M.mod_confused(3)
 		M.ear_damage += rand(0, 1)
 		M.ear_deaf = max(M.ear_deaf,5)
 

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -141,7 +141,7 @@ var/global/const/FALLOFF_SOUNDS = 0.5
 				S.environment = DRUGGED
 			else if (M.drowsyness)
 				S.environment = DIZZY
-			else if (M.confused)
+			else if (M.is_confused())
 				S.environment = DIZZY
 			else if (M.stat == UNCONSCIOUS)
 				S.environment = UNDERWATER

--- a/code/modules/ai/ai_holder_disabled.dm
+++ b/code/modules/ai/ai_holder_disabled.dm
@@ -29,7 +29,7 @@
 	return FALSE
 
 /datum/ai_holder/proc/is_confused()
-	return holder.confused > 0 && respect_confusion
+	return holder.is_confused() && respect_confusion
 
 // Called by the main loop.
 /datum/ai_holder/proc/handle_disabled()

--- a/code/modules/augment/active/nerve_dampeners.dm
+++ b/code/modules/augment/active/nerve_dampeners.dm
@@ -37,7 +37,7 @@
 		if (!ticks_remaining) // ...but comes at a price. Brief short term benefit for a long-term comedown
 			to_chat(owner, SPAN_WARNING("You abruptly feel intensely exhausted as sensation returns."))
 			owner.drowsyness = max(owner.drowsyness, 15)
-			owner.confused = max(owner.confused, 15)
+			owner.set_confused(15)
 			owner.slurring = max(owner.slurring, 30)
 			owner.chem_effects[CE_PAINKILLER] = 0
 			owner.stamina = 0

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -29,7 +29,7 @@
 			continue
 		to_chat(S, SPAN_WARNING("Your integrated sensors detect an ionospheric anomaly. Your systems will be impacted as you begin a partial restart."))
 		var/ionbug = rand(5, 15)
-		S.confused += ionbug
+		S.mod_confused(ionbug)
 		S.eye_blurry += ionbug-1
 	for(var/mob/living/silicon/S in SSmobs.mob_list)
 		if(isdrone(S) || !(isAI(S) || isrobot(S)))

--- a/code/modules/genetics/side_effects.dm
+++ b/code/modules/genetics/side_effects.dm
@@ -72,4 +72,4 @@
 
 /datum/genetics/side_effect/confuse/finish(mob/living/carbon/human/H)
 	if(!H.reagents.has_reagent(/datum/reagent/dylovene))
-		H.confused += 100
+		H.set_confused(CONFUSED_MAX)

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -473,7 +473,7 @@
 			if(!O.blinded)
 				O.flash_eyes(FLASH_PROTECTION_MODERATE - protection)
 				O.eye_blurry += flash_time
-				O.confused += (flash_time + 2)
+				O.mod_confused(flash_time + 2)
 
 /obj/item/mech_equipment/flash/attack_self(mob/user)
 	. = ..()
@@ -519,7 +519,7 @@
 			if(!O.blinded)
 				O.flash_eyes(FLASH_PROTECTION_MAJOR - protection)
 				O.eye_blurry += flash_time
-				O.confused += (flash_time + 2)
+				O.mod_confused(flash_time + 2)
 
 				if(isanimal(O)) //Hit animals a bit harder
 					O.Stun(flash_time)

--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -290,7 +290,7 @@
 
 	if(affecting.incapacitated(INCAPACITATION_ALL))
 		break_strength--
-	if(affecting.confused)
+	if(affecting.is_confused())
 		break_strength--
 	if(affecting.eye_blind)
 		break_strength--
@@ -303,7 +303,7 @@
 	if(shock >= 50)
 		break_strength--
 
-	if(assailant.confused)
+	if(assailant.is_confused())
 		break_strength++
 	if(assailant.eye_blind)
 		break_strength++

--- a/code/modules/mob/living/carbon/xenobiological/slime_AI.dm
+++ b/code/modules/mob/living/carbon/xenobiological/slime_AI.dm
@@ -7,8 +7,8 @@
 			attacked = 50 // Let's not get into absurdly long periods of rage
 		--attacked
 
-	if(confused > 0)
-		--confused
+	handle_confused()
+	if (is_confused())
 		return
 
 	if(nutrition < get_starve_nutrition()) // If a slime is starving, it starts losing its friends
@@ -113,7 +113,7 @@
 		AIproc = 0
 		return // If we're dead or have a client, we don't need AI, if we're feeding, we continue feeding
 
-	if(confused)
+	if(is_confused())
 		AIproc = 0
 		return
 
@@ -185,7 +185,7 @@
 /mob/living/carbon/slime/proc/UpdateFace()
 	var/newmood = ""
 	a_intent = I_HELP
-	if(confused)
+	if(is_confused())
 		newmood = "pout"
 	else if(rabid || attacked)
 		newmood = "angry"

--- a/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
+++ b/code/modules/mob/living/carbon/xenobiological/xenobiological.dm
@@ -235,7 +235,7 @@
 				visible_message(SPAN_WARNING("\The [M] manages to wrestle \the [src] off!"))
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
-				confused = max(confused, 2)
+				set_confused(2)
 				Feedstop()
 				UpdateFace()
 				step_away(src, M)
@@ -250,7 +250,7 @@
 				visible_message(SPAN_WARNING("\The [M] manages to wrestle \the [src] off \the [Victim]!"))
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
-				confused = max(confused, 2)
+				set_confused(2)
 				Feedstop()
 				UpdateFace()
 				step_away(src, M)
@@ -265,7 +265,7 @@
 			var/success = prob(40)
 			visible_message(SPAN_WARNING("\The [M] pushes \the [src]![success ? " \The [src] looks momentarily disoriented!" : ""]"))
 			if(success)
-				confused = max(confused, 2)
+				set_confused(2)
 				UpdateFace()
 				playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 			else

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -132,8 +132,7 @@
 	handle_impaired_hearing()
 
 /mob/living/proc/handle_confused()
-	if(confused)
-		confused = max(0, confused - 1)
+	confused--
 	return confused
 
 /mob/living/proc/handle_impaired_vision()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -135,7 +135,7 @@ default behaviour is:
 		spawn(0)
 			..()
 			var/saved_dir = AM.dir
-			if ((confused || (MUTATION_CLUMSY in mutations)) && !MOVING_DELIBERATELY(src))
+			if ((is_confused() || (MUTATION_CLUMSY in mutations)) && !MOVING_DELIBERATELY(src))
 				AM.slam_into(src)
 			if (!istype(AM, /atom/movable) || AM.anchored)
 				return
@@ -455,7 +455,7 @@ default behaviour is:
 	drowsyness = 0
 	druggy = 0
 	jitteriness = 0
-	confused = 0
+	clear_confused()
 
 	heal_overall_damage(getBruteLoss(), getFireLoss())
 
@@ -839,7 +839,7 @@ default behaviour is:
 	. = 0
 	if(incapacitated(INCAPACITATION_UNRESISTING))
 		. += 100
-	if(confused)
+	if(is_confused())
 		. += 10
 	if(weakened)
 		. += 15
@@ -854,7 +854,7 @@ default behaviour is:
 	. = 0
 	if(jitteriness)
 		. -= 2
-	if(confused)
+	if(is_confused())
 		. -= 2
 	if(eye_blind)
 		. -= 5

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -83,10 +83,11 @@
 		if(EMP_ACT_HEAVY)
 			take_organ_damage(0, 16, ORGAN_DAMAGE_SILICON_EMP)
 			if(prob(50)) Stun(rand(5,10))
-			else confused = (min(confused + 2, 40))
+			else
+				mod_confused(2, 40)
 		if(EMP_ACT_LIGHT)
 			take_organ_damage(0, 7, ORGAN_DAMAGE_SILICON_EMP)
-			confused = (min(confused + 2, 30))
+			mod_confused(2, 30)
 	flash_eyes(affect_silicon = 1)
 	to_chat(src, SPAN_DANGER("<B>*BZZZT*</B>"))
 	to_chat(src, SPAN_DANGER("Warning: Electromagnetic pulse detected."))

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
@@ -46,7 +46,7 @@
 		var/mob/living/L = target
 		if(prob(G.stun_chance))
 			L.Weaken(0.5)
-			L.confused += 1
+			L.mod_confused(1)
 			G.visible_message(SPAN_WARNING("\The [L] is bowled over by the impact of [G]'s attack!"))
 
 /datum/ai_holder/simple_animal/goat/king/react_to_attack(atom/movable/attacker)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -859,6 +859,59 @@
 	sleeping = max(sleeping + amount,0)
 	return
 
+
+/**
+ * Sets a mob's confused value.
+ *
+ * Parameters:
+ * - `amount` (Positive Int) - The confused value to set. Decimal values are rounded.
+ * - `limit` (Positive Int, default `CONFUSED_MAX`) - The maximum value `confused` can be set to. Decimal values are rounded.
+ *
+ * Returns integer. The new value of `confused`.
+ */
+/mob/proc/set_confused(amount, limit = CONFUSED_MAX)
+	confused = clamp(round(amount), 0, round(limit))
+	return confused
+
+
+/**
+ * Modifies a mob's confused value by `mod_amount`.
+ *
+ * Parameters:
+ * - `mod_amount` (Integer) - The amount to modify `confused` by. Allows negative values for subtraction. Decimal values are rounded.
+ * - `floor` (Positive Integer, default `0`) - The minimum value to set `confused` to. Decimal values are rounded.
+ * - `ceiling` (Positive Integer, default `CONFUSED_MAX`) - The maximum value to set `confused` to. Decimal values are rounded.
+ *
+ * Returns integer. The new value of `confused`.
+ */
+/mob/proc/mod_confused(mod_amount, floor = 0, ceiling = CONFUSED_MAX)
+	confused += round(mod_amount)
+	confused = clamp(confused, round(floor), round(ceiling))
+	return confused
+
+
+/**
+ * Sets a mob's confused value to `0`.
+ *
+ * Returns integer. The new value of `confused`.
+ */
+/mob/proc/clear_confused()
+	confused = 0
+	return confused
+
+
+/**
+ * Whether or not the mob's confusion level is at the threshhold.
+ *
+ * Parameters:
+ * - `threshhold` (Positive Integer, default `1`) - The threshhold at which the mob should be considered confused.
+ *
+ * Returns boolean.
+ */
+/mob/proc/is_confused(threshhold = 1)
+	return confused >= threshhold
+
+
 /mob/proc/get_species()
 	return ""
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -88,7 +88,8 @@
 	var/bhunger = 0			//Carbon
 
 	var/druggy = 0			//Carbon
-	var/confused = 0		//Carbon
+	/// Positive Integer. The mob's current confusion level. Ticks down every `Fire()` in SSMobs. See `set_confused()`, `mod_confused()`, `clear_confused()`, and `is_confused()`.
+	VAR_PRIVATE/confused = 0
 	var/sleeping = 0		//Carbon
 	var/resting = FALSE			//Carbon
 	var/lying = 0

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -151,7 +151,7 @@
 
 	if(owner && BP_IS_CRYSTAL(src)) // Crystalline robotics == piezoelectrics.
 		owner.Weaken(4 - severity)
-		owner.confused = max(owner.confused, 6 - (severity * 2))
+		owner.set_confused(6 - (severity * 2))
 		return
 
 	var/burn_damage = 0

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -210,7 +210,7 @@
 		if (owner)
 			owner.flash_eyes()
 			owner.eye_blurry += damage_secondary
-			owner.confused += damage_secondary * 2
+			owner.mod_confused(damage_secondary * 2)
 			owner.Paralyse(damage_secondary)
 			owner.Weaken(round(damageTaken, 1))
 			if (prob(30))
@@ -221,7 +221,7 @@
 		return
 
 	to_chat(owner, SPAN_NOTICE(SPAN_STYLE("font-size: 10", "<B>I can't remember which way is forward...</B>")))
-	owner.confused += damage
+	owner.mod_confused(damage)
 
 /obj/item/organ/internal/brain/proc/handle_disabilities()
 	if(owner.stat)

--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -178,7 +178,7 @@
 				SPAN_DANGER("Blood sprays out from \the [owner]'s [spray_organ]!"),
 				FONT_HUGE(SPAN_DANGER("Blood sprays out from your [spray_organ]!"))
 			)
-			owner.confused = max(1, owner.confused)
+			owner.set_confused(1)
 			owner.eye_blurry = 2
 
 			//AB occurs every heartbeat, this only throttles the visible effect

--- a/code/modules/organs/internal/species/ipc.dm
+++ b/code/modules/organs/internal/species/ipc.dm
@@ -235,9 +235,9 @@
 	if (!owner || owner.stat)
 		return
 	if (damage > min_bruised_damage)
-		if (prob(1) && owner.confused < 1)
+		if (prob(1) && !owner.is_confused())
 			to_chat(owner, SPAN_WARNING("Your comprehension of spacial positioning goes temporarily awry."))
-			owner.confused += 3
+			owner.set_confused(3)
 		if (prob(1) && owner.eye_blurry < 1)
 			to_chat(owner, SPAN_WARNING("Your optical interpretations become transiently erratic."))
 			owner.eye_blurry += 6

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -352,9 +352,9 @@
 	if(istype(target, /mob/living))
 		var/mob/living/L = target
 		var/potency = rand(potency_min, potency_max)
-		L.confused += potency
+		L.mod_confused(potency)
 		L.eye_blurry += potency
-		if(L.confused >= 10)
+		if(L.is_confused(10))
 			L.Stun(1)
 			L.drop_l_hand()
 			L.drop_r_hand()

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -29,7 +29,7 @@
 		if(M.eyecheck() < FLASH_PROTECTION_MAJOR)
 			M.flash_eyes()
 			M.eye_blurry += (brightness / 2)
-			M.confused += (brightness / 2)
+			M.mod_confused(brightness / 2)
 
 	//snap pop
 	playsound(src, 'sound/effects/snap.ogg', 50, 1)

--- a/code/modules/projectiles/projectile/special.dm
+++ b/code/modules/projectiles/projectile/special.dm
@@ -129,7 +129,7 @@
 /obj/item/projectile/beam/mindflayer/on_hit(atom/target, blocked = 0)
 	if(ishuman(target))
 		var/mob/living/carbon/human/M = target
-		M.confused += rand(5,8)
+		M.mod_confused(rand(5, 8))
 
 /obj/item/projectile/chameleon
 	name = "bullet"

--- a/code/modules/psionics/faculties/coercion.dm
+++ b/code/modules/psionics/faculties/coercion.dm
@@ -48,7 +48,7 @@
 			M.flash_eyes()
 			M.eye_blind = max(M.eye_blind,3)
 			M.ear_deaf = max(M.ear_deaf,6)
-			M.confused = rand(3,8)
+			M.set_confused(rand(3, 8))
 		return TRUE
 
 /singleton/psionic_power/coercion/mindread

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Core.dm
@@ -176,7 +176,7 @@
 			S.Feedstop()
 	if(M.chem_doses[type] == removed)
 		M.visible_message(SPAN_WARNING("[S]'s flesh sizzles where the water touches it!"), SPAN_DANGER("Your flesh burns in the water!"))
-		M.confused = max(M.confused, 2)
+		M.set_confused(2)
 
 /datum/reagent/water/boiling
 	name = "Boiling water"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -148,7 +148,7 @@
 		M.slurring = max(M.slurring, 30)
 	if(effective_dose >= strength * 3) // Confusion - walking in random directions
 		M.add_chemical_effect(CE_PAINKILLER, 150/strength)
-		M.confused = max(M.confused, 20)
+		M.set_confused(20)
 	if(effective_dose >= strength * 4) // Blurry vision
 		M.add_chemical_effect(CE_PAINKILLER, 150/strength)
 		M.eye_blurry = max(M.eye_blurry, 10)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drinks.dm
@@ -766,8 +766,7 @@
 	M.adjustToxLoss(-2 * removed)
 	if(M.dizziness)
 		M.dizziness = max(0, M.dizziness - 15)
-	if(M.confused)
-		M.confused = max(0, M.confused - 5)
+	M.mod_confused(-5)
 
 /datum/reagent/drink/dry_ramen
 	name = "Dry Ramen"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food.dm
@@ -447,7 +447,7 @@
 			to_chat(M, SPAN_WARNING("Your [eye_protection] protects your eyes from the pepperspray!"))
 	else
 		to_chat(M, SPAN_WARNING("The pepperspray gets in your eyes!"))
-		M.confused += 2
+		M.mod_confused(2)
 		if(mouth_covered)
 			M.eye_blurry = max(M.eye_blurry, effective_strength * 3)
 			M.eye_blind = max(M.eye_blind, effective_strength)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -349,7 +349,7 @@
 	if(prob(75))
 		H.drowsyness++
 	if(prob(25))
-		H.confused++
+		H.mod_confused(1)
 
 /datum/reagent/deletrathol/overdose(mob/living/carbon/M)
 	..()
@@ -415,7 +415,7 @@
 	M.add_chemical_effect(CE_BRAIN_REGEN, 1)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		H.confused++
+		H.mod_confused(1)
 		H.drowsyness++
 
 /datum/reagent/imidazoline
@@ -458,7 +458,7 @@
 			if(!BP_IS_ROBOTIC(I))
 				if(I.organ_tag == BP_BRAIN)
 					// if we have located an organic brain, apply side effects
-					H.confused++
+					H.mod_confused(1)
 					H.drowsyness++
 					// peridaxon only heals minor brain damage
 					if(I.damage >= I.min_bruised_damage)
@@ -520,7 +520,7 @@
 	M.dizziness = 0
 	M.drowsyness = 0
 	M.stuttering = 0
-	M.confused = 0
+	M.clear_confused()
 	var/datum/reagents/ingested = M.get_ingested_reagents()
 	if(ingested)
 		for(var/datum/reagent/R in ingested.reagent_list)
@@ -987,7 +987,7 @@
 	if(dosage >= 1)
 		if(prob(5)) M.Sleeping(3)
 		M.dizziness =  max(M.dizziness, 3)
-		M.confused =   max(M.confused, 3)
+		M.set_confused(3)
 	if(dosage >= 0.3)
 		if(prob(5)) M.Paralyse(1)
 		M.drowsyness = max(M.drowsyness, 3)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -142,7 +142,7 @@
 
 /datum/reagent/toxin/venom/affect_blood(mob/living/carbon/M, removed)
 	if(prob(volume*2))
-		M.confused = max(M.confused, 3)
+		M.set_confused(3)
 	..()
 
 /datum/reagent/toxin/cryotoxin
@@ -341,7 +341,7 @@
 
 /datum/reagent/toxin/taxine/affect_blood(mob/living/carbon/M, removed)
 	..()
-	M.confused += 1.5
+	M.mod_confused(2)
 
 /datum/reagent/toxin/taxine/overdose(mob/living/carbon/M)
 	..()
@@ -643,7 +643,7 @@
 	M.add_chemical_effect(CE_SEDATE, 1)
 
 	if(M.chem_doses[type] <= metabolism * threshold)
-		M.confused += 2
+		M.mod_confused(2)
 		M.drowsyness += 2
 
 	if(M.chem_doses[type] < 2 * threshold)
@@ -683,7 +683,7 @@
 	var/threshold = 2 + (0.4 * GET_TRAIT_LEVEL(M, /singleton/trait/boon/clear_mind))
 
 	if(M.chem_doses[type] >= metabolism * threshold * 0.5)
-		M.confused = max(M.confused, 2)
+		M.set_confused(2)
 		M.add_chemical_effect(CE_VOICELOSS, 1)
 	if(M.chem_doses[type] > threshold * 0.5)
 		M.make_dizzy(3)
@@ -714,7 +714,7 @@
 	M.add_chemical_effect(M.add_chemical_effect(CE_SLOWDOWN, 1))
 
 	if(prob(80))
-		M.confused = max(M.confused, 10)
+		M.set_confused(10)
 	if(prob(50))
 		M.drowsyness = max(M.drowsyness, 3)
 	if(prob(10))
@@ -848,7 +848,7 @@
 	var/drug_strength = 4 - (0.8 * GET_TRAIT_LEVEL(M, /singleton/trait/boon/clear_mind))
 
 	M.make_dizzy(drug_strength)
-	M.confused = max(M.confused, drug_strength * 5)
+	M.set_confused(drug_strength * 5)
 	..()
 
 /datum/reagent/drugs/mindbreaker

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -544,22 +544,22 @@
 				if (M.eyecheck() < FLASH_PROTECTION_MODERATE)
 					M.flash_eyes(2)
 					M.weakened = min(10, (created_volume / 20))
-					M.confused = min(20, (created_volume / 5))
+					M.set_confused(min(20, (created_volume / 5)))
 					M.eye_blurry = min(40, (created_volume / 5))
 				else
 					M.stunned = min(10, (created_volume / 30))
-					M.confused = min(20, (created_volume / 10))
+					M.set_confused(min(20, (created_volume / 10)))
 					M.eye_blurry = min(40, (created_volume / 10))
 
 			if(2 to 4)
 				if (M.eyecheck() < FLASH_PROTECTION_MODERATE)
 					M.flash_eyes(2)
 					M.stunned = min(5, (created_volume / 30))
-					M.confused = min(10, (created_volume / 10))
+					M.set_confused(min(10, (created_volume / 10)))
 					M.eye_blurry = min(20, (created_volume / 10))
 				else
 					M.stunned = min(5, (created_volume / 60))
-					M.confused = min(10, (created_volume / 20))
+					M.set_confused(min(20, (created_volume / 20)))
 					M.eye_blurry = min(20, (created_volume / 20))
 		playsound(location, 'sound/effects/bang.ogg', 50, 1, 30)
 

--- a/code/modules/spells/targeted/shatter_mind.dm
+++ b/code/modules/spells/targeted/shatter_mind.dm
@@ -22,7 +22,7 @@
 	if(prob(5))
 		to_chat(H, SPAN_WARNING("You feel unhinged."))
 	H.adjust_hallucination(5,5)
-	H.confused += 2
+	H.mod_confused(2)
 	H.dizziness += 2
 	if(H.hallucination_power > 50)
 		H.adjustBrainLoss(5)

--- a/code/modules/spells/targeted/targeted.dm
+++ b/code/modules/spells/targeted/targeted.dm
@@ -168,7 +168,7 @@ Targeted spells have two useful flags: INCLUDEUSER and SELECTABLE. These are exp
 	target.eye_blind += amt_eye_blind
 	target.eye_blurry += amt_eye_blurry
 	target.dizziness += amt_dizziness
-	target.confused += amt_confused
+	target.mod_confused(amt_confused)
 	target.stuttering += amt_stuttering
 	if(effect_state)
 		var/obj/o = new /obj/effect/temporary(get_turf(target), effect_duration, 'icons/effects/effects.dmi', effect_state)

--- a/code/modules/tension/tension.dm
+++ b/code/modules/tension/tension.dm
@@ -86,7 +86,7 @@
 			threat *= 2 // Target cannot see src.
 
 	// Handle statuses.
-	if(confused)
+	if(is_confused())
 		threat /= 2
 
 	// if(has_modifier_of_type(/datum/modifier/berserk))
@@ -128,7 +128,7 @@
 			threat *= 2 // Target cannot see src.
 
 	// Handle statuses.
-	if(confused)
+	if(is_confused())
 		threat /= 2
 
 	// if(has_modifier_of_type(/datum/modifier/berserk))
@@ -239,7 +239,7 @@
 		tension *= 10
 		return tension
 
-	if(confused)
+	if(is_confused())
 		tension *= 2
 
 	return tension

--- a/code/modules/xenoarcheaology/effects/human_ifier.dm
+++ b/code/modules/xenoarcheaology/effects/human_ifier.dm
@@ -97,7 +97,7 @@
 			to_chat(living, SPAN_DANGER(FONT_LARGE("\The [holder] emits a blinding flash of light!")))
 		living.flash_eyes(FLASH_PROTECTION_MAJOR)
 		living.Stun(1)
-		living.confused += 5
+		living.mod_confused(5)
 	playsound(holder, "sound/effects/supermatter.ogg", 100, TRUE)
 	H.death()
 


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
balance: Mob confusion should now be limited to 30 seconds. Note that if you are hit by an effect that increases your confusion, it can still extend this time - This change only prevents the total stack from exceeding 30 seconds if you're being spammed by something.
/:cl:

## Other Changes
- `/mob/var/confused` is now a private var to enforce usage of the new procs listed below.
- Added `set_confused()`, `mod_confused()`, `clear_confused()`, and `is_confused()` to allow manipulating and accessing `confused`.
- Added `CONFUSED_MAX` to define a maximum value for confused. For now, this is set to `15` which, after factoring in SSMobs wait time, should become a maximum of 30 seconds.