### PR TITLE
Closets/Crates are now puncheable

### DIFF
--- a/code/game/antagonist/outsider/vox.dm
+++ b/code/game/antagonist/outsider/vox.dm
@@ -93,7 +93,6 @@ GLOBAL_LIST_EMPTY(vox_artifact_spawners)
 	desc = "A pulsating mass of flesh and steel."
 	icon = 'maps/antag_spawn/vox/vox.dmi'
 	icon_state = "printer"
-	breakable = FALSE
 	anchored = TRUE
 	density = TRUE
 	var/favors = 0
@@ -269,7 +268,6 @@ GLOBAL_LIST_EMPTY(vox_artifact_spawners)
 	desc = "An old, dusty machine meant to analyze various bluespace anomalies and send research data directly to SCGEC Observatory."
 	icon = 'icons/obj/machines/research/xenoarcheology_scanner.dmi'
 	icon_state = "scanner"
-	breakable = FALSE
 	anchored = FALSE
 	density = TRUE
 	var/points = 0

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -236,7 +236,7 @@
 // If you don't call parent in this proc, you must make all appropriate checks yourself.
 // If you do, you must respect the return value.
 /obj/machinery/attack_hand(mob/user)
-	if((. = ..())) // Buckling, climbers, punching on harm; unlikely to return true.
+	if((. = ..())) // Buckling, climbers; unlikely to return true unless on harm intent and damage is dealt.
 		return
 	if(!CanPhysicallyInteract(user))
 		return FALSE // The interactions below all assume physical access to the machine. If this is not the case, we let the machine take further action.

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -242,6 +242,9 @@
 
 
 /obj/attack_hand(mob/living/user)
+	. = ..()
+	if (.)
+		return
 	if (Adjacent(user))
 		add_fingerprint(user)
 
@@ -276,7 +279,6 @@
 				)
 		damage_health(damage, attack.get_damage_type(), attack.damage_flags())
 		return TRUE
-	..()
 
 /obj/is_fluid_pushable(amt)
 	return ..() && w_class <= round(amt/20)

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -3,7 +3,7 @@
 	w_class = ITEM_SIZE_NO_CONTAINER
 	layer = STRUCTURE_LAYER
 
-	var/breakable
+	var/fragile
 	var/parts
 	var/list/connections = list("0", "0", "0", "0")
 	var/list/other_connections = list("0", "0", "0", "0")
@@ -16,7 +16,7 @@
 
 /obj/structure/damage_health(damage, damage_type, damage_flags, severity, skip_can_damage_check)
 	if (damage && HAS_FLAGS(damage_flags, DAMAGE_FLAG_TURF_BREAKER))
-		if (breakable)
+		if (fragile)
 			return kill_health()
 		damage = max(damage, 10)
 	..()
@@ -117,6 +117,15 @@
 
 	return ..()
 
+/obj/structure/proc/dump_contents()
+	for(var/mob/M in src)
+		M.dropInto(loc)
+		if(M.client)
+			M.client.eye = M.client.mob
+			M.client.perspective = MOB_PERSPECTIVE
+
+	for(var/atom/movable/AM in src)
+		AM.dropInto(loc)
 
 /obj/structure/proc/can_visually_connect()
 	return anchored

--- a/code/game/objects/structures/crates_lockers/closets/secure/_secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/_secure_closets.dm
@@ -6,6 +6,7 @@
 	setup = CLOSET_HAS_LOCK | CLOSET_CAN_BE_WELDED
 	locked = TRUE
 	health_max = 200
+	health_min_damage = 5
 
 /obj/structure/closet/secure_closet/slice_into_parts(obj/item/weldingtool/WT, mob/user)
 	to_chat(user, SPAN_NOTICE("\The [src] is too strong to be taken apart."))

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -90,6 +90,8 @@
 	closet_appearance = /singleton/closet_appearance/crate/secure
 	setup = CLOSET_HAS_LOCK
 	locked = TRUE
+	health_max = 200
+	health_min_damage = 5
 
 /obj/structure/closet/crate/secure/Initialize()
 	. = ..()

--- a/code/game/objects/structures/crates_lockers/largecrate.dm
+++ b/code/game/objects/structures/crates_lockers/largecrate.dm
@@ -5,6 +5,8 @@
 	icon_state = "densecrate"
 	density = TRUE
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_CLIMBABLE
+	health_max = 100
+	health_min_damage = 4
 
 /obj/structure/largecrate/Initialize()
 	. = ..()
@@ -14,17 +16,16 @@
 		I.forceMove(src)
 
 /obj/structure/largecrate/attack_hand(mob/user as mob)
+	if (user.a_intent == I_HURT)
+		return ..()
 	to_chat(user, SPAN_NOTICE("You need a crowbar to pry this open!"))
-	return
-
 
 /obj/structure/largecrate/use_tool(obj/item/tool, mob/user, list/click_params)
 	// Crowbar - Open crate
 	if (isCrowbar(tool))
 		var/obj/item/stack/material/wood/A = new(loc)
 		transfer_fingerprints_to(A)
-		for (var/atom/movable/item as anything in contents)
-			item.dropInto(loc)
+		dump_contents()
 		user.visible_message(
 			SPAN_NOTICE("\The [user] pries \the [src] open with \a [tool]."),
 			SPAN_NOTICE("You pry \the [src] open with \the [tool]."),
@@ -35,6 +36,11 @@
 
 	return ..()
 
+/obj/structure/largecrate/on_death()
+	var/obj/item/stack/material/wood/A = new(loc)
+	transfer_fingerprints_to(A)
+	dump_contents()
+	qdel_self()
 
 /obj/structure/largecrate/mule
 	name = "MULE crate"


### PR DESCRIPTION
🆑 emmanuelbassil
tweak: As part of the damage standardization, can now damage closets/crates with melee attacks.
tweak: Damaging a closet also relays some damage to whatever's inside.
tweak: Secure closets/crates are tougher than regular closets/crates.
/🆑 

I also changed breakable (which is unused at the moment) to become 'fragile'. This var instantly kills a structure if hit by hulk or a turf breaker. 
Technically you *could* punch a closet open, but given for a regular non-hulk; non-clawed human 60% of attacks succeed on regular closets and 20% on secure closets, you're more likely to break your hand angrily punching metal. Also applied this to large crates, which you can now punch or stun baton open.
