### PR TITLE
Fix parrot drop message visible to observers

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -664,7 +664,7 @@
 		return -1
 
 	if(!held_item)
-		to_chat(usr, SPAN_WARNING("You have nothing to drop!"))
+		to_chat(src, SPAN_WARNING("You have nothing to drop!"))
 		return 0
 
 	if(!drop_gently)


### PR DESCRIPTION
(Probably) fixes this annoying thing observers have:  
![image](https://github.com/Baystation12/Baystation12/assets/32931701/13727979-63b5-42c3-9d4e-16451b3db68a)
