### PR TITLE
Add gunpowder

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -30,5 +30,5 @@ bca4aa1184eca550a6d9543a93d720ba6dc10b20
 # obj/effect/ -> obj/
 8cd28ed954d5873c1b20f35ce58aa5820803ec4c
 
-# datum/effect/effect/system & datum/effect/system -> datum/effect
+# datum/effect & datum/effect/system -> datum/effect
 96f09a4736ccdc33d9651aa9f162d27e3263b127

--- a/code/datums/supplypacks/dispenser_cartridges/chemistry.dm
+++ b/code/datums/supplypacks/dispenser_cartridges/chemistry.dm
@@ -205,3 +205,13 @@
 		/obj/item/reagent_containers/chem_disp_cartridge/tungsten = 2
 	)
 	cost = 15
+
+/singleton/hierarchy/supply_pack/dispenser_cartridges/oxygen
+	name = "Reagent refill - oxygen"
+	containername = "oxygen reagent cartridge crate"
+	containertype = /obj/structure/closet/crate/secure
+	access = list(access_chemistry)
+	contains = list(
+		/obj/item/reagent_containers/chem_disp_cartridge/oxygen = 2
+	)
+	cost = 15

--- a/code/modules/hydroponics/trays/tray.dm
+++ b/code/modules/hydroponics/trays/tray.dm
@@ -76,7 +76,8 @@
 		/datum/reagent/adminordrazine =                 1,
 		/datum/reagent/toxin/fertilizer/eznutrient =    1,
 		/datum/reagent/toxin/fertilizer/robustharvest = 1,
-		/datum/reagent/toxin/fertilizer/left4zed =      1
+		/datum/reagent/toxin/fertilizer/left4zed =      1,
+		/datum/reagent/toxin/fertilizer/potash =        1
 		)
 	var/static/list/weedkiller_reagents = list(
 		/datum/reagent/hydrazine =          -4,
@@ -124,7 +125,8 @@
 		/datum/reagent/adminordrazine =                  list(  1,    1,   1  ),
 		/datum/reagent/toxin/fertilizer/robustharvest =  list(  0,    0.2, 0  ),
 		/datum/reagent/toxin/fertilizer/left4zed =       list(  0,    0,   0.2),
-		/datum/reagent/drugs/three_eye =                       list(  -1  , 0,   0.5)
+		/datum/reagent/drugs/three_eye =                       list(  -1  , 0,   0.5),
+		/datum/reagent/toxin/fertilizer/potash =         list(  0,5,   0.5,   0)
 		)
 
 	// Mutagen list specifies minimum value for the mutation to take place, rather

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Other.dm
@@ -576,3 +576,11 @@
 
 /datum/reagent/colored_hair_dye/chaos/affect_touch(mob/living/carbon/human/H, removed)
 	apply_dye_color(H, Frand(1, 254), Frand(1, 254), Frand(1, 254))
+
+/datum/reagent/gunpowder
+	name = "Gunpowder"
+	description = "The earliest chemical explosive known to mankind."
+	taste_description = "spicy toasted beans"
+	reagent_state = SOLID
+	color = "#161414"
+	value = 7

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -447,6 +447,14 @@
 /datum/reagent/toxin/fertilizer/robustharvest
 	name = "Robust Harvest"
 
+/datum/reagent/toxin/fertilizer/potash
+	name = "Potassium Nitrate"
+	description = "Also known as Saltpetre. Useful as a fertilizer."
+	taste_description = "sharp salt"
+	reagent_state = SOLID
+	color = "#c7beb9"
+	value = 0.9
+
 /datum/reagent/toxin/plantbgone
 	name = "Plant-B-Gone"
 	description = "A harmful toxic mixture to kill plantlife. Do not ingest!"
@@ -465,7 +473,7 @@
 			W.visible_message(SPAN_NOTICE("The fungi are completely dissolved by the solution!"))
 
 /datum/reagent/toxin/plantbgone/touch_obj(obj/O, volume)
-	if(istype(O, /obj/vine))
+	if(istype(O, /obj/effect/vine))
 		qdel(O)
 
 /datum/reagent/toxin/plantbgone/affect_blood(mob/living/carbon/M, removed)
@@ -1154,7 +1162,7 @@
 	if(istype(M))
 		for(var/obj/item/organ/external/E in M.organs)
 			if(LAZYLEN(E.implants))
-				for(var/obj/spider/spider in E.implants)
+				for(var/obj/effect/spider/spider in E.implants)
 					if(prob(25))
 						E.implants -= spider
 						M.visible_message(SPAN_NOTICE("The dying form of \a [spider] emerges from inside \the [M]'s [E.name]."))

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -597,6 +597,33 @@
 	e.start()
 	holder.clear_reagents()
 
+/datum/chemical_reaction/gunpowder
+	name = "Gunpowder"
+	result = /datum/reagent/gunpowder
+	required_reagents = list(/datum/reagent/sodiumchloride = 1, /datum/reagent/toxin/fertilizer/potash = 1, /datum/reagent/sulfur = 1)
+	result_amount = 3
+	mix_message = "The solution sizzles down into ashy black powder."
+
+/datum/chemical_reaction/explosion_gunpowder
+	name = "Explosion"
+	result = null
+	required_reagents = list(/datum/reagent/gunpowder = 1)
+	result_amount = 3
+	minimum_temperature = 200 CELSIUS
+	mix_message = "The powder violently bursts into flame."
+
+/datum/chemical_reaction/explosion_gunpowder/on_reaction(datum/reagents/holder, created_volume, reaction_flags)
+	..()
+	var/datum/effect/reagents_explosion/e = new()
+	e.set_up(round (created_volume/5, 1), holder.my_atom, 0, 0)
+	if(isliving(holder.my_atom))
+		e.amount *= 0.5
+		var/mob/living/L = holder.my_atom
+		if(L.stat!=DEAD)
+			e.amount *= 0.5
+	e.start()
+	holder.clear_reagents()
+
 /datum/chemical_reaction/napalm
 	name = "Napalm"
 	result = /datum/reagent/napalm
@@ -1272,7 +1299,7 @@
 
 /datum/chemical_reaction/slime/golem/on_reaction(datum/reagents/holder)
 	..()
-	var/obj/golemrune/Z = new /obj/golemrune(get_turf(holder.my_atom))
+	var/obj/effect/golemrune/Z = new /obj/effect/golemrune(get_turf(holder.my_atom))
 	Z.announce_to_ghosts()
 
 //Sepia
@@ -3160,3 +3187,11 @@
 	catalysts = list(
 		/datum/reagent/enzyme = 1
 	)
+
+/datum/chemical_reaction/potash
+	name = "Potassium Nitrate"
+	result = /datum/reagent/toxin/fertilizer/potash
+	required_reagents = list(/datum/reagent/oxygen = 3, /datum/reagent/potassium = 1, /datum/reagent/fuel = 1)
+	result_amount = 3
+	minimum_temperature = 200 CELSIUS
+	mix_message = "The mixture solidifies into a salt-like substance."

--- a/code/modules/reagents/dispenser/dispenser_presets.dm
+++ b/code/modules/reagents/dispenser/dispenser_presets.dm
@@ -20,7 +20,8 @@
 			/obj/item/reagent_containers/chem_disp_cartridge/ethanol,
 			/obj/item/reagent_containers/chem_disp_cartridge/sugar,
 			/obj/item/reagent_containers/chem_disp_cartridge/acid,
-			/obj/item/reagent_containers/chem_disp_cartridge/tungsten
+			/obj/item/reagent_containers/chem_disp_cartridge/tungsten,
+			/obj/item/reagent_containers/chem_disp_cartridge/oxygen
 		)
 
 /obj/machinery/chemical_dispenser/ert

--- a/code/modules/reagents/dispenser/presets/chemistry.dm
+++ b/code/modules/reagents/dispenser/presets/chemistry.dm
@@ -81,6 +81,8 @@
 /obj/item/reagent_containers/chem_disp_cartridge/tungsten
 	spawn_reagent = /datum/reagent/tungsten
 
-
 /obj/item/reagent_containers/chem_disp_cartridge/boron
 	spawn_reagent = /datum/reagent/toxin/boron
+
+/obj/item/reagent_containers/chem_disp_cartridge/oxygen
+	spawn_reagent = /datum/reagent/oxygen

--- a/code/modules/xenoarcheaology/triggers/chemical.dm
+++ b/code/modules/xenoarcheaology/triggers/chemical.dm
@@ -45,7 +45,8 @@
 		/datum/reagent/napalm,
 		/datum/reagent/napalm/b,
 		/datum/reagent/nitroglycerin,
-		/datum/reagent/toxin/phoron/oxygen
+		/datum/reagent/toxin/phoron/oxygen,
+		/datum/reagent/gunpowder
 	)
 	trigger_type = TRIGGER_COMPLEX
 

--- a/html/changelogs/AutoChangeLog-pr-34207.yml
+++ b/html/changelogs/AutoChangeLog-pr-34207.yml
@@ -1,0 +1,6 @@
+author: emmanuelbassil
+delete-after: true
+changes:
+  - bugfix: Fixes being unable to punch spiderlings to death
+  - tweak: Can now damage any object with health using your fists of justice; similar
+      to existing behavior with melee weapons.


### PR DESCRIPTION
:cl: Lamasmaster
rscadd: Introduce gunpowder as an explosive chemical. Inbetween potassium/water and other higher grade explosives.
tweak: Readds oxygen to chemical dispensers.
/:cl:

Intended to be a medium effort/medium devastation alternative to either getting potassium/water or nitroglycerin and such.
For some reason oxygen was removed from the dispensers despite still being in files. Added back to dispensers.