### PR TITLE
Adjust info, notice, warning, danger, subtle colors

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -185,8 +185,6 @@
 
 #define SPAN_WARNING(X) SPAN_CLASS("warning", "[X]")
 
-#define SPAN_SUCCESS(X) SPAN_CLASS("success", "[X]")
-
 #define SPAN_GOOD(X) SPAN_CLASS("good", "[X]")
 
 #define SPAN_BAD(X) SPAN_CLASS("bad", "[X]")

--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -185,6 +185,8 @@
 
 #define SPAN_WARNING(X) SPAN_CLASS("warning", "[X]")
 
+#define SPAN_SUCCESS(X) SPAN_CLASS("success", "[X]")
+
 #define SPAN_GOOD(X) SPAN_CLASS("good", "[X]")
 
 #define SPAN_BAD(X) SPAN_CLASS("bad", "[X]")

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -339,7 +339,6 @@ h1.alert, h2.alert		{color: #a4bad6;}
 .notice					{color: #327fd1;}
 .alium					{color: #00ff00;}
 .cult					{color: #aa1c1c;}
-.success				{color: #28a745;}
 .legion					{color: #e09000; font-weight: bold; font-family: 'Courier New', Courier, monospace}
 
 /* Languages */

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -334,7 +334,7 @@ h1.alert, h2.alert		{color: #a4bad6;}
 .subtle					{color: #808991; font-style: italic;}
 .boldannounce			{color: #c51e1e;	font-weight: bold;}
 .rose					{color: #ff5050;}
-.info					{color: #1dc9e4; font-style: italic;}
+.info					{color: #b13ef3; font-style: italic;}
 .debug					{color: #ff66ff;}
 .notice					{color: #327fd1;}
 .alium					{color: #00ff00;}

--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -329,16 +329,17 @@ h1.alert, h2.alert		{color: #a4bad6;}
 .disarm					{color: #990000;}
 .passive				{color: #660000;}
 
-.danger					{color: #c51e1e;}
-.warning				{color: #c51e1e;	font-style: italic;}
-.subtle					{color: #4343ca; font-size: 75%; font-style: italic;}
+.danger					{color: #f73e50; font-weight: bold;}
+.warning				{color: #f58e09; font-weight: bold; font-style: italic;}
+.subtle					{color: #808991; font-style: italic;}
 .boldannounce			{color: #c51e1e;	font-weight: bold;}
 .rose					{color: #ff5050;}
-.info					{color: #6685f5;}
+.info					{color: #1dc9e4; font-style: italic;}
 .debug					{color: #ff66ff;}
-.notice					{color: #6685f5;}
+.notice					{color: #327fd1;}
 .alium					{color: #00ff00;}
 .cult					{color: #aa1c1c;}
+.success				{color: #28a745;}
 .legion					{color: #e09000; font-weight: bold; font-family: 'Courier New', Courier, monospace}
 
 /* Languages */

--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -331,7 +331,7 @@ h1.alert, h2.alert		{color: #000080;}
 .subtle					{color: #919ca7; font-style: italic;}
 .boldannounce			{color: #ff0000;	font-weight: bold;}
 .rose					{color: #ff5050;}
-.info					{color: #03bad6; font-style: italic;}
+.info					{color: #9b53c4; font-style: italic;}
 .debug					{color: #ff00ff;}
 .notice					{color: #0d5ef3;}
 .alium					{color: #00ff00;}

--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -336,7 +336,6 @@ h1.alert, h2.alert		{color: #000080;}
 .notice					{color: #0d5ef3;}
 .alium					{color: #00ff00;}
 .cult					{color: #800080; font-weight: bold; font-style: italic;}
-.success				{color: #28a745;}
 .legion					{color: #e09000; font-weight: bold; font-family: 'Courier New', Courier, monospace}
 
 /* Languages */

--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -326,16 +326,17 @@ h1.alert, h2.alert		{color: #000080;}
 .disarm					{color: #990000;}
 .passive				{color: #660000;}
 
-.danger					{color: #ff0000;}
-.warning				{color: #ff0000;	font-style: italic;}
-.subtle					{color: #000099; font-size: 75%; font-style: italic;}
+.danger					{color: #dc3545; font-weight: bold;}
+.warning				{color: #cc7606; font-weight: bold; font-style: italic;}
+.subtle					{color: #919ca7; font-style: italic;}
 .boldannounce			{color: #ff0000;	font-weight: bold;}
 .rose					{color: #ff5050;}
-.info					{color: #0000CC;}
+.info					{color: #03bad6; font-style: italic;}
 .debug					{color: #ff00ff;}
-.notice					{color: #000099;}
+.notice					{color: #0d5ef3;}
 .alium					{color: #00ff00;}
 .cult					{color: #800080; font-weight: bold; font-style: italic;}
+.success				{color: #28a745;}
 .legion					{color: #e09000; font-weight: bold; font-family: 'Courier New', Courier, monospace}
 
 /* Languages */

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -91,7 +91,7 @@ h1.alert, h2.alert		{color: #000080;}
 .bigwarning				{color: #cc7606; font-weight: bold; font-style: italic; font-size: 115%;}
 .boldannounce			{color: #ff0000; font-weight: bold;}
 .rose					{color: #ff5050;}
-.info					{color: #03bad6; font-style: italic;}
+.info					{color: #9b53c4; font-style: italic;}
 .debug					{color: #ff00ff;}
 .notice					{color: #0d5ef3;}
 .subtle					{color: #919ca7; font-style: italic;}

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -100,7 +100,6 @@ h1.alert, h2.alert		{color: #000080;}
 .cultannounce			{color: #800080; font-style: italic; font-size: 175%;}
 .mfauna					{color: #884422; font-weight: bold; font-size: 125%;}
 .antagdesc				{color: #ff0033; font-size: 125%}
-.success				{color: #28a745;}
 .legion					{color: #e09000; font-weight: bold; font-family: 'Courier New', Courier, monospace}
 
 .reflex_shoot			{color: #000099; font-style: italic;}

--- a/code/stylesheet.dm
+++ b/code/stylesheet.dm
@@ -85,21 +85,22 @@ h1.alert, h2.alert		{color: #000080;}
 
 .italic				{font-style: italic;}
 .bold					{font-weight: bold;}
-.danger					{color: #ff0000; font-weight: bold;}
-.bigdanger					{color: #ff0000; font-weight: bold; font-size: 115%;}
-.warning				{color: #ff0000; font-style: italic;}
-.bigwarning				{color: #ff0000; font-style: italic; font-size: 115%;}
+.danger					{color: #dc3545; font-weight: bold;}
+.bigdanger				{color: #dc3545; font-weight: bold; font-size: 115%;}
+.warning				{color: #cc7606; font-weight: bold; font-style: italic;}
+.bigwarning				{color: #cc7606; font-weight: bold; font-style: italic; font-size: 115%;}
 .boldannounce			{color: #ff0000; font-weight: bold;}
 .rose					{color: #ff5050;}
-.info					{color: #0000cc;}
+.info					{color: #03bad6; font-style: italic;}
 .debug					{color: #ff00ff;}
-.notice					{color: #000099;}
-.subtle					{color: #000099; font-size: 75%; font-style: italic;}
+.notice					{color: #0d5ef3;}
+.subtle					{color: #919ca7; font-style: italic;}
 .alium					{color: #00ff00;}
 .cult					{color: #800080; font-weight: bold; font-style: italic;}
 .cultannounce			{color: #800080; font-style: italic; font-size: 175%;}
 .mfauna					{color: #884422; font-weight: bold; font-size: 125%;}
 .antagdesc				{color: #ff0033; font-size: 125%}
+.success				{color: #28a745;}
 .legion					{color: #e09000; font-weight: bold; font-family: 'Courier New', Courier, monospace}
 
 .reflex_shoot			{color: #000099; font-style: italic;}


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
tweak: Colors used for certain types of in-chat messages have been adjusted. Primarily, there is now a different in color between warning (red -> orange bold italic) and danger (red bold), and notice (blue), info (blue -> purple), and subtle (blue -> gray italic).
/:cl:

Comparison of old to new colors:

![Code_x1kB0uEzZT](https://github.com/Baystation12/Baystation12/assets/11140088/00d85352-656b-4bfc-971c-d4ca220c8220)

New colors with color blindness simulations:

![ColourSimulations_x64_UccapZp1we](https://github.com/Baystation12/Baystation12/assets/11140088/889ee927-5c09-46e5-86b0-6e11f5e5f6a2)

![ColourSimulations_x64_zt2HTNx93e](https://github.com/Baystation12/Baystation12/assets/11140088/7f318bb5-ee12-4f72-a007-3e052d3ebde6)
