### PR TITLE
Allow filtering of types that are not abstract

### DIFF
--- a/code/_helpers/functional.dm
+++ b/code/_helpers/functional.dm
@@ -77,6 +77,13 @@
 	if (!. && feedback_receiver)
 		to_chat(feedback_receiver, SPAN_WARNING("Value must be a boolean (Strict)."))
 
+
+/proc/is_not_abstract_predicate(datum/thing, feedback_receiver)
+	. = !is_abstract(thing)
+	if (!. && feedback_receiver)
+		to_chat(feedback_receiver, SPAN_WARNING("Datum must not be abstract."))
+
+
 /proc/can_locate(atom/container, container_thing)
 	return (locate(container_thing) in container)
 

--- a/code/_helpers/lists.dm
+++ b/code/_helpers/lists.dm
@@ -693,6 +693,24 @@ Checks if a list has the same entries and values as an element of big.
 		if(istype(entry, type))
 			. += entry
 
+
+/**
+ * Filters a list, returning only entries that match all of the provided predicates.
+ *
+ * **Parameters**:
+ * - `to_filter` (list) - List to filter.
+ * - `predicates` (list) - Predicate procs to filter against.
+ *
+ * Returns list.
+ */
+/proc/filter_list_predicates(list/to_filter, list/predicates)
+	RETURN_TYPE(/list)
+	. = list()
+	for (var/entry in to_filter)
+		if (all_predicates_true(entry, predicates))
+			. += entry
+
+
 /proc/group_by(list/group_list, key, value)
 	var/values = group_list[key]
 	if(!values)

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -10,6 +10,19 @@
 		return typesof(thing) - thing.type
 	return list()
 
+
+/// `typesof()` without abstract types included.
+/proc/types_of_real_objects(datum/thing)
+	RETURN_TYPE(/list)
+	return filter_list_predicates(typesof(thing), /proc/is_not_abstract_predicate)
+
+
+/// `subtypesof()` without abstract types included.
+/proc/subtypes_of_real_objects(datum/thing)
+	RETURN_TYPE(/list)
+	return filter_list_predicates(subtypesof(thing), /proc/is_not_abstract_predicate)
+
+
 //Checks if all high bits in req_mask are set in bitfield
 #define BIT_TEST_ALL(bitfield, req_mask) ((~(bitfield) & (req_mask)) == 0)
 


### PR DESCRIPTION
## Changelog
No user facing changes.

## Other Changes
- Added `is_not_abstract_predicate()` predicate for checking datums that are abstract.
- Added `filter_list_predicates()` global proc for filtering a list against a set of predicates.
- Added `types_of_real_objects()` and `subtypes_of_real_objects()` global procs as alternatives to `typesof()` and `subtypesof()` that filter out abstract types.