### PR TITLE
Fix airlock red circle triangle exclaimnation mark icon

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -360,7 +360,6 @@
 	operating = DOOR_OPERATING_YES
 
 	do_animate("opening")
-	icon_state = "door0"
 	set_opacity(0)
 	if(width > 1)
 		set_fillers_opacity(0)


### PR DESCRIPTION
Fixes red circle triangle exclaimnation mark airlock opening icon

This:
![image](https://imgur.com/S3YVIwi.png)

```yml
🆑SuhEugene
bugfix: Fixed red circle triangle exclaimnation mark airlock opening icon
/🆑
```