### PR TITLE
Fixes placing mobs in mounted sleepers

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -186,7 +186,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		return FALSE
 
 	// Target checks
-	if (!Adjacent(target))
+	if (isturf(target.loc) && !Adjacent(target))
 		if (!silent)
 			FEEDBACK_FAILURE(src, "You must remain next to \the [target].")
 		return FALSE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -520,7 +520,11 @@
 
 /mob/proc/start_pulling(atom/movable/AM)
 
-	if ( !AM || !usr || src==AM || !isturf(src.loc) )	//if there's no person pulling OR the person is pulling themself OR the object being pulled is inside something: abort!
+	if ( !AM || !usr || src==AM || !isturf(src.loc))	//if there's no person pulling OR the person is pulling themself OR the object being pulled is inside something: abort!
+		return
+
+	if (!Adjacent(AM))
+		to_chat(src, SPAN_WARNING("You must remain next to \the [AM]."))
 		return
 
 	if (AM.anchored)


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: Fixes being unable to place mobs into a mounted sleeper.
/🆑 

Oversight when having sanity checks apply to all machinery that fit mobs is that adjacency checks failed on any such mounted machinery. Added a check where it only checks for adjacency if the machine is actually on a turf.

Also; found some weird bug where start_pulling() is constantly triggered no matter the distance if you pull someone who is pulling someone else. If both these people don't do anything, it will trigger this unlimited range pull. Added adjacency check on start_pulling().