### PR TITLE
Remove arterial bleed confusion

### DIFF
--- a/code/modules/organs/internal/heart.dm
+++ b/code/modules/organs/internal/heart.dm
@@ -178,8 +178,6 @@
 				SPAN_DANGER("Blood sprays out from \the [owner]'s [spray_organ]!"),
 				FONT_HUGE(SPAN_DANGER("Blood sprays out from your [spray_organ]!"))
 			)
-			owner.set_confused(1)
-			owner.eye_blurry = 2
 
 			//AB occurs every heartbeat, this only throttles the visible effect
 			next_blood_squirt = world.time + 80


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
balance: Arterial bleeds no longer cause confusion or blurred vision when they trigger.
/:cl:
