### PR TITLE
(WIP) Reworks the suit storage system

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -437,6 +437,7 @@
 #include "code\datums\singletons\shared_list\_shared_list.dm"
 #include "code\datums\singletons\shared_list\path.dm"
 #include "code\datums\singletons\shared_list\sound.dm"
+#include "code\datums\singletons\shared_list\storage.dm"
 #include "code\datums\state_machine\paper_fortune_fsm.dm"
 #include "code\datums\state_machine\state.dm"
 #include "code\datums\state_machine\transition.dm"

--- a/code/datums/singletons/shared_list/storage.dm
+++ b/code/datums/singletons/shared_list/storage.dm
@@ -1,0 +1,140 @@
+/singleton/shared_list/path/storage
+	abstract_type = /singleton/shared_list/path/storage
+	var/list/items = null
+
+/// The 'default' list - small oxygen tanks, flashlights, and radios.						Use this category sparingly - nearly anything can hold them.
+/singleton/shared_list/path/storage/emergency
+	items = list(
+		/obj/item/device/flashlight,
+		/obj/item/device/radio,
+		/obj/item/tank/oxygen_emergency,
+		/obj/item/tank/oxygen_emergency_extended,
+		/obj/item/tank/oxygen_emergency_double,
+		/obj/item/tank/oxygen_scba,
+		/obj/item/tank/nitrogen_emergency,
+		/obj/item/tank/nitrogen_emergency_double,
+		/obj/item/tank/air_sac
+		)
+
+/// Paperwork/formal stuff. Pens, papers, stamps, etc. Also includes forensics.				These are usually small. Equipment belt stuff.
+/singleton/shared_list/path/storage/bureaucracy
+	items = list(
+		/obj/item/paper,
+		/obj/item/photo,
+		/obj/item/stamp,
+		/obj/item/pen,
+		/obj/item/device/megaphone,
+		/obj/item/device/taperecorder,
+		/obj/item/flame/lighter,
+		/obj/item/taperoll/bureaucracy,
+		/obj/item/storage/fancy/smokable,
+		/obj/item/clothing/head/beret,
+		/obj/item/clothing/head/soft,
+		/obj/item/reagent_containers/spray/luminol,
+		/obj/item/sample,
+		/obj/item/storage/csi_markers,
+		/obj/item/csi_marker,
+		/obj/item/swabber,
+		/obj/item/device/uv_light,
+		/obj/item/modular_computer/pda,
+		/obj/item/modular_computer/tablet,
+		/obj/item/folder
+		)
+
+/// Most handheld engineering tools - screwdrivers, geiger counters, t-ray scanners, etc.	These are usually small. Standard toolbelt stuff.
+/singleton/shared_list/path/storage/engineering
+	items = list(
+		/obj/item/device/geiger,
+		/obj/item/inducer,
+		/obj/item/device/multitool,
+		/obj/item/device/t_scanner,
+		/obj/item/device/scanner/gas,
+		/obj/item/extinguisher,
+		/obj/item/taperoll/engineering,
+		/obj/item/taperoll/atmos,
+		/obj/item/tape_roll,
+		/obj/item/crowbar,
+		/obj/item/screwdriver,
+		/obj/item/swapper/power_drill,
+		/obj/item/swapper/jaws_of_life,
+		/obj/item/weldingtool,
+		/obj/item/welder_tank,
+		/obj/item/wirecutters,
+		/obj/item/wrench,
+		/obj/item/device/robotanalyzer,
+		/obj/item/stack/cable_coil
+		)
+
+/// Anything handheld and medical - health scanners, syringes, pills, etc.					These are usually small. Medical belt stuff.
+/singleton/shared_list/path/storage/medical
+	items = list(
+		/obj/item/bodybag,
+		/obj/item/device/scanner/health,
+		/obj/item/stack/medical,
+		/obj/item/taperoll/medical,
+		/obj/item/storage/med_pouch,
+		/obj/item/storage/pill_bottle,
+		/obj/item/reagent_containers/dropper,
+		/obj/item/reagent_containers/glass/beaker,
+		/obj/item/reagent_containers/glass/bottle,
+		/obj/item/reagent_containers/hypospray,
+		/obj/item/reagent_containers/ivbag,
+		/obj/item/reagent_containers/pill,
+		/obj/item/reagent_containers/syringe
+		)
+
+/// Science-related gear. Xenoarch measuring tape, xenobotany scanners, GCSes, etc.			These should be small, or medium at most (plant/fossil bags).
+/singleton/shared_list/path/storage/science
+	items = list(
+		/obj/item/device/gps,
+		/obj/item/device/scanner,
+		/obj/item/taperoll/research,
+		/obj/item/material/minihoe,
+		/obj/item/storage/plants,
+		/obj/item/device/robotanalyzer,
+		/obj/item/device/core_sampler,
+		/obj/item/device/measuring_tape,
+		/obj/item/storage/bag/fossils,
+		/obj/item/device/ano_scanner,
+		/obj/item/device/depth_scanner,
+		/obj/item/pinpointer/radio,
+		/obj/item/pickaxe/xeno,
+		/obj/item/storage/excavation
+		)
+
+/// Defensive, less-lethal security items - flashes, pepperspray, warrants, etc.				These should be small, or medium at most (batons, helmets).
+/singleton/shared_list/path/storage/security
+	items = list(
+		/obj/item/device/flash,
+		/obj/item/device/holowarrant,
+		/obj/item/device/hailer,
+		/obj/item/handcuffs,
+		/obj/item/taperoll/police,
+		/obj/item/melee/baton,
+		/obj/item/melee/telebaton,
+		/obj/item/clothing/head/helmet,
+		/obj/item/reagent_containers/spray/pepper
+		)
+
+/// Offensive combat items. Guns, grenades, ammo casings, magazines, etc.					These can be large (guns, including long arms).
+/singleton/shared_list/path/storage/combat
+	items = list(
+		/obj/item/handcuffs,
+		/obj/item/melee/baton,
+		/obj/item/melee/telebaton,
+		/obj/item/grenade,
+		/obj/item/melee/energy/sword,
+		/obj/item/clothing/head/helmet,
+		/obj/item/ammo_casing,
+		/obj/item/ammo_magazine,
+		/obj/item/gun
+		)
+
+/// Oxygen tanks (small and large), suit coolers, inflatable briefcases.						These will often be large - they're for EVA suits only.
+/singleton/shared_list/path/storage/eva
+	items = list(
+		/obj/item/tank,
+		/obj/item/device/suit_cooling_unit,
+		/obj/item/tape_roll,
+		/obj/item/storage/briefcase/inflatable
+		)

--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -127,7 +127,8 @@
 	name = "cult armour"
 	icon_state = "cult_armour"
 	desc = "A bulky suit of armour, bristling with spikes. It looks space proof."
-	allowed = list(/obj/item/book/tome,/obj/item/melee/cultblade,/obj/item/tank,/obj/item/device/suit_cooling_unit)
+	allowed = list(/obj/item/book/tome,/obj/item/melee/cultblade)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva)
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT,
 		bullet = ARMOR_BALLISTIC_RIFLE,

--- a/code/game/objects/items/bodybag.dm
+++ b/code/game/objects/items/bodybag.dm
@@ -6,6 +6,7 @@
 	icon = 'icons/obj/closets/bodybag.dmi'
 	icon_state = "bodybag_folded"
 	w_class = ITEM_SIZE_SMALL
+
 /obj/item/bodybag/attack_self(mob/user)
 	var/obj/structure/closet/body_bag/R = new /obj/structure/closet/body_bag(user.loc)
 	R.add_fingerprint(user)

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -185,7 +185,11 @@
 		/obj/item/bonegel,
 		/obj/item/FixOVein,
 		/obj/item/stack/medical/advanced/bruise_pack,
-		/obj/item/stack/nanopaste
+		/obj/item/stack/nanopaste,
+		/obj/item/clothing/mask/surgical,
+		/obj/item/clothing/head/surgery,
+		/obj/item/clothing/gloves/latex,
+		/obj/item/reagent_containers/dropper
 	)
 	startswith = list(
 		/obj/item/bonesetter,

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -779,6 +779,7 @@ BLIND     // can't see anything
 		/obj/item/tank/oxygen_scba,
 		/obj/item/tank/nitrogen_emergency
 	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency)
 	slot_flags = SLOT_OCLOTHING
 	item_flags = ITEM_FLAG_WASHER_ALLOWED
 	blood_overlay_type = "suit"

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/clothing/species/vox/obj_suit_vox.dmi'
 	item_icons = list(slot_wear_suit_str = 'icons/mob/species/vox/onmob_suit_vox.dmi')
 	w_class = ITEM_SIZE_NORMAL
-	allowed = list(/obj/item/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/melee/energy/sword,/obj/item/handcuffs,/obj/item/tank)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/combat)
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR,
 		bullet = ARMOR_BALLISTIC_PISTOL,
@@ -88,7 +88,7 @@
 	name = "advanced alien armour"
 	icon_state = "vox-raider"
 	desc = "A sleek, greyish suit of armor over a tight bodysuit. Lighter than it looks."
-	allowed = list(/obj/item/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/melee/energy/sword,/obj/item/handcuffs,/obj/item/tank,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/inflatable_dispenser,/obj/item/rcd)
+	allowed = list(/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/inflatable_dispenser,/obj/item/rcd)
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT,
 		bullet = ARMOR_BALLISTIC_RESISTANT,

--- a/code/modules/clothing/spacesuits/captain.dm
+++ b/code/modules/clothing/spacesuits/captain.dm
@@ -34,18 +34,7 @@
 	max_pressure_protection = VOIDSUIT_MAX_PRESSURE
 	min_pressure_protection = 0
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS
-	allowed = list(
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
-		/obj/item/device/flashlight,
-		/obj/item/gun/energy,
-		/obj/item/gun/projectile,
-		/obj/item/ammo_magazine,
-		/obj/item/ammo_casing,
-		/obj/item/melee/baton,
-		/obj/item/handcuffs
-	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/combat)
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR,
 		bullet = ARMOR_BALLISTIC_RESISTANT,

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -48,6 +48,10 @@
 	name = "emergency softsuit"
 	icon_state = "space_emergency"
 	desc = "A thin, ungainly softsuit colored in blaze orange for rescuers to easily locate. Looks pretty fragile."
+	allowed = list(
+		/obj/item/device/suit_cooling_unit
+		)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency) //No large tanks/jetpacks
 
 /obj/item/clothing/suit/space/emergency/Initialize()
 	. = ..()

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -212,6 +212,8 @@
 		chest = new chest_type(src)
 		if(allowed)
 			chest.allowed = allowed
+		if(storage)
+			chest.storage = storage
 
 	for(var/obj/item/piece in list(gloves,helmet,boots,chest))
 		if(!istype(piece))

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -37,7 +37,6 @@
 
 /obj/item/clothing/suit/space/rig
 	name = "chestpiece"
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	heat_protection =    UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
 	cold_protection =    UPPER_TORSO|LOWER_TORSO|LEGS|ARMS

--- a/code/modules/clothing/spacesuits/rig/suits/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/combat.dm
@@ -32,30 +32,14 @@
 		SPECIES_UNATHI = 'icons/mob/species/unathi/onmob_suit_unathi.dmi'
 		)
 	allowed = list(
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/ammo_magazine,
-		/obj/item/ammo_casing,
-		/obj/item/handcuffs,
-		/obj/item/device/t_scanner,
 		/obj/item/rcd,
 		/obj/item/rpd,
-		/obj/item/crowbar,
-		/obj/item/screwdriver,
-		/obj/item/weldingtool,
-		/obj/item/wirecutters,
-		/obj/item/wrench,
-		/obj/item/device/multitool,
-		/obj/item/device/radio,
-		/obj/item/device/scanner/gas,
 		/obj/item/storage/briefcase/inflatable,
-		/obj/item/melee/baton,
-		/obj/item/gun,
 		/obj/item/storage/firstaid,
 		/obj/item/reagent_containers/hypospray,
-		/obj/item/roller_bed,
-		/obj/item/device/suit_cooling_unit
+		/obj/item/roller_bed
 	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/combat, /singleton/shared_list/path/storage/engineering)
 
 /obj/item/clothing/shoes/magboots/rig/combat
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL, SPECIES_UNATHI, SPECIES_IPC)
@@ -118,29 +102,14 @@
 		SPECIES_UNATHI = 'icons/mob/species/unathi/onmob_suit_unathi.dmi'
 		)
 	allowed = list(
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/ammo_magazine,
-		/obj/item/ammo_casing,
-		/obj/item/handcuffs,
-		/obj/item/device/t_scanner,
 		/obj/item/rcd,
-		/obj/item/crowbar,
-		/obj/item/screwdriver,
-		/obj/item/weldingtool,
-		/obj/item/wirecutters,
-		/obj/item/wrench,
-		/obj/item/device/multitool,
-		/obj/item/device/radio,
-		/obj/item/device/scanner/gas,
+		/obj/item/rpd,
 		/obj/item/storage/briefcase/inflatable,
-		/obj/item/melee/baton,
-		/obj/item/gun,
 		/obj/item/storage/firstaid,
 		/obj/item/reagent_containers/hypospray,
-		/obj/item/roller_bed,
-		/obj/item/device/suit_cooling_unit
+		/obj/item/roller_bed
 	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/combat, /singleton/shared_list/path/storage/engineering)
 
 /obj/item/clothing/shoes/magboots/rig/military
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL, SPECIES_UNATHI, SPECIES_IPC)

--- a/code/modules/clothing/spacesuits/rig/suits/ert.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/ert.dm
@@ -36,29 +36,14 @@
 /obj/item/clothing/suit/space/rig/ert
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_IPC)
 	allowed = list(
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/ammo_magazine,
-		/obj/item/ammo_casing,
-		/obj/item/handcuffs,
-		/obj/item/device/t_scanner,
 		/obj/item/rcd,
 		/obj/item/rpd,
-		/obj/item/crowbar,
-		/obj/item/screwdriver,
-		/obj/item/weldingtool,
-		/obj/item/wirecutters,
-		/obj/item/wrench,
-		/obj/item/device/multitool,
-		/obj/item/device/radio,
-		/obj/item/device/scanner/gas,
 		/obj/item/storage/briefcase/inflatable,
-		/obj/item/melee/baton,
-		/obj/item/gun,
 		/obj/item/storage/firstaid,
 		/obj/item/reagent_containers/hypospray,
 		/obj/item/roller_bed
 	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/combat, /singleton/shared_list/path/storage/engineering)
 
 /obj/item/clothing/shoes/magboots/rig/ert
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_IPC)

--- a/code/modules/clothing/spacesuits/rig/suits/light.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/light.dm
@@ -30,15 +30,9 @@
 	breach_threshold = 18 //comparable to voidsuits
 	species_restricted = list(SPECIES_HUMAN,SPECIES_IPC)
 	allowed = list(
-		/obj/item/gun,
-		/obj/item/ammo_magazine,
-		/obj/item/ammo_casing,
-		/obj/item/melee/baton,
-		/obj/item/handcuffs,
-		/obj/item/tank,
-		/obj/item/device/suit_cooling_unit,
 		/obj/item/cell
 	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/combat)
 	max_w_class = ITEM_SIZE_SMALL
 	slots = 3 STORAGE_FREEFORM
 

--- a/code/modules/clothing/spacesuits/rig/suits/merc.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/merc.dm
@@ -81,17 +81,8 @@
 		SPECIES_UNATHI = 'icons/mob/species/unathi/onmob_suit_unathi.dmi',
 		SPECIES_VOX = 'icons/mob/species/vox/onmob_suit_vox.dmi'
 	)
-	allowed = list(
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/device/suit_cooling_unit,
-		/obj/item/gun,
-		/obj/item/ammo_magazine,
-		/obj/item/ammo_casing,
-		/obj/item/melee/baton,
-		/obj/item/melee/energy/sword,
-		/obj/item/handcuffs
-	)
+	allowed = list()
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/combat)
 
 /obj/item/clothing/shoes/magboots/rig/merc
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_IPC, SPECIES_VOX)

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -20,9 +20,6 @@
 /obj/item/clothing/suit/space/rig/industrial
 	species_restricted = list(SPECIES_HUMAN,SPECIES_IPC)
 	allowed = list(
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/device/suit_cooling_unit,
 		/obj/item/storage/briefcase,
 		/obj/item/storage/secure/briefcase
 	)
@@ -71,9 +68,6 @@
 /obj/item/clothing/suit/space/rig/industrial
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_IPC)
 	allowed = list(
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/device/suit_cooling_unit,
 		/obj/item/stack/flag,
 		/obj/item/storage/ore,
 		/obj/item/device/t_scanner,
@@ -144,9 +138,6 @@
 		SPECIES_UNATHI = 'icons/mob/species/unathi/onmob_suit_unathi.dmi'
 		)
 	allowed = list(
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/device/suit_cooling_unit,
 		/obj/item/storage/toolbox,
 		/obj/item/storage/briefcase/inflatable,
 		/obj/item/inflatable_dispenser,
@@ -233,18 +224,15 @@
 	)
 	allowed = list(
 		/obj/item/gun,
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/device/suit_cooling_unit,
 		/obj/item/storage/ore,
 		/obj/item/storage/toolbox,
 		/obj/item/storage/briefcase/inflatable,
 		/obj/item/inflatable_dispenser,
-		/obj/item/device/t_scanner,
 		/obj/item/pickaxe,
 		/obj/item/rcd,
 		/obj/item/rpd
 	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/engineering)
 /obj/item/clothing/shoes/magboots/rig/ce
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_IPC)
 	sprite_sheets = list(
@@ -284,22 +272,10 @@
 /obj/item/clothing/suit/space/rig/hazmat
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_IPC)
 	allowed = list(
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/device/suit_cooling_unit,
 		/obj/item/stack/flag,
-		/obj/item/storage/excavation,
 		/obj/item/pickaxe,
-		/obj/item/device/scanner/health,
-		/obj/item/device/measuring_tape,
-		/obj/item/device/ano_scanner,
-		/obj/item/device/depth_scanner,
-		/obj/item/device/core_sampler,
-		/obj/item/device/gps,
-		/obj/item/pinpointer/radio,
-		/obj/item/pickaxe/xeno,
-		/obj/item/storage/bag/fossils
 	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/science)
 
 /obj/item/clothing/shoes/magboots/rig/hazmat
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_IPC)
@@ -352,16 +328,12 @@
 /obj/item/clothing/suit/space/rig/medical
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL, SPECIES_UNATHI, SPECIES_IPC)
 	allowed = list(
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/device/suit_cooling_unit,
 		/obj/item/storage/firstaid,
-		/obj/item/device/scanner/health,
-		/obj/item/stack/medical,
 		/obj/item/roller_bed,
 		/obj/item/auto_cpr,
 		/obj/item/inflatable_dispenser
 	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/medical)
 
 /obj/item/clothing/shoes/magboots/rig/medical
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL, SPECIES_UNATHI, SPECIES_IPC)
@@ -414,16 +386,8 @@
 
 /obj/item/clothing/suit/space/rig/hazard
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI, SPECIES_IPC)
-	allowed = list(
-		/obj/item/gun,
-		/obj/item/ammo_magazine,
-		/obj/item/ammo_casing,
-		/obj/item/handcuffs,
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/device/suit_cooling_unit,
-		/obj/item/melee/baton
-	)
+	allowed = list()
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/combat)
 
 /obj/item/clothing/shoes/magboots/rig/hazard
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI, SPECIES_IPC)
@@ -484,11 +448,7 @@
 	)
 	breach_threshold = 18
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
-	allowed = list(
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/device/suit_cooling_unit
-	)
+	allowed = list()
 	max_w_class = null
 	slots = null
 

--- a/code/modules/clothing/spacesuits/rig/suits/vox.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/vox.dm
@@ -37,17 +37,9 @@
 /obj/item/clothing/suit/space/rig/vox_rig
 	species_restricted = list(SPECIES_VOX)
 	allowed = list(
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/ammo_magazine,
-		/obj/item/ammo_casing,
-		/obj/item/ammo_magazine/shotholder,
-		/obj/item/handcuffs,
-		/obj/item/device/radio,
-		/obj/item/melee/baton,
-		/obj/item/gun,
 		/obj/item/pickaxe
 	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/combat)
 
 /obj/item/clothing/shoes/magboots/rig/vox_rig
 	species_restricted = list(SPECIES_VOX)

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -122,12 +122,9 @@
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	allowed = list(
-		/obj/item/device/flashlight,
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
 		/obj/item/device/suit_cooling_unit
 	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva)
 	armor = list(
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SMALL

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -24,17 +24,7 @@
 	)
 	desc = "A crimson spacesuit sporting clean lines and durable plating. Robust, reliable, and slightly suspicious."
 	w_class = ITEM_SIZE_NORMAL
-	allowed = list(
-		/obj/item/gun,
-		/obj/item/ammo_magazine,
-		/obj/item/ammo_casing,
-		/obj/item/melee/baton,
-		/obj/item/melee/energy/sword,
-		/obj/item/handcuffs,
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency
-	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/combat)
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR,
 		bullet = ARMOR_BALLISTIC_RESISTANT,

--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -46,7 +46,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SMALL
 		)
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/melee/energy/sword,/obj/item/handcuffs)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/combat)
 	siemens_coefficient = 0.3
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_IPC, SPECIES_VOX)
 	sprite_sheets = list(

--- a/code/modules/clothing/spacesuits/void/misc.dm
+++ b/code/modules/clothing/spacesuits/void/misc.dm
@@ -4,7 +4,7 @@
 	desc = "A heavily armored suit that protects against moderate damage. Used in special operations."
 	icon_state = "deathsquad"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS
-	allowed = list(/obj/item/gun,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/handcuffs,/obj/item/tank)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/combat)
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT,
 		bullet = ARMOR_BALLISTIC_RESISTANT,
@@ -51,7 +51,13 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 		)
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/storage/ore,/obj/item/device/t_scanner,/obj/item/pickaxe,/obj/item/rcd,/obj/item/rpd)
+	allowed = list(
+		/obj/item/storage/ore,
+		/obj/item/device/t_scanner,
+		/obj/item/pickaxe,
+		/obj/item/rcd,
+		/obj/item/rpd
+		)
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	species_restricted = list(SPECIES_SKRELL,SPECIES_HUMAN)

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -39,7 +39,13 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT
 		)
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/rcd,/obj/item/rpd)
+	allowed = list(
+		/obj/item/storage/toolbox,
+		/obj/item/storage/briefcase/inflatable,
+		/obj/item/rcd,
+		/obj/item/rpd
+		)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/engineering)
 
 /obj/item/clothing/suit/space/void/engineering/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/engineering
@@ -84,7 +90,14 @@
 		rad = ARMOR_RAD_MINOR
 		)
 	max_pressure_protection = ENG_VOIDSUIT_MAX_PRESSURE
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/stack/flag,/obj/item/device/suit_cooling_unit,/obj/item/storage/ore,/obj/item/device/t_scanner,/obj/item/pickaxe, /obj/item/rcd,/obj/item/rpd)
+	allowed = list(
+		/obj/item/stack/flag,
+		/obj/item/storage/ore,
+		/obj/item/device/t_scanner,
+		/obj/item/pickaxe,
+		/obj/item/rcd,
+		/obj/item/rpd
+		)
 
 /obj/item/clothing/suit/space/void/mining/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/mining
@@ -116,7 +129,11 @@
 		slot_l_hand_str = "medical_voidsuit",
 		slot_r_hand_str = "medical_voidsuit",
 	)
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/firstaid,/obj/item/device/scanner/health,/obj/item/stack/medical)
+	allowed = list(
+		/obj/item/storage/firstaid,
+		/obj/item/roller_bed
+		)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/medical)
 	armor = list(
 		melee = ARMOR_MELEE_KNIVES,
 		laser = ARMOR_LASER_MINOR,
@@ -167,7 +184,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR
 		)
-	allowed = list(/obj/item/gun,/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/melee/baton)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/combat)
 	siemens_coefficient = 0.3
 
 /obj/item/clothing/suit/space/void/security/prepared
@@ -215,7 +232,13 @@
 		)
 	max_heat_protection_temperature = FIRESUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	max_pressure_protection = FIRESUIT_MAX_PRESSURE
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/rcd,/obj/item/rpd)
+	allowed = list(
+		/obj/item/storage/toolbox,
+		/obj/item/storage/briefcase/inflatable,
+		/obj/item/rcd,
+		/obj/item/rpd
+		)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/engineering)
 
 /obj/item/clothing/suit/space/void/atmos/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/atmos
@@ -297,7 +320,6 @@
 	name = "streamlined medical voidsuit"
 	icon_state = "rig-medicalalt"
 	desc = "A more recent and stylish model of Vey-Med voidsuit, with a minor upgrade to radiation shielding."
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/firstaid,/obj/item/device/scanner/health,/obj/item/stack/medical)
 	armor = list(
 		melee = ARMOR_MELEE_KNIVES,
 		laser = ARMOR_LASER_MINOR,
@@ -341,7 +363,6 @@
 		bomb = ARMOR_BOMB_PADDED,
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR)
-	allowed = list(/obj/item/gun,/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/melee/baton)
 
 /obj/item/clothing/suit/space/void/security/alt/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/security/alt
@@ -421,7 +442,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT
 		)
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/rcd,/obj/item/rpd)
 
 /obj/item/clothing/suit/space/void/engineering/salvage/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/engineering/salvage
@@ -454,7 +474,13 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SMALL
 		)
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/toolbox,/obj/item/storage/briefcase/inflatable,/obj/item/device/t_scanner,/obj/item/rcd,/obj/item/rpd)
+	allowed = list(
+		/obj/item/storage/toolbox,
+		/obj/item/storage/briefcase/inflatable,
+		/obj/item/device/t_scanner,
+		/obj/item/rcd,
+		/obj/item/rpd
+		)
 
 /obj/item/clothing/suit/space/void/pilot/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/pilot
@@ -477,7 +503,9 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 	)
-	allowed = list(/obj/item/gun,/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit)
+	allowed = list(
+		/obj/item/gun
+		)
 
 /obj/item/clothing/head/helmet/space/void/retro
 	name = "retro voidsuit helmet"

--- a/code/modules/clothing/spacesuits/void/void.dm
+++ b/code/modules/clothing/spacesuits/void/void.dm
@@ -46,7 +46,6 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR
 		)
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit)
 	flags_inv = HIDEGLOVES | HIDESHOES | HIDEJUMPSUIT | HIDETAIL | CLOTHING_BULKY
 	heat_protection = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -1,6 +1,6 @@
 
 /obj/item/clothing/suit/armor
-	allowed = list(/obj/item/gun/energy,/obj/item/device/radio,/obj/item/reagent_containers/spray/pepper,/obj/item/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/handcuffs,/obj/item/gun/magnetic,/obj/item/clothing/head/helmet,/obj/item/device/flashlight)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/security, /singleton/shared_list/path/storage/combat)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	flags_inv = CLOTHING_BULKY
@@ -223,7 +223,7 @@
 		bomb = ARMOR_BOMB_PADDED
 		)
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
-	allowed = list(/obj/item/gun/energy,/obj/item/device/radio,/obj/item/reagent_containers/spray/pepper,/obj/item/gun/projectile,/obj/item/ammo_magazine,/obj/item/ammo_casing,/obj/item/melee/baton,/obj/item/handcuffs,/obj/item/gun/magnetic)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/security, /singleton/shared_list/path/storage/combat)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	item_flags = ITEM_FLAG_THICKMATERIAL
 	cold_protection = UPPER_TORSO|LOWER_TORSO
@@ -467,14 +467,6 @@
 	icon_state = "centcom"
 	w_class = ITEM_SIZE_HUGE//bulky item
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
-	allowed = list(
-		/obj/item/gun/energy,
-		/obj/item/melee/baton,
-		/obj/item/handcuffs,
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
-	)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	cold_protection = UPPER_TORSO | LOWER_TORSO | LEGS | FEET | ARMS | HANDS
 	min_cold_protection_temperature = SPACE_SUIT_MIN_COLD_PROTECTION_TEMPERATURE

--- a/code/modules/clothing/suits/bio.dm
+++ b/code/modules/clothing/suits/bio.dm
@@ -30,16 +30,10 @@
 	permeability_coefficient = 0
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
 	allowed = list(
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
-		/obj/item/pen,
-		/obj/item/device/flashlight/pen,
-		/obj/item/device/scanner/health,
-		/obj/item/device/ano_scanner,
 		/obj/item/clothing/head/bio_hood,
 		/obj/item/clothing/mask/gas
 	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/science)
 	armor = list(
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -11,7 +11,13 @@
 	blood_overlay_type = "armor"
 	body_parts_covered = 0
 	species_restricted = null
-	allowed = list (/obj/item/reagent_containers/spray/plantbgone,/obj/item/device/scanner/plant,/obj/item/seeds,/obj/item/reagent_containers/glass/bottle,/obj/item/material/minihoe)
+	allowed = list (
+		/obj/item/reagent_containers/spray/plantbgone,
+		/obj/item/device/scanner/plant,
+		/obj/item/seeds,
+		/obj/item/reagent_containers/glass/bottle,
+		/obj/item/material/minihoe
+		)
 
 //Captain
 /obj/item/clothing/suit/captunic
@@ -51,7 +57,9 @@
 	gas_transfer_coefficient = 0.90
 	permeability_coefficient = 0.50
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
-	allowed = list (/obj/item/material/knife)
+	allowed = list (
+		/obj/item/material/knife
+		)
 
 //Chef
 /obj/item/clothing/suit/chef/classic
@@ -90,20 +98,10 @@
 	blood_overlay_type = "coat"
 	body_parts_covered = UPPER_TORSO|ARMS
 	allowed = list(
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
-		/obj/item/device/flashlight,
-		/obj/item/gun/energy,
-		/obj/item/gun/projectile,
-		/obj/item/ammo_magazine,
-		/obj/item/ammo_casing,
-		/obj/item/melee/baton,
-		/obj/item/handcuffs,
 		/obj/item/storage/fancy/smokable,
-		/obj/item/flame/lighter,
-		/obj/item/device/taperecorder
+		/obj/item/flame/lighter
 	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/bureaucracy,  /singleton/shared_list/path/storage/security, /singleton/shared_list/path/storage/combat)
 	armor = list(
 		melee = ARMOR_MELEE_KNIVES,
 		bullet = ARMOR_BALLISTIC_SMALL,
@@ -124,19 +122,7 @@
 	name = "jacket"
 	desc = "A forensics technician jacket."
 	body_parts_covered = UPPER_TORSO|ARMS
-	allowed = list(
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
-		/obj/item/device/flashlight,
-		/obj/item/gun/energy,
-		/obj/item/gun/projectile,
-		/obj/item/ammo_magazine,
-		/obj/item/ammo_casing,
-		/obj/item/melee/baton,
-		/obj/item/handcuffs,
-		/obj/item/device/taperecorder
-	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/bureaucracy,  /singleton/shared_list/path/storage/security, /singleton/shared_list/path/storage/combat)
 	armor = list(
 		melee = ARMOR_MELEE_SMALL,
 		bullet = ARMOR_BALLISTIC_MINOR,
@@ -162,22 +148,9 @@
 	blood_overlay_type = "armor"
 	species_restricted = null
 	allowed = list (
-		/obj/item/device/scanner/gas,
-		/obj/item/device/flashlight,
-		/obj/item/device/multitool,
-		/obj/item/device/radio,
-		/obj/item/device/t_scanner,
-		/obj/item/crowbar,
-		/obj/item/screwdriver,
-		/obj/item/weldingtool,
-		/obj/item/wirecutters,
-		/obj/item/wrench,
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
-		/obj/item/clothing/mask/gas,
-		/obj/item/taperoll/engineering
-	)
+		/obj/item/clothing/mask/gas
+		)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/engineering)
 	body_parts_covered = UPPER_TORSO
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
 
@@ -215,6 +188,7 @@
 	name = "medical hazard vest"
 	desc = "A high-visibility vest used in work zones. This one is has a blue cross!"
 	icon_state = "hazard_med"
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/medical)
 
 /obj/item/clothing/suit/storage/toggle/highvis
 	name = "high visibility jacket"
@@ -232,6 +206,7 @@
 	blood_overlay_type = "coat"
 	body_parts_covered = UPPER_TORSO|ARMS
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/bureaucracy)
 
 /obj/item/clothing/suit/storage/toggle/suit_double
 	name = "double-breasted suit jacket"
@@ -240,6 +215,7 @@
 	blood_overlay_type = "coat"
 	body_parts_covered = UPPER_TORSO|ARMS
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/bureaucracy)
 
 /obj/item/clothing/suit/storage/toggle/suit/blue
 	name = "blue suit jacket"
@@ -259,19 +235,7 @@
 	desc = "A high-visibility jacket worn by medical first responders."
 	icon_state = "fr_jacket"
 	blood_overlay_type = "armor"
-	allowed = list(
-		/obj/item/stack/medical,
-		/obj/item/reagent_containers/dropper,
-		/obj/item/reagent_containers/hypospray,
-		/obj/item/reagent_containers/syringe,
-		/obj/item/device/scanner/health,
-		/obj/item/device/flashlight,
-		/obj/item/device/radio,
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
-		/obj/item/reagent_containers/ivbag
-	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/medical)
 	body_parts_covered = UPPER_TORSO|ARMS
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
 
@@ -291,19 +255,10 @@
 	icon_state = "chest-rig"
 	blood_overlay_type = "armor"
 	allowed = list(
-		/obj/item/device/flashlight,
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
 		/obj/item/clothing/mask/gas,
-		/obj/item/device/radio,
-		/obj/item/taperoll,
-		/obj/item/clothing/head/hardhat,
-		/obj/item/handcuffs,
-		/obj/item/melee/baton,
-		/obj/item/grenade,
-		/obj/item/gun
+		/obj/item/clothing/head/hardhat
 	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/security)
 
 	body_parts_covered = UPPER_TORSO
 
@@ -313,24 +268,10 @@
 	icon_state = "engi-chest-rig"
 	blood_overlay_type = "armor"
 	allowed = list (
-		/obj/item/device/flashlight,
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
 		/obj/item/clothing/mask/gas,
-		/obj/item/device/radio,
-		/obj/item/taperoll,
-		/obj/item/clothing/head/hardhat,
-		/obj/item/device/scanner/gas,
-		/obj/item/device/multitool,
-		/obj/item/device/t_scanner,
-		/obj/item/crowbar,
-		/obj/item/screwdriver,
-		/obj/item/weldingtool,
-		/obj/item/wirecutters,
-		/obj/item/wrench,
-		/obj/item/gun
+		/obj/item/clothing/head/hardhat
 	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/engineering)
 
 /obj/item/clothing/suit/storage/medical_chest_rig
 	name = "\improper MT chest-rig"
@@ -338,22 +279,10 @@
 	icon_state = "med-chest-rig"
 	blood_overlay_type = "armor"
 	allowed = list(
-		/obj/item/device/flashlight,
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
 		/obj/item/clothing/mask/gas,
-		/obj/item/device/radio,
-		/obj/item/taperoll,
 		/obj/item/clothing/head/hardhat,
-		/obj/item/stack/medical,
-		/obj/item/reagent_containers/dropper,
-		/obj/item/reagent_containers/hypospray,
-		/obj/item/reagent_containers/syringe,
-		/obj/item/device/scanner/health,
-		/obj/item/reagent_containers/ivbag,
-		/obj/item/gun
 	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/medical)
 
 /obj/item/clothing/suit/surgicalapron
 	name = "surgical apron"
@@ -362,20 +291,21 @@
 	blood_overlay_type = "armor"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	allowed = list(
-		/obj/item/stack/medical,
-		/obj/item/reagent_containers/dropper,
-		/obj/item/reagent_containers/hypospray,
-		/obj/item/reagent_containers/syringe,
-		/obj/item/device/scanner/health,
-		/obj/item/device/flashlight,
-		/obj/item/device/radio,
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
-		/obj/item/scalpel,
-		/obj/item/retractor,
-		/obj/item/hemostat,
+		/obj/item/storage/firstaid/surgery,
+		/obj/item/bonesetter,
 		/obj/item/cautery,
+		/obj/item/circular_saw,
+		/obj/item/hemostat,
+		/obj/item/retractor,
+		/obj/item/scalpel,
+		/obj/item/surgicaldrill,
 		/obj/item/bonegel,
-		/obj/item/FixOVein
+		/obj/item/FixOVein,
+		/obj/item/stack/medical/advanced/bruise_pack,
+		/obj/item/stack/nanopaste,
+		/obj/item/clothing/mask/surgical,
+		/obj/item/clothing/head/surgery,
+		/obj/item/clothing/gloves/latex,
+		/obj/item/reagent_containers/dropper
 	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/medical)

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -4,7 +4,7 @@
 	icon_state = "labcoat"
 	blood_overlay_type = "coat"
 	body_parts_covered = UPPER_TORSO|ARMS
-	allowed = list(/obj/item/device/scanner/gas,/obj/item/stack/medical,/obj/item/reagent_containers/dropper,/obj/item/reagent_containers/syringe,/obj/item/reagent_containers/hypospray,/obj/item/device/scanner/health,/obj/item/device/flashlight/pen,/obj/item/reagent_containers/glass/bottle,/obj/item/reagent_containers/glass/beaker,/obj/item/reagent_containers/pill,/obj/item/storage/pill_bottle,/obj/item/paper)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/bureaucracy,  /singleton/shared_list/path/storage/medical, /singleton/shared_list/path/storage/science)
 	armor = list(
 		bio = ARMOR_BIO_RESISTANT
 		)

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -36,16 +36,7 @@
 	desc = "Yarr."
 	icon_state = "pirate"
 	w_class = ITEM_SIZE_NORMAL
-	allowed = list(
-		/obj/item/gun,
-		/obj/item/ammo_magazine,
-		/obj/item/ammo_casing,
-		/obj/item/melee/baton,
-		/obj/item/handcuffs,
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency
-	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/combat)
 	armor = list(
 		melee = ARMOR_MELEE_MAJOR,
 		bullet = ARMOR_BALLISTIC_PISTOL,
@@ -105,12 +96,8 @@
 	w_class = ITEM_SIZE_NORMAL
 	item_flags = null
 	allowed = list(
-		/obj/item/device/flashlight,
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
 		/obj/item/toy
-	)
+		)
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS|HANDS|LEGS|FEET
 
@@ -484,6 +471,7 @@
 	icon_state = "hospitalgown"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	allowed = null
+	singleton/shared_list/path/storage = null
 
 /obj/item/clothing/suit/hospital/blue
 	color = "#99ccff"

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -77,7 +77,12 @@
 		)
 	action_button_name = "Toggle Winter Hood"
 	hoodtype = /obj/item/clothing/head/winterhood
-	allowed = list (/obj/item/pen, /obj/item/paper, /obj/item/device/flashlight,/obj/item/storage/fancy/smokable, /obj/item/storage/fancy/matches, /obj/item/reagent_containers/food/drinks/flask)
+	allowed = list (
+		/obj/item/storage/fancy/smokable,
+		/obj/item/storage/fancy/matches,
+		/obj/item/reagent_containers/food/drinks/flask
+		)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency)
 	siemens_coefficient = 0.6
 
 /obj/item/clothing/head/winterhood

--- a/code/modules/clothing/suits/utility.dm
+++ b/code/modules/clothing/suits/utility.dm
@@ -22,14 +22,11 @@
 	body_parts_covered = UPPER_TORSO | LOWER_TORSO| ARMS
 	armor = list(laser = ARMOR_LASER_MINOR, energy = ARMOR_ENERGY_MINOR, bomb = ARMOR_BOMB_MINOR)
 	allowed = list(
-		/obj/item/device/flashlight,
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
 		/obj/item/extinguisher,
 		/obj/item/crowbar/emergency_forcing_tool,
 		/obj/item/clothing/head
-	)
+		)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency)
 
 	gas_transfer_coefficient = 0.90
 	permeability_coefficient = 0.50
@@ -101,6 +98,9 @@
 	item_flags = null
 	max_heat_protection_temperature = ARMOR_MAX_HEAT_PROTECTION_TEMPERATURE
 	siemens_coefficient = 0
+	allowed = list(
+		/obj/item/clothing/head/bomb_hood
+		)
 
 /obj/item/clothing/suit/bomb_suit/Initialize()
 	. = ..()
@@ -112,8 +112,8 @@
 
 /obj/item/clothing/suit/bomb_suit/security
 	icon_state = "bombsuitsec"
-	allowed = list(/obj/item/gun/energy,/obj/item/melee/baton,/obj/item/handcuffs)
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|FEET|ARMS|HANDS
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/security)
 
 /*
  * Radiation protection
@@ -141,14 +141,10 @@
 	permeability_coefficient = 0.50
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS|HANDS|FEET
 	allowed = list(
-		/obj/item/device/flashlight,
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
 		/obj/item/clothing/head/radiation,
-		/obj/item/clothing/mask/gas,
-		/obj/item/device/geiger
-	)
+		/obj/item/clothing/mask/gas
+		)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/engineering)
 	armor = list(
 		bio = ARMOR_BIO_RESISTANT,
 		rad = ARMOR_RAD_SHIELDED

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -103,7 +103,6 @@
 	icon = 'icons/obj/weapons/ammo.dmi'
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	slot_flags = SLOT_BELT
-	item_state = "syringe_kit"
 	matter = list(MATERIAL_STEEL = 500)
 	throwforce = 5
 	w_class = ITEM_SIZE_SMALL

--- a/code/modules/skrell/skrell_rigs.dm
+++ b/code/modules/skrell/skrell_rigs.dm
@@ -8,13 +8,7 @@
 	sprite_sheets = list(
 		SPECIES_SKRELL = 'icons/mob/species/skrell/onmob_chest_rig_skrell.dmi'
 	)
-	allowed = list(
-		/obj/item/gun,
-		/obj/item/ammo_magazine,
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/device/suit_cooling_unit
-	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/combat)
 
 /obj/item/clothing/head/helmet/space/rig/ert/skrell
 	name = "skrellian recon hardsuit helmet"

--- a/code/modules/xenoarcheaology/tools/equipment.dm
+++ b/code/modules/xenoarcheaology/tools/equipment.dm
@@ -31,7 +31,11 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 	)
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/stack/flag,/obj/item/storage/excavation,/obj/item/pickaxe,/obj/item/device/scanner/health,/obj/item/device/measuring_tape,/obj/item/device/ano_scanner,/obj/item/device/depth_scanner,/obj/item/device/core_sampler,/obj/item/device/gps,/obj/item/pinpointer/radio,/obj/item/pickaxe/xeno,/obj/item/storage/bag/fossils)
+	allowed = list(
+		/obj/item/stack/flag,
+		/obj/item/pickaxe
+		)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/science)
 
 /obj/item/clothing/head/helmet/space/void/excavation
 	name = "excavation voidsuit helmet"

--- a/code/modules/xenoarcheaology/tools/tools.dm
+++ b/code/modules/xenoarcheaology/tools/tools.dm
@@ -13,7 +13,6 @@
 	icon = 'icons/obj/mining_satchel.dmi'
 	icon_state = "satchel"
 	slot_flags = SLOT_BELT | SLOT_POCKET
-	w_class = ITEM_SIZE_NORMAL
 	storage_slots = 50
 	max_storage_space = 200
 	max_w_class = ITEM_SIZE_NORMAL

--- a/maps/torch/items/clothing/solgov-suit.dm
+++ b/maps/torch/items/clothing/solgov-suit.dm
@@ -2,6 +2,7 @@
 	abstract_type = /obj/item/clothing/suit/solgov
 	name = "master solgov suit"
 	icon = 'maps/torch/icons/obj/obj_suit_solgov.dmi'
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/bureaucracy)
 	item_icons = list(slot_wear_suit_str = 'maps/torch/icons/mob/onmob_suit_solgov.dmi')
 	sprite_sheets = list(
 		SPECIES_UNATHI = 'maps/torch/icons/mob/unathi/onmob_suit_solgov_unathi.dmi'
@@ -11,6 +12,7 @@
 /obj/item/clothing/suit/storage/solgov
 	abstract_type = /obj/item/clothing/suit/storage/solgov
 	name = "master solgov suit with pockets"
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/bureaucracy)
 	icon = 'maps/torch/icons/obj/obj_suit_solgov.dmi'
 	item_icons = list(slot_wear_suit_str = 'maps/torch/icons/mob/onmob_suit_solgov.dmi')
 	sprite_sheets = list(
@@ -26,21 +28,6 @@
 	icon_state = "blackservice"
 	body_parts_covered = UPPER_TORSO|ARMS
 	siemens_coefficient = 0.9
-	allowed = list(
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
-		/obj/item/device/flashlight,
-		/obj/item/pen,
-		/obj/item/clothing/head/soft,
-		/obj/item/clothing/head/beret,
-		/obj/item/storage/fancy/smokable,
-		/obj/item/flame/lighter,
-		/obj/item/device/taperecorder,
-		/obj/item/device/scanner/gas,
-		/obj/item/device/radio,
-		/obj/item/taperoll
-	)
 	valid_accessory_slots = list(
 		ACCESSORY_SLOT_ARMBAND,
 		ACCESSORY_SLOT_MEDAL,
@@ -279,16 +266,7 @@
 	item_icons = list(slot_wear_suit_str = 'maps/torch/icons/mob/onmob_suit_solgov.dmi')
 	body_parts_covered = UPPER_TORSO|ARMS
 	siemens_coefficient = 0.9
-	allowed = list(
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
-		/obj/item/device/flashlight,
-		/obj/item/clothing/head/soft,
-		/obj/item/clothing/head/beret,
-		/obj/item/device/radio,
-		/obj/item/pen
-	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/bureaucracy)
 	valid_accessory_slots = list(ACCESSORY_SLOT_MEDAL,ACCESSORY_SLOT_RANK,ACCESSORY_SLOT_INSIGNIA)
 
 /obj/item/clothing/suit/dress/solgov/fleet/sailor
@@ -306,6 +284,7 @@
 	icon = 'maps/torch/icons/obj/obj_suit_solgov.dmi'
 	item_icons = list(slot_wear_suit_str = 'maps/torch/icons/mob/onmob_suit_solgov.dmi')
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA,ACCESSORY_SLOT_RANK)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/bureaucracy)
 
 
 /obj/item/clothing/suit/storage/hooded/wintercoat/solgov/fleet
@@ -322,32 +301,10 @@
 	item_icons = list(slot_wear_suit_str = 'maps/torch/icons/mob/onmob_suit_solgov.dmi')
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA,ACCESSORY_SLOT_RANK)
 	allowed = list (
-		/obj/item/pen,
-		/obj/item/clothing/head/soft,
-		/obj/item/clothing/head/beret,
-		/obj/item/storage/fancy/smokable,
-		/obj/item/flame/lighter,
-		/obj/item/device/taperecorder,
-		/obj/item/device/scanner/gas,
-		/obj/item/device/radio,
-		/obj/item/taperoll,
-		/obj/item/device/scanner/gas,
-		/obj/item/device/flashlight,
-		/obj/item/device/multitool,
-		/obj/item/device/radio,
-		/obj/item/device/t_scanner,
-		/obj/item/crowbar,
-		/obj/item/screwdriver,
-		/obj/item/weldingtool,
-		/obj/item/wirecutters,
-		/obj/item/wrench,
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
 		/obj/item/clothing/mask/gas,
-		/obj/item/taperoll/engineering,
 		/obj/item/clothing/head/hardhat
-	)
+		)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/bureaucracy, /singleton/shared_list/path/storage/engineering)
 
 /obj/item/clothing/suit/storage/jacket/solgov/fleet/medical
 	name = "fleet jacket"
@@ -355,122 +312,37 @@
 	icon_state = "navymedjacket"
 	item_state = "navymedjacket"
 	allowed = list (
-		/obj/item/pen,
-		/obj/item/clothing/head/soft,
-		/obj/item/clothing/head/beret,
-		/obj/item/storage/fancy/smokable,
-		/obj/item/flame/lighter,
-		/obj/item/device/taperecorder,
-		/obj/item/device/scanner/gas,
-		/obj/item/device/radio,
-		/obj/item/taperoll,
-		/obj/item/stack/medical,
-		/obj/item/reagent_containers/dropper,
-		/obj/item/reagent_containers/hypospray,
-		/obj/item/reagent_containers/syringe,
-		/obj/item/device/scanner/health,
-		/obj/item/device/flashlight,
-		/obj/item/device/radio,
 		/obj/item/clothing/head/hardhat,
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
-		/obj/item/reagent_containers/ivbag
-	)
+		)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/bureaucracy, /singleton/shared_list/path/storage/medical)
 
 /obj/item/clothing/suit/storage/jacket/solgov/fleet/security
 	name = "fleet jacket"
 	desc = "A jacket commonly issued by the fleet to its security staff. It sports some discrete red markings, and has elbow pads."
 	icon_state = "navysecjacket"
 	item_state = "navysecjacket"
-	allowed = list (
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
-		/obj/item/device/flashlight,
-		/obj/item/pen,
-		/obj/item/clothing/head/soft,
-		/obj/item/clothing/head/beret,
-		/obj/item/storage/fancy/smokable,
-		/obj/item/flame/lighter,
-		/obj/item/device/taperecorder,
-		/obj/item/device/scanner/gas,
-		/obj/item/device/radio,
-		/obj/item/taperoll,
-		/obj/item/gun/energy,
-		/obj/item/device/radio,
-		/obj/item/reagent_containers/spray/pepper,
-		/obj/item/gun/projectile,
-		/obj/item/ammo_magazine,
-		/obj/item/ammo_casing,
-		/obj/item/melee/baton,
-		/obj/item/handcuffs,
-		/obj/item/gun/magnetic,
-		/obj/item/clothing/head/helmet
-	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/bureaucracy, /singleton/shared_list/path/storage/security)
 
 /obj/item/clothing/suit/storage/jacket/solgov/fleet/service
 	name = "fleet jacket"
 	desc = "A jacket commonly issued by the fleet to its service staff. It sports some discrete green markings."
 	icon_state = "navysrvjacket"
 	item_state = "navysrvjacket"
-	allowed = list (
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
-		/obj/item/device/flashlight,
-		/obj/item/pen,
-		/obj/item/clothing/head/soft,
-		/obj/item/clothing/head/beret,
-		/obj/item/storage/fancy/smokable,
-		/obj/item/flame/lighter,
-		/obj/item/device/taperecorder,
-		/obj/item/device/scanner/gas,
-		/obj/item/device/radio,
-		/obj/item/taperoll
-	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/bureaucracy)
 
 /obj/item/clothing/suit/storage/jacket/solgov/fleet/supply
 	name = "fleet jacket"
 	desc = "A jacket commonly issued by the fleet to its deck staff. It sports some discrete brown markings, and has elbow pads."
 	icon_state = "navysupjacket"
 	item_state = "navysupjacket"
-	allowed = list (
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
-		/obj/item/device/flashlight,
-		/obj/item/pen,
-		/obj/item/clothing/head/soft,
-		/obj/item/clothing/head/beret,
-		/obj/item/storage/fancy/smokable,
-		/obj/item/flame/lighter,
-		/obj/item/device/taperecorder,
-		/obj/item/device/scanner/gas,
-		/obj/item/device/radio,
-		/obj/item/taperoll
-	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/bureaucracy)
 
 /obj/item/clothing/suit/storage/jacket/solgov/fleet/command
 	name = "fleet jacket"
 	desc = "A jacket commonly issued by the fleet to its command staff. It sports some gold markings."
 	icon_state = "navycomjacket"
 	item_state = "navycomjacket"
-	allowed = list (
-		/obj/item/tank/oxygen_emergency,
-		/obj/item/tank/oxygen_emergency_extended,
-		/obj/item/tank/nitrogen_emergency,
-		/obj/item/device/flashlight,
-		/obj/item/pen,
-		/obj/item/clothing/head/soft,
-		/obj/item/clothing/head/beret,
-		/obj/item/storage/fancy/smokable,
-		/obj/item/flame/lighter,
-		/obj/item/device/taperecorder,
-		/obj/item/device/scanner/gas,
-		/obj/item/device/radio,
-		/obj/item/taperoll
-	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/bureaucracy)
 
 //SolGov Hardsuits
 
@@ -557,7 +429,6 @@
 		SPECIES_UNATHI = 'maps/torch/icons/obj/unathi/obj_suit_solgov_unathi.dmi',
 		SPECIES_SKRELL = 'maps/torch/icons/obj/skrell/obj_suit_solgov_skrell.dmi',
 		)
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/storage/briefcase/inflatable)
 
 /obj/item/clothing/suit/space/void/command/Initialize()
 	. = ..()
@@ -592,7 +463,12 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT
 		)
-	allowed = list(/obj/item/device/flashlight,/obj/item/tank,/obj/item/device/suit_cooling_unit,/obj/item/stack/flag,/obj/item/device/scanner/health,/obj/item/device/gps,/obj/item/pinpointer/radio,/obj/item/material/hatchet/machete,/obj/item/shovel)
+	allowed = list(
+		/obj/item/stack/flag,
+		/obj/item/material/hatchet/machete,
+		/obj/item/shovel
+		)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/science)
 
 /obj/item/clothing/suit/space/void/exploration/prepared
 	helmet = /obj/item/clothing/head/helmet/space/void/exploration

--- a/maps/torch/items/rigs.dm
+++ b/maps/torch/items/rigs.dm
@@ -42,13 +42,9 @@
 	item_icons = list(slot_wear_suit_str = 'maps/torch/icons/mob/onmob_suit_solgov.dmi')
 	species_restricted = list(SPECIES_HUMAN,SPECIES_IPC)
 	allowed = list(
-		/obj/item/gun,
-		/obj/item/ammo_magazine,
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/device/suit_cooling_unit,
 		/obj/item/storage/secure/briefcase
-	)
+		)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/combat, /singleton/shared_list/path/storage/bureaucracy)
 
 /obj/item/clothing/shoes/magboots/rig/command
 	icon = 'maps/torch/icons/obj/obj_feet_solgov.dmi'
@@ -179,16 +175,10 @@
 /obj/item/clothing/suit/space/rig/command/medical
 	icon_state = "command_med_rig"
 	allowed = list(
-		/obj/item/gun,
-		/obj/item/ammo_magazine,
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/device/suit_cooling_unit,
 		/obj/item/storage/firstaid,
-		/obj/item/device/scanner/health,
-		/obj/item/stack/medical,
 		/obj/item/roller_bed
 	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/combat, /singleton/shared_list/path/storage/medical)
 /obj/item/clothing/shoes/magboots/rig/command/medical
 /obj/item/clothing/gloves/rig/command/medical
 
@@ -231,15 +221,7 @@
 	icon_state = "command_sec_rig"
 /obj/item/clothing/suit/space/rig/command/security
 	icon_state = "command_sec_rig"
-	allowed = list(
-		/obj/item/gun,
-		/obj/item/ammo_magazine,
-		/obj/item/handcuffs,
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/device/suit_cooling_unit,
-		/obj/item/melee/baton
-	)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/security, /singleton/shared_list/path/storage/combat)
 /obj/item/clothing/shoes/magboots/rig/command/security
 /obj/item/clothing/gloves/rig/command/security
 
@@ -283,23 +265,10 @@
 /obj/item/clothing/suit/space/rig/command/science
 	icon_state = "command_sci_rig"
 	allowed = list(
-		/obj/item/gun,
-		/obj/item/ammo_magazine,
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/device/suit_cooling_unit,
 		/obj/item/stack/flag,
-		/obj/item/storage/excavation,
-		/obj/item/device/scanner/health,
-		/obj/item/device/measuring_tape,
-		/obj/item/device/ano_scanner,
-		/obj/item/device/depth_scanner,
-		/obj/item/device/core_sampler,
-		/obj/item/device/gps,
-		/obj/item/pinpointer/radio,
-		/obj/item/pickaxe,
-		/obj/item/storage/bag/fossils
-	)
+		/obj/item/pickaxe
+		)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/combat, /singleton/shared_list/path/storage/science)
 
 /obj/item/clothing/shoes/magboots/rig/command/science
 /obj/item/clothing/gloves/rig/command/science
@@ -356,19 +325,10 @@
 /obj/item/clothing/suit/space/rig/command/exploration
 	icon_state = "command_exp_rig"
 	allowed = list(
-		/obj/item/gun,
-		/obj/item/ammo_magazine,
-		/obj/item/device/flashlight,
-		/obj/item/tank,
-		/obj/item/device/suit_cooling_unit,
 		/obj/item/stack/flag,
-		/obj/item/storage/excavation,
-		/obj/item/device/scanner,
-		/obj/item/device/depth_scanner,
-		/obj/item/device/gps,
-		/obj/item/pinpointer/radio,
-		/obj/item/storage/plants
-	)
+		/obj/item/pickaxe
+		)
+	singleton/shared_list/path/storage = list(/singleton/shared_list/path/storage/emergency, /singleton/shared_list/path/storage/eva, /singleton/shared_list/path/storage/combat, /singleton/shared_list/path/storage/science)
 
 /obj/item/rig/exploration/equipped
 	initial_modules = list(


### PR DESCRIPTION
Okay, so, this literally came to me in a dream last night, I woke up at 2AM with the idea to rework the suit storage system.
So I did.

Things this does **not** change:
- The pocket slots
- The inner pockets of your suit
- Jumpsuits
- Belts

Previously, suit items - for clarity, I mean oversuits like labcoats, hazard vests and voidsuits, not jumpsuit items - used manual whitelisting and inheritance for every suit. If you wanted a labcoat to be able to hold a pill bottle, you had to manually add it to the labcoat storage list... and also the EMT jacket storage list, and the medical chest rig storage list, because we've got _so_ many reskins and similar items for basically everything and half of them don't use inheritance for various reasons.

Anyway, it's a pain in the ass when you're adding new items and it's really easy to forget 'wait, should this fit on that?', and from a player perspective, it's completely arbitrary and unintuitive what should fit on where. You kinda just learn to accept it.

BUT NO MORE!

We're keeping the old system for very specific items (cult robes, for example, can accept cult swords and cult tomes), but _most_ suits have been reworked to use **storage flags** instead. There's eight overall.

- **Emergency**: the default list, that nearly every suit has access to. Small tanks (SCBA and emergency), flashlights and radios. Be very careful when adding something to this list.
- **Bureaucracy**: paperwork/roleplay stuff like papers, stamps, and tape recorders. Also includes forensic gear like evidence markers.
- **Engineering**: if it can fit on a toolbelt, it's probably in this category. Again, remember that these flags determine what goes in _generic engineering suit storage_, so don't give this to a RCD or inflatables dispenser.
- **Medical**: see above, but for medical gear. For the same reason as above, we're not giving this flag to roller beds or first-aid kits, or you'd be able to put them on your labcoat, which is a little absurd.
- **Science**: if it's used for xenoarchaeology, xenobotany, exploration or vague science-related shenanigans, it's probably in here. This is the most varied of the groups. 
- **Security**: defensive and less-lethal combat gear, as well as RP security equipment like hailers and warrant projectors. This is not for guns and grenades! 
- **Combat**: guns and grenades. There's a few things that overlap with the Security category here (batons and handcuffs). Exclusively used by armor and armored spacesuits.
- **EVA**: anything that should be used with a voidsuit or RIG suit, like jetpacks, suit cooling units, large oxygen tanks, and inflatables dispensers. This does _not_ apply to emergency softsuits.

The **actual gameplay effect** of this is fairly minimal - it's mostly things like being able to wear your tape recorder on your snazzy suit jacket, or . The real genius is how this allows for creating new items and then assigning them storage flags for a much more reliable and intuitive system.

That being said, it _probably needs a balance pass_ and it _touches a hell of a lot of files_, so it probably merits discussion beyond just a code review.

:cl: TheNightingale
tweak: Reworks the suit storage system to use broad categories of items rather than requiring individual item whitelists. See PR 34256 for further details.
/:cl: