### PR TITLE
Removes admin log for throwing people via gravikinetic

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -560,7 +560,6 @@
 			return
 		else if(target != locked)
 			if(locked in view(holder.wearer))
-				admin_attack_log(holder.wearer, holder.loc, "used [src] to throw their target at [target].")
 				endanimation() //End animation without waiting for delete, so throw won't be affected
 				locked.throw_at(target, 14, 1.5, holder.wearer)
 				locked = null


### PR DESCRIPTION
:cl: 
admin: Removes attack log for using the gravikinetic.
/:cl:

Tends to just clog up the chat for people using the single-target gravi rigmodule. Isn't really griefworthy enough to warrant the logs.