### PR TITLE
apply zmimic to space in maps where space is multi-z

### DIFF
--- a/code/__defines/MC.dm
+++ b/code/__defines/MC.dm
@@ -169,9 +169,3 @@ if(Datum.is_processing) {\
 ****/
 
 #define addtimer(args...) _addtimer(args, source ="[__FILE__]#[__LINE__]")
-
-/****
- *  Helper for waits
- ****/
-
-#define UNTIL(X) while(!(X)) stoplag()

--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -119,7 +119,3 @@
 #define LIGHT_NARROW 45
 
 #define DARKSIGHT_GRADIENT_SIZE 480
-// Max number of ambient groups, amount over this value will simply not be created
-#define AMBIENT_GROUP_MAX_BITS 24
-// Ambient group used for exterior turfs not on planets - Could also replace Space turf legacy starlight implementation
-#define SPACE_AMBIENT_GROUP 1

--- a/code/controllers/subsystems/skybox.dm
+++ b/code/controllers/subsystems/skybox.dm
@@ -6,6 +6,9 @@ SUBSYSTEM_DEF(skybox)
 	/// The background color of space in the current round
 	var/static/background_color
 
+	/// The same hue as background_color, but with a low saturation and high value
+	var/static/starlight_color
+
 	/// The skybox icon file to use for backgrounds. Expects to be 736x736
 	var/static/skybox_icon = 'icons/skybox/skybox.dmi'
 
@@ -44,7 +47,9 @@ SUBSYSTEM_DEF(skybox)
 		space.icon_state = "white"
 		space.AddOverlays(dust)
 		space_appearance_cache[index] = space.appearance
-	background_color = RANDOM_RGB
+	var/hue = rand(0, 359)
+	background_color = rgb(hue, rand(25, 80), rand(25, 80), space=COLORSPACE_HSV)
+	starlight_color = rgb(hue, 25, 90, space=COLORSPACE_HSV)
 
 
 /datum/controller/subsystem/skybox/proc/get_skybox(z)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -56,7 +56,7 @@
 		update_light()
 
 	if (!mapload || (!istype(src, /turf/space) && is_outside()))
-		SSambient_lighting.queued += src
+		SSambient_lighting.queue += src
 
 	if (opacity)
 		has_opaque_atom = TRUE

--- a/code/modules/multiz/basic.dm
+++ b/code/modules/multiz/basic.dm
@@ -42,13 +42,25 @@ var/global/list/z_levels = list()// Each bit re... haha just kidding this is a l
 		return null
 	return HasBelow(turf.z) ? get_step(turf, DOWN) : null
 
+
+/proc/GetAboveZlevels(z)
+	RETURN_TYPE(/list)
+	. = list()
+	for(var/level = z, HasAbove(level), level++)
+		. |= level + 1
+
+
+/proc/GetBelowZlevels(z)
+	RETURN_TYPE(/list)
+	. = list()
+	for(var/level = z, HasBelow(level), level--)
+		. |= level - 1
+
+
 /proc/GetConnectedZlevels(z)
 	RETURN_TYPE(/list)
-	. = list(z)
-	for(var/level = z, HasBelow(level), level--)
-		. |= level-1
-	for(var/level = z, HasAbove(level), level++)
-		. |= level+1
+	return list(z) + GetAboveZlevels(z) + GetBelowZlevels(z)
+
 
 /proc/AreConnectedZLevels(zA, zB)
 	return zA == zB || (zB in GetConnectedZlevels(zA))

--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -28,7 +28,7 @@ GLOBAL_VAR(planet_repopulation_disabled)
 	var/sun_brightness_modifier = 0.5
 
 	/// Sun control
-	var/ambient_group_index = -1
+	var/ambient_group_index
 
 	var/maxx
 	var/maxy
@@ -251,11 +251,12 @@ GLOBAL_VAR(planet_repopulation_disabled)
 	//We do a gradient instead of linear interpolation because linear interpolations of colours are unintuitive
 	var/new_color = UNLINT(gradient(low_color, high_color, space = COLORSPACE_HSV, index=interpolate_weight))
 
-	if(ambient_group_index > 0)
-		var/datum/ambient_group/A = SSambient_lighting.ambient_groups[ambient_group_index]
-		A.set_color(new_color, new_brightness)
-	else
+	if (isnull(ambient_group_index))
 		ambient_group_index = SSambient_lighting.create_ambient_group(new_color, new_brightness)
+	else if (ambient_group_index)
+		var/datum/ambient_group/group = SSambient_lighting.ambient_groups[ambient_group_index]
+		group.set_color(new_color, new_brightness)
+
 
 /obj/overmap/visitable/sector/exoplanet/proc/generate_map()
 	var/list/grasscolors = plant_colors.Copy()

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/space,
+/turf/space/open,
 /area/space)
 "ab" = (
 /obj/structure/table/standard,
@@ -13,19 +13,19 @@
 /obj/shuttle_landmark/skipjack/deck5{
 	name = "4th Deck, Aft Starboard"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "ad" = (
 /obj/shuttle_landmark/torch/deck5/guppy{
 	name = "4th Deck, Starboard"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "ae" = (
 /obj/shuttle_landmark/merc/deck5{
 	name = "4th Deck, Fore Starboard"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "af" = (
 /turf/simulated/wall/prepainted,
@@ -41,7 +41,7 @@
 /area/maintenance/fourthdeck/aft)
 "ai" = (
 /obj/shuttle_landmark/scavver_gantry/torch/three,
-/turf/space,
+/turf/space/open,
 /area/space)
 "aj" = (
 /obj/structure/sign/warning/docking_area,
@@ -366,7 +366,7 @@
 /obj/shuttle_landmark/torch/deck5/aquila{
 	name = "4th Deck, Aft"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "bo" = (
 /turf/simulated/wall/prepainted,
@@ -528,11 +528,11 @@
 "bK" = (
 /obj/shuttle_landmark/icgnv_hound/dock,
 /obj/shuttle_landmark/sfv_arbiter/dock,
-/turf/space,
+/turf/space/open,
 /area/space)
 "bM" = (
 /obj/shuttle_landmark/merchant/out,
-/turf/space,
+/turf/space/open,
 /area/space)
 "bN" = (
 /turf/simulated/floor/plating,
@@ -7049,7 +7049,7 @@
 /area/hallway/primary/fourthdeck/aft)
 "xO" = (
 /obj/shuttle_landmark/vox_raider/dock,
-/turf/space,
+/turf/space/open,
 /area/space)
 "xP" = (
 /obj/machinery/door/airlock/glass/command{
@@ -7311,7 +7311,7 @@
 /area/quartermaster/hangar/catwalks_port)
 "yr" = (
 /obj/shuttle_landmark/merc/dock,
-/turf/space,
+/turf/space/open,
 /area/space)
 "yu" = (
 /obj/floor_decal/techfloor{
@@ -9444,7 +9444,7 @@
 /area/crew_quarters/lounge)
 "Gt" = (
 /obj/shuttle_landmark/scavver_gantry/torch,
-/turf/space,
+/turf/space/open,
 /area/space)
 "Gu" = (
 /obj/floor_decal/industrial/warning{
@@ -10536,22 +10536,22 @@
 /area/maintenance/fourthdeck/port)
 "Kn" = (
 /obj/shuttle_landmark/skipjack/dock,
-/turf/space,
+/turf/space/open,
 /area/space)
 "Ko" = (
 /obj/shuttle_landmark/ert/dock,
 /obj/shuttle_landmark/skrellscout/dock,
-/turf/space,
+/turf/space/open,
 /area/space)
 "Kp" = (
 /obj/shuttle_landmark/ert/deck5{
 	name = "4th Deck, Fore Port"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "Kq" = (
 /obj/landmark/test/space_turf,
-/turf/space,
+/turf/space/open,
 /area/space)
 "Kt" = (
 /obj/structure/railing/mapped,
@@ -12715,7 +12715,7 @@
 	pixel_y = -22;
 	req_access = list("ACCESS_MAINT")
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "QC" = (
 /obj/floor_decal/corner/brown{
@@ -14988,7 +14988,7 @@
 /area/maintenance/fourthdeck/port)
 "WB" = (
 /obj/shuttle_landmark/admin/out,
-/turf/space,
+/turf/space/open,
 /area/space)
 "WC" = (
 /obj/floor_decal/corner/mauve{

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/space,
+/turf/space/open,
 /area/space)
 "ab" = (
 /obj/structure/cable{
@@ -267,7 +267,7 @@
 "aV" = (
 /obj/structure/lattice,
 /obj/structure/grille,
-/turf/space,
+/turf/space/open,
 /area/space)
 "aW" = (
 /turf/simulated/wall/r_wall/hull,
@@ -295,7 +295,7 @@
 /area/maintenance/thirddeck/starboard)
 "bb" = (
 /obj/structure/lattice,
-/turf/space,
+/turf/space/open,
 /area/space)
 "bc" = (
 /obj/floor_decal/corner/yellow{
@@ -2435,7 +2435,7 @@
 "fI" = (
 /obj/structure/grille,
 /obj/structure/lattice,
-/turf/space,
+/turf/space/open,
 /area/space)
 "fJ" = (
 /turf/simulated/floor/wood/walnut,
@@ -2872,7 +2872,7 @@
 /obj/shuttle_landmark/ninja/deck4{
 	name = "3rd Deck, Aft"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "gF" = (
 /obj/structure/cable/green{
@@ -8888,7 +8888,7 @@
 /obj/shuttle_landmark/torch/deck4/exploration_shuttle{
 	name = "3rd Deck, Fore Port"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "uP" = (
 /obj/floor_decal/corner/grey/diagonal{
@@ -15415,7 +15415,7 @@
 /obj/shuttle_landmark/skipjack/deck4{
 	name = "3rd Deck, Aft Port"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "LO" = (
 /obj/machinery/sparker{
@@ -15554,7 +15554,7 @@
 /obj/shuttle_landmark/ert/deck4{
 	name = "3rd Deck, Starboard"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "Mc" = (
 /obj/structure/table/woodentable/walnut,
@@ -15912,7 +15912,7 @@
 /obj/shuttle_landmark/merc/deck4{
 	name = "3rd Deck, Port"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "Nc" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -16265,7 +16265,7 @@
 /obj/shuttle_landmark/torch/deck4/aquila{
 	name = "3rd Deck, Fore"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "Oc" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/space,
+/turf/space/open,
 /area/space)
 "ab" = (
 /obj/structure/disposalpipe/segment{
@@ -57,11 +57,11 @@
 "af" = (
 /obj/structure/lattice,
 /obj/structure/grille,
-/turf/space,
+/turf/space/open,
 /area/space)
 "ag" = (
 /obj/structure/lattice,
-/turf/space,
+/turf/space/open,
 /area/space)
 "ah" = (
 /obj/machinery/power/tracker,
@@ -2135,7 +2135,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "eh" = (
 /obj/machinery/power/fusion_core/mapped{
@@ -3458,7 +3458,7 @@
 /obj/shuttle_landmark/merc/deck3{
 	name = "2nd Deck, Aft"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "gY" = (
 /obj/floor_decal/industrial/warning/corner,
@@ -3506,7 +3506,7 @@
 	pixel_x = 32;
 	pixel_y = 32
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "hg" = (
 /obj/structure/catwalk,
@@ -3878,21 +3878,21 @@
 	dir = 4
 	},
 /obj/structure/lattice,
-/turf/space,
+/turf/space/open,
 /area/space)
 "ik" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
 /obj/structure/lattice,
-/turf/space,
+/turf/space/open,
 /area/space)
 "il" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 10
 	},
 /obj/structure/lattice,
-/turf/space,
+/turf/space/open,
 /area/space)
 "io" = (
 /obj/machinery/light/small,
@@ -4239,20 +4239,20 @@
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging/junction{
 	dir = 4
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "ji" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 4
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "jj" = (
 /obj/machinery/atmospherics/pipe/simple/heat_exchanging{
 	dir = 9
 	},
 /obj/structure/lattice,
-/turf/space,
+/turf/space/open,
 /area/space)
 "jk" = (
 /obj/machinery/door/airlock/external{
@@ -4313,7 +4313,7 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "jw" = (
 /obj/machinery/disposal,
@@ -4502,7 +4502,7 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /obj/structure/disposalpipe/segment,
-/turf/space,
+/turf/space/open,
 /area/space)
 "jX" = (
 /obj/item/device/radio/intercom{
@@ -4972,7 +4972,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "kW" = (
 /obj/structure/closet/emcloset,
@@ -5111,7 +5111,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "lo" = (
 /obj/structure/sign/directions/supply{
@@ -6327,7 +6327,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "oN" = (
 /obj/floor_decal/techfloor{
@@ -6411,7 +6411,7 @@
 	dir = 8;
 	icon_state = "pipe-c"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "pg" = (
 /obj/structure/cable{
@@ -6448,7 +6448,7 @@
 "pl" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment,
-/turf/space,
+/turf/space/open,
 /area/space)
 "po" = (
 /obj/structure/table/rack,
@@ -6996,7 +6996,7 @@
 /obj/shuttle_landmark/torch/deck3/aquila{
 	name = "2nd Deck, Aft Port"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "qv" = (
 /obj/structure/catwalk,
@@ -9099,7 +9099,7 @@
 	pixel_x = 32;
 	pixel_y = -32
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "wc" = (
 /obj/machinery/atmospherics/binary/pump{
@@ -12682,13 +12682,13 @@
 /obj/shuttle_landmark/skipjack/deck3{
 	name = "2nd Deck, Fore Port"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "FT" = (
 /obj/shuttle_landmark/torch/deck3/exploration_shuttle{
 	name = "2nd Deck, Port"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "FV" = (
 /obj/machinery/computer/teleporter{
@@ -12706,7 +12706,7 @@
 /obj/shuttle_landmark/torch/deck3/guppy{
 	name = "2nd Deck, Fore"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "Gd" = (
 /obj/structure/cable/cyan{
@@ -13004,7 +13004,7 @@
 /area/maintenance/seconddeck/aftport)
 "Hb" = (
 /obj/shuttle_landmark/petrov/out,
-/turf/space,
+/turf/space/open,
 /area/space)
 "Hc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
@@ -13988,7 +13988,7 @@
 /obj/shuttle_landmark/ert/deck3{
 	name = "2nd Deck, Fore Starboard"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "Kc" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/black{
@@ -14212,7 +14212,7 @@
 /obj/shuttle_landmark/ninja/deck3{
 	name = "2nd Deck, Aft Starboard"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "Lc" = (
 /obj/floor_decal/industrial/warning,
@@ -16657,7 +16657,7 @@
 /obj/structure/sign/solgov{
 	pixel_y = -32
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "Tg" = (
 /obj/structure/cable/green{
@@ -18246,7 +18246,7 @@
 	dir = 4;
 	pixel_x = -32
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "YQ" = (
 /turf/simulated/wall/prepainted,
@@ -18405,7 +18405,7 @@
 /obj/structure/sign/solgov{
 	pixel_y = 32
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "Zl" = (
 /obj/structure/cable/green{

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -1,24 +1,24 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aaa" = (
-/turf/space,
+/turf/space/open,
 /area/space)
 "aab" = (
 /obj/shuttle_landmark/merc/deck2{
 	name = "1st Deck, Aft Starboard"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "aac" = (
 /obj/shuttle_landmark/torch/deck2/exploration_shuttle{
 	name = "1st Deck, Fore Starboard"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "aad" = (
 /obj/shuttle_landmark/torch/deck2/guppy{
 	name = "1st Deck, Aft"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "aae" = (
 /obj/structure/closet/firecloset,
@@ -125,7 +125,7 @@
 /obj/shuttle_landmark/skipjack/deck2{
 	name = "1st Deck, Fore"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "aas" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
@@ -195,7 +195,7 @@
 /obj/structure/disposaloutlet{
 	dir = 4
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "aaC" = (
 /obj/machinery/atmospherics/valve{
@@ -871,7 +871,7 @@
 "abM" = (
 /obj/structure/lattice,
 /obj/structure/grille,
-/turf/space,
+/turf/space/open,
 /area/space)
 "abN" = (
 /turf/simulated/wall/r_wall/hull,
@@ -1839,7 +1839,7 @@
 /area/maintenance/firstdeck/aftstarboard)
 "adA" = (
 /obj/structure/lattice,
-/turf/space,
+/turf/space/open,
 /area/space)
 "adB" = (
 /obj/floor_decal/corner/paleblue/three_quarters{
@@ -8263,7 +8263,7 @@
 /obj/shuttle_landmark/ert/deck2{
 	name = "1st Deck, Fore Port"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "aAb" = (
 /obj/structure/bed/chair/padded/red{
@@ -14006,13 +14006,13 @@
 /obj/shuttle_landmark/ninja/deck2{
 	name = "1st Deck, Aft Port"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "aWo" = (
 /obj/shuttle_landmark/torch/deck2/aquila{
 	name = "1st Deck, Port"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "aWQ" = (
 /obj/structure/closet/secure_closet/guncabinet/sidearm,
@@ -14028,7 +14028,7 @@
 /obj/structure/sign/solgov{
 	pixel_y = -32
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "aXh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
@@ -14437,7 +14437,7 @@
 /obj/structure/sign/solgov{
 	pixel_y = 32
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "bBm" = (
 /obj/floor_decal/industrial/warning/fulltile,

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
-/turf/space,
+/turf/space/open,
 /area/space)
 "ab" = (
 /obj/wallframe_spawn/reinforced/polarized{
@@ -28,7 +28,7 @@
 /area/space)
 "ae" = (
 /obj/structure/lattice,
-/turf/space,
+/turf/space/open,
 /area/space)
 "af" = (
 /turf/simulated/wall/r_wall/hull,
@@ -3382,7 +3382,7 @@
 /obj/shuttle_landmark/torch/deck1/exploration_shuttle{
 	name = "B-Deck, Fore Port"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "gm" = (
 /turf/unsimulated/mask,
@@ -4680,7 +4680,7 @@
 "kE" = (
 /obj/structure/lattice,
 /obj/machinery/nav_light/starboard,
-/turf/space,
+/turf/space/open,
 /area/space)
 "kH" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
@@ -6161,7 +6161,7 @@
 "pe" = (
 /obj/structure/lattice,
 /obj/machinery/nav_light,
-/turf/space,
+/turf/space/open,
 /area/space)
 "pf" = (
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
@@ -6731,7 +6731,7 @@
 "qN" = (
 /obj/structure/lattice,
 /obj/machinery/nav_light/port,
-/turf/space,
+/turf/space/open,
 /area/space)
 "qO" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -9403,7 +9403,7 @@
 /obj/landmark/map_data{
 	height = 6
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "xQ" = (
 /obj/machinery/embedded_controller/radio/airlock/docking_port{
@@ -9623,13 +9623,13 @@
 /obj/shuttle_landmark/skipjack/deck1{
 	name = "B-Deck, Port"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "yB" = (
 /obj/shuttle_landmark/torch/deck1/guppy{
 	name = "B-Deck, Aft Starboard"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "yD" = (
 /turf/simulated/floor/tiled/dark,
@@ -9706,7 +9706,7 @@
 /obj/shuttle_landmark/merc/deck1{
 	name = "B-Deck, Aft"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "zf" = (
 /obj/structure/bed/chair/comfy/blue{
@@ -9927,7 +9927,7 @@
 /obj/shuttle_landmark/ninja/deck1{
 	name = "B-Deck, Aft Port"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "Ac" = (
 /obj/machinery/optable,
@@ -10420,7 +10420,7 @@
 /obj/shuttle_landmark/torch/deck1/aquila{
 	name = "B-Deck, Fore Starboard"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "Cc" = (
 /obj/structure/closet/medical_wall{
@@ -14763,7 +14763,7 @@
 /obj/shuttle_landmark/ert/deck1{
 	name = "B-Deck, Fore"
 	},
-/turf/space,
+/turf/space/open,
 /area/space)
 "UW" = (
 /obj/paint/red,


### PR DESCRIPTION
Multi-z space can now optionally use /turf/space/open to have zmimic behavior on levels above the bottom of a z group

Has a couple of edge cases regarding vertical cascading on middle of vertical volume changeturf I haven't looked at yet, but otherwise is fine

Is only implemented for main map DMMs, will expand to any others once the previous thing is locked down

Also makes skybox color ranges a little saner, and adds skybox lighting that's based on the same hue but is always bright enough to not look like a bad club

Requires a config change for STARLIGHT to a non-zero value; doesn't currently make much of a difference because of lighting changes, but 0.25~0.3 wasn't overwhelming