### PR TITLE
Removes server-crashing TC option

### DIFF
--- a/code/datums/uplink/badassery.dm
+++ b/code/datums/uplink/badassery.dm
@@ -57,26 +57,6 @@
 /datum/uplink_item/item/badassery/random_one/can_buy(obj/item/device/uplink/U)
 	return U.uses
 
-/datum/uplink_item/item/badassery/random_many
-	name = "Random Items"
-	desc = "Buys you as many random items as you can afford. Convenient packaging NOT included!"
-
-/datum/uplink_item/item/badassery/random_many/cost(telecrystals, obj/item/device/uplink/U)
-	return max(1, telecrystals)
-
-/datum/uplink_item/item/badassery/random_many/get_goods(obj/item/device/uplink/U, loc)
-	var/list/bought_items = list()
-	for(var/datum/uplink_item/UI in get_random_uplink_items(U, U.uses, loc))
-		UI.purchase_log(U)
-		var/obj/item/I = UI.get_goods(U, loc)
-		if(istype(I))
-			bought_items += I
-
-	return bought_items
-
-/datum/uplink_item/item/badassery/random_many/purchase_log(obj/item/device/uplink/U)
-	log_and_message_admins("used \the [U.loc] to buy \a [src]")
-
 /****************
 * Surplus Crate *
 ****************/


### PR DESCRIPTION
So, _someone_, not naming any names here but they're kind of an idiot, might've stumbled on a game-breaking bug where spending large amounts of TC on random items at once, crashes the server. And that certain someone, who shall go unnamed, got an antag ban for it, which was honestly entirely fucking valid. And making this PR is that someone's way of apologising for the inconvenience.

Anyway, yeah, if you spend like a million TC on random items all at once it kills the server. Not an issue unless admins give you like a million TC, but since there's already a _safe, reasonable_ 'random item' option that _doesn't_ crash the server, we're just gonna... remove this one for now...

Might make another PR later to put a TC cap on it if that's desired.

:cl: TheNightingale
rscdel: Removes the 'spend all your TC at once on random items' option because it crashed the server (twice). You can still do it by purchasing _one_ random item at a time, but not all at once.
/:cl: