### PR TITLE
Skip abstract types in merchant list generation

### DIFF
--- a/code/datums/trading/trade.dm
+++ b/code/datums/trading/trade.dm
@@ -62,37 +62,22 @@
 		add_to_pool(trading_items, possible_trading_items, force = 1)
 		add_to_pool(wanted_items, possible_wanted_items, force = 1)
 
-/datum/trader/proc/generate_pool(list/trading_pool)
-	. = list()
-	// Add types
-	for(var/type in trading_pool)
-		var/status = trading_pool[type]
-		if(status & TRADER_THIS_TYPE)
-			. += type
-		if(status & TRADER_SUBTYPES_ONLY)
-			. += subtypesof(type)
 
-	// Remove blacklisted
-	for (var/type in .)
-		var/status = trading_pool[type]
-		if (HAS_FLAGS(status, TRADER_BLACKLIST) || !validate_type_for_trade(type))
-			. -= type
-		if (HAS_FLAGS(status, TRADER_BLACKLIST_SUB))
-			. -= subtypesof(type)
-
-
-/**
- * Validates a given type can be used for trading. Intended to prevent certain items from being attainable via merchants.
- *
- * Returns boolean.
- */
-/datum/trader/proc/validate_type_for_trade(type)
-	if (isatom(type))
-		var/atom/atom = type
-		// Block abstracts
-		if (type == initial(atom.abstract_type))
-			return FALSE
-	return TRUE
+/datum/trader/proc/generate_pool(list/pool)
+	var/list/result = list()
+	for (var/path in pool)
+		var/status = pool[path]
+		if (GET_FLAGS(status, TRADER_THIS_TYPE) && !is_abstract(path))
+			result += path
+		if (GET_FLAGS(status, TRADER_SUBTYPES_ONLY))
+			result += subtypesof_real(path)
+	for (var/path in result)
+		var/status = pool[path]
+		if (GET_FLAGS(status, TRADER_BLACKLIST))
+			result -= path
+		if (GET_FLAGS(status, TRADER_BLACKLIST_SUB))
+			result -= subtypesof(path)
+	return result
 
 
 //If this hits 0 then they decide to up and leave.


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Merchant traders should no longer include invalid/inaccessible abstract types in their pools.
/:cl:

## Dependencies
- Uses the procs added by #34266