### PR TITLE
Alerts surgeons when an organ is decaying

### DIFF
--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -44,6 +44,11 @@
 		if(I && I.damage > 0 && !BP_IS_ROBOTIC(I) && (!(I.status & ORGAN_DEAD) || I.can_recover()) && (I.surface_accessible || affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED)))
 			user.visible_message("[user] starts treating damage to [target]'s [I.name] with [tool_name].", \
 			"You start treating damage to [target]'s [I.name] with [tool_name]." )
+		else if(I && !(I.status & ORGAN_CUT_AWAY) && (I.status & ORGAN_DEAD) && I.parent_organ == affected.organ_tag && !BP_IS_ROBOTIC(I))
+			if (!I.can_recover())
+				to_chat(user, SPAN_WARNING("[target]'s [I.name] is fully necrotic; [tool_name] won't help here."))
+			else
+				to_chat(user, SPAN_WARNING("[target]'s [I.name] is decaying; you'll need more than just [tool_name] here."))
 	target.custom_pain("The pain in your [affected.name] is living hell!",100,affecting = affected)
 	playsound(target.loc, 'sound/items/bonegel.ogg', 50, TRUE)
 	..()

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -46,9 +46,9 @@
 			"You start treating damage to [target]'s [I.name] with [tool_name]." )
 		else if(I && !(I.status & ORGAN_CUT_AWAY) && (I.status & ORGAN_DEAD) && I.parent_organ == affected.organ_tag && !BP_IS_ROBOTIC(I))
 			if (!I.can_recover())
-				to_chat(user, SPAN_WARNING("[target]'s [I.name] is fully necrotic; [tool_name] won't help here."))
+				to_chat(user, SPAN_WARNING("\The [target]'s [I.name] is fully necrotic; [tool_name] won't help here."))
 			else
-				to_chat(user, SPAN_WARNING("[target]'s [I.name] is decaying; you'll need more than just [tool_name] here."))
+				to_chat(user, SPAN_WARNING("\The [target]'s [I.name] is decaying; you'll need more than just [tool_name] here."))
 	target.custom_pain("The pain in your [affected.name] is living hell!",100,affecting = affected)
 	playsound(target.loc, 'sound/items/bonegel.ogg', 50, TRUE)
 	..()


### PR DESCRIPTION
Previously, if you tried to ATK someone's necrotic organ, you wouldn't get any messages about "hey, that's necrotic, that ain't gonna work buddy". Now, you will. Additionally, the feedback on treating decaying organs has been clarified a little.

TL;DR: blatant medical hugbox coder favoritism

:cl: TheNightingale
tweak: Surgeons are now given feedback when they're trying to perform standard organ repair surgery on a decaying/dead organ.
/:cl: