### PR TITLE
fix spiderlings not growing when in limbs

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -283,7 +283,7 @@
 	else if(prob(1))
 		src.visible_message(SPAN_NOTICE("\The [src] skitters."))
 
-	if (istype(loc, /turf) && amount_grown > 0)
+	if (istype(loc, /turf) || istype(loc, /obj/item/organ/external) && amount_grown > 0)
 		amount_grown += rand(0,2)
 
 /obj/effect/decal/cleanable/spiderling_remains


### PR DESCRIPTION
:cl: Mucker
bugfix: Spiderlings should now grow properly while in your limbs, and eventually pop out. 
/:cl: