### PR TITLE
Fix airlock contoller icon

### DIFF
--- a/code/game/machinery/embedded_controller/airlock_controllers_dummy.dm
+++ b/code/game/machinery/embedded_controller/airlock_controllers_dummy.dm
@@ -2,7 +2,7 @@
 /obj/machinery/dummy_airlock_controller
 	name = "airlock control terminal"
 	icon = 'icons/obj/doors/airlock_machines.dmi'
-	icon_state = "airlock_control_standby"
+	icon_state = "airlock_control_off"
 	layer = ABOVE_OBJ_LAYER
 
 	var/datum/topic_state/remote/remote_state


### PR DESCRIPTION
Changes ![image](https://github.com/Baystation12/Baystation12/assets/32931701/7feebe18-dde6-4f5d-a36a-638c593b5699) to ![image](https://github.com/Baystation12/Baystation12/assets/32931701/f42fc633-296d-4871-b155-3c175b0cb3fd)

```yml
🆑SuhEugene
bugfix: Fixed airlock control terminal icon.
/🆑
```
