### PR TITLE
Self-destruct Can Trigger Evacuation

### DIFF
--- a/code/controllers/evacuation/evacuation.dm
+++ b/code/controllers/evacuation/evacuation.dm
@@ -39,6 +39,9 @@ var/global/datum/evacuation_controller/evacuation_controller
 	var/datum/announcement/priority/evac_called =   new(0)
 	var/datum/announcement/priority/evac_recalled = new(0)
 
+/datum/evacuation_controller/proc/new_evac_prep_delay(new_delay_time)
+	evac_prep_delay = new_delay_time
+
 /datum/evacuation_controller/proc/auto_recall(_recall)
 	recall = _recall
 
@@ -104,8 +107,9 @@ var/global/datum/evacuation_controller/evacuation_controller
 
 	if(!can_cancel())
 		return 0
+	if(!emergency_evacuation)
+		evac_cooldown_time = world.time + (world.time - evac_called_at)
 
-	evac_cooldown_time = world.time + (world.time - evac_called_at)
 	state = EVAC_COOLDOWN
 
 	evac_ready_time =   null
@@ -131,7 +135,7 @@ var/global/datum/evacuation_controller/evacuation_controller
 
 	var/estimated_time = round(get_eta()/60,1)
 	if (emergency_evacuation)
-		evac_waiting.Announce(replacetext(GLOB.using_map.emergency_shuttle_docked_message, "%ETD%", "[estimated_time] minute\s"), new_sound = sound('sound/effects/Evacuation.ogg', volume = 35))
+		evac_waiting.Announce(replacetext(GLOB.using_map.emergency_shuttle_docked_message, "%ETD%", "[estimated_time] minute\s"), new_sound = sound('sound/effects/Evacuation.ogg', volume = 30))
 	else
 		priority_announcement.Announce(replacetext(replacetext(GLOB.using_map.shuttle_docked_message, "%dock_name%", "[GLOB.using_map.dock_name]"),  "%ETD%", "[estimated_time] minute\s"))
 	if(config.announce_evac_to_irc)

--- a/code/controllers/evacuation/evacuation.dm
+++ b/code/controllers/evacuation/evacuation.dm
@@ -39,9 +39,6 @@ var/global/datum/evacuation_controller/evacuation_controller
 	var/datum/announcement/priority/evac_called =   new(0)
 	var/datum/announcement/priority/evac_recalled = new(0)
 
-/datum/evacuation_controller/proc/new_evac_prep_delay(new_delay_time)
-	evac_prep_delay = new_delay_time
-
 /datum/evacuation_controller/proc/auto_recall(_recall)
 	recall = _recall
 

--- a/code/controllers/evacuation/evacuation.dm
+++ b/code/controllers/evacuation/evacuation.dm
@@ -96,7 +96,7 @@ var/global/datum/evacuation_controller/evacuation_controller
 			GLOB.using_map.emergency_shuttle_called_announcement()
 	else
 		if(!skip_announce)
-			priority_announcement.Announce(replacetext(replacetext(GLOB.using_map.shuttle_called_message, "%dock_name%", "[GLOB.using_map.dock_name]"),  "%ETA%", "[round(get_eta()/60)] minute\s"))
+			priority_announcement.Announce(replacetext(replacetext(GLOB.using_map.shuttle_called_message, "%dock_name%", "[GLOB.using_map.dock_name]"),  "%ETA%", "[round(get_eta()/60,0.5)] minute\s"))
 
 	return 1
 
@@ -130,7 +130,7 @@ var/global/datum/evacuation_controller/evacuation_controller
 /datum/evacuation_controller/proc/finish_preparing_evac()
 	state = EVAC_LAUNCHING
 
-	var/estimated_time = round(get_eta()/60,1)
+	var/estimated_time = round(get_eta()/60,0.5)
 	if (emergency_evacuation)
 		evac_waiting.Announce(replacetext(GLOB.using_map.emergency_shuttle_docked_message, "%ETD%", "[estimated_time] minute\s"), new_sound = sound('sound/effects/Evacuation.ogg', volume = 30))
 	else
@@ -146,9 +146,9 @@ var/global/datum/evacuation_controller/evacuation_controller
 	state = EVAC_IN_TRANSIT
 
 	if (emergency_evacuation)
-		priority_announcement.Announce(replacetext(replacetext(GLOB.using_map.emergency_shuttle_leaving_dock, "%dock_name%", "[GLOB.using_map.dock_name]"),  "%ETA%", "[round(get_eta()/60,1)] minute\s"))
+		priority_announcement.Announce(replacetext(replacetext(GLOB.using_map.emergency_shuttle_leaving_dock, "%dock_name%", "[GLOB.using_map.dock_name]"),  "%ETA%", "[round(get_eta()/60,0.5)] minute\s"))
 	else
-		priority_announcement.Announce(replacetext(replacetext(GLOB.using_map.shuttle_leaving_dock, "%dock_name%", "[GLOB.using_map.dock_name]"),  "%ETA%", "[round(get_eta()/60,1)] minute\s"))
+		priority_announcement.Announce(replacetext(replacetext(GLOB.using_map.shuttle_leaving_dock, "%dock_name%", "[GLOB.using_map.dock_name]"),  "%ETA%", "[round(get_eta()/60,0.5)] minute\s"))
 
 	return 1
 

--- a/code/controllers/evacuation/evacuation_pods.dm
+++ b/code/controllers/evacuation/evacuation_pods.dm
@@ -42,10 +42,10 @@
 				pod.move_time = (evac_transit_delay/10)
 				pod.launch(src)
 
-		priority_announcement.Announce(replacetext(replacetext(GLOB.using_map.emergency_shuttle_leaving_dock, "%dock_name%", "[GLOB.using_map.dock_name]"),  "%ETA%", "[round(get_eta()/60,1)] minute\s"))
+		priority_announcement.Announce(replacetext(replacetext(GLOB.using_map.emergency_shuttle_leaving_dock, "%dock_name%", "[GLOB.using_map.dock_name]"),  "%ETA%", "[round(get_eta()/60,0.5)] minute\s"))
 	else
 		// Bluespace Jump
-		priority_announcement.Announce(replacetext(replacetext(GLOB.using_map.shuttle_leaving_dock, "%dock_name%", "[GLOB.using_map.dock_name]"),  "%ETA%", "[round(get_eta()/60,1)] minute\s"))
+		priority_announcement.Announce(replacetext(replacetext(GLOB.using_map.shuttle_leaving_dock, "%dock_name%", "[GLOB.using_map.dock_name]"),  "%ETA%", "[round(get_eta()/60,0.5)] minute\s"))
 		SetUniversalState(/datum/universal_state/bluespace_jump, arguments=list(GLOB.using_map.station_levels))
 
 /datum/evacuation_controller/starship/finish_evacuation()

--- a/code/datums/security_state.dm
+++ b/code/datums/security_state.dm
@@ -267,7 +267,7 @@
 
 	psionic_control_level = PSI_IMPLANT_DISABLED
 
-	var/static/datum/announcement/priority/security/security_announcement_delta = new(do_log = 0, do_newscast = 1, new_sound = sound('sound/effects/siren.ogg'))
+	var/static/datum/announcement/priority/security/security_announcement_delta = new(do_log = 0, do_newscast = 1, new_sound = sound('sound/effects/siren.ogg', volume = 70))
 
 /singleton/security_level/default/code_delta/switching_up_to()
 	security_announcement_delta.Announce("The self-destruct mechanism has been engaged. All crew are instructed to obey all instructions given by heads of staff. Any violations of these orders can be punished by death. This is not a drill.", "Attention! Delta security level reached!")

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -11,6 +11,7 @@ var/global/bomb_set
 	unacidable = TRUE
 	interact_offline = TRUE
 
+	var/evacuate = FALSE
 	var/deployable = 0
 	var/extended = 0
 	var/lighthack = 0
@@ -165,9 +166,10 @@ var/global/bomb_set
 
 /obj/machinery/nuclearbomb/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
 	var/data[0]
+	data["evacuate"] = evacuate
 	data["hacking"] = 0
 	data["auth"] = is_auth(user)
-	data["moveable_anchor"] = !istype(src, /obj/machinery/nuclearbomb/station)
+	data["is_regular_nuke"] = !istype(src, /obj/machinery/nuclearbomb/station)
 	if(is_auth(user))
 		if(yes_code)
 			data["authstatus"] = timing ? "Functional/Set" : "Functional"
@@ -289,6 +291,11 @@ var/global/bomb_set
 				if(safety)
 					secure_device()
 				update_icon()
+			if(href_list["evacuate"])
+				if(timing)
+					to_chat(usr, SPAN_WARNING("Cannot alter evacuation during countdown."))
+					return
+				evacuate = !evacuate
 			if(href_list["anchor"])
 				if(removal_stage == 5)
 					anchored = FALSE
@@ -490,13 +497,14 @@ var/global/bomb_set
 			return
 	..()
 	visible_message(SPAN_WARNING("Warning. The self-destruct sequence override will be disabled [self_destruct_cutoff] seconds before detonation."))
-	if(!evacuation_controller)
-		visible_message(SPAN_DANGER("Warning. Unable to initiate evacuation procedures."))
-		return
-	for (var/datum/evacuation_option/EO in evacuation_controller.available_evac_options())
-		if(EO.abandon_ship)
-			evacuation_controller.new_evac_prep_delay(timeleft SECONDS - 1 MINUTE)
-			evacuation_controller.handle_evac_option(EO.option_target, usr)
+	if(evacuate)
+		if(!evacuation_controller)
+			visible_message(SPAN_DANGER("Warning. Unable to initiate evacuation procedures."))
+			return
+		for (var/datum/evacuation_option/EO in evacuation_controller.available_evac_options())
+			if(EO.abandon_ship)
+				evacuation_controller.new_evac_prep_delay(timeleft SECONDS - 1 MINUTE)
+				evacuation_controller.handle_evac_option(EO.option_target, usr)
 
 /obj/machinery/nuclearbomb/station/secure_device()
 	if(timeleft <= self_destruct_cutoff)

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -503,7 +503,8 @@ var/global/bomb_set
 			return
 		for (var/datum/evacuation_option/EO in evacuation_controller.available_evac_options())
 			if(EO.abandon_ship)
-				evacuation_controller.new_evac_prep_delay(timeleft SECONDS - 1 MINUTE)
+				evacuation_controller.evac_prep_delay = timeleft SECONDS - 2 MINUTES
+				evacuation_controller.evac_launch_delay = timeleft SECONDS - 0.5 MINUTES
 				evacuation_controller.handle_evac_option(EO.option_target, usr)
 
 /obj/machinery/nuclearbomb/station/secure_device()
@@ -514,6 +515,8 @@ var/global/bomb_set
 	for (var/datum/evacuation_option/EO in evacuation_controller.available_evac_options())
 		if(EO.option_target == "cancel_abandon_ship")
 			evacuation_controller.handle_evac_option(EO.option_target, usr)
+			evacuation_controller.evac_prep_delay = 5 MINUTES
+			evacuation_controller.evac_launch_delay = 3 MINUTES
 
 /obj/machinery/nuclearbomb/station/Process()
 	..()

--- a/nano/templates/nuclear_bomb.tmpl
+++ b/nano/templates/nuclear_bomb.tmpl
@@ -1,10 +1,10 @@
-<!-- 
+<!--
 Title: Nuke Control Panel/Nuclear Bomb Defusion
 Used In File(s): \code\game\gamemodes\nuclear\nuclearbomb.dm
 -->
 <div class="item">
 	<b>Authorization Disk:</b> {{if data.auth}}{{:helper.link('++++++++++', 'eject', {'auth' : 1})}} {{else}} {{:helper.link('----------', 'disk', {'auth' : 1})}}{{/if}}
-</div>	
+</div>
 <hr>
 <div class="item">
 	<div><b>Status:</b> {{:data.authstatus}} - {{:data.safe}}</div>
@@ -30,23 +30,31 @@ Used In File(s): \code\game\gamemodes\nuclear\nuclearbomb.dm
 	</div>
 	<div class="item">
 		{{if data.auth && data.yescode}}
+			{{if data.is_regular_nuke}}
+				<div class="item">
+					<b>Anchor:</b> {{:helper.link('Engaged', 'locked', {'anchor' : 1}, data.anchored ? 'selected' : '')}}{{:helper.link('Disengaged', 'unlocked', {'anchor' : 0}, data.anchored ? '' : 'selected')}}
+				</div>
+			{{else}}
+				<div class="item">
+					<b>Evacuate:</b> {{:helper.link('Yes', '', {'evacuate' : 1}, data.evacuate ? 'selected' : '')}}{{:helper.link('No', 'alert', {'evacuate' : 1}, data.evacuate ? '' : 'redButton')}}
+				</div>
+			{{/if}}
 			<div class="item">
 				<b>Safety:</b> {{:helper.link('Engaged', 'info', {'safety' : 1}, data.safety ? 'selected' : '')}}{{:helper.link('Disengaged', 'alert', {'safety' : 0}, data.safety ? '' : 'redButton')}}
 			</div>
-			{{if data.moveable_anchor}}
-			<div class="item">
-				<b>Anchor:</b> {{:helper.link('Engaged', 'locked', {'anchor' : 1}, data.anchored ? 'selected' : '')}}{{:helper.link('Disengaged', 'unlocked', {'anchor' : 0}, data.anchored ? '' : 'selected')}}
-			</div>
-			{{/if}}
 		{{else}}
+			{{if data.is_regular_nuke}}
+				<div class="item">
+					<b>Anchor:</b> {{:helper.link('Engaged', 'locked', null, 'disabled')}}{{:helper.link('Disengaged', 'unlocked', null, 'disabled')}}
+				</div>
+			{{else}}
+				<div class="item">
+					<b>Evacuate:</b> {{:helper.link('Yes', '', null, 'disabled')}}{{:helper.link('No', 'alert', null, 'disabled')}}
+				</div>
+			{{/if}}
 			<div class="item">
 				<b>Safety:</b> {{:helper.link('Engaged', 'info', null, 'disabled')}}{{:helper.link('Disengaged', 'alert', null, 'disabled')}}
 			</div>
-			{{if data.moveable_anchor}}
-			<div class="item">
-                		<b>Anchor:</b> {{:helper.link('Engaged', 'locked', null, 'disabled')}}{{:helper.link('Disengaged', 'unlocked', null, 'disabled')}}
-			</div>
-			{{/if}}
 		{{/if}}
 	</div>
 	<hr>

--- a/nano/templates/nuclear_bomb.tmpl
+++ b/nano/templates/nuclear_bomb.tmpl
@@ -1,10 +1,10 @@
-<!-- 
+<!--
 Title: Nuke Control Panel/Nuclear Bomb Defusion
 Used In File(s): \code\game\gamemodes\nuclear\nuclearbomb.dm
 -->
 <div class="item">
 	<b>Authorization Disk:</b> {{if data.auth}}{{:helper.link('++++++++++', 'eject', {'auth' : 1})}} {{else}} {{:helper.link('----------', 'disk', {'auth' : 1})}}{{/if}}
-</div>	
+</div>
 <hr>
 <div class="item">
 	<div><b>Status:</b> {{:data.authstatus}} - {{:data.safe}}</div>
@@ -30,23 +30,31 @@ Used In File(s): \code\game\gamemodes\nuclear\nuclearbomb.dm
 	</div>
 	<div class="item">
 		{{if data.auth && data.yescode}}
-			<div class="item">
-				<b>Safety:</b> {{:helper.link('Engaged', 'info', {'safety' : 1}, data.safety ? 'selected' : '')}}{{:helper.link('Disengaged', 'alert', {'safety' : 0}, data.safety ? '' : 'redButton')}}
-			</div>
-			{{if data.moveable_anchor}}
+			{{if data.is_regular_nuke}}
 			<div class="item">
 				<b>Anchor:</b> {{:helper.link('Engaged', 'locked', {'anchor' : 1}, data.anchored ? 'selected' : '')}}{{:helper.link('Disengaged', 'unlocked', {'anchor' : 0}, data.anchored ? '' : 'selected')}}
 			</div>
+			{{else}}
+			<div class="item">
+				<b>Evacuate:</b> {{:helper.link('Yes', '', {'evacuate' : 1}, data.evacuate ? 'selected' : '')}}{{:helper.link('No', 'alert', 'evacuate' : 1, data.evacuate ? '' : 'redButton')}}
+			</div>
 			{{/if}}
+			<div class="item">
+				<b>Safety:</b> {{:helper.link('Engaged', 'info', {'safety' : 1}, data.safety ? 'selected' : '')}}{{:helper.link('Disengaged', 'alert', {'safety' : 0}, data.safety ? '' : 'redButton')}}
+			</div>
 		{{else}}
+			{{if data.is_regular_nuke}}
+			<div class="item">
+                <b>Anchor:</b> {{:helper.link('Engaged', 'locked', null, 'disabled')}}{{:helper.link('Disengaged', 'unlocked', null, 'disabled')}}
+			</div>
+			{{else}}
+			<div class="item">
+				<b>Evacuate:</b> {{:helper.link('Yes', '', null, 'disabled')}}{{:helper.link('No', 'alert', null, 'disabled')}}
+			</div>
+			{{/if}}
 			<div class="item">
 				<b>Safety:</b> {{:helper.link('Engaged', 'info', null, 'disabled')}}{{:helper.link('Disengaged', 'alert', null, 'disabled')}}
 			</div>
-			{{if data.moveable_anchor}}
-			<div class="item">
-                		<b>Anchor:</b> {{:helper.link('Engaged', 'locked', null, 'disabled')}}{{:helper.link('Disengaged', 'unlocked', null, 'disabled')}}
-			</div>
-			{{/if}}
 		{{/if}}
 	</div>
 	<hr>

--- a/nano/templates/nuclear_bomb.tmpl
+++ b/nano/templates/nuclear_bomb.tmpl
@@ -24,10 +24,11 @@ Used In File(s): \code\game\gamemodes\nuclear\nuclearbomb.dm
 				<b>Timer:</b> {{:helper.link('On', 'play', null, 'disabled')}}{{:helper.link('Off', 'pause', null, 'disabled')}}
 			</div>
 			<div class="item">
-				<b>Time:</b> {{:helper.link('-', '', null, 'disabled')}}{{:helper.link('-', '', null, 'disabled')}} {{:data.time}} {{:helper.link('+', '', null, 'disabled')}}{{:helper.link('++', '', null, 'disabled')}}
+				<b>Time:</b> {{:helper.link('--', '', null, 'disabled')}}{{:helper.link('-', '', null, 'disabled')}} {{:data.time}} {{:helper.link('+', '', null, 'disabled')}}{{:helper.link('++', '', null, 'disabled')}}
 			</div>
 		{{/if}}
 	</div>
+	<hr>
 	<div class="item">
 		{{if data.auth && data.yescode}}
 			{{if data.is_regular_nuke}}


### PR DESCRIPTION
:cl:
tweak: The self-destruct now has the option to trigger evacuation procedures.
tweak: Lowers volume of delta siren.
tweak: Lowers volume of evacuation siren.
/:cl:

The new wait timer for the evac pods will be two minutes behind the set timer on the self-destruct and they will fully launch around 15 seconds before detonation.

![image](https://github.com/Baystation12/Baystation12/assets/12041669/e4a95391-2a91-4745-b664-4469e9d91f6e)