### PR TITLE
Fix vv handler for the confused var locked to 15

### DIFF
--- a/code/modules/mob/vv_handlers.dm
+++ b/code/modules/mob/vv_handlers.dm
@@ -6,4 +6,4 @@
 
 /singleton/vv_set_handler/mob_confused/handle_set_var(datum/O, variable, var_value, client)
 	var/mob/mob = O
-	mob.set_confused(var_value)
+	mob.set_confused(var_value, var_value)


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
admin: Altering the confused var with view variables is no longer limited to a value of 15.
/:cl: