### PR TITLE
Allows custom names and descriptions for more non-uniformed items

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/accessories.dm
+++ b/code/modules/client/preference_setup/loadout/lists/accessories.dm
@@ -65,7 +65,6 @@
 	description = "A medal or ribbon awarded to corporate personnel for significant accomplishments."
 	path = /obj/item/clothing/accessory/medal
 	cost = 8
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/accessory/ntaward/New()
@@ -80,19 +79,16 @@
 /datum/gear/accessory/armband_security
 	display_name = "security armband"
 	path = /obj/item/clothing/accessory/armband
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/accessory/armband_cargo
 	display_name = "cargo armband"
 	path = /obj/item/clothing/accessory/armband/cargo
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/accessory/armband_medical
 	display_name = "medical armband"
 	path = /obj/item/clothing/accessory/armband/med
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/accessory/armband_emt
@@ -101,13 +97,11 @@
 	allowed_roles = list(
 		/datum/job/doctor
 	)
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/accessory/armband_engineering
 	display_name = "engineering armband"
 	path = /obj/item/clothing/accessory/armband/engine
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/accessory/armband_hydro
@@ -118,7 +112,6 @@
 		/datum/job/scientist,
 		/datum/job/assistant
 	)
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/accessory/armband_nt
@@ -129,7 +122,6 @@
 /datum/gear/accessory/ftu_pin
 	display_name = "Free Trade Union pin"
 	path = /obj/item/clothing/accessory/ftu_pin
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/accessory/chaplain
@@ -138,7 +130,6 @@
 	allowed_roles = list(
 		/datum/job/chaplain
 	)
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/accessory/chaplain/New()

--- a/code/modules/client/preference_setup/loadout/lists/eyegear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/eyegear.dm
@@ -25,7 +25,6 @@
 	display_name = "Science Eyewear"
 	description = "Provides research and chemical assessments."
 	path = /obj/item/clothing/glasses
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/eyes/science/New()
@@ -64,7 +63,6 @@
 	display_name = "Medical Eyewear"
 	description = "Provides medical vision overlays."
 	path = /obj/item/clothing/glasses
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/eyes/medical/New()
@@ -82,7 +80,6 @@
 	display_name = "Meson Eyewear"
 	description = "Provides meson-vision."
 	path = /obj/item/clothing/glasses
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/eyes/meson/New()
@@ -98,7 +95,6 @@
 	display_name = "Sanitation Eyewear"
 	description = "Provides filth-vision."
 	path = /obj/item/clothing/glasses
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/eyes/janitor/New()
@@ -161,7 +157,6 @@
 /datum/gear/eyes/material
 	display_name = "Material Eyewear"
 	path = /obj/item/clothing/glasses
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/eyes/material/New()

--- a/code/modules/client/preference_setup/loadout/lists/gloves.dm
+++ b/code/modules/client/preference_setup/loadout/lists/gloves.dm
@@ -13,13 +13,11 @@
 	display_name = "gloves, latex"
 	path = /obj/item/clothing/gloves/latex
 	cost = 3
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 /datum/gear/gloves/nitrile
 	display_name = "gloves, nitrile"
 	path = /obj/item/clothing/gloves/latex/nitrile
 	cost = 3
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 /datum/gear/gloves/rainbow
 	display_name = "gloves, rainbow"

--- a/code/modules/client/preference_setup/loadout/lists/headwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/headwear.dm
@@ -146,7 +146,7 @@
 /datum/gear/head/surgical
 	display_name = "standard surgical caps"
 	path = /obj/item/clothing/head/surgery
-	flags = GEAR_HAS_TYPE_SELECTION | GEAR_HAS_NO_CUSTOMIZATION
+	flags = GEAR_HAS_TYPE_SELECTION
 
 /datum/gear/head/surgical/custom
 	display_name = "surgical cap, colour select"
@@ -177,7 +177,6 @@
 /datum/gear/head/corporateberet
 	display_name = "corporate beret selection"
 	path = /obj/item/clothing/head/beret
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 /datum/gear/head/corporateberet/New()
 	..()

--- a/code/modules/client/preference_setup/loadout/lists/suits.dm
+++ b/code/modules/client/preference_setup/loadout/lists/suits.dm
@@ -155,7 +155,6 @@
 /datum/gear/suit/medcoat
 	display_name = "medical suit selection"
 	path = /obj/item/clothing/suit
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 /datum/gear/suit/medcoat/New()
 	..()

--- a/code/modules/client/preference_setup/loadout/lists/tactical.dm
+++ b/code/modules/client/preference_setup/loadout/lists/tactical.dm
@@ -6,7 +6,7 @@
 /datum/gear/tactical/helm_covers
 	display_name = "helmet covers"
 	path = /obj/item/clothing/accessory/helmet_cover
-	flags = GEAR_HAS_SUBTYPE_SELECTION | GEAR_HAS_NO_CUSTOMIZATION
+	flags = GEAR_HAS_SUBTYPE_SELECTION
 
 /datum/gear/tactical/kneepads
 	display_name = "kneepads"

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -135,7 +135,6 @@
 		/datum/job/doctor,
 		/datum/job/medical_trainee
 	)
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 /datum/gear/accessory/armband_corpsman
 	display_name = "medical armband"
@@ -147,7 +146,6 @@
 		/datum/job/doctor,
 		/datum/job/medical_trainee
 	)
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 /datum/gear/accessory/armband_engineering
 	allowed_roles = ENGINEERING_ROLES
@@ -159,7 +157,6 @@
 		/datum/job/scientist_assistant,
 		/datum/job/assistant
 	)
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 /datum/gear/accessory/armband_nt
 	allowed_branches = CIVILIAN_BRANCHES

--- a/maps/torch/loadout/loadout_head.dm
+++ b/maps/torch/loadout/loadout_head.dm
@@ -139,7 +139,6 @@
 /datum/gear/tactical/armor_tag_flag
 	display_name = "Armor Tag Selection - Flags"
 	path = /obj/item/clothing/accessory/armor_tag
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/tactical/armor_tag_flag/New()
@@ -154,7 +153,6 @@
 /datum/gear/tactical/armor_tag_blood
 	display_name = "Armor Tag Selection - Blood Type"
 	path = /obj/item/clothing/accessory/armor_tag
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/tactical/armor_tag_blood/New()
@@ -174,7 +172,6 @@
 /datum/gear/tactical/armor_tag_corporate
 	display_name = "Armor Tag Selection - Corporate Insignia"
 	path = /obj/item/clothing/accessory/armor_tag
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 
 /datum/gear/tactical/armor_tag_corporate/New()

--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -200,7 +200,6 @@
 	allowed_branches = list(
 		/datum/mil_branch/solgov
 	)
-	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 /datum/gear/suit/chest_rig/New()
 	allowed_roles = TECHNICAL_ROLES + SECURITY_ROLES + list(


### PR DESCRIPTION
So, turns out a lot of loadout items had GEAR_HAS_NO_CUSTOMIZATION (meaning you can't change the name or description) when they really didn't need it. I've gone through and limited it exclusively to uniformed items (like EC/Fleet gear and medals/awards/patches). You still can't customise your SecHUD name/desc, but that's a balance thing and I'm trying to avoid touching balance at all in this PR.

:cl: TheNightingale
tweak: More non-uniformed items have customisation enabled in the loadout.
/:cl: