### PR TITLE
admin light_maker fix

### DIFF
--- a/code/modules/admin/buildmode/light_maker.dm
+++ b/code/modules/admin/buildmode/light_maker.dm
@@ -3,7 +3,7 @@
 	icon_state = "buildmode8"
 
 	var/light_range = 3
-	var/light_power = 3
+	var/light_power = 1
 	var/light_color = COLOR_WHITE
 
 /datum/build_mode/light_maker/Help()


### PR DESCRIPTION
## Hello comrades! 
Admins in build mode have for some reason light power in light maker by default = 3 while max power for light is 1. That's makes us to manually change light power each time. I'm fixing this mistake

### Changelog
🆑 cuddleandtea
bugfix: Corrected light build mode default power to 1.
/🆑 