### PR TITLE
Makes storage take priority on use_after

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -352,6 +352,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
  * resolve chain will be called.
  */
 /atom/proc/use_tool(obj/item/tool, mob/living/user, list/click_params)
+	SHOULD_CALL_PARENT(TRUE)
 	return FALSE
 
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -275,9 +275,9 @@
 		R.activate_module(src)
 		R.hud_used.update_robot_modules_display()
 
-/obj/item/attackby(obj/item/W, mob/user)
-	if((. = SSfabrication.try_craft_with(src, W, user)))
-		return
+/obj/item/use_tool(obj/item/W, mob/living/user, list/click_params)
+	if(SSfabrication.try_craft_with(src, W, user))
+		return TRUE
 
 	if(istype(W, /obj/item/storage))
 		var/obj/item/storage/S = W
@@ -285,8 +285,28 @@
 			if(S.collection_mode) //Mode is set to collect all items
 				if(isturf(src.loc))
 					S.gather_all(src.loc, user)
+					return TRUE
 			else if (S.can_be_inserted(src, user))
 				S.handle_item_insertion(src)
+				return TRUE
+	return ..()
+
+///Eventually should be deleted in favor of use_tool; keeping duplicate until downstream attackbys are replaced.
+/obj/item/attackby(obj/item/W, mob/living/user, list/click_params)
+	if(SSfabrication.try_craft_with(src, W, user))
+		return TRUE
+
+	if(istype(W, /obj/item/storage))
+		var/obj/item/storage/S = W
+		if(S.use_to_pickup)
+			if(S.collection_mode) //Mode is set to collect all items
+				if(isturf(src.loc))
+					S.gather_all(src.loc, user)
+					return TRUE
+			else if (S.can_be_inserted(src, user))
+				S.handle_item_insertion(src)
+				return TRUE
+	return ..()
 
 /obj/item/can_embed()
 	if (!canremove)

--- a/code/game/objects/items/devices/scanners/_scanner.dm
+++ b/code/game/objects/items/devices/scanners/_scanner.dm
@@ -36,27 +36,27 @@
 		return
 	return TRUE
 
-/obj/item/device/scanner/afterattack(atom/A, mob/user, proximity)
-	if(!proximity)
-		return
+/obj/item/device/scanner/use_after(atom/target, mob/living/user, click_parameters)
 	if(!can_use(user))
 		return
-	if(is_valid_scan_target(A))
+	if(is_valid_scan_target(target))
 		user.visible_message(
-			SPAN_NOTICE("\The [user] runs \the [src] over \the [A]."),
-			SPAN_NOTICE("You run \the [src] over \the [A]."),
+			SPAN_NOTICE("\The [user] runs \the [src] over \the [target]."),
+			SPAN_NOTICE("You run \the [src] over \the [target]."),
 			range = 2
 		)
 		if(scan_sound)
 			playsound(src, scan_sound, 30)
-		if(use_delay && !do_after(user, use_delay, A, DO_PUBLIC_UNIQUE))
-			to_chat(user, "You stop scanning \the [A] with \the [src].")
-			return
-		scan(A, user)
+		if(use_delay && !do_after(user, use_delay, target, DO_PUBLIC_UNIQUE))
+			to_chat(user, "You stop scanning \the [target] with \the [src].")
+			return TRUE
+		scan(target, user)
 		if(!scan_title)
-			scan_title = "[capitalize(name)] scan - [A]"
+			scan_title = "[capitalize(name)] scan - [target]"
+		return TRUE
 	else
-		to_chat(user, "You cannot get any results from \the [A] with \the [src].")
+		to_chat(user, "You cannot get any results from \the [target] with \the [src].")
+		return TRUE
 
 /obj/item/device/scanner/proc/is_valid_scan_target(atom/O)
 	return FALSE

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -341,6 +341,7 @@
 			if (src && user.machine == src)
 				interact(user)
 		return TRUE
+	return ..()
 
 /**
  * Returns a string forming a basic name of the stack. By default, this is `name`.

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -28,9 +28,9 @@
 	/// Can this backpack be opened while worn on the back?
 	var/worn_access = TRUE
 
-/obj/item/storage/backpack/attackby(obj/item/W as obj, mob/user as mob)
-	if (src.use_sound)
-		playsound(src.loc, src.use_sound, 50, 1, -5)
+/obj/item/storage/backpack/use_tool(obj/item/tool, mob/living/user, list/click_params)
+	if (use_sound)
+		playsound(loc, use_sound, 50, 1, -5)
 	return ..()
 
 /obj/item/storage/backpack/equipped(mob/user, slot)
@@ -73,11 +73,11 @@
 	..()
 	return
 
-/obj/item/storage/backpack/holding/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/storage/backpack/holding/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(istype(W, /obj/item/storage/backpack/holding) || istype(W, /obj/item/storage/bag/trash/bluespace))
 		to_chat(user, SPAN_WARNING("The Bluespace interfaces of the two devices conflict and malfunction."))
 		qdel(W)
-		return 1
+		return TRUE
 	return ..()
 
 	//Please don't clutter the parent storage item with stupid hacks.

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -281,10 +281,9 @@
 	update_icon()
 
 //This proc is called when you want to place an item into the storage item.
-/obj/item/storage/attackby(obj/item/W as obj, mob/user as mob)
-	. = ..()
-	if (.) //if the item was used as a crafting component, just return
-		return
+/obj/item/storage/use_tool(obj/item/W, mob/living/user, list/click_params)
+	if ((. = ..())) //if the item was used as a crafting component, just return
+		return TRUE
 
 	if(isrobot(user) && (W == user.get_active_hand()))
 		return //Robots can't store their modules.
@@ -293,7 +292,23 @@
 		return
 
 	W.add_fingerprint(user)
-	return handle_item_insertion(W)
+	handle_item_insertion(W)
+	return TRUE
+
+///Eventually should be deleted in favor of use_tool; keeping duplicate until downstream attackbys are replaced.
+/obj/item/storage/attackby(obj/item/W, mob/living/user, click_params)
+	if ((. = ..())) //if the item was used as a crafting component, just return
+		return TRUE
+
+	if(isrobot(user) && (W == user.get_active_hand()))
+		return //Robots can't store their modules.
+
+	if(!can_be_inserted(W, user))
+		return
+
+	W.add_fingerprint(user)
+	handle_item_insertion(W)
+	return TRUE
 
 /obj/item/storage/attack_hand(mob/user as mob)
 	if(ishuman(user))

--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -17,15 +17,15 @@
 
 	. = ..()
 
-/obj/item/storage/backpack/weldpack/attackby(obj/item/W as obj, mob/user as mob)
+/obj/item/storage/backpack/weldpack/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(isWelder(W))
 		var/obj/item/weldingtool/T = W
 		if (!T.tank)
 			to_chat(user, SPAN_WARNING("\The [T] has no tank attached!"))
-			return
+			return TRUE
 		if (!T.tank.can_refuel)
 			to_chat(user, SPAN_WARNING("\The [T]'s [T.tank.name] does not have a refuelling port."))
-			return
+			return TRUE
 		if (T.welding)
 			if (user.a_intent == I_HURT)
 				user.visible_message(
@@ -36,30 +36,30 @@
 				explosion(get_turf(src), 4, EX_ACT_HEAVY)
 				if (!QDELETED(src))
 					qdel(src)
-				return
+				return TRUE
 			else
 				to_chat(user, SPAN_WARNING("You need to turn \the [T] off before you can refuel it. Or use harm intent if you're suicidal."))
-				return
+				return TRUE
 		if (!reagents.trans_to_obj(T.tank, T.tank.max_fuel))
 			to_chat(user, SPAN_WARNING("\The [T]'s [T.tank.name] is already full."))
-			return
+			return TRUE
 		to_chat(user, SPAN_NOTICE("You refill \the [T] with \the [src]."))
 		playsound(src, 'sound/effects/refill.ogg', 50, 1, -6)
-		return
+		return TRUE
 
 	else if(istype(W, /obj/item/welder_tank))
 		var/obj/item/welder_tank/tank = W
 		if (!tank.can_refuel)
 			to_chat(user, SPAN_WARNING("\The [tank] does not have a refuelling port."))
-			return
+			return TRUE
 		if (!reagents.trans_to_obj(tank, tank.max_fuel))
 			to_chat(user, SPAN_WARNING("\The [tank] is already full."))
-			return
+			return TRUE
 		to_chat(user, SPAN_NOTICE("You refuel \the [tank] with \the [src]."))
 		playsound(loc, 'sound/effects/refill.ogg', 50, 1, -6)
-		return
+		return TRUE
 
-	..()
+	else return ..()
 
 /obj/item/storage/backpack/weldpack/afterattack(obj/O as obj, mob/user as mob, proximity)
 	if(!proximity) // this replaces and improves the get_dist(src,O) <= 1 checks used previously

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -189,12 +189,11 @@
 	if (damtype == DAMAGE_BURN)
 		. |= DAMAGE_FLAG_LASER
 
-/obj/attackby(obj/item/O, mob/user)
-	if (isWrench(O) && HAS_FLAGS(obj_flags, OBJ_FLAG_ANCHORABLE))
-		wrench_floor_bolts(user, O)
+/obj/use_tool(obj/item/tool, mob/living/user, list/click_params)
+	if (isWrench(tool) && HAS_FLAGS(obj_flags, OBJ_FLAG_ANCHORABLE))
+		wrench_floor_bolts(user, tool)
 		return TRUE
 	return ..()
-
 
 /**
  * Whether or not the object can be anchored in its current state/position. Assumes the anchorable flag has already been checked.

--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -28,6 +28,7 @@ LINEN BINS
 				new /obj/item/reagent_containers/glass/rag(get_turf(src))
 			qdel(src)
 		return TRUE
+	return ..()
 
 /obj/item/bedsheet/blue
 	icon_state = "sheetblue"

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -321,6 +321,7 @@
 				SPAN_NOTICE("You label \the [src]: \"[examtext]\""),\
 				"You hear someone scribbling a note.")
 				return TRUE
+	return ..()
 
 /obj/item/smallDelivery/on_update_icon()
 	ClearOverlays()

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -111,7 +111,7 @@ var/global/list/obj/machinery/message_server/message_servers = list()
 
 /obj/machinery/message_server/use_tool(obj/item/tool, mob/living/user, list/click_params)
 	if (!istype(tool, /obj/item/stock_parts/circuitboard/message_monitor))
-		return
+		return ..()
 	if (spamfilter_limit >= initial(spamfilter_limit) * 2)
 		to_chat(user, SPAN_WARNING("\The [src] already has as many boards as it can hold."))
 		return TRUE

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -57,7 +57,7 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 7 "uses of .len" '\.len\b' -P
-exactly 384 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 380 "attackby() override" '\/attackby\((.*)\)'  -P
 exactly 15 "uses of examine()" '[.|\s]examine\(' -P # If this fails it's likely because you used '/atom/proc/examine(mob)' instead of '/proc/examinate(mob, atom)' - Exception: An examine()-proc may call other examine()-procs
 exactly 7 "direct modifications of overlays list" '\boverlays((\s*[|^=+&-])|(\.(Cut)|(Add)|(Copy)|(Remove)|(Remove)))' -P
 exactly 0 "new/list list instantiations" 'new\s*/list' -P


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: Gas scanner no longer scans the inside of your backpack on storage
/🆑 

Alright, so just a heads up: 
Obj/item and obj/item/storage now have their attackby functions done by use_tool. However; I also kept the attackby to avoid breaking all of its children. This is temporary until more and more attackbys are killed.
Changed backpack's attackby to use_tool; and made sure all of the children backpack attackbys were also done.

Now since storage is run before use_after, any behavior in use_after is not fired if you're storing an item. If you want to override baseline attacking/storage functionality, use_before should be used.

Also added should_call_parent to use_tool; not sure where it even went. This is important since baseline wrench/unwrench functionality now moved from obj/attackby to obj/use_tool. 
