### PR TITLE
Chewable spit out and drone designator in belt

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -8,6 +8,7 @@
 	icon_state = "utilitybelt"
 	item_state = "utility"
 	storage_slots = 7
+	force = 2
 	item_flags = ITEM_FLAG_IS_BELT
 	max_w_class = ITEM_SIZE_NORMAL
 	slot_flags = SLOT_BELT
@@ -106,7 +107,6 @@
 	item_state = "utility"
 	overlay_flags = BELT_OVERLAY_ITEMS
 	can_hold = list(
-		///obj/item/combitool,
 		/obj/item/crowbar,
 		/obj/item/screwdriver,
 		/obj/item/weldingtool,
@@ -132,7 +132,8 @@
 		/obj/item/tape_roll,
 		/obj/item/clothing/head/beret,
 		/obj/item/material/knife/folding,
-		/obj/item/swapper
+		/obj/item/swapper,
+		/obj/item/device/drone_designator
 		)
 
 
@@ -496,7 +497,8 @@
 		/obj/item/clothing/head/beret,
 		/obj/item/material/knife/folding,
 		/obj/item/storage/firstaid/light,
-		/obj/item/device/flash
+		/obj/item/device/flash,
+		/obj/item/device/drone_designator
 		)
 	can_holster = list(/obj/item/material/hatchet/machete)
 	sound_in = 'sound/effects/holster/sheathin.ogg'

--- a/code/modules/clothing/masks/chewable.dm
+++ b/code/modules/clothing/masks/chewable.dm
@@ -1,9 +1,7 @@
 /obj/item/clothing/mask/chewable
-	name = "chewable item master"
-	desc = "You're not sure what this is. You should probably ahelp it."
 	icon = 'icons/obj/clothing/obj_mask.dmi'
 	body_parts_covered = 0
-
+	abstract_type = /obj/item/clothing/mask/chewable
 	var/type_butt = null
 	var/chem_volume = 0
 	var/chewtime = 0
@@ -54,7 +52,7 @@
 /obj/item/clothing/mask/chewable/Process()
 	chew(1)
 	if(chewtime < 1)
-		extinguish()
+		spit_out()
 
 /obj/item/clothing/mask/chewable/tobacco
 	name = "wad"
@@ -73,19 +71,26 @@
 	desc = "A disgusting spitwad."
 	icon_state = "spit-chew"
 
-/obj/item/clothing/mask/chewable/proc/extinguish(mob/user, no_message)
+/obj/item/clothing/mask/chewable/proc/spit_out(no_message)
 	STOP_PROCESSING(SSobj, src)
+	var/mob/chewer
+	if (ismob(loc))
+		chewer = loc
+		if (!no_message)
+			to_chat(chewer, SPAN_NOTICE("You spit out \the [name]."))
+
 	if (type_butt)
-		var/obj/item/butt = new type_butt(get_turf(src))
+		var/obj/item/butt = new type_butt()
+		if (chewer)
+			chewer.put_in_hands(butt)
+		else
+			butt.forceMove(get_turf(src))
 		transfer_fingerprints_to(butt)
 		butt.color = color
 		if(brand)
 			butt.desc += " This one is \a [brand]."
-		if(ismob(loc))
-			var/mob/living/M = loc
-			if (!no_message)
-				to_chat(M, SPAN_NOTICE("You spit out the [name]."))
-		qdel(src)
+
+	qdel(src)
 
 /obj/item/clothing/mask/chewable/tobacco/lenni
 	name = "chewing tobacco"


### PR DESCRIPTION
🆑 emmanuelbassil
tweak: The Torch learns some manners. Chewables like chewing tobacco and gum now spit out into an empty hand first. If no available hand, then the floor like current behavior.
tweak: Can now place drone telemetry designator in tool belt and exploration machete belt.
tweak: Can now use belts to whip/lash when on harm intent.
/🆑 

Also renamed extinguish() to spit_out() to avoid confusion with another extinguish() proc that also works on items.
Existing code checked whether the chewable was actually in a mob; I'm assuming some of them can run out and turn into trash even when not in someone's mouth; possibly? (although unlikely as SSObjs stops processing once it's unequipped). Nonetheless, if it ain't broke don't fix it and I kept that check although unless I'm missing something 10 times out of 10 chewer will be a mob.
