### PR TITLE
Adds fast and slow modes to cryo cells

### DIFF
--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -159,6 +159,11 @@
 	else
 		. = 80 * (1 - bodytemperature / species.cold_level_3)
 		. = max(20, .)
+	if(istype(loc, /obj/machinery/atmospherics/unary/cryo_cell))
+		var/obj/machinery/atmospherics/unary/cryo_cell/cryo = loc
+		if(cryo.current_stasis_mult)
+			var/gcf_stasis_mult = cryo.current_stasis_mult
+			. = . * gcf_stasis_mult
 	return round(.)
 
 /mob/living/carbon/human

--- a/nano/templates/cryo.tmpl
+++ b/nano/templates/cryo.tmpl
@@ -51,3 +51,15 @@ Used In File(s): \code\game\machinery\cryo.dm
 		{{:helper.link('Eject Beaker', 'eject', {'ejectBeaker' : 1}, data.isBeakerLoaded ? null : 'disabled')}}
 	</div>
 </div>
+<div class="item">&nbsp;</div>
+<div class="item">
+	<div class="itemLabel">
+		Cryostasis Speed:
+	</div>
+	<div class="itemContent" style="width: 40%;">
+		{{:helper.link('Fast', null, {'goFast' : 1}, data.current_stasis_mult === data.fast_stasis_mult ? 'selected' : null)}}
+		{{:helper.link('Regular', null, {'goRegular' : 1}, data.current_stasis_mult === 1 ? 'selected' : null)}}
+		{{:helper.link('Slow', null, {'goSlow' : 1}, data.current_stasis_mult === data.slow_stasis_mult ? 'selected' : null)}}
+	</div>
+</div>
+</div>


### PR DESCRIPTION
:cl: TheNightingale
tweak: Adds fast-mode and slow-mode to cryo cells. By upgrading the manipulators, you can make it heal up to 50% faster or 50% slower.
/:cl:

TL;DR of how it works:
The 'base' cryogenic factor is 20x if you don't touch the freezer - i.e. occupants will take 20x as long to have life ticks (and process medicine, bleeding, organ failure etc).
_Fast_ decreases the cryogenic factor slightly, with further decreases based on manipulator upgrade level, to a minimum of 0.66 * cryofactor (50% faster). This means cryo will work faster for them, but the stasis won't be as powerful (good for healing people, bad for MSOF/triage).
_Slow_ increases the stasis factor slightly, with further increases based on manipulator upgrade level, to a maximum of 1.5 x cryofactor (50% slower). Stronger stasis, but the cryox/clonex will take longer to process (bad for healing, good for MSOF/triage).
_Regular_ is what we have right now, and a nice middle-ground.

This is all shown and adjusted in the cryo interface.