### PR TITLE
Injector controllers can set injectors on with var

### DIFF
--- a/code/game/machinery/atmo_control.dm
+++ b/code/game/machinery/atmo_control.dm
@@ -15,6 +15,7 @@
 	var/list/input_info = list()
 	var/list/output_info = list()
 	var/list/sensor_info = list()
+	var/injecting
 	var/input_tag
 	var/output_tag
 	var/sensor_tag
@@ -33,6 +34,20 @@
 /obj/machinery/computer/air_control/Initialize()
 	. = ..()
 	set_frequency(frequency)
+
+	var/datum/signal/signal = new
+
+	signal.transmission_method = 1 //radio signal
+	signal.source = src
+
+	if(injecting == 1)
+		signal.data = list ("tag" = input_tag, "power_toggle" = 1)
+	else
+		signal.data = list ("tag" = input_tag, "power_toggle" = 0)
+
+	signal.data["sigtype"] = "command"
+	signal.data["status"] = TRUE
+	radio_connection.post_signal(src, signal, radio_filter = RADIO_ATMOSIA)
 
 /obj/machinery/computer/air_control/Destroy()
 	if(radio_controller)

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -648,7 +648,8 @@
 	name = "Oxygen Supply Control";
 	output_tag = "d3so2_out";
 	sensor_name = "Oxygen Supply Tank";
-	sensor_tag = "d3so2_sensor"
+	sensor_tag = "d3so2_sensor";
+	injecting = 1
 	},
 /obj/floor_decal/industrial/outline/blue,
 /obj/machinery/alarm{
@@ -14848,7 +14849,8 @@
 	name = "Oxygen Supply Control";
 	output_tag = "d3po2_out";
 	sensor_name = "Oxygen Supply Tank";
-	sensor_tag = "d3po2_sensor"
+	sensor_tag = "d3po2_sensor";
+	injecting = 1
 	},
 /obj/floor_decal/industrial/outline/blue,
 /obj/machinery/alarm{
@@ -15311,7 +15313,8 @@
 	name = "Hydrogen Supply Control";
 	output_tag = "d3sh_out";
 	sensor_name = "Hydrogen Supply Tank";
-	sensor_tag = "d3sh_sensor"
+	sensor_tag = "d3sh_sensor";
+	injecting = 1
 	},
 /obj/floor_decal/industrial/outline/orange,
 /turf/simulated/floor/tiled/techfloor,
@@ -19307,7 +19310,8 @@
 	name = "Hydrogen Supply Control";
 	output_tag = "d3ph_out";
 	sensor_name = "Hydrogen Supply Tank";
-	sensor_tag = "d3ph_sensor"
+	sensor_tag = "d3ph_sensor";
+	injecting = 1
 	},
 /obj/floor_decal/industrial/outline/orange,
 /turf/simulated/floor/tiled/techfloor,

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -6770,7 +6770,8 @@
 	output_tag = "cooling_out";
 	pressure_setting = 100;
 	sensor_name = "Engine Core";
-	sensor_tag = "engine_sensor"
+	sensor_tag = "engine_sensor";
+	injecting = 1
 	},
 /obj/structure/cable/cyan{
 	d1 = 2;
@@ -11927,7 +11928,8 @@
 	name = "Waste Tank Control";
 	output_tag = "waste_out";
 	sensor_name = "Waste Tank";
-	sensor_tag = "waste_sensor"
+	sensor_tag = "waste_sensor";
+	injecting = 1
 	},
 /obj/machinery/light{
 	dir = 8;
@@ -12632,7 +12634,8 @@
 	name = "Fuel Supply Control";
 	output_tag = "fuel_out";
 	sensor_name = "Fuel Tank";
-	sensor_tag = "fuel_sensor"
+	sensor_tag = "fuel_sensor";
+	injecting = 1
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/fuelbay)
@@ -17151,7 +17154,8 @@
 	input_tag = "rust_injector";
 	name = "R-UST Gas Injection Controls";
 	sensor_name = "Fusion Chamber";
-	sensor_tag = "rust_sensor"
+	sensor_tag = "rust_sensor";
+	injecting = 1
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/vacant/prototype/control)

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -957,7 +957,8 @@
 	name = "Hydrogen Supply Control";
 	output_tag = "d1sh_out";
 	sensor_name = "Hydrogen Supply Tank";
-	sensor_tag = "d1sh_sensor"
+	sensor_tag = "d1sh_sensor";
+	injecting = 1
 	},
 /obj/floor_decal/industrial/outline/orange,
 /turf/simulated/floor/tiled/techfloor,
@@ -968,7 +969,8 @@
 	name = "Oxygen Supply Control";
 	output_tag = "d1so2_out";
 	sensor_name = "Oxygen Supply Tank";
-	sensor_tag = "d1so2_sensor"
+	sensor_tag = "d1so2_sensor";
+	injecting = 1
 	},
 /obj/floor_decal/industrial/outline/blue,
 /obj/machinery/alarm{
@@ -13364,7 +13366,8 @@
 	name = "Hydrogen Supply Control";
 	output_tag = "d1ph_out";
 	sensor_name = "Hydrogen Supply Tank";
-	sensor_tag = "d1ph_sensor"
+	sensor_tag = "d1ph_sensor";
+	injecting = 1
 	},
 /obj/floor_decal/industrial/outline/orange,
 /turf/simulated/floor/tiled/techfloor,
@@ -13376,7 +13379,8 @@
 	name = "Oxygen Supply Control";
 	output_tag = "d1po2_out";
 	sensor_name = "Oxygen Supply Tank";
-	sensor_tag = "d1po2_sensor"
+	sensor_tag = "d1po2_sensor";
+	injecting = 1
 	},
 /obj/floor_decal/industrial/outline/blue,
 /obj/machinery/alarm{


### PR DESCRIPTION
Instead of just reverting #34281 I decided to let the injector control computers have a variable that controls whether the injector starts on or not. Controlled by a variable.
Also sets D1, 2, and 3 important injectors to auto-enable.
:cl: cdbrunow
bugfix: Injectors that are important and supposed to be on are now on at roundstart.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->