### PR TITLE
Gives 3/4 items named 'military pistol' distinct names

### DIFF
--- a/maps/torch/items/weapons.dm
+++ b/maps/torch/items/weapons.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/pistol/m22f
-	name = "military pistol"
+	name = "heavy military pistol"
 	desc = "A Hephaestus Industries M22F. A large pistol issued as an SCGDF service weapon."
 	magazine_type = /obj/item/ammo_magazine/pistol/double
 	allowed_magazines = /obj/item/ammo_magazine/pistol/double

--- a/packs/factions/iccgn/weapons.dm
+++ b/packs/factions/iccgn/weapons.dm
@@ -1,5 +1,5 @@
 /obj/item/gun/projectile/pistol/optimus
-	name = "military pistol"
+	name = "Terran heavy military pistol"
 	desc = "A HelTek Optimus. A heavy pistol best known as one of the Confederation Navy's service weapons."
 	icon = 'packs/factions/iccgn/weapons.dmi'
 	icon_state = "optimus"
@@ -13,7 +13,7 @@
 
 
 /obj/item/gun/projectile/pistol/bobcat
-	name = "military pistol"
+	name = "Terran military pistol"
 	desc = "An Amaranth Armorers P87 Bobcat. A market pistol issued as a Confederation Navy service weapon."
 	icon = 'packs/factions/iccgn/weapons.dmi'
 	w_class = ITEM_SIZE_SMALL


### PR DESCRIPTION
Renames the SCG M22F pistol (the one that takes doublestack mags) as the "heavy military pistol" to make it distinguishable from the normal M19 pistol that MAs normally carry. Renames the Terran Bobcat and Optimus pistols to be "Terran military pistol" and "Terran heavy military pistol" respectively.

🆑 SingingSpock
tweak: Renames the SCG pistol that takes doublestack mags the "heavy military pistol"
tweak: Renames the Terran pistols the "Terran military pistol" and "Terran heavy military pistol"
/:cl: