### PR TITLE
Radio Incapacitation Tweaks

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -331,13 +331,18 @@
 	if (!broadcasting)
 		// Sedation chemical effect should prevent radio use (Chloral and Soporific)
 		var/mob/living/carbon/C = M
-		if ((istype(C)) && (C.chem_effects[CE_SEDATE] || C.incapacitated(INCAPACITATION_UNRESISTING)))
-			to_chat(M, SPAN_WARNING("You're unable to reach \the [src]."))
-			return 0
+		if (istype(C))
+			if ((C.chem_effects[CE_SEDATE] || C.incapacitated(INCAPACITATION_UNRESISTING)))
+				to_chat(M, SPAN_WARNING("You're unable to reach \the [src]."))
+				return 0
 
-		if((istype(C)) && C.radio_interrupt_cooldown > world.time)
-			to_chat(M, SPAN_WARNING("You're disrupted as you reach for \the [src]."))
-			return 0
+			if (C.chem_effects[CE_VOICELOSS])
+				to_chat(M, SPAN_WARNING("Your voice is too quiet for \the [src] to pickup!"))
+				return FALSE
+
+			if (C.radio_interrupt_cooldown > world.time)
+				to_chat(M, SPAN_WARNING("You're disrupted as you reach for \the [src]."))
+				return 0
 
 		if(istype(M)) M.trigger_aiming(TARGET_CAN_RADIO)
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -331,7 +331,7 @@
 	if (!broadcasting)
 		// Sedation chemical effect should prevent radio use (Chloral and Soporific)
 		var/mob/living/carbon/C = M
-		if ((istype(C)) && (C.chem_effects[CE_SEDATE] || C.incapacitated(INCAPACITATION_DISRUPTED)))
+		if ((istype(C)) && (C.chem_effects[CE_SEDATE] || C.incapacitated(INCAPACITATION_UNRESISTING)))
 			to_chat(M, SPAN_WARNING("You're unable to reach \the [src]."))
 			return 0
 


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
balance: Radios can now be used while weakened, but are still blocked when paralyzed or stunned.
balance: Radios can no longer be used while under the voiceloss chemical effect (The one that forces you to whisper). This applies to amaspores (Amatoxin poisoning) and vecoronium bromide (Paralysis pen).
/:cl:

## Bug Fixes
- Closes #30019