### PR TITLE
jukebox sound range fix

### DIFF
--- a/code/datums/audio/jukebox.dm
+++ b/code/datums/audio/jukebox.dm
@@ -8,7 +8,7 @@
 	var/volume_max = 50
 	var/volume_step = 10
 	var/frequency = 1
-	var/range = 7
+	var/range = 10
 	var/falloff = 1
 	var/template
 	var/ui_title


### PR DESCRIPTION
## Hello comrades! 
Some adj. with jukebox sound radius. Same as merged fix for instruments: https://github.com/Baystation12/Baystation12/pull/34245
Now they sound the same, and it's good.

### Changes
* jukebox sound goes on 10 instead of 7 tiles

### Changelog

🆑
tweak: more radius for jukebox sound
/🆑
