### PR TITLE
fix objects not falling through openspace

### DIFF
--- a/code/modules/multiz/movement.dm
+++ b/code/modules/multiz/movement.dm
@@ -196,7 +196,7 @@
 /obj/can_fall(anchor_bypass = FALSE, turf/location_override = loc)
 	return ..(anchor_fall)
 
-/obj/can_fall(anchor_bypass = FALSE, turf/location_override = loc)
+/obj/effect/can_fall(anchor_bypass = FALSE, turf/location_override = loc)
 	return FALSE
 
 /obj/decal/cleanable/can_fall(anchor_bypass = FALSE, turf/location_override = loc)


### PR DESCRIPTION
:cl: Mucker
bugfix: Objects will once again fall through openspace when affected by gravity.
/:cl:

caused by #34221 