### PR TITLE
Fixes pointing at closets

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/__closet.dm
+++ b/code/game/objects/structures/crates_lockers/closets/__closet.dm
@@ -555,10 +555,6 @@
 		return TRUE
 	return ..()
 
-/obj/structure/closet/CtrlAltClick(mob/user)
-	verb_toggleopen()
-	return TRUE
-
 /obj/structure/closet/emp_act(severity)
 	for (var/atom/A as anything in src)
 		A.emp_act(severity)


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: Can now point at closets/crates again
tweak: Ctrl + Alt + Click no longer opens and closes closets. Alt + Click still locks/unlocks as before.
/🆑 