### PR TITLE
Fixes self-buckling when incapacitated

### DIFF
--- a/code/game/objects/buckling.dm
+++ b/code/game/objects/buckling.dm
@@ -102,7 +102,7 @@
 			to_chat(user, SPAN_WARNING("\The [target] must be restrained to buckle them to \the [src]."))
 		return FALSE
 	if (user)
-		if (user.incapacitated())
+		if (user != target && user.incapacitated())
 			if (!silent)
 				to_chat(user, SPAN_WARNING("You're in no condition to buckle things right now."))
 			return FALSE


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: Slywater
bugfix: You can once again buckle yourself while incapacitated, and interact with items from a chair (assuming you're not in pain crit).
/:cl:

Fixes #33947