### PR TITLE
Fix combat boots having no sprite

### DIFF
--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -34,7 +34,7 @@
 /obj/item/clothing/shoes/combat //Basically SWAT shoes combined with galoshes.
 	name = "combat boots"
 	desc = "When you REALLY want to turn up the heat."
-	icon_state = "jungle"
+	icon_state = "swat"
 	force = 5
 	armor = list(
 		melee = ARMOR_MELEE_VERY_HIGH,


### PR DESCRIPTION
I can't be bothered to recolor a sprite to make them brown again. You get whatever swat boots are instead.

## Changelog
:cl: SierraKomodo
bugfix: Combat boots now have a sprite.
/:cl: