### PR TITLE
Fix closet icon test output

### DIFF
--- a/code/unit_tests/closets.dm
+++ b/code/unit_tests/closets.dm
@@ -53,21 +53,21 @@
 		)
 		var/fail_msg = "Insane closet appearances found: "
 		if(LAZYLEN(bad_singleton))
-			fail_msg += "\nSingleton did not add itself to appropriate global list:\n[jointext("\t[bad_icon]", "\n")]."
+			fail_msg += "\nSingleton did not add itself to appropriate global list:\n\t[jointext(bad_icon, "\n\t")]."
 		if(LAZYLEN(bad_icon))
-			fail_msg += "\nNull final icon values:\n[jointext("\t[bad_icon]", "\n")]."
+			fail_msg += "\nNull final icon values:\n\t[jointext(bad_icon, "\n\t")]."
 		if(LAZYLEN(bad_colour))
-			fail_msg += "\nNull color values:\n[jointext("\t[bad_colour]", "\n")]."
+			fail_msg += "\nNull color values:\n\t[jointext(bad_colour, "\n\t")]."
 		if(LAZYLEN(bad_base_icon))
-			fail_msg += "\nNull base icon value:\n[jointext("\t[bad_base_icon]", "\n")]."
+			fail_msg += "\nNull base icon value:\n\t[jointext(bad_base_icon, "\n\t")]."
 		if(LAZYLEN(bad_base_state))
-			fail_msg += "\nMissing state from base icon:\n[jointext("\t[bad_base_state]", "\n")]."
+			fail_msg += "\nMissing state from base icon:\n\t[jointext(bad_base_state, "\n\t")]."
 		if(LAZYLEN(bad_decal_icon))
-			fail_msg += "\nDecal icon not set but decal lists populated:\n[jointext("\t[bad_decal_icon]", "\n")]."
+			fail_msg += "\nDecal icon not set but decal lists populated:\n\t[jointext(bad_decal_icon, "\n\t")]."
 		if(LAZYLEN(bad_decal_colour))
-			fail_msg += "\nNull color in final decal entry:\n[jointext("\t[bad_decal_colour]", "\n")]."
+			fail_msg += "\nNull color in final decal entry:\n\t[jointext(bad_decal_colour, "\n\t")]."
 		if(LAZYLEN(bad_decal_state))
-			fail_msg += "\nNon-existent decal icon state:\n[jointext("\t[bad_decal_state]", "\n")]."
+			fail_msg += "\nNon-existent decal icon state:\n\t[jointext(bad_decal_state, "\n\t")]."
 
 		fail(fail_msg)
 	else


### PR DESCRIPTION
No user facing changes.

Fixes the sane closet icon test displaying `/list` instead of the actual list of failures.