### PR TITLE
fix: Oregen no longer using the wrong value

### DIFF
--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -61,7 +61,9 @@
 			var/tmp_cell
 			TRANSLATE_AND_VERIFY_COORD(x, y)
 
-			if(tmp_cell < rare_val)      // Surface metals.
+                        var/mapval = (!isnull(tmp_cell) ? map[tmp_cell] : null)
+
+			if(mapval < rare_val)      // Surface metals.
 				T.resources[MATERIAL_IRON] =     rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)
 				T.resources[MATERIAL_ALUMINIUM] =     rand(RESOURCE_MID_MIN, RESOURCE_MID_MAX)
 				T.resources[MATERIAL_GOLD] =     rand(RESOURCE_LOW_MIN,  RESOURCE_LOW_MAX)
@@ -72,7 +74,7 @@
 				T.resources[MATERIAL_PHORON] =   0
 				T.resources[MATERIAL_OSMIUM] =   0
 				T.resources[MATERIAL_HYDROGEN] = 0
-			else if(tmp_cell < deep_val) // Rare metals.
+			else if(mapval < deep_val) // Rare metals.
 				T.resources[MATERIAL_GOLD] =     rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
 				T.resources[MATERIAL_SILVER] =   rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)
 				T.resources[MATERIAL_URANIUM] =  rand(RESOURCE_MID_MIN,  RESOURCE_MID_MAX)

--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -61,7 +61,9 @@
 			var/tmp_cell
 			TRANSLATE_AND_VERIFY_COORD(x, y)
 
-                        var/mapval = (!isnull(tmp_cell) ? map[tmp_cell] : null)
+			var/mapval = null
+			if(!isnull(temp_cell))
+				mapval = map[tmp_cell]
 
 			if(mapval < rare_val)      // Surface metals.
 				T.resources[MATERIAL_IRON] =     rand(RESOURCE_HIGH_MIN, RESOURCE_HIGH_MAX)

--- a/code/modules/random_map/noise/ore.dm
+++ b/code/modules/random_map/noise/ore.dm
@@ -62,7 +62,7 @@
 			TRANSLATE_AND_VERIFY_COORD(x, y)
 
 			var/mapval = null
-			if(!isnull(temp_cell))
+			if(!isnull(tmp_cell))
 				mapval = map[tmp_cell]
 
 			if(mapval < rare_val)      // Surface metals.


### PR DESCRIPTION
This has apparently been broken and gone unnoticed since day 1.

The ore generator never actually looked up the noise values from the map! Instead, it had been using the _flattened map position_ (array index, if we glued the last X-pos of each row to the first X-pos of the next) **raw**.

This combined with the implementation details practically meant that _effectively the whole map generated as the rarest possible type_.

Why has this not been noticed, considering there's a sanity check?

Glad you asked - it's because the sanity check never checked the actual tile values, it checked _the map character_, which had been _**straight up lying**_ because it **does** generate based on the noise value and not position!

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->