### PR TITLE
Ties wheelchair speed to athletics skill

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/wheelchair.dm
@@ -7,6 +7,9 @@
 	var/driving = 0
 	var/mob/living/pulling = null
 	var/bloodiness
+	var/next_selfmove = 0
+	var/selfmove_penalty_base = 3
+	var/selfmove_penalty_coeff = 12
 
 
 /obj/structure/bed/chair/wheelchair/Initialize()
@@ -59,6 +62,12 @@
 	if(pulling && buckled_mob && (buckled_mob == user))
 		to_chat(user, SPAN_WARNING("You cannot drive while being pushed."))
 		return
+
+	if (!pulling)
+		if (world.time < next_selfmove) // Slow the occupant down if they're driving; they're in a wheelchair after all
+			return
+		var/penalty_multiplier = (SKILL_MAX - buckled_mob.get_skill_value(SKILL_HAULING)) / SKILL_MAX // Penalty depends on athleticism
+		next_selfmove = world.time + selfmove_penalty_base + selfmove_penalty_coeff * penalty_multiplier
 
 	// Let's roll
 	driving = 1


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: Slywater
tweak: Wheelchair movement speed is now tied to the user's athletics skill.
/:cl: