### PR TITLE
Fix pre-game vote timers not ticking

### DIFF
--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -3,6 +3,7 @@ SUBSYSTEM_DEF(vote)
 	wait = 1 SECOND
 	priority = SS_PRIORITY_VOTE
 	flags = SS_NO_TICK_CHECK | SS_KEEP_TIMING
+	runlevels = RUNLEVELS_PREGAME | RUNLEVELS_GAME
 
 	var/last_started_time        //To enforce delay between votes.
 	var/antag_added              //Enforces a maximum of one added antag per round.


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Pre-game votes now tick down properly again.
/:cl: