### PR TITLE
Assorted Ballistics Changes

### DIFF
--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -10,7 +10,6 @@
 	max_shells = 6
 	fire_delay = 12 //Revolvers are naturally slower-firing
 	ammo_type = /obj/item/ammo_casing/pistol/magnum
-	var/chamber_offset = 0 //how many empty chambers in the cylinder until you hit a round
 	mag_insert_sound = 'sound/weapons/guns/interaction/rev_magin.ogg'
 	mag_remove_sound = 'sound/weapons/guns/interaction/rev_magout.ogg'
 	accuracy = 2

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -128,12 +128,31 @@
 
 	return ..()
 
+/obj/item/gun/projectile/shotgun/pump/DrawChamber()
+	var/chamberlist = ""
+	if (chambered)
+		if (chambered.BB)
+			chamberlist += "◉|"
+		else
+			chamberlist += "◎|"
+	else
+		chamberlist += "🌣|"
+	if (length(loaded) > 0)
+		var/obj/item/ammo_casing/casinglist = loaded
+		if (casinglist[1].BB)
+			chamberlist += "◉"
+		else
+			chamberlist += "◎"
+	else
+		chamberlist += "🌣"
+	return chamberlist
+
 /obj/item/gun/projectile/shotgun/pump/empty
 	starts_loaded = FALSE
 
 /obj/item/gun/projectile/shotgun/pump/sawn
 	name = "riot shotgun"
-	desc = "A mass-produced shotgun by Mars Security Industries. The rugged ZX-870 'Bulldog' is common throughout most frontier worlds. This one has had it's stock cut off..."
+	desc = "A mass-produced shotgun by Mars Security Industries. The rugged ZX-870 'Bulldog' is common throughout most frontier worlds. This one has had its stock cut off..."
 	icon = 'icons/obj/guns/shotguns.dmi'
 	icon_state = "rshotgun"
 	item_state = "rshotgun"

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -56,6 +56,10 @@
 			to_chat(user, SPAN_NOTICE("You work the bolt open."))
 	else
 		to_chat(user, SPAN_NOTICE("You work the bolt closed."))
+		if (length(loaded))
+			chambered = loaded[1]
+		else
+			chambered = null
 		playsound(src.loc, 'sound/weapons/guns/interaction/rifle_boltforward.ogg', 50, 1)
 		bolt_open = 0
 	add_fingerprint(user)
@@ -77,6 +81,22 @@
 		return
 	..()
 
+/obj/item/gun/projectile/heavysniper/getAmmo()
+	var/bullets = 0
+	if (loaded)
+		bullets += length(loaded)
+	if (ammo_magazine && ammo_magazine.stored_ammo)
+		bullets += length(ammo_magazine.stored_ammo)
+	return bullets
+
+/obj/item/gun/projectile/heavysniper/DrawChamber()
+	if (chambered)
+		if (chambered.BB)
+			return "◉"
+		else
+			return "◎"
+	else
+		return "🌣"
 
 /obj/item/gun/projectile/heavysniper/boltaction
 	name = "bolt action rifle"

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -209,13 +209,12 @@
 	damage = 45
 	armor_penetration = 25
 	penetrating = 1
-	distance_falloff = 1.5
+	distance_falloff = 1
 
 /obj/item/projectile/bullet/rifle/military
 	fire_sound = 'sound/weapons/gunshot/gunshot2.ogg'
 	damage = 40
 	armor_penetration = 35
-	distance_falloff = 1
 
 /obj/item/projectile/bullet/rifle/shell
 	fire_sound = 'sound/weapons/gunshot/sniper.ogg'


### PR DESCRIPTION
:cl: Karl Johansson
rscadd: You can see what's currently in the chamber of a gun on examine.
rscadd: You can load non-magazine weapons by booping them with an appropriate loader.
tweak: Opening the bolt on bolt-action weapons unloads anything inside, not just empties.
tweak: 5mmR weapons are more accurate at long range.
/:cl:

### "More information?"
When examining any gun that uses the `CYCLE_CASINGS` casing handling method (revolvers, flare guns, double-barreled shotguns, etc.) or a pump-action shotgun or a bolt action rifle with a weapons expertise skill of experienced or higher will allow you to view the chamber of the weapon so you can tell the status of the round inside, such as whether it's spent or not. This is because all of these weapons (although most egregiously revolvers) count empty cartridges in their round count which, while it does make sense and could even be considered realistic, can make using them harder. It also means that you can actually know what's going on inside your gun without having to code dive to find out how exactly it works.

The next change is another quality of life change. It's been generalized a lot to allow for expansion later (still not certain about going all in on replacing shotholders with handfuls of rounds), but currently it serves to allow pump-action shotguns to be loaded by clicking on it with a shotgun shell holder in hand, rather than having to manually go back and forth between the two items. There's still a small cooldown when doing this so that you can't just spam shells into your shotgun.

The bolt action weapon changes are mostly to resolve a pet peeve of mine, although they do mean that now all guns are capable of ejecting loaded ammo, whereas before bolt action weapons were uniquely unable to do this. I also think it makes their operation more immersive and makes the decision of reloading them slightly more impactful.

The 5mmR cartridge has been changed to be as accurate as the 7mmR cartridge on the grounds that I felt that the nerf was somewhat arbitrary and I wasn't satisfied with the explanation I was given as to why they were nerfed, since there are 3 different sniper weapons that use the calibre.

Spellcheck's a spellcheck. "it's" is a contraction of "it is". "its" is the possessive form of "it".

### "Is there bugs?"
I hope not. I've tested this to the best of my abilities and I believe I've resolved everything. Unfortunately I am also me, so there might still be oversights. On the bright side, I never saw any runtimes. If this merge conflicts with something else, I'll probably just remove the part that is conflicting and try and add it again later, if that's allowed.

### "My eyes are bleeding."
I've done my best to lay things out in a roughly coherent manner, although I'm not particularly well-versed in good coding practices. I'm completely open to redoing this from the ground up if it's required.

### "I don't agree with these changes."
I will remove changes that are deemed unnecessary or break contribution guidelines if it is requested.