### PR TITLE
Fix spiderlings growing that shouldn't grow

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -283,7 +283,7 @@
 	else if(prob(1))
 		src.visible_message(SPAN_NOTICE("\The [src] skitters."))
 
-	if (istype(loc, /turf) || istype(loc, /obj/item/organ/external) && amount_grown > 0)
+	if ((istype(loc, /turf) || istype(loc, /obj/item/organ/external)) && amount_grown > 0)
 		amount_grown += rand(0,2)
 
 /obj/decal/cleanable/spiderling_remains


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Fixed an issue where maintenance spiderlings became big spiders when disturbed.
/:cl: