### PR TITLE
Fire Extinguisher Fix

### DIFF
--- a/code/game/objects/effects/chem/water.dm
+++ b/code/game/objects/effects/chem/water.dm
@@ -37,8 +37,8 @@
 			if(reagents.total_volume < 1)
 				break
 			if(T == get_turf(target))
-				for(var/atom/A in splash_others)
-					reagents.splash(A, reagents.total_volume/length(splash_others)) //splash anything left
+				for(var/atom/A in (splash_others + splash_mobs))
+					reagents.splash(A, reagents.total_volume/length(splash_others + splash_mobs)) //splash anything left
 				break
 
 		sleep(delay)

--- a/code/game/objects/effects/chem/water.dm
+++ b/code/game/objects/effects/chem/water.dm
@@ -37,8 +37,10 @@
 			if(reagents.total_volume < 1)
 				break
 			if(T == get_turf(target))
-				for(var/atom/A in (splash_others + splash_mobs))
-					reagents.splash(A, reagents.total_volume/length(splash_others + splash_mobs)) //splash anything left
+				var/list/splash_targets = splash_others + splash_mobs
+				var/splash_amount = reagents.total_volume / length(splash_targets)
+				for(var/atom/atom in splash_targets)
+					reagents.splash(atom, splash_amount)
 				break
 
 		sleep(delay)


### PR DESCRIPTION
:cl:
bugfix: Fire extinguisher spray should now act as expected without having to directly click on target.
/:cl:

Fixes #34115

Removed `use_before` override as it's no longer needed. 