### PR TITLE
nerf nurse spiderling injection

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/nurse.dm
@@ -56,7 +56,7 @@
 		var/obj/item/organ/external/O = H.get_organ(target_zone)
 		if(O)
 			var/eggcount = 0
-			for(var/obj/spider/eggcluster/E in O.implants)
+			for(var/obj/spider/eggcluster/small/E in O.implants)
 				eggcount++
 			if(!eggcount)
 				var/eggs = new egg_type(O, src)


### PR DESCRIPTION
:cl: Mucker
tweak: Nurse spiders will only inject 1 - 3 spiderlings sometimes, instead of 6 - 12. 
/:cl: