### PR TITLE
fix engine injector depowering itself in Initialize

### DIFF
--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -36,7 +36,7 @@
 
 	set_frequency(frequency)
 	broadcast_status()
-	update_icon()
+
 
 /obj/machinery/atmospherics/unary/outlet_injector/Destroy()
 	unregister_radio(src, frequency)


### PR DESCRIPTION
:cl:
bugfix: Mapped injectors don't turn themselves off during game setup.
/:cl:

closes #34290