### PR TITLE
add verb for deleting crew records

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -99,7 +99,8 @@ var/global/list/admin_verbs_admin = list(
 	/client/proc/cmd_admin_notarget,
 	/datum/admins/proc/setroundlength,
 	/datum/admins/proc/toggleroundendvote,
-	/datum/admins/proc/togglemoderequirementchecks
+	/datum/admins/proc/togglemoderequirementchecks,
+	/client/proc/delete_crew_record
 )
 var/global/list/admin_verbs_ban = list(
 	/client/proc/unban_panel,
@@ -901,3 +902,28 @@ var/global/list/admin_verbs_mod = list(
 	if(!S) return
 	T.add_spell(new S)
 	log_and_message_admins("gave [key_name(T)] the spell [S].")
+
+/client/proc/delete_crew_record()
+	set category = "Admin"
+	set name = "Delete Crew Record"
+	set desc = "Delete a crew record from the global crew list."
+
+	var/list/entries = list()
+
+	for (var/datum/computer_file/report/crew_record/entry in GLOB.all_crew_records)
+		entries["[entry.get_name()], [entry.get_job()]"] = entry
+
+	if (!length(entries))
+		return
+
+	var/choice = input("Pick a record to delete:", "Delete Crew Record") as null | anything in entries
+
+	if (!choice)
+		return
+
+	var/check = alert("Are you sure you want to delete [choice]?", "Delete Record?", "Yes", "No")
+	var/datum/computer_file/report/crew_record/record = entries[choice]
+
+	if (check == "Yes")
+		GLOB.all_crew_records.Remove(record)
+		log_and_message_admins("has removed [record.get_name()], [record.get_job()]'s crew record.")

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -131,8 +131,14 @@ GLOBAL_VAR_INIT(arrest_security_status, "Arrest")
 // Used by character creation to create a record for new arrivals.
 /proc/CreateModularRecord(mob/living/carbon/human/H)
 	var/datum/computer_file/report/crew_record/CR = new/datum/computer_file/report/crew_record()
-	GLOB.all_crew_records.Add(CR)
 	CR.load_from_mob(H)
+
+	//ensure we don't get duplicated records
+	for (var/datum/computer_file/report/crew_record/record as anything in GLOB.all_crew_records)
+		if ((CR.get_name() == record.get_name()))
+			qdel(record)
+
+	GLOB.all_crew_records.Add(CR)
 	return CR
 
 // Gets crew records filtered by set of positions


### PR DESCRIPTION
:cl: Mucker
admin: Added a command for removing crew records permanently.
tweak: Crew records (should) no longer duplicate under certain circumstances.
/:cl:

figure we needed something to get rid of the people who join with meme-names, or worse