### PR TITLE
Change all machinery/attackby to use_tool

### DIFF
--- a/code/game/machinery/CableLayer.dm
+++ b/code/game/machinery/CableLayer.dm
@@ -26,15 +26,14 @@
 	user.visible_message("\The [user] [!on?"dea":"a"]ctivates \the [src].", "You switch [src] [on? "on" : "off"]")
 	return TRUE
 
-/obj/machinery/cablelayer/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/cablelayer/use_tool(obj/item/O, mob/living/user, list/click_params)
 	if(istype(O, /obj/item/stack/cable_coil))
-
 		var/result = load_cable(O)
 		if(!result)
 			to_chat(user, SPAN_WARNING("\The [src]'s cable reel is full."))
 		else
 			to_chat(user, "You load [result] lengths of cable into [src].")
-		return
+		return TRUE
 
 	if(isWirecutter(O))
 		if(cable && cable.amount)
@@ -48,6 +47,8 @@
 				CC.amount = m
 		else
 			to_chat(usr, SPAN_WARNING("There's no more cable on the reel."))
+		return TRUE
+	return ..()
 
 /obj/machinery/cablelayer/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -173,17 +173,17 @@
 		updateUsrDialog()
 		go_out()
 
-/obj/machinery/sleeper/attackby(obj/item/I, mob/user)
+/obj/machinery/sleeper/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if(istype(I, /obj/item/reagent_containers/glass))
-		add_fingerprint(user)
-		if(!beaker)
-			if(!user.unEquip(I, src))
-				return
-			beaker = I
-			user.visible_message(SPAN_NOTICE("\The [user] adds \a [I] to \the [src]."), SPAN_NOTICE("You add \a [I] to \the [src]."))
-		else
-			to_chat(user, SPAN_WARNING("\The [src] has a beaker already."))
+		if(beaker)
+			to_chat(user, SPAN_WARNING("There is already a beaker loaded in \the [src]."))
+			return TRUE
+		if(!user.unEquip(I, src))
+			return TRUE
+		beaker = I
+		user.visible_message(SPAN_NOTICE("\The [user] adds \a [I] to \the [src]."), SPAN_NOTICE("You add \a [I] to \the [src]."))
 		return TRUE
+
 	return ..()
 
 /obj/machinery/sleeper/user_can_move_target_inside(mob/target, mob/user)

--- a/code/game/machinery/_machines_base/machine_construction/_construction.dm
+++ b/code/game/machinery/_machines_base/machine_construction/_construction.dm
@@ -78,11 +78,14 @@
 		machine.attack_hand(user)
 		return TRUE
 
+/*
+This returning FALSE means if component_attackby under use_tool called this it will also return FALSE; which means the use_tool call will proceed.
+In that same vein, the attackby() children of this proc will also continue the rest of its code if this crashes; since this check is called at the beginning.
+*/
 /singleton/machine_construction/proc/attackby(obj/item/I, mob/user, obj/machinery/machine)
 	if(!validate_state(machine))
 		crash_with("Machine [log_info_line(machine)] violated the state assumptions of the construction state [type]!")
-		machine.use_tool(I, user)
-		return TRUE
+		return FALSE
 
 /singleton/machine_construction/proc/mechanics_info()
 

--- a/code/game/machinery/_machines_base/machine_construction/_construction.dm
+++ b/code/game/machinery/_machines_base/machine_construction/_construction.dm
@@ -81,7 +81,7 @@
 /singleton/machine_construction/proc/attackby(obj/item/I, mob/user, obj/machinery/machine)
 	if(!validate_state(machine))
 		crash_with("Machine [log_info_line(machine)] violated the state assumptions of the construction state [type]!")
-		machine.attackby(I, user)
+		machine.use_tool(I, user)
 		return TRUE
 
 /singleton/machine_construction/proc/mechanics_info()

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -252,8 +252,9 @@
 
 
 /obj/machinery/post_anchor_change()
-	..()
+	update_use_power(anchored)
 	power_change()
+	..()
 
 /**
  * Called by machines that can hold a mob (sleeper, suit cycler, etc.), checking if mob can be moved before doing so.

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -243,15 +243,11 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 
 /obj/machinery/can_anchor(obj/item/tool, mob/user, silent)
 	if (use_power == POWER_USE_ACTIVE)
-		to_chat(user, SPAN_WARNING("Turn \the [src] off first!"))
+		if (!silent)
+			to_chat(user, SPAN_WARNING("Turn \the [src] off first!"))
 		return FALSE
 	return ..()
 
-
-/obj/machinery/post_anchor_change()
-	update_use_power(anchored)
-	power_change()
-	..()
 
 /obj/machinery/post_anchor_change()
 	update_use_power(anchored)

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -236,8 +236,8 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 /// Called whenever an attached component updates it's status. Override to handle updates to the machine.
 /obj/machinery/proc/component_stat_change(obj/item/stock_parts/part, old_stat, flag)
 
-/obj/machinery/attackby(obj/item/I, mob/user)
-	if(component_attackby(I, user))
+/obj/machinery/use_tool(obj/item/tool, mob/living/user, list/click_params)
+	if (component_attackby(tool, user))
 		return TRUE
 	return ..()
 

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -239,11 +239,15 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 /obj/machinery/use_tool(obj/item/tool, mob/living/user, list/click_params)
 	if (component_attackby(tool, user))
 		return TRUE
+	if (isWrench(tool) && HAS_FLAGS(obj_flags, OBJ_FLAG_ANCHORABLE) && use_power == POWER_USE_ACTIVE)
+		to_chat(user, SPAN_WARNING("Turn \the [src] off first!"))
+		return TRUE
 	return ..()
 
 /obj/machinery/post_anchor_change()
+	update_use_power(anchored)
 	power_change()
-	return ..()
+	..()
 
 /// Passes `attackby()` calls through to components within the machine, if they are accessible.
 /obj/machinery/proc/component_attackby(obj/item/I, mob/user)

--- a/code/game/machinery/_machines_base/machinery_components.dm
+++ b/code/game/machinery/_machines_base/machinery_components.dm
@@ -239,10 +239,19 @@ GLOBAL_LIST_INIT(machine_path_to_circuit_type, cache_circuits_by_build_path())
 /obj/machinery/use_tool(obj/item/tool, mob/living/user, list/click_params)
 	if (component_attackby(tool, user))
 		return TRUE
-	if (isWrench(tool) && HAS_FLAGS(obj_flags, OBJ_FLAG_ANCHORABLE) && use_power == POWER_USE_ACTIVE)
-		to_chat(user, SPAN_WARNING("Turn \the [src] off first!"))
-		return TRUE
 	return ..()
+
+/obj/machinery/can_anchor(obj/item/tool, mob/user, silent)
+	if (use_power == POWER_USE_ACTIVE)
+		to_chat(user, SPAN_WARNING("Turn \the [src] off first!"))
+		return FALSE
+	return ..()
+
+
+/obj/machinery/post_anchor_change()
+	update_use_power(anchored)
+	power_change()
+	..()
 
 /obj/machinery/post_anchor_change()
 	update_use_power(anchored)

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -992,6 +992,9 @@ FIRE ALARM
 	..()
 
 /obj/machinery/firealarm/use_tool(obj/item/W, mob/living/user, list/click_params)
+	if ((. = ..()))
+		return
+
 	if(isScrewdriver(W) && buildstage == 2)
 		wiresexposed = !wiresexposed
 		update_icon()
@@ -1059,7 +1062,7 @@ FIRE ALARM
 
 	to_chat(user, SPAN_WARNING("You fumble with \the [W] and trigger the alarm!"))
 	alarm()
-	return ..()
+	return TRUE
 
 /obj/machinery/firealarm/Process()//Note: this processing was mostly phased out due to other code, and only runs when needed
 	if(inoperable())

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -808,15 +808,14 @@
 			apply_mode()
 			return TOPIC_REFRESH
 
-/obj/machinery/alarm/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/alarm/use_tool(obj/item/W, mob/living/user, list/click_params)
 	switch(buildstage)
 		if(2)
-			if(isScrewdriver(W))  // Opening that Air Alarm up.
-//				to_chat(user, "You pop the Air Alarm's maintence panel open.")
+			if (isScrewdriver(W))
 				wiresexposed = !wiresexposed
 				to_chat(user, "The wires have been [wiresexposed ? "exposed" : "unexposed"]")
 				update_icon()
-				return
+				return TRUE
 
 			if (wiresexposed && isWirecutter(W))
 				user.visible_message(SPAN_WARNING("[user] has cut the wires inside \the [src]!"), "You have cut the wires inside \the [src].")
@@ -824,55 +823,58 @@
 				new/obj/item/stack/cable_coil(get_turf(src), 5)
 				buildstage = 1
 				update_icon()
-				return
+				return TRUE
 
-			if (istype(W, /obj/item/card/id) || istype(W, /obj/item/modular_computer))// trying to unlock the interface with an ID card
+			if (istype(W, /obj/item/card/id) || istype(W, /obj/item/modular_computer))
 				if(inoperable())
 					to_chat(user, "It does nothing")
-					return
+					return TRUE
+				if(allowed(usr) && !wires.IsIndexCut(AALARM_WIRE_IDSCAN))
+					locked = !locked
+					to_chat(user, SPAN_NOTICE("You [ locked ? "lock" : "unlock"] the Air Alarm interface."))
 				else
-					if(allowed(usr) && !wires.IsIndexCut(AALARM_WIRE_IDSCAN))
-						locked = !locked
-						to_chat(user, SPAN_NOTICE("You [ locked ? "lock" : "unlock"] the Air Alarm interface."))
-					else
-						to_chat(user, SPAN_WARNING("Access denied."))
-			return
+					to_chat(user, SPAN_WARNING("Access denied."))
+				return TRUE
 
 		if(1)
-			if(isCoil(W))
+			if (isCoil(W))
 				var/obj/item/stack/cable_coil/C = W
 				if (C.use(5))
 					to_chat(user, SPAN_NOTICE("You wire \the [src]."))
 					buildstage = 2
 					update_icon()
-					return
+					return TRUE
 				else
 					to_chat(user, SPAN_WARNING("You need 5 pieces of cable to do wire \the [src]."))
-					return
+					return TRUE
 
-			else if(isCrowbar(W))
+			if (isCrowbar(W))
 				to_chat(user, "You start prying out the circuit.")
 				playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
-				if(do_after(user, (W.toolspeed * 2) SECONDS, src, DO_REPAIR_CONSTRUCT) && buildstage == 1)
-					to_chat(user, "You pry out the circuit!")
-					var/obj/item/airalarm_electronics/circuit = new /obj/item/airalarm_electronics()
-					circuit.dropInto(user.loc)
-					buildstage = 0
-					update_icon()
-				return
+				if (!do_after(user, (W.toolspeed * 2) SECONDS, src, DO_REPAIR_CONSTRUCT))
+					return TRUE
+
+				to_chat(user, "You pry out the circuit!")
+				var/obj/item/airalarm_electronics/circuit = new /obj/item/airalarm_electronics()
+				circuit.dropInto(user.loc)
+				buildstage = 0
+				update_icon()
+				return TRUE
+
 		if(0)
-			if(istype(W, /obj/item/airalarm_electronics))
+			if (istype(W, /obj/item/airalarm_electronics))
 				to_chat(user, "You insert the circuit!")
 				qdel(W)
 				buildstage = 1
 				update_icon()
-				return
+				return TRUE
 
-			else if(isWrench(W))
+			if (isWrench(W))
 				to_chat(user, "You remove the fire alarm assembly from the wall!")
 				new /obj/item/frame/air_alarm(get_turf(user))
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 				qdel(src)
+				return TRUE
 
 	return ..()
 
@@ -988,27 +990,34 @@ FIRE ALARM
 		alarm(rand(30/severity, 60/severity))
 	..()
 
-/obj/machinery/firealarm/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/firealarm/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(isScrewdriver(W) && buildstage == 2)
 		wiresexposed = !wiresexposed
 		update_icon()
-		return
+		return TRUE
 
 	if(wiresexposed)
 		switch(buildstage)
 			if(2)
 				if(isMultitool(W))
-					src.detecting = !( src.detecting )
-					if (src.detecting)
-						user.visible_message(SPAN_NOTICE("\The [user] has reconnected [src]'s detecting unit!"), SPAN_NOTICE("You have reconnected [src]'s detecting unit."))
-					else
-						user.visible_message(SPAN_NOTICE("\The [user] has disconnected [src]'s detecting unit!"), SPAN_NOTICE("You have disconnected [src]'s detecting unit."))
-				else if(isWirecutter(W))
-					user.visible_message(SPAN_NOTICE("\The [user] has cut the wires inside \the [src]!"), SPAN_NOTICE("You have cut the wires inside \the [src]."))
+					detecting = !detecting
+					user.visible_message(
+						SPAN_NOTICE("\The [user] has [detecting? "re" : "dis"]connected \the [src]'s detecting unit!"),
+						SPAN_NOTICE("You have [detecting? "re" : "dis"]connected \the [src]'s detecting unit.")
+					)
+					return TRUE
+
+				if (isWirecutter(W))
+					user.visible_message(
+						SPAN_NOTICE("\The [user] has cut the wires inside \the [src]!"),
+						SPAN_NOTICE("You have cut the wires inside \the [src].")
+					)
 					new/obj/item/stack/cable_coil(get_turf(src), 5)
 					playsound(src.loc, 'sound/items/Wirecutter.ogg', 50, 1)
 					buildstage = 1
 					update_icon()
+					return TRUE
+
 			if(1)
 				if(istype(W, /obj/item/stack/cable_coil))
 					var/obj/item/stack/cable_coil/C = W
@@ -1016,35 +1025,40 @@ FIRE ALARM
 						to_chat(user, SPAN_NOTICE("You wire \the [src]."))
 						buildstage = 2
 						update_icon()
-						return
+						return TRUE
 					else
 						to_chat(user, SPAN_WARNING("You need 5 pieces of cable to wire \the [src]."))
-						return
-				else if(isCrowbar(W))
+						return TRUE
+				if(isCrowbar(W))
 					to_chat(user, "You start prying out the circuit.")
 					playsound(src.loc, 'sound/items/Crowbar.ogg', 50, 1)
-					if (do_after(user, (W.toolspeed * 2) SECONDS, src, DO_REPAIR_CONSTRUCT))
-						to_chat(user, "You pry out the circuit!")
-						var/obj/item/firealarm_electronics/circuit = new /obj/item/firealarm_electronics()
-						circuit.dropInto(user.loc)
-						buildstage = 0
-						update_icon()
+					if (!do_after(user, (W.toolspeed * 2) SECONDS, src, DO_REPAIR_CONSTRUCT))
+						return TRUE
+
+					to_chat(user, "You pry out the circuit!")
+					var/obj/item/firealarm_electronics/circuit = new /obj/item/firealarm_electronics()
+					circuit.dropInto(user.loc)
+					buildstage = 0
+					update_icon()
+					return TRUE
 			if(0)
 				if(istype(W, /obj/item/firealarm_electronics))
 					to_chat(user, "You insert the circuit!")
 					qdel(W)
 					buildstage = 1
 					update_icon()
+					return TRUE
 
-				else if(isWrench(W))
+				if (isWrench(W))
 					to_chat(user, "You remove the fire alarm assembly from the wall!")
 					new /obj/item/frame/fire_alarm(get_turf(user))
 					playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 					qdel(src)
-		return
+					return TRUE
 
-	src.alarm()
-	return
+	to_chat(user, SPAN_WARNING("You fumble with \the [W] and trigger the alarm!"))
+	alarm()
+	return ..()
 
 /obj/machinery/firealarm/Process()//Note: this processing was mostly phased out due to other code, and only runs when needed
 	if(inoperable())

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -825,7 +825,7 @@
 				update_icon()
 				return TRUE
 
-			if (istype(W, /obj/item/card/id) || istype(W, /obj/item/modular_computer))
+			if (isid(W) || istype(W, /obj/item/modular_computer))
 				if(inoperable())
 					to_chat(user, "It does nothing")
 					return TRUE
@@ -871,7 +871,8 @@
 
 			if (isWrench(W))
 				to_chat(user, "You remove the fire alarm assembly from the wall!")
-				new /obj/item/frame/air_alarm(get_turf(user))
+				var/obj/item/frame/air_alarm/frame = new /obj/item/frame/air_alarm(get_turf(user))
+				transfer_fingerprints_to(frame)
 				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 				qdel(src)
 				return TRUE

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -205,7 +205,7 @@
 		return GM.return_pressure()
 	return 0
 
-/obj/machinery/portable_atmospherics/canister/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/portable_atmospherics/canister/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(istype(user, /mob/living/silicon/robot) && istype(W, /obj/item/tank/jetpack))
 		var/datum/gas_mixture/thejetpack = W:air_contents
 		var/env_pressure = thejetpack.return_pressure()

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -103,38 +103,36 @@
 	if (network)
 		network.update = 1
 
-/obj/machinery/portable_atmospherics/attackby(obj/item/W as obj, mob/user as mob)
-	if ((istype(W, /obj/item/tank) && !( src.destroyed )))
-		if (src.holding)
+/obj/machinery/portable_atmospherics/use_tool(obj/item/W, mob/living/user, list/click_params)
+	if ((istype(W, /obj/item/tank) && !destroyed))
+		if (holding)
+			to_chat(user, SPAN_WARNING("\The [src] already contains a tank!"))
 			return
 		if(!user.unEquip(W, src))
-			return
-		src.holding = W
+			return TRUE
+		holding = W
 		update_icon()
-		return
+		return TRUE
 
-	else if(isWrench(W))
+	if(isWrench(W))
 		if(connected_port)
 			disconnect()
 			to_chat(user, SPAN_NOTICE("You disconnect \the [src] from the port."))
 			update_icon()
-			return
+			return TRUE
 		else
 			var/obj/machinery/atmospherics/portables_connector/possible_port = locate(/obj/machinery/atmospherics/portables_connector) in loc
 			if(possible_port)
 				if(connect(possible_port))
 					to_chat(user, SPAN_NOTICE("You connect \the [src] to the port."))
 					update_icon()
-					return
+					return TRUE
 				else
 					to_chat(user, SPAN_NOTICE("\The [src] failed to connect to the port."))
-					return
+					return TRUE
 			else
 				to_chat(user, SPAN_NOTICE("Nothing happens."))
-				return ..()
-
-	else if (istype(W, /obj/item/device/scanner/gas))
-		return
+				return TRUE
 
 	return ..()
 

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -203,7 +203,7 @@
 	base_type = /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary
 	machine_name = "large stationary portable scrubber"
 	machine_desc = "This is simply a large portable scrubber that can't be moved once it's bolted into place, and is otherwise identical."
-	obj_flags = null
+	obj_flags = EMPTY_BITFIELD
 
 /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if(isWrench(I))

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -156,6 +156,7 @@
 	volume = 50000
 	volume_rate = 5000
 	base_type = /obj/machinery/portable_atmospherics/powered/scrubber/huge
+	obj_flags = OBJ_FLAG_ANCHORABLE
 
 	uncreated_component_parts = list(/obj/item/stock_parts/power/apc)
 	maximum_component_parts = list(/obj/item/stock_parts = 15)
@@ -190,21 +191,10 @@
 	else
 		icon_state = "scrubber:0"
 
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/attackby(obj/item/I as obj, mob/user as mob)
-	if(isWrench(I))
-		if(use_power == POWER_USE_ACTIVE)
-			to_chat(user, SPAN_WARNING("Turn \the [src] off first!"))
-			return
-
-		anchored = !anchored
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		to_chat(user, SPAN_NOTICE("You [anchored ? "wrench" : "unwrench"] \the [src]."))
-
-		return
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/use_tool(obj/item/I, mob/living/user, list/click_params)
 	//doesn't hold tanks
 	if(istype(I, /obj/item/tank))
-		return
-
+		return FALSE
 	return ..()
 
 
@@ -213,10 +203,11 @@
 	base_type = /obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary
 	machine_name = "large stationary portable scrubber"
 	machine_desc = "This is simply a large portable scrubber that can't be moved once it's bolted into place, and is otherwise identical."
+	obj_flags = null
 
-/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/attackby(obj/item/I as obj, mob/user as mob)
+/obj/machinery/portable_atmospherics/powered/scrubber/huge/stationary/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if(isWrench(I))
 		to_chat(user, SPAN_WARNING("The bolts are too tight for you to unscrew!"))
-		return
+		return TRUE
 
 	return ..()

--- a/code/game/machinery/barrier.dm
+++ b/code/game/machinery/barrier.dm
@@ -21,7 +21,7 @@
 			message += SPAN_WARNING(" The locking clamps have other ideas.")
 		to_chat(user, message)
 
-/obj/machinery/barrier/attackby(obj/item/I, mob/user)
+/obj/machinery/barrier/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if (isid(I))
 		var/success = allowed(user)
 		var/message = " to no effect"
@@ -41,12 +41,9 @@
 			anchored = emagged ? FALSE : locked
 			update_icon()
 		return TRUE
-	if (user.a_intent == I_HURT)
-		return ..()
 	if (isWelder(I))
 		var/obj/item/weldingtool/W = I
-		if (!W.welding)
-			to_chat(user, SPAN_WARNING("\The [I] isn't turned on."))
+		if (!W.can_use(1, user))
 			return TRUE
 		if (!emagged)
 			to_chat(user, SPAN_WARNING("\The [src]'s locking clamps are not damaged."))
@@ -56,20 +53,21 @@
 			"You start to repair \the [src]'s locking clamps with \the [I].",
 			"You hear a hissing flame."
 		)
-		if (do_after(user, (I.toolspeed * 15) SECONDS, src, DO_REPAIR_CONSTRUCT))
-			to_chat(user, SPAN_NOTICE("There - Good as new."))
-			emagged = FALSE
-			if (locked)
-				visible_message(
-					"\The [src]'s clamps engage, locking onto \the [get_turf(src)].",
-					"You hear metal sliding and creaking.",
-					range = 5
-				)
-				anchored = TRUE
-			update_icon()
+		if (!do_after(user, (I.toolspeed * 15) SECONDS, src, DO_REPAIR_CONSTRUCT))
+			return TRUE
+		W.remove_fuel(1, user)
+		to_chat(user, SPAN_NOTICE("You finished repairing \the [src]'s locking clamps."))
+		emagged = FALSE
+		if (locked)
+			visible_message(
+				"\The [src]'s clamps engage, locking onto \the [get_turf(src)].",
+				"You hear metal sliding and creaking.",
+				range = 5
+			)
+			anchored = TRUE
+		update_icon()
 		return TRUE
-	to_chat(user, SPAN_WARNING("You can't think of a way to use \the [I] on \the [src]."))
-	return TRUE
+	return ..()
 
 /obj/machinery/barrier/emag_act(remaining_charges, mob/user, emag_source)
 	if (user)

--- a/code/game/machinery/biogenerator.dm
+++ b/code/game/machinery/biogenerator.dm
@@ -83,12 +83,17 @@
 		return SPAN_NOTICE("You must turn \the [src] off first.")
 	return ..()
 
-/obj/machinery/biogenerator/attackby(obj/item/O, mob/user)
-	if((. = component_attackby(O, user)))
-		return
-	if(processing)
+/obj/machinery/biogenerator/examine(mob/user)
+	. = ..()
+	if (processing)
 		to_chat(user, SPAN_NOTICE("\The [src] is currently processing."))
-	if(istype(O, /obj/item/reagent_containers/glass))
+	if (ingredients >= capacity)
+		to_chat(user, SPAN_NOTICE("\The [src] is full!"))
+
+/obj/machinery/biogenerator/use_tool(obj/item/O, mob/living/user, list/click_params)
+	if((. = ..()))
+		return
+	if (istype(O, /obj/item/reagent_containers/glass))
 		if(beaker)
 			to_chat(user, SPAN_NOTICE("The [src] is already loaded."))
 			return TRUE
@@ -98,9 +103,7 @@
 			updateUsrDialog()
 			return TRUE
 
-	if(ingredients >= capacity)
-		to_chat(user, SPAN_NOTICE("\The [src] is already full! Activate it."))
-	else if(istype(O, /obj/item/storage/plants))
+	if (istype(O, /obj/item/storage/plants))
 		var/obj/item/storage/plants/P = O
 		var/hadPlants = 0
 		for(var/obj/item/reagent_containers/food/snacks/grown/G in P.contents)
@@ -113,16 +116,19 @@
 		P.finish_bulk_removal() //Now do the UI stuff once.
 		if(!hadPlants)
 			to_chat(user, SPAN_NOTICE("\The [P] has no produce inside."))
-		else if(ingredients < capacity)
+		if (ingredients < capacity)
 			to_chat(user, SPAN_NOTICE("You empty \the [P] into \the [src]."))
+		return TRUE
 
-
-	else if(!istype(O, /obj/item/reagent_containers/food/snacks/grown))
+	if (!istype(O, /obj/item/reagent_containers/food/snacks/grown))
 		to_chat(user, SPAN_NOTICE("You cannot put this in \the [src]."))
-	else if(user.unEquip(O, src))
+		return TRUE
+
+	if(user.unEquip(O, src))
 		ingredients++
 		to_chat(user, SPAN_NOTICE("You put \the [O] in \the [src]"))
 	update_icon()
+	return TRUE
 
 /**
  *  Display the NanoUI window for the vending machine.

--- a/code/game/machinery/bluespace_drive.dm
+++ b/code/game/machinery/bluespace_drive.dm
@@ -96,15 +96,17 @@
 		verbs -= verb
 	update_icon()
 
+/obj/machinery/bluespacedrive/use_grab(obj/item/grab/grab, list/click_params)
+	to_chat(grab.assailant, SPAN_WARNING("\The [src] pulls at \the [grab.affecting] but they're too heavy."))
+	return TRUE
 
-/obj/machinery/bluespacedrive/attackby(obj/item/item, mob/user)
-	if (istype(item, /obj/item/grab))
-		var/obj/item/grab/grab = item
-		to_chat(user, SPAN_WARNING("\The [src] pulls at \the [grab.affecting] but they're too heavy."))
+/obj/machinery/bluespacedrive/use_tool(obj/item/item, mob/living/user, list/click_params)
+	if ((. = ..()))
 		return
+
 	if (issilicon(user) || !user.unEquip(item, src))
 		to_chat(user, SPAN_WARNING("\The [src] pulls at \the [item] but it's attached to you."))
-		return
+		return TRUE
 	user.visible_message(
 		SPAN_WARNING("\The [user] reaches out \a [item] to \the [src], warping briefly as it disappears in a flash of blue light, scintillating motes left behind."),
 		SPAN_DANGER("You touch \the [src] with \the [item], the field buckling around it before retracting with a crackle as it leaves small, blue scintillas on your hand as you flinch away."),
@@ -112,9 +114,10 @@
 	)
 	qdel(item)
 	if (prob(5))
-		playsound(loc, 'sound/items/eatfood.ogg', 40)		//Yum
+		playsound(loc, 'sound/items/eatfood.ogg', 40)
 	else
 		playsound(loc, 'sound/machines/BSD_interact.ogg', 40)
+	return TRUE
 
 
 /obj/machinery/bluespacedrive/examine_damage_state(mob/user)

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -25,8 +25,10 @@
 	. = ..()
 	update_icon()
 
-/obj/machinery/button/attackby(obj/item/W, mob/user as mob)
-	return attack_hand(user)
+/obj/machinery/button/use_tool(obj/item/tool, mob/living/user, list/click_params)
+	if (attack_hand(user))
+		return TRUE
+	return ..()
 
 /obj/machinery/button/interface_interact(user)
 	if(!CanInteract(user, DefaultTopicState()))

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -164,24 +164,24 @@
 		kill_health()
 		return TRUE
 
-/obj/machinery/camera/attackby(obj/item/W as obj, mob/living/user as mob)
+/obj/machinery/camera/use_tool(obj/item/W, mob/living/user, list/click_params)
 	update_coverage()
 	var/datum/wires/camera/camera_wires = wires
-	// DECONSTRUCTION
+
 	if(isScrewdriver(W))
-//		to_chat(user, SPAN_NOTICE("You start to [panel_open ? "close" : "open"] the camera's panel."))
-		//if(toggle_panel(user)) // No delay because no one likes screwdrivers trying to be hip and have a duration cooldown
 		panel_open = !panel_open
 		user.visible_message(
-			SPAN_WARNING("[user] screws the camera's panel [panel_open ? "open" : "closed"]!"),
-			SPAN_NOTICE("You screw the camera's panel [panel_open ? "open" : "closed"].")
+			SPAN_WARNING("\The [user] screws \the [src]'s panel [panel_open ? "open" : "closed"]!"),
+			SPAN_NOTICE("You screw \the [src]'s panel [panel_open ? "open" : "closed"].")
 		)
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
+		return TRUE
 
-	else if((isWirecutter(W) || isMultitool(W)) && panel_open)
-		return wires.Interact(user)
+	if ((isWirecutter(W) || isMultitool(W)) && panel_open)
+		wires.Interact(user)
+		return TRUE
 
-	else if(isWelder(W) && (camera_wires.CanDeconstruct() || (MACHINE_IS_BROKEN(src))))
+	if (isWelder(W) && (camera_wires.CanDeconstruct() || (MACHINE_IS_BROKEN(src))))
 		if(weld(W, user))
 			if(assembly)
 				assembly.dropInto(loc)
@@ -189,7 +189,7 @@
 				assembly.camera_name = c_tag
 				assembly.camera_network = english_list(network, "Exodus", ",", ",")
 				assembly.update_icon()
-				assembly.dir = src.dir
+				assembly.dir = dir
 				if(MACHINE_IS_BROKEN(src))
 					assembly.state = 2
 					to_chat(user, SPAN_NOTICE("You repaired \the [src] frame."))
@@ -200,10 +200,9 @@
 					new /obj/item/stack/cable_coil(loc, 2)
 				assembly = null //so qdel doesn't eat it.
 			qdel(src)
-			return
+			return TRUE
 
-	// OTHER
-	else if (can_use() && istype(W, /obj/item/paper) && isliving(user))
+	if (can_use() && istype(W, /obj/item/paper) && isliving(user))
 		var/mob/living/U = user
 		var/obj/item/paper/X = W
 		var/itemname = X.name
@@ -214,9 +213,9 @@
 			if(U.name == "Unknown") to_chat(O, "<b>[U]</b> holds \a [itemname] up to one of your cameras ...")
 			else to_chat(O, "<b><a href='byond://?src=\ref[O];track2=\ref[O];track=\ref[U];trackname=[U.name]'>[U]</a></b> holds \a [itemname] up to one of your cameras ...")
 			show_browser(O, text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", itemname, info), text("window=[]", itemname))
+		return TRUE
 
-	else
-		..()
+	return ..()
 
 
 /**

--- a/code/game/machinery/computer/guestpass.dm
+++ b/code/game/machinery/computer/guestpass.dm
@@ -67,16 +67,16 @@
 	..()
 	uid = "[random_id("guestpass_serial_number",100,999)]-G[rand(10,99)]"
 
-/obj/machinery/computer/guestpass/attackby(obj/O, mob/user)
-	if(istype(O, /obj/item/card/id))
+/obj/machinery/computer/guestpass/use_tool(obj/item/O, mob/living/user, list/click_params)
+	if (isid(O))
 		if(!giver && user.unEquip(O))
 			O.forceMove(src)
 			giver = O
 			updateUsrDialog()
 		else if(giver)
 			to_chat(user, SPAN_WARNING("There is already ID card inside."))
-		return
-	..()
+		return TRUE
+	return ..()
 
 /obj/machinery/computer/guestpass/interface_interact(mob/user)
 	ui_interact(user)

--- a/code/game/machinery/computer/law.dm
+++ b/code/game/machinery/computer/law.dm
@@ -4,12 +4,13 @@
 	icon_screen = "command"
 	var/mob/living/silicon/current
 
-/obj/machinery/computer/upload/attackby(obj/item/O, mob/user)
+/obj/machinery/computer/upload/use_tool(obj/item/O, mob/living/user, list/click_params)
 	if(istype(O, /obj/item/aiModule))
 		var/obj/item/aiModule/M = O
 		M.install(src, user)
-	else
-		..()
+		return TRUE
+
+	return ..()
 
 /obj/machinery/computer/upload/ai
 	name = "\improper AI upload console"

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -24,19 +24,16 @@
 	var/message = "<span class='notice'>System bootup complete. Please select an option.</span>"	// The message that shows on the main menu.
 	var/auth = 0 // Are they authenticated?
 
-/obj/machinery/computer/message_monitor/attackby(obj/item/O as obj, mob/living/user as mob)
+/obj/machinery/computer/message_monitor/use_tool(obj/item/O, mob/living/user, list/click_params)
 	if(inoperable())
-		..()
-		return
-	if(!istype(user))
-		return
+		return ..()
+
 	if(isScrewdriver(O) && emag)
 		//Stops people from just unscrewing the monitor and putting it back to get the console working again.
 		to_chat(user, SPAN_WARNING("It is too hot to mess with!"))
-		return
+		return TRUE
 
-	..()
-	return
+	return ..()
 
 /obj/machinery/computer/message_monitor/emag_act(remaining_charges, mob/user)
 	// Will create sparks and print out the console's password. You will then have to wait a while for the console to be back online.

--- a/code/game/machinery/cracker.dm
+++ b/code/game/machinery/cracker.dm
@@ -36,19 +36,20 @@
 	update_icon()
 	return TRUE
 
-/obj/machinery/portable_atmospherics/cracker/attackby(obj/item/thing, mob/user)
+/obj/machinery/portable_atmospherics/cracker/use_tool(obj/item/thing, mob/living/user, list/click_params)
 	// remove deuterium as a reagent
 	if(thing.is_open_container() && thing.reagents)
 		if(!reagent_buffer[MATERIAL_DEUTERIUM] || reagent_buffer[MATERIAL_DEUTERIUM] <= 0)
 			to_chat(user, SPAN_WARNING("There is no deuterium stored in \the [src]."))
-			return
+			return TRUE
 		var/transfer_amt = min(thing.reagents.maximum_volume, reagent_buffer[MATERIAL_DEUTERIUM])
 		thing.reagents.add_reagent(MATERIAL_DEUTERIUM, transfer_amt)
 		thing.update_icon()
 		reagent_buffer[MATERIAL_DEUTERIUM] -= transfer_amt
 		user.visible_message(SPAN_NOTICE("\The [user] siphons [transfer_amt] unit\s of deuterium from \the [src] into \the [thing]."))
-		return
-	. = ..()
+		return TRUE
+
+	return ..()
 
 /obj/machinery/portable_atmospherics/cracker/power_change()
 	. = ..()

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -224,18 +224,19 @@
 	if(istype(new_state))
 		updateUsrDialog()
 
-/obj/machinery/atmospherics/unary/cryo_cell/attackby(obj/G, mob/user as mob)
-	if(component_attackby(G, user))
+/obj/machinery/atmospherics/unary/cryo_cell/use_tool(obj/item/G, mob/living/user, list/click_params)
+	if (!istype(G, /obj/item/reagent_containers/glass))
+		return ..()
+
+	if (beaker)
+		to_chat(user, SPAN_WARNING("A beaker is already loaded into the machine."))
 		return TRUE
-	if(istype(G, /obj/item/reagent_containers/glass))
-		if(beaker)
-			to_chat(user, SPAN_WARNING("A beaker is already loaded into the machine."))
-			return
-		if(!user.unEquip(G, src))
-			return // Temperature will be adjusted on Entered()
-		beaker =  G
-		user.visible_message("[user] adds \a [G] to \the [src]!", "You add \a [G] to \the [src]!")
-	return
+	if (!user.unEquip(G, src))
+		return TRUE
+
+	beaker =  G
+	user.visible_message("\The [user] adds \a [G] to \the [src]!", "You add \a [G] to \the [src]!")
+	return TRUE
 
 /obj/machinery/atmospherics/unary/cryo_cell/on_update_icon()
 	ClearOverlays()

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -249,12 +249,11 @@
 	else
 		icon_state = "access_button_off"
 
-/obj/machinery/access_button/attackby(obj/item/I as obj, mob/user as mob)
-	//Swiping ID on the access button
+/obj/machinery/access_button/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if (istype(I, /obj/item/card/id) || istype(I, /obj/item/modular_computer))
 		attack_hand(user)
-		return
-	..()
+		return TRUE
+	return ..()
 
 /obj/machinery/access_button/interface_interact(mob/user)
 	if(!CanInteract(user, DefaultTopicState()))

--- a/code/game/machinery/doors/blast_door.dm
+++ b/code/game/machinery/doors/blast_door.dm
@@ -138,12 +138,10 @@
 /obj/machinery/door/blast/get_material_melting_point()
 	return 10000 // Blast doors are implicitly heavily fire resistant and are used for containing high-temperature areas like burn chambers.
 
-// Proc: attackby()
-// Parameters: 2 (C - Item this object was clicked with, user - Mob which clicked this object)
-// Description: If we are clicked with crowbar or wielded fire axe, try to manually open the door.
-// This only works on broken doors or doors without power. Also allows repair with Plasteel.
-/obj/machinery/door/blast/attackby(obj/item/C as obj, mob/user as mob)
-	add_fingerprint(user, 0, C)
+
+///If we are clicked with crowbar or wielded fire axe, try to manually open the door.
+///This only works on broken doors or doors without power. Also allows repair with Plasteel.
+/obj/machinery/door/blast/use_tool(obj/item/C, mob/living/user, list/click_params)
 	if(isCrowbar(C) || (istype(C, /obj/item/material/twohanded/fireaxe) && C:wielded == 1))
 		if(((!is_powered()) || MACHINE_IS_BROKEN(src)) && !( operating ))
 			to_chat(user, SPAN_NOTICE("You begin prying at \the [src]..."))
@@ -151,16 +149,17 @@
 				force_toggle()
 		else
 			to_chat(user, SPAN_NOTICE("[src]'s motors resist your effort."))
-		return
+		return TRUE
+
 	if(istype(C, /obj/item/stack/material) && C.get_material_name() == MATERIAL_PLASTEEL)
 		var/amt = ceil(get_damage_value() / 150)
 		if(!amt)
 			to_chat(user, SPAN_NOTICE("\The [src] is already fully functional."))
-			return
+			return TRUE
 		var/obj/item/stack/P = C
 		if(!P.can_use(amt))
 			to_chat(user, SPAN_WARNING("You don't have enough sheets to repair this! You need at least [amt] sheets."))
-			return
+			return TRUE
 		to_chat(user, SPAN_NOTICE("You begin repairing \the [src]..."))
 		if(do_after(user, 5 SECONDS, src, DO_REPAIR_CONSTRUCT))
 			if(P.use(amt))
@@ -170,7 +169,7 @@
 				to_chat(user, SPAN_WARNING("You don't have enough sheets to repair this! You need at least [amt] sheets."))
 		else
 			to_chat(user, SPAN_WARNING("You must remain still while working on \the [src]."))
-		return
+		return TRUE
 
 	return ..()
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -192,10 +192,9 @@
 	if(needs_to_close)
 		addtimer(new Callback(src, .proc/attempt_autoclose), 10 SECONDS) //Just in case a fire alarm is turned off while the firedoor is going through an autoclose cycle
 
-/obj/machinery/door/firedoor/attackby(obj/item/C, mob/user)
-	add_fingerprint(user, 0, C)
+/obj/machinery/door/firedoor/use_tool(obj/item/C, mob/living/user, list/click_params)
 	if(operating)
-		return //Already doing something.
+		return TRUE
 
 	if(isWelder(C) && !repairing)
 		var/obj/item/weldingtool/W = C
@@ -208,7 +207,7 @@
 			playsound(loc, 'sound/items/Welder.ogg', 50, TRUE)
 			if(do_after(user, (C.toolspeed * 2) SECONDS, src, DO_REPAIR_CONSTRUCT))
 				if(!W.remove_fuel(2, user))
-					return
+					return TRUE
 				blocked = !blocked
 				user.visible_message(
 					SPAN_DANGER("\The [user] [blocked ? "welds \the [src] shut" : "cuts open \the [src]"]."),
@@ -217,7 +216,7 @@
 				)
 				playsound(loc, 'sound/items/Welder2.ogg', 50, TRUE)
 				update_icon()
-				return
+			return TRUE
 
 	if(density && isScrewdriver(C))
 		hatch_open = !hatch_open
@@ -228,7 +227,7 @@
 		)
 		playsound(loc, 'sound/items/Screwdriver.ogg', 25, TRUE)
 		update_icon()
-		return
+		return TRUE
 
 	if(blocked && isCrowbar(C) && !repairing)
 		if(!hatch_open)
@@ -249,15 +248,15 @@
 						SPAN_ITALIC("You hear metal coming loose and clattering.")
 					)
 					deconstruct(user)
-		return
+		return TRUE
 
 	if(blocked)
 		to_chat(user, SPAN_DANGER("\The [src] is welded shut!"))
-		return
+		return TRUE
 
 	if(isCrowbar(C) || istype(C,/obj/item/material/twohanded/fireaxe))
 		if(operating)
-			return
+			return TRUE
 
 		if(blocked && isCrowbar(C))
 			user.visible_message(
@@ -265,12 +264,13 @@
 				SPAN_WARNING("You try to pry \the [src] [density ? "open" : "closed"], but it's been welded in place!"),
 				SPAN_WARNING("You hear the unhappy sound of metal straining and groaning.")
 			)
-			return
+			return TRUE
 
 		if(istype(C,/obj/item/material/twohanded/fireaxe))
 			var/obj/item/material/twohanded/fireaxe/F = C
 			if(!F.wielded)
-				return
+				to_chat(user, SPAN_WARNING("You need to wield \the [C]!"))
+				return TRUE
 
 		user.visible_message(
 			SPAN_WARNING("\The [user] wedges \the [C] into \the [src] and starts forcing it [density ? "open" : "closed"]!"),
@@ -301,7 +301,8 @@
 				spawn(0)
 					locked = FALSE
 					close()
-			return
+		return TRUE
+
 	return ..()
 
 /obj/machinery/door/firedoor/deconstruct(mob/user, moved = FALSE)

--- a/code/game/machinery/doors/simple.dm
+++ b/code/game/machinery/doors/simple.dm
@@ -108,18 +108,15 @@
 			return attack_hand(user)
 
 
-/obj/machinery/door/unpowered/simple/attackby(obj/item/I as obj, mob/user as mob)
-	src.add_fingerprint(user, 0, I)
-	if (user.a_intent == I_HURT)
-		return ..()
-
+/obj/machinery/door/unpowered/simple/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if(istype(I, /obj/item/key) && lock)
 		var/obj/item/key/K = I
 		if(!lock.toggle(I))
 			to_chat(user, SPAN_WARNING("\The [K] does not fit in the lock!"))
-		return
+		return TRUE
+
 	if(lock && lock.pick_lock(I,user))
-		return
+		return TRUE
 
 	if(istype(I,/obj/item/material/lock_construct))
 		if(lock)
@@ -127,18 +124,18 @@
 		else
 			var/obj/item/material/lock_construct/L = I
 			lock = L.create_lock(src,user)
-		return
+		return TRUE
 
 	if(istype(I, /obj/item/stack/material) && I.get_material_name() == src.get_material_name())
 		if(MACHINE_IS_BROKEN(src))
 			to_chat(user, SPAN_NOTICE("It looks like \the [src] is pretty busted. It's going to need more than just patching up now."))
-			return
+			return TRUE
 		if (!get_damage_value())
 			to_chat(user, SPAN_NOTICE("Nothing to fix!"))
-			return
+			return TRUE
 		if(!density)
 			to_chat(user, SPAN_WARNING("\The [src] must be closed before you can repair it."))
-			return
+			return TRUE
 
 		//figure out how much metal we need
 		var/obj/item/stack/stack = I
@@ -148,21 +145,25 @@
 			to_chat(user, SPAN_NOTICE("You fit [stack.get_exact_name(used)] to damaged and broken parts on \the [src]."))
 			stack.use(used)
 			restore_health(used * DOOR_REPAIR_AMOUNT)
-		return
+		return TRUE
 
-	if(src.operating) return
+	if(operating)
+		return TRUE
+
+	if ((. = ..()))
+		return
 
 	if(lock && lock.isLocked())
 		to_chat(user, "\The [src] is locked!")
+		return TRUE
 
 	if(operable())
 		if(src.density)
 			open()
 		else
 			close()
-		return
+		return TRUE
 
-	return
 
 /obj/machinery/door/unpowered/simple/examine(mob/user, distance)
 	. = ..()

--- a/code/game/machinery/doors/unpowered.dm
+++ b/code/game/machinery/doors/unpowered.dm
@@ -9,11 +9,10 @@
 	..()
 	return
 
-/obj/machinery/door/unpowered/attackby(obj/item/I as obj, mob/user as mob)
-	if(istype(I, /obj/item/melee/energy/blade))	return
-	if(src.locked)	return
-	..()
-	return
+/obj/machinery/door/unpowered/use_tool(obj/item/I, mob/living/user, list/click_params)
+	if(locked)
+		return TRUE
+	return ..()
 
 /obj/machinery/door/unpowered/emag_act()
 	return -1

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -184,11 +184,9 @@
 /obj/machinery/door/window/CanFluidPass(coming_from)
 	return !density || ((dir in GLOB.cardinal) && coming_from != dir)
 
-/obj/machinery/door/window/attackby(obj/item/I as obj, mob/user as mob)
-
-	//If it's in the process of opening/closing, ignore the click
+/obj/machinery/door/window/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if (operating == DOOR_OPERATING_YES)
-		return
+		return ..()
 
 	//Emags and ninja swords? You may pass.
 	if (istype(I, /obj/item/melee/energy/blade))
@@ -199,12 +197,12 @@
 			playsound(src.loc, "sparks", 50, 1)
 			playsound(src.loc, 'sound/weapons/blade1.ogg', 50, 1)
 			visible_message(SPAN_WARNING("The glass door was sliced open by [user]!"))
-		return 1
+		return TRUE
 
 	//If it's emagged, crowbar can pry electronics out.
 	if (operating == DOOR_OPERATING_BROKEN && isCrowbar(I))
 		playsound(src.loc, 'sound/items/Crowbar.ogg', 100, 1)
-		user.visible_message("[user] removes the electronics from the windoor.", "You start to remove electronics from the windoor.")
+		user.visible_message("\The [user] starts removing the electronics from the windoor.", "You start to remove electronics from the windoor.")
 		if (do_after(user, 4 SECONDS, src, DO_REPAIR_CONSTRUCT))
 			to_chat(user, SPAN_NOTICE("You removed the windoor electronics!"))
 
@@ -222,24 +220,21 @@
 
 			shatter(src)
 			operating = DOOR_OPERATING_NO
-			return
+		return TRUE
 
-	if (user.a_intent == I_HURT)
-		return ..()
-
-	src.add_fingerprint(user, 0, I)
-
-	if (src.allowed(user))
-		if (src.density)
+	if (allowed(user))
+		if (density)
 			open()
 		else
 			if (emagged)
 				to_chat(user, SPAN_WARNING("\The [src] seems to be stuck and refuses to close!"))
-				return
+				return TRUE
 			close()
+		return TRUE
 
-	else if (src.density)
+	else if (density)
 		flick(text("[]deny", src.base_state), src)
+		return TRUE
 
 /obj/machinery/door/window/create_electronics(electronics_type = /obj/item/airlock_electronics)
 	electronics = ..()

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -5,7 +5,7 @@ var/global/list/doppler_arrays = list()
 	desc = "A highly precise directional sensor array which measures the release of quants from decaying tachyons. The doppler shifting of the mirror-image formed by these quants can reveal the size, location and temporal affects of energetic disturbances within a large radius ahead of the array."
 	icon = 'icons/obj/machines/research/doppler_array.dmi'
 	icon_state = "tdoppler"
-	obj_flags = OBJ_FLAG_ROTATABLE
+	obj_flags = OBJ_FLAG_ROTATABLE | OBJ_FLAG_ANCHORABLE
 	construct_state = /singleton/machine_construction/default/panel_closed
 	var/currentlyfacing
 	var/direct
@@ -50,15 +50,6 @@ var/global/list/doppler_arrays = list()
 		AddOverlays("[initial(icon_state)]-open")
 	if(inoperable())
 		icon_state = "[initial(icon_state)]-off"
-
-/obj/machinery/doppler_array/attackby(obj/item/W, mob/user)
-	if(component_attackby(W, user))
-		return TRUE
-	else if(isWrench(W))
-		anchored = !anchored
-		to_chat(user, SPAN_NOTICE("You wrench the stabilising bolts [anchored ? "into place" : "loose"]."))
-		playsound(loc, 'sound/items/Ratchet.ogg', 40)
-		update_icon()
 
 /obj/machinery/doppler_array/proc/getcurrentdirection()
 	switch(direct)

--- a/code/game/machinery/embedded_controller/airlock_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/airlock_docking_controller.dm
@@ -11,8 +11,8 @@
 		var/datum/computer/file/embedded_program/docking/airlock/docking_program = program
 		docking_program.display_name = display_name
 
-/obj/machinery/embedded_controller/radio/airlock/docking_port/attackby(obj/item/W, mob/user)
-	if (isMultitool(W)) //give them part of code, would take few tries to get full
+/obj/machinery/embedded_controller/radio/airlock/docking_port/use_tool(obj/item/W, mob/living/user, list/click_params)
+	if (isMultitool(W))
 		var/datum/computer/file/embedded_program/docking/airlock/docking_program = program
 		var/code = docking_program.docking_codes
 		if(!code)
@@ -20,8 +20,9 @@
 		else
 			code = stars(code)
 		to_chat(user,"[W]'s screen displays '[code]'")
-	else
-		..()
+		return TRUE
+
+	return ..()
 
 /obj/machinery/embedded_controller/radio/airlock/docking_port/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/nanoui/master_ui = null, datum/topic_state/state = GLOB.default_state)
 	var/data[0]

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -33,16 +33,16 @@
 //		src.sd_SetLuminosity(0)
 
 //Don't want to render prison breaks impossible
-/obj/machinery/flasher/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/flasher/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(isWirecutter(W))
-		add_fingerprint(user, 0, W)
-		src.disable = !src.disable
-		if (src.disable)
-			user.visible_message(SPAN_WARNING("[user] has disconnected the [src]'s flashbulb!"), SPAN_WARNING("You disconnect the [src]'s flashbulb!"))
-		if (!src.disable)
-			user.visible_message(SPAN_WARNING("[user] has connected the [src]'s flashbulb!"), SPAN_WARNING("You connect the [src]'s flashbulb!"))
-	else
-		..()
+		disable = !disable
+		user.visible_message(
+			SPAN_WARNING("\The [user] has [disable ? "dis" : ""]connected \the [src]'s flashbulb!"),
+			SPAN_WARNING("You [disable? "dis" : ""]connect \the [src]'s flashbulb!")
+		)
+		return TRUE
+
+	return ..()
 
 //Let the AI trigger them directly.
 /obj/machinery/flasher/attack_ai()
@@ -107,6 +107,7 @@
 	anchored = FALSE
 	base_state = "pflash"
 	density = TRUE
+	obj_flags = OBJ_FLAG_ANCHORABLE
 
 /obj/machinery/flasher/portable/HasProximity(atom/movable/AM as mob|obj)
 	if(!anchored || disable || last_flash && world.time < last_flash + 150)
@@ -120,18 +121,12 @@
 	if(isanimal(AM))
 		flash()
 
-/obj/machinery/flasher/portable/attackby(obj/item/W as obj, mob/user as mob)
-	if(isWrench(W))
-		add_fingerprint(user)
-		src.anchored = !src.anchored
-
-		if (!src.anchored)
-			user.show_message(text(SPAN_WARNING("[src] can now be moved.")))
-			ClearOverlays()
-
-		else if (src.anchored)
-			user.show_message(text(SPAN_WARNING("[src] is now secured.")))
-			AddOverlays("[base_state]-s")
+/obj/machinery/flasher/portable/post_anchor_change()
+	if (anchored)
+		AddOverlays("[base_state]-s")
+	else
+		ClearOverlays()
+	..()
 
 /obj/machinery/button/flasher
 	name = "flasher button"

--- a/code/game/machinery/floor_light.dm
+++ b/code/game/machinery/floor_light.dm
@@ -37,32 +37,38 @@ var/global/list/floor_light_cache = list()
 	use_power = POWER_USE_ACTIVE
 
 
-/obj/machinery/floor_light/attackby(obj/item/W, mob/user)
-	if(isScrewdriver(W))
+/obj/machinery/floor_light/use_tool(obj/item/W, mob/living/user, list/click_params)
+	if (isScrewdriver(W))
 		anchored = !anchored
 		if(use_power)
 			update_use_power(POWER_USE_OFF)
 			queue_icon_update()
 		visible_message(SPAN_NOTICE("\The [user] has [anchored ? "attached" : "detached"] \the [src]."))
-	else if(isWelder(W) && (health_damaged() || MACHINE_IS_BROKEN(src)))
+		return TRUE
+
+	if (isWelder(W) && (health_damaged() || MACHINE_IS_BROKEN(src)))
 		var/obj/item/weldingtool/WT = W
 		if(!WT.can_use(1, user))
-			return
+			return TRUE
 		playsound(src.loc, 'sound/items/Welder.ogg', 50, 1)
 		if(!do_after(user, (W.toolspeed * 2) SECONDS, src, DO_REPAIR_CONSTRUCT))
-			return
+			return TRUE
 		if(!src || !WT.remove_fuel(1, user))
-			return
+			return TRUE
 		visible_message(SPAN_NOTICE("\The [user] has repaired \the [src]."))
 		set_broken(FALSE)
 		revive_health()
-	else if(isWrench(W))
+		return TRUE
+
+	if (isWrench(W))
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
 		to_chat(user, SPAN_NOTICE("You dismantle the floor light."))
 		new /obj/item/stack/material/steel(src.loc, 1)
 		new /obj/item/stack/material/glass(src.loc, 1)
 		qdel(src)
-	return
+		return TRUE
+
+	return ..()
 
 /obj/machinery/floor_light/on_death()
 	..()

--- a/code/game/machinery/floorlayer.dm
+++ b/code/game/machinery/floorlayer.dm
@@ -37,8 +37,7 @@
 	)
 	return TRUE
 
-/obj/machinery/floorlayer/attackby(obj/item/W as obj, mob/user as mob)
-
+/obj/machinery/floorlayer/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(isWrench(W))
 		var/m = input("Choose work mode", "Mode") as null|anything in mode
 		mode[m] = !mode[m]
@@ -47,14 +46,14 @@
 			SPAN_NOTICE("\The [user] has set \the [src] [m] mode [!O?"off":"on"]."),
 			SPAN_NOTICE("You set \the [src] [m] mode [!O?"off":"on"].")
 		)
-		return
+		return TRUE
 
 	if(istype(W, /obj/item/stack/tile))
 		if(!user.unEquip(W, T))
-			return
+			return TRUE
 		to_chat(user, SPAN_NOTICE("\The [W] successfully loaded."))
 		TakeTile(T)
-		return
+		return TRUE
 
 	if(isCrowbar(W))
 		if(!length(contents))
@@ -65,12 +64,13 @@
 				to_chat(user, SPAN_NOTICE("You remove the [E] from /the [src]."))
 				E.dropInto(loc)
 				T = null
-		return
+		return TRUE
 
 	if(isScrewdriver(W))
 		T = input("Choose tile type.", "Tiles") as null|anything in contents
-		return
-	..()
+		return TRUE
+
+	return ..()
 
 /obj/machinery/floorlayer/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -244,7 +244,7 @@ var/global/const/HOLOPAD_MODE = RANGE_BASED
 		to_chat(user, SPAN_NOTICE("You add \the [O] to \the [src]'s notifications list. It will now be pinged whenever a call is received."))
 		return TRUE
 
-	..()
+	return ..()
 
 /**
  * Proc to link/unlink PDAs

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -104,17 +104,17 @@
 		icon_state = "migniter-p"
 //		src.sd_SetLuminosity(0)
 
-/obj/machinery/sparker/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/sparker/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(isScrewdriver(W))
-		add_fingerprint(user)
 		disable = !disable
 		if(disable)
 			user.visible_message(SPAN_WARNING("[user] has disabled the [src]!"), SPAN_WARNING("You disable the connection to the [src]."))
 		else if(!disable)
 			user.visible_message(SPAN_WARNING("[user] has reconnected the [src]!"), SPAN_WARNING("You fix the connection to the [src]."))
 		update_icon()
-	else
-		..()
+		return TRUE
+
+	return ..()
 
 /obj/machinery/sparker/attack_ai()
 	if (anchored)

--- a/code/game/machinery/kitchen/cookers.dm
+++ b/code/game/machinery/kitchen/cookers.dm
@@ -134,31 +134,31 @@
 			to_chat(user, "The contents of \the [src] will now be [cook_modes[mode]["desc"]].")
 
 
-/obj/machinery/cooker/attackby(obj/item/I, mob/user)
+/obj/machinery/cooker/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if (is_processing)
 		to_chat(user, SPAN_WARNING("Turn off \the [src] first."))
-		return
-	. = component_attackby(I, user)
-	if (.)
+		return TRUE
+	if ((. = ..()))
 		return
 	if (stat)
 		to_chat(user, SPAN_WARNING("\The [src] is in no condition to operate."))
-		return
+		return TRUE
 	if (!istype(I, /obj/item/reagent_containers/food/snacks))
 		to_chat(user, SPAN_WARNING("Cooking \a [I] wouldn't be very tasty."))
-		return
+		return TRUE
 	var/obj/item/reagent_containers/food/snacks/F = I
 	if (!F.can_use_cooker)
 		to_chat(user, SPAN_WARNING("Cooking \a [I] wouldn't be very tasty."))
-		return
+		return TRUE
 	if (length(cooking) >= capacity)
 		to_chat(user, SPAN_WARNING("\The [src] is already full up."))
-		return
+		return TRUE
 	if (!user.unEquip(I))
-		return
+		return TRUE
 	user.visible_message("\The [user] puts \the [I] into \the [src].")
 	I.forceMove(src)
 	cooking += I
+	return TRUE
 
 
 /obj/machinery/cooker/Process()

--- a/code/game/machinery/kitchen/gibber.dm
+++ b/code/game/machinery/kitchen/gibber.dm
@@ -74,16 +74,18 @@
 		return SPAN_NOTICE("You must wait for \the [src] to finish operating first!")
 	return ..()
 
-/obj/machinery/gibber/attackby(obj/item/W, mob/user)
+/obj/machinery/gibber/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(!operating)
-		return
-	else if(istype(W, /obj/item/organ))
+		return TRUE
+
+	if (istype(W, /obj/item/organ))
 		if(!user.unEquip(W))
-			return
+			return TRUE
 		qdel(W)
 		user.visible_message(SPAN_DANGER("\The [user] feeds \the [W] into \the [src], obliterating it."))
-	else
-		return ..()
+		return TRUE
+
+	return ..()
 
 /obj/machinery/gibber/user_can_move_target_inside(mob/target, mob/user)
 	if (occupant)

--- a/code/game/machinery/kitchen/icecream.dm
+++ b/code/game/machinery/kitchen/icecream.dm
@@ -99,7 +99,7 @@
 	popup.set_content(dat)
 	popup.open()
 
-/obj/machinery/icecream_vat/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/icecream_vat/use_tool(obj/item/O, mob/living/user, list/click_params)
 	if(istype(O, /obj/item/reagent_containers/food/snacks/icecream))
 		var/obj/item/reagent_containers/food/snacks/icecream/I = O
 		if(!I.ice_creamed)
@@ -115,11 +115,12 @@
 				to_chat(user, SPAN_WARNING("There is not enough icecream left!"))
 		else
 			to_chat(user, SPAN_NOTICE("[O] already has icecream in it."))
-		return 1
-	else if(O.is_open_container())
+		return TRUE
+
+	if(O.is_open_container())
 		return
-	else
-		..()
+
+	return ..()
 
 /obj/machinery/icecream_vat/proc/make(mob/user, make_type, amount)
 	for(var/R in get_ingredient_list(make_type))

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -10,7 +10,7 @@
 	idle_power_usage = 5
 	active_power_usage = 100
 	atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_NO_REACT | ATOM_FLAG_OPEN_CONTAINER
-	obj_flags = OBJ_FLAG_CAN_TABLE
+	obj_flags = OBJ_FLAG_CAN_TABLE | OBJ_FLAG_ANCHORABLE
 	construct_state = /singleton/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
@@ -55,8 +55,8 @@
 *   Item Adding
 ********************/
 
-/obj/machinery/microwave/attackby(obj/item/O as obj, mob/user as mob)
-	if(broken > 0)
+/obj/machinery/microwave/use_tool(obj/item/O, mob/living/user, list/click_params)
+	if (broken > 0)
 		// Start repairs by using a screwdriver
 		if(broken == 2 && isScrewdriver(O))
 			user.visible_message( \
@@ -69,9 +69,10 @@
 					SPAN_NOTICE("You have fixed part of the microwave.") \
 				)
 				broken = 1 // Fix it a bit
+			return TRUE
 
 		// Finish repairs using a wrench
-		else if(broken == 1 && isWrench(O))
+		if (broken == 1 && isWrench(O))
 			user.visible_message( \
 				SPAN_NOTICE("\The [user] starts to fix part of the microwave."), \
 				SPAN_NOTICE("You start to fix part of the microwave.") \
@@ -85,23 +86,17 @@
 				dirtiness = 0 // just to be sure
 				update_icon()
 				atom_flags = ATOM_FLAG_NO_TEMP_CHANGE | ATOM_FLAG_OPEN_CONTAINER
+			return TRUE
 
 		// Otherwise, we can't add anything to the micrwoave
 		else
 			to_chat(user, SPAN_WARNING("It's broken, and this isn't the right way to fix it!"))
-		return
+			return TRUE
 
-	else if((. = component_attackby(O, user)))
-		dispose()
-		return
-
-	else if(dirtiness == 100) // The microwave is all dirty, so it can't be used!
+	if(dirtiness == 100) // The microwave is all dirty, so it can't be used!
 		var/has_rag = istype(O, /obj/item/reagent_containers/glass/rag)
 		var/has_cleaner = O.reagents != null && O.reagents.has_reagent(/datum/reagent/space_cleaner, 5)
-
-		// If they're trying to clean it, let them
 		if (has_rag || has_cleaner)
-
 			user.visible_message( \
 				SPAN_NOTICE("\The [user] starts to clean the microwave."), \
 				SPAN_NOTICE("You start to clean the microwave.") \
@@ -125,15 +120,15 @@
 
 		// Otherwise, bad luck!
 		else
-			to_chat(user, SPAN_WARNING("You need to clean [src] before you use it!"))
-			return
+			to_chat(user, SPAN_WARNING("You need to clean \the [src] before you use it!"))
+			return TRUE
 
-	else if(is_type_in_list(O, GLOB.microwave_accepts_items))
-
+	if (is_type_in_list(O, GLOB.microwave_accepts_items))
 		if (length(ingredients) >= GLOB.microwave_maximum_item_storage)
 			to_chat(user, SPAN_WARNING("This [src] is full of ingredients - you can't fit any more."))
+			return TRUE
 
-		else if(istype(O, /obj/item/stack)) // This is bad, but I can't think of how to change it
+		if (istype(O, /obj/item/stack)) // This is bad, but I can't think of how to change it
 			var/obj/item/stack/S = O
 			if(S.use(1))
 				var/stack_item = new O.type (src)
@@ -145,30 +140,29 @@
 
 		else
 			if (!user.unEquip(O, src))
-				return
+				return TRUE
 			LAZYADD(ingredients, O)
 			user.visible_message( \
 				SPAN_NOTICE("\The [user] has added \the [O] to \the [src]."), \
 				SPAN_NOTICE("You add \the [O] to \the [src]."))
 			return TRUE
 
-		return
-
-	else if(istype(O,/obj/item/reagent_containers/glass) || \
+	if (istype(O,/obj/item/reagent_containers/glass) || \
 	        istype(O,/obj/item/reagent_containers/food/drinks) || \
 	        istype(O,/obj/item/reagent_containers/food/condiment) \
 		)
 		if (!O.reagents)
-			return
+			to_chat(user, SPAN_WARNING("\The [O] is empty!"))
+			return TRUE
 		for (var/datum/reagent/R in O.reagents.reagent_list)
 			if (!(R.type in GLOB.microwave_accepts_reagents))
-				to_chat(user, SPAN_WARNING("Your [O] contains components unsuitable for cookery."))
-		return
+				to_chat(user, SPAN_WARNING("\The [O] contains components unsuitable for cookery."))
+		return TRUE
 
-	else if(istype(O, /obj/item/storage))
+	if (istype(O, /obj/item/storage))
 		if (length(ingredients) >= GLOB.microwave_maximum_item_storage)
-			to_chat(user, SPAN_WARNING("[src] is completely full!"))
-			return
+			to_chat(user, SPAN_WARNING("\The [src] is completely full!"))
+			return TRUE
 
 		var/obj/item/storage/bag/P = O
 		var/objects_loaded = 0
@@ -190,29 +184,14 @@
 		else
 			to_chat(user, SPAN_WARNING("\The [P] doesn't contain any compatible items to put into \the [src]!"))
 
-		return
-
-	else if(istype(O, /obj/item/grab))
-		var/obj/item/grab/G = O
-		to_chat(user, SPAN_WARNING("This is ridiculous. You can't fit \the [G.affecting] in \the [src]."))
-		return
-
-	else if(isWrench(O))
-		user.visible_message( \
-			SPAN_NOTICE("\The [user] begins [anchored ? "unsecuring" : "securing"] the microwave."), \
-			SPAN_NOTICE("You attempt to [anchored ? "unsecure" : "secure"] the microwave.")
-			)
-		if (do_after(user, (O.toolspeed * 2) SECONDS, src, DO_REPAIR_CONSTRUCT))
-			anchored = !anchored
-			user.visible_message( \
-			SPAN_NOTICE("\The [user] [anchored ? "secures" : "unsecures"] the microwave."), \
-			SPAN_NOTICE("You [anchored ? "secure" : "unsecure"] the microwave.")
-			)
-
-	else
-		to_chat(user, SPAN_WARNING("You have no idea what you can cook with this [O]."))
+		return TRUE
 
 	updateUsrDialog()
+	return ..()
+
+/obj/machinery/microwave/use_grab(obj/item/grab/grab, list/click_params)
+	to_chat(grab.assailant, SPAN_WARNING("This is ridiculous. You can't fit \the [grab.affecting] in \the [src]."))
+	return TRUE
 
 /obj/machinery/microwave/components_are_accessible(path)
 	return (broken == 0) && ..()

--- a/code/game/machinery/kitchen/microwave.dm
+++ b/code/game/machinery/kitchen/microwave.dm
@@ -156,8 +156,9 @@
 			return TRUE
 		for (var/datum/reagent/R in O.reagents.reagent_list)
 			if (!(R.type in GLOB.microwave_accepts_reagents))
-				to_chat(user, SPAN_WARNING("\The [O] contains components unsuitable for cookery."))
-		return TRUE
+				to_chat(user, SPAN_WARNING("\The [O] contains \the [R] which is unsuitable for cookery."))
+				return TRUE
+		return FALSE //This will call reagent_container's use_after which handles transferring reagents.
 
 	if (istype(O, /obj/item/storage))
 		if (length(ingredients) >= GLOB.microwave_maximum_item_storage)

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -256,29 +256,30 @@
 *   Item Adding
 ********************/
 
-/obj/machinery/smartfridge/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/smartfridge/use_tool(obj/item/O, mob/living/user, list/click_params)
 	if(isScrewdriver(O))
 		panel_open = !panel_open
 		user.visible_message("[user] [panel_open ? "opens" : "closes"] the maintenance panel of \the [src].", "You [panel_open ? "open" : "close"] the maintenance panel of \the [src].")
 		update_icon()
 		SSnano.update_uis(src)
-		return
+		return TRUE
 
 	if(isMultitool(O) || isWirecutter(O))
 		if(panel_open)
 			attack_hand(user)
-		return
+		return TRUE
 
 	if(!is_powered())
 		to_chat(user, SPAN_NOTICE("\The [src] is unpowered and useless."))
-		return
+		return TRUE
 
 	if(accept_check(O))
 		if(!user.unEquip(O))
-			return
+			return TRUE
 		stock_item(O)
 		user.visible_message(SPAN_NOTICE("\The [user] has added \the [O] to \the [src]."), SPAN_NOTICE("You add \the [O] to \the [src]."))
 		update_icon()
+		return TRUE
 
 	else if(istype(O, /obj/item/storage))
 		var/obj/item/storage/bag/P = O
@@ -293,13 +294,8 @@
 			user.visible_message(SPAN_NOTICE("\The [user] loads \the [src] with the contents of \the [P]."), SPAN_NOTICE("You load \the [src] with the contents of \the [P]."))
 			if(length(P.contents) > 0)
 				to_chat(user, SPAN_NOTICE("Some items were refused."))
-
-	else if ((obj_flags & OBJ_FLAG_ANCHORABLE) && isWrench(O))
-		return ..()
-
-	else
-		to_chat(user, SPAN_NOTICE("\The [src] smartly refuses [O]."))
-	return 1
+		return TRUE
+	return ..()
 
 /obj/machinery/smartfridge/secure/emag_act(remaining_charges, mob/user)
 	if(!emagged)

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -66,10 +66,13 @@
 		set_state(!on)
 		return TRUE
 
-/obj/machinery/light_switch/attackby(obj/item/tool as obj, mob/user as mob)
+/obj/machinery/light_switch/use_tool(obj/item/tool, mob/living/user, list/click_params)
 	if (isScrewdriver(tool))
-		new /obj/item/frame/light_switch(user.loc, 1)
+		var/obj/item/frame/light_switch/frame = new /obj/item/frame/light_switch(user.loc, 1)
+		transfer_fingerprints_to(frame)
 		qdel(src)
+		return TRUE
+	return ..()
 
 
 /obj/machinery/light_switch/powered()

--- a/code/game/machinery/navbeacon.dm
+++ b/code/game/machinery/navbeacon.dm
@@ -37,29 +37,33 @@ var/global/list/navbeacons = list()
 	else
 		icon_state = "[state]"
 
-/obj/machinery/navbeacon/attackby(obj/item/I, mob/user)
+/obj/machinery/navbeacon/use_tool(obj/item/I, mob/living/user, list/click_params)
 	var/turf/T = loc
 	if(!T.is_plating())
-		return		// prevent intraction when T-scanner revealed
+		return TRUE// prevent intraction when T-scanner revealed
 
 	if(isScrewdriver(I))
 		open = !open
-
-		user.visible_message("\The [user] [open ? "opens" : "closes"] cover of \the [src].", "You [open ? "open" : "close"] cover of \the [src].")
-
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [open ? "opens" : "closes"] cover of \the [src]."),
+			SPAN_NOTICE("You [open ? "open" : "close"] cover of \the [src].")
+		)
 		update_icon()
+		return TRUE
 
-	else if(I.GetIdCard())
+	if (I.GetIdCard())
 		if(open)
-			if (src.allowed(user))
-				src.locked = !src.locked
-				to_chat(user, "Controls are now [src.locked ? "locked." : "unlocked."]")
+			if (allowed(user))
+				locked = !locked
+				to_chat(user, "Controls are now [locked ? "locked." : "unlocked."]")
 			else
 				to_chat(user, SPAN_WARNING("Access denied."))
 			updateDialog()
 		else
 			to_chat(user, "You must open the cover first!")
-	return
+		return TRUE
+
+	return ..()
 
 /obj/machinery/navbeacon/interface_interact(mob/user)
 	interact(user)

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -46,9 +46,8 @@ var/global/bomb_set
 			addtimer(new Callback(src, .proc/explode), 0)
 		SSnano.update_uis(src)
 
-/obj/machinery/nuclearbomb/attackby(obj/item/O as obj, mob/user as mob, params)
+/obj/machinery/nuclearbomb/use_tool(obj/item/O, mob/living/user, list/click_params)
 	if(isScrewdriver(O))
-		add_fingerprint(user)
 		ClearOverlays()
 		if(auth)
 			if(panel_open == 0)
@@ -68,7 +67,7 @@ var/global/bomb_set
 				to_chat(user, "You screw the control panel of \the [src] back on.")
 				playsound(src, 'sound/items/Screwdriver.ogg', 50, 1)
 			flick("lock", src)
-		return
+		return TRUE
 
 	if(panel_open && isMultitool(O) || isWirecutter(O))
 		return attack_hand(user)
@@ -76,9 +75,8 @@ var/global/bomb_set
 	if(extended)
 		if(istype(O, /obj/item/disk/nuclear))
 			if(!user.unEquip(O, src))
-				return
+				return TRUE
 			auth = O
-			add_fingerprint(user)
 			return attack_hand(user)
 
 	if(anchored)
@@ -87,57 +85,86 @@ var/global/bomb_set
 				if(isWelder(O))
 					var/obj/item/weldingtool/WT = O
 					if(!WT.can_use(5, user))
-						return
+						return TRUE
 
-					user.visible_message("[user] starts cutting loose the anchoring bolt covers on [src].", "You start cutting loose the anchoring bolt covers with [O]...")
+					user.visible_message(
+						SPAN_NOTICE("\The [user] starts cutting loose the anchoring bolt covers on \the [src]."),
+						SPAN_NOTICE("You start cutting loose the anchoring bolt covers on \the [src] with \the [O].")
+					)
+
 					if(do_after(user, (O.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
-						if(!src || !user || !WT.remove_fuel(5, user)) return
-						user.visible_message("\The [user] cuts through the bolt covers on \the [src].", "You cut through the bolt cover.")
+						if(!src || !user || !WT.remove_fuel(5, user)) return TRUE
+						user.visible_message(
+							SPAN_NOTICE("\The [user] cuts through the bolt covers on \the [src]."),
+							SPAN_NOTICE("You cut through the bolt covers on \the [src].")
+						)
 						removal_stage = 1
-				return
+					return TRUE
 
 			if(1)
 				if(isCrowbar(O))
-					user.visible_message("[user] starts forcing open the bolt covers on [src].", "You start forcing open the anchoring bolt covers with [O]...")
+					user.visible_message(
+						SPAN_NOTICE("\The [user] starts forcing open the bolt covers on \the [src]."),
+						SPAN_NOTICE("You start forcing open the anchoring bolt covers on \the [src] with \the [O].")
+					)
 
 					if(do_after(user, (O.toolspeed * 1.5) SECONDS, src, DO_REPAIR_CONSTRUCT))
-						if(!src || !user) return
-						user.visible_message("\The [user] forces open the bolt covers on \the [src].", "You force open the bolt covers.")
+						if(!src || !user) return TRUE
+						user.visible_message(
+							SPAN_NOTICE("\The [user] forces open the bolt covers on \the [src]."),
+							SPAN_NOTICE("You force open the bolt covers.")
+						)
 						removal_stage = 2
-				return
+					return TRUE
 
 			if(2)
 				if(isWelder(O))
 					var/obj/item/weldingtool/WT = O
 					if(!WT.can_use(5, user))
-						return
+						return TRUE
 
-					user.visible_message("[user] starts cutting apart the anchoring system sealant on [src].", "You start cutting apart the anchoring system's sealant with [O]...")
+					user.visible_message(
+						SPAN_NOTICE("\The [user] starts cutting apart the anchoring system sealant on \the [src]."),
+						SPAN_NOTICE("You start cutting apart the anchoring system's sealant on \the [src] with \the [O].")
+					)
+
 					if(do_after(user, (O.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
-						if(!src || !user || !WT.remove_fuel(5, user)) return
-						user.visible_message("\The [user] cuts apart the anchoring system sealant on \the [src].", "You cut apart the anchoring system's sealant.")
+						if(!src || !user || !WT.remove_fuel(5, user)) return TRUE
+						user.visible_message(
+							SPAN_NOTICE("\The [user] cuts apart the anchoring system sealant on \the [src]."),
+							SPAN_NOTICE("You cut apart the anchoring system's sealant.")
+						)
 						removal_stage = 3
-				return
+					return TRUE
 
 			if(3)
 				if(isWrench(O))
-					user.visible_message("[user] begins unwrenching the anchoring bolts on [src].", "You begin unwrenching the anchoring bolts...")
+					user.visible_message(
+						SPAN_NOTICE("\The [user] begins unwrenching the anchoring bolts on \the [src]."),
+						SPAN_NOTICE("You begin unwrenching the anchoring bolts on \the [src].")
+					)
 					if(do_after(user, (O.toolspeed * 5) SECONDS, src, DO_REPAIR_CONSTRUCT))
-						if(!src || !user) return
+						if(!src || !user) return TRUE
 						user.visible_message("[user] unwrenches the anchoring bolts on [src].", "You unwrench the anchoring bolts.")
 						removal_stage = 4
-				return
+					return TRUE
 
 			if(4)
 				if(isCrowbar(O))
-					user.visible_message("[user] begins lifting [src] off of the anchors.", "You begin lifting the device off the anchors...")
+					user.visible_message(
+						SPAN_NOTICE("\The [user] begins lifting \the [src] off of its anchors."),
+						SPAN_NOTICE("You begin lifting \the [src] off its anchors.")
+						)
 					if(do_after(user, (O.toolspeed * 8) SECONDS, src, DO_REPAIR_CONSTRUCT))
-						if(!src || !user) return
-						user.visible_message("\The [user] crowbars \the [src] off of the anchors. It can now be moved.", "You jam the crowbar under the nuclear device and lift it off its anchors. You can now move it!")
+						if(!src || !user) return TRUE
+						user.visible_message(
+							SPAN_NOTICE("\The [user] crowbars \the [src] off of the anchors. It can now be moved."),
+							SPAN_NOTICE("You jam the crowbar under \the [src] and lift it off its anchors. You can now move it!")
+						)
 						anchored = FALSE
 						removal_stage = 5
-				return
-	..()
+					return TRUE
+	return ..()
 
 /obj/machinery/nuclearbomb/physical_attack_hand(mob/user)
 	if(!extended && deployable)
@@ -470,11 +497,6 @@ var/global/bomb_set
 /obj/machinery/nuclearbomb/station/LateInitialize(mapload, ...)
 	// Relies on turfs to have their `flooring` var set, which is done during init.
 	queue_icon_update()
-
-
-/obj/machinery/nuclearbomb/station/attackby(obj/item/O as obj, mob/user as mob)
-	if(isWrench(O))
-		return
 
 /obj/machinery/nuclearbomb/station/Topic(href, href_list)
 	if((. = ..()))

--- a/code/game/machinery/nuke_cylinder_dispenser.dm
+++ b/code/game/machinery/nuke_cylinder_dispenser.dm
@@ -35,21 +35,27 @@
 		add_fingerprint(user)
 	return TRUE
 
-/obj/machinery/nuke_cylinder_dispenser/attackby(obj/item/O, mob/user)
+/obj/machinery/nuke_cylinder_dispenser/use_tool(obj/item/O, mob/living/user, list/click_params)
 	if(!open && is_powered() && isid(O))
 		var/obj/item/card/id/id = O
 		if(check_access(id))
 			locked = !locked
 			user.visible_message("[user] [locked ? "locks" : "unlocks"] \the [src].", "You [locked ? "lock" : "unlock"] \the [src].")
 			update_icon()
-		return
+		return TRUE
+
 	if(open && istype(O, /obj/item/nuclear_cylinder) && (length(cylinders) < 6))
-		user.visible_message("[user] begins inserting \the [O] into storage.", "You begin inserting \the [O] into storage.")
+		user.visible_message(
+			SPAN_NOTICE("\The [user] begins inserting \the [O] into storage."),
+			SPAN_NOTICE("You begin inserting \the [O] into storage.")
+		)
 		if(do_after(user, 8 SECONDS, src, DO_PUBLIC_UNIQUE) && open && (length(cylinders) < 6) && user.unEquip(O, src))
 			user.visible_message("[user] places \the [O] into storage.", "You place \the [O] into storage.")
 			cylinders.Add(O)
 			update_icon()
-		add_fingerprint(user)
+		return TRUE
+
+	return ..()
 
 /obj/machinery/nuke_cylinder_dispenser/MouseDrop(atom/over)
 	if(!CanMouseDrop(over, usr))

--- a/code/game/machinery/oxygen_pump.dm
+++ b/code/game/machinery/oxygen_pump.dm
@@ -145,7 +145,7 @@
 		return
 	return 1
 
-/obj/machinery/oxygen_pump/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/oxygen_pump/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(isScrewdriver(W))
 		toggle_stat(MACHINE_STAT_MAINT)
 		user.visible_message(
@@ -156,18 +156,24 @@
 			icon_state = icon_state_open
 		if(!stat)
 			icon_state = icon_state_closed
-		//TO-DO: Open icon
+		return TRUE
+
 	if(istype(W, /obj/item/tank) && (GET_FLAGS(stat, MACHINE_STAT_MAINT)))
 		if(tank)
 			to_chat(user, SPAN_WARNING("\The [src] already has a tank installed!"))
-		else
-			if(!user.unEquip(W, src))
-				return
-			tank = W
-			user.visible_message(SPAN_NOTICE("\The [user] installs \the [tank] into \the [src]."), SPAN_NOTICE("You install \the [tank] into \the [src]."))
-			src.add_fingerprint(user)
+			return TRUE
+
+		if(!user.unEquip(W, src))
+			return TRUE
+		tank = W
+		user.visible_message(SPAN_NOTICE("\The [user] installs \the [tank] into \the [src]."), SPAN_NOTICE("You install \the [tank] into \the [src]."))
+		return TRUE
+
 	if(istype(W, /obj/item/tank) && !stat)
-		to_chat(user, SPAN_WARNING("Please open the maintenance hatch first."))
+		to_chat(user, SPAN_WARNING("You need to open the maintenance hatch first."))
+		return TRUE
+
+	return ..()
 
 /obj/machinery/oxygen_pump/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/pager.dm
+++ b/code/game/machinery/pager.dm
@@ -16,8 +16,8 @@
 		var/area/A = get_area(src)
 		location = A.name
 
-/obj/machinery/pager/attackby(obj/item/W, mob/user as mob)
-	return attack_hand(user)
+/obj/machinery/pager/use_tool(obj/item/tool, mob/living/user, list/click_params)
+	return attack_hand(user) || ..()
 
 /obj/machinery/pager/interface_interact(mob/living/user)
 	if(!CanInteract(user, GLOB.default_state))

--- a/code/game/machinery/pipe/pipe_dispenser.dm
+++ b/code/game/machinery/pipe/pipe_dispenser.dm
@@ -5,6 +5,7 @@
 	density = TRUE
 	anchored = FALSE
 	stat_immune = MACHINE_STAT_NOSCREEN//Doesn't need screen, just input for the parts wanted
+	obj_flags = OBJ_FLAG_ANCHORABLE
 
 	construct_state = /singleton/machine_construction/default/panel_closed
 	uncreated_component_parts = null
@@ -65,47 +66,32 @@
 	interact(user)
 	return TRUE
 
+/obj/machinery/pipedispenser/CanUseTopic(mob/user)
+	if (!anchored)
+		to_chat(user, "You need to anchor \the [src] to be able to operate it.")
+		return STATUS_CLOSE
+	return ..()
+
 /obj/machinery/pipedispenser/interact(mob/user)
 	var/datum/browser/popup = new (user, "Pipe List", "[src] Control Panel")
 	popup.set_content(get_console_data(GLOB.all_pipe_datums_by_category, TRUE))
 	popup.open()
 
-/obj/machinery/pipedispenser/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/pipedispenser/post_anchor_change()
+	if (anchored)
+		set_stat(MACHINE_STAT_MAINT, FALSE)
+	else
+		set_stat(MACHINE_STAT_MAINT, TRUE)
+	..()
+
+/obj/machinery/pipedispenser/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if (istype(W, /obj/item/pipe) || istype(W, /obj/item/machine_chassis))
 		if(!user.unEquip(W))
-			return
+			return TRUE
 		to_chat(user, SPAN_NOTICE("You put \the [W] back into \the [src]."))
-		add_fingerprint(user)
 		qdel(W)
-		return
-	if(!panel_open)
-		if(isWrench(W))
-			add_fingerprint(user)
-			if(anchored)
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-				to_chat(user, SPAN_NOTICE("You begin to unfasten \the [src] from the floor..."))
-				if (do_after(user, (W.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
-					user.visible_message( \
-						SPAN_NOTICE("\The [user] unfastens \the [src]."), \
-						SPAN_NOTICE("You have unfastened \the [src]. Now it can be pulled somewhere else."), \
-						"You hear ratchet.")
-					anchored = FALSE
-					set_stat(MACHINE_STAT_MAINT, TRUE)
-					update_use_power(POWER_USE_OFF)
-					if(user.machine==src)
-						close_browser(user, "window=pipedispenser")
-			else
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-				to_chat(user, SPAN_NOTICE("You begin to fasten \the [src] to the floor..."))
-				if (do_after(user, (W.toolspeed * 2) SECONDS, src, DO_REPAIR_CONSTRUCT))
-					user.visible_message( \
-						SPAN_NOTICE("\The [user] fastens \the [src]."), \
-						SPAN_NOTICE("You have fastened \the [src]. Now it can dispense pipes."), \
-						"You hear ratchet.")
-					anchored = TRUE
-					set_stat(MACHINE_STAT_MAINT, FALSE)
-					update_use_power(POWER_USE_IDLE)
-			return
+		return TRUE
+
 	return ..()
 
 /obj/machinery/pipedispenser/disposal

--- a/code/game/machinery/pipe/pipelayer.dm
+++ b/code/game/machinery/pipe/pipelayer.dm
@@ -40,13 +40,12 @@
 	)
 	return TRUE
 
-/obj/machinery/pipelayer/attackby(obj/item/W as obj, mob/user as mob)
-
+/obj/machinery/pipelayer/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(isWrench(W))
 		P_type_t = input("Choose pipe type", "Pipe type") as null|anything in Pipes
 		P_type = Pipes[P_type_t]
 		user.visible_message(SPAN_NOTICE("[user] has set \the [src] to manufacture [P_type_t]."), SPAN_NOTICE("You set \the [src] to manufacture [P_type_t]."))
-		return
+		return TRUE
 
 	if(isCrowbar(W))
 		a_dis=!a_dis
@@ -54,10 +53,9 @@
 			SPAN_NOTICE("[user] has [!a_dis?"de":""]activated auto-dismantling."),
 			SPAN_NOTICE("You [!a_dis?"de":""]activate auto-dismantling.")
 		)
-		return
+		return TRUE
 
 	if(istype(W, /obj/item/stack/material) && W.get_material_name() == MATERIAL_STEEL)
-
 		var/result = load_metal(W)
 		if(isnull(result))
 			to_chat(user, SPAN_WARNING("Unable to load [W] - no metal found."))
@@ -65,8 +63,7 @@
 			to_chat(user, SPAN_NOTICE("\The [src] is full."))
 		else
 			user.visible_message(SPAN_NOTICE("[user] has loaded metal into \the [src]."), SPAN_NOTICE("You load metal into \the [src]"))
-
-		return
+		return TRUE
 
 	if(isScrewdriver(W))
 		if(metal)
@@ -81,8 +78,9 @@
 				user.visible_message(SPAN_NOTICE("[user] removes [m] sheet\s of metal from the \the [src]."), SPAN_NOTICE("You remove [m] sheet\s of metal from \the [src]"))
 		else
 			to_chat(user, "\The [src] is empty.")
-		return
-	..()
+		return TRUE
+
+	return ..()
 
 /obj/machinery/pipelayer/examine(mob/user)
 	. = ..()

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -57,10 +57,10 @@
 
 	var/datum/effect/spark_spread/spark_system	//the spark system, used for generating... sparks?
 
-	var/wrenching = 0
 	var/last_target			//last target fired at, prevents turrets from erratically firing at all valid targets in range
 
 	req_access = list(list(access_security, access_bridge))
+	obj_flags = OBJ_FLAG_ANCHORABLE
 
 /obj/machinery/porta_turret/crescent
 	enabled = 0
@@ -274,7 +274,7 @@ var/global/list/turret_icons
 			queue_icon_update()
 
 
-/obj/machinery/porta_turret/attackby(obj/item/I, mob/user)
+/obj/machinery/porta_turret/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if(MACHINE_IS_BROKEN(src))
 		if(isCrowbar(I))
 			//If the turret is destroyed, you can remove it with a crowbar to
@@ -300,35 +300,9 @@ var/global/list/turret_icons
 		if(enabled || raised)
 			to_chat(user, SPAN_WARNING("You cannot unsecure an active turret!"))
 			return TRUE
-		if(wrenching)
-			to_chat(user, SPAN_WARNING("Someone is already [anchored ? "un" : ""]securing the turret!"))
-			return TRUE
-		if(!anchored && isinspace())
-			to_chat(user, SPAN_WARNING("Cannot secure turrets in space!"))
-			return TRUE
+		else return ..()
 
-		user.visible_message(
-			SPAN_WARNING("\The [user] begins [anchored ? "un" : ""]securing the turret."),
-			SPAN_NOTICE("You begin [anchored ? "un" : ""]securing the turret.")
-		)
-
-		wrenching = 1
-		if(do_after(user, (I.toolspeed * 5) SECONDS, src, DO_REPAIR_CONSTRUCT))
-			//This code handles moving the turret around. After all, it's a portable turret!
-			if(!anchored)
-				playsound(loc, 'sound/items/Ratchet.ogg', 100, 1)
-				anchored = TRUE
-				update_icon()
-				to_chat(user, SPAN_NOTICE("You secure the exterior bolts on the turret."))
-			else if(anchored)
-				playsound(loc, 'sound/items/Ratchet.ogg', 100, 1)
-				anchored = FALSE
-				to_chat(user, SPAN_NOTICE("You unsecure the exterior bolts on the turret."))
-				update_icon()
-		wrenching = 0
-		return TRUE
-
-	else if(istype(I, /obj/item/card/id)||istype(I, /obj/item/modular_computer))
+	else if (isid(I) ||istype(I, /obj/item/modular_computer))
 		//Behavior lock/unlock mangement
 		if(allowed(user))
 			locked = !locked
@@ -646,7 +620,7 @@ var/global/list/turret_icons
 	var/gun_charge = 0			//the gun charge of the gun type installed
 
 
-/obj/machinery/porta_turret_construct/attackby(obj/item/I, mob/user)
+/obj/machinery/porta_turret_construct/use_tool(obj/item/I, mob/living/user, list/click_params)
 	//this is a bit unwieldy but self-explanatory
 	switch(build_step)
 		if(0)	//first step
@@ -655,14 +629,14 @@ var/global/list/turret_icons
 				to_chat(user, SPAN_NOTICE("You secure the external bolts."))
 				anchored = TRUE
 				build_step = 1
-				return
+				return TRUE
 
 			else if(isCrowbar(I) && !anchored)
 				playsound(loc, 'sound/items/Crowbar.ogg', 75, 1)
 				to_chat(user, SPAN_NOTICE("You dismantle the turret construction."))
 				new /obj/item/stack/material/steel( loc, 5)
 				qdel(src)
-				return
+				return TRUE
 
 		if(1)
 			if(istype(I, /obj/item/stack/material) && I.get_material_name() == MATERIAL_STEEL)
@@ -673,27 +647,26 @@ var/global/list/turret_icons
 					icon_state = "turret_frame2"
 				else
 					to_chat(user, SPAN_WARNING("You need two sheets of metal to continue construction."))
-				return
+				return TRUE
 
 			else if (isWrench(I))
 				playsound(loc, 'sound/items/Ratchet.ogg', 75, 1)
 				to_chat(user, SPAN_NOTICE("You unfasten the external bolts."))
 				anchored = FALSE
 				build_step = 0
-				return
-
+				return TRUE
 
 		if(2)
 			if (isWrench(I))
 				playsound(loc, 'sound/items/Ratchet.ogg', 100, 1)
 				to_chat(user, SPAN_NOTICE("You bolt the metal armor into place."))
 				build_step = 3
-				return
+				return TRUE
 
 			else if(isWelder(I))
 				var/obj/item/weldingtool/WT = I
 				if(!WT.can_use(5, user))
-					return
+					return TRUE
 
 				playsound(loc, pick('sound/items/Welder.ogg', 'sound/items/Welder2.ogg'), 50, 1)
 				if(do_after(user, (I.toolspeed * 2) SECONDS, src, DO_REPAIR_CONSTRUCT))
@@ -701,53 +674,46 @@ var/global/list/turret_icons
 					build_step = 1
 					to_chat(user, "You remove the turret's interior metal armor.")
 					new /obj/item/stack/material/steel( loc, 2)
-					return
-
+				return TRUE
 
 		if(3)
 			if(istype(I, /obj/item/gun/energy)) //the gun installation part
-
 				if(isrobot(user))
-					return
+					return FALSE
 				var/obj/item/gun/energy/E = I //typecasts the item to an energy gun
 				if(!user.unEquip(I))
 					to_chat(user, SPAN_NOTICE("\the [I] is stuck to your hand, you cannot put it in \the [src]"))
-					return
+					return TRUE
 				installation = I.type //installation becomes I.type
 				gun_charge = E.power_supply.charge //the gun's charge is stored in gun_charge
 				to_chat(user, SPAN_NOTICE("You add [I] to the turret."))
 				target_type = /obj/machinery/porta_turret
-
 				build_step = 4
-				qdel(I) //delete the gun :(
-				return
+				qdel(I)
+				return TRUE
 
 			else if (isWrench(I))
 				playsound(loc, 'sound/items/Ratchet.ogg', 100, 1)
 				to_chat(user, SPAN_NOTICE("You remove the turret's metal armor bolts."))
 				build_step = 2
-				return
+				return TRUE
 
 		if(4)
 			if(isprox(I))
 				build_step = 5
 				if(!user.unEquip(I))
 					to_chat(user, SPAN_NOTICE("\the [I] is stuck to your hand, you cannot put it in \the [src]"))
-					return
+					return TRUE
 				to_chat(user, SPAN_NOTICE("You add the prox sensor to the turret."))
 				qdel(I)
-				return
-
-			//attack_hand() removes the gun
+				return TRUE
 
 		if(5)
 			if(isScrewdriver(I))
 				playsound(loc, 'sound/items/Screwdriver.ogg', 100, 1)
 				build_step = 6
 				to_chat(user, SPAN_NOTICE("You close the internal access hatch."))
-				return
-
-			//attack_hand() removes the prox sensor
+				return TRUE
 
 		if(6)
 			if(istype(I, /obj/item/stack/material) && I.get_material_name() == MATERIAL_STEEL)
@@ -757,29 +723,30 @@ var/global/list/turret_icons
 					build_step = 7
 				else
 					to_chat(user, SPAN_WARNING("You need two sheets of metal to continue construction."))
-				return
+				return TRUE
 
 			else if (isScrewdriver(I))
 				playsound(loc, 'sound/items/Screwdriver.ogg', 100, 1)
 				build_step = 5
 				to_chat(user, SPAN_NOTICE("You open the internal access hatch."))
-				return
+				return TRUE
 
 		if(7)
 			if(isWelder(I))
 				var/obj/item/weldingtool/WT = I
 				if(!WT.can_use(5, user))
-					return
+					return TRUE
 
 				playsound(loc, pick('sound/items/Welder.ogg', 'sound/items/Welder2.ogg'), 50, 1)
 				if(do_after(user, (I.toolspeed * 3) SECONDS, src, DO_REPAIR_CONSTRUCT))
 					if(!src || !WT.remove_fuel(5, user))
-						return
+						return TRUE
 					build_step = 8
 					to_chat(user, SPAN_NOTICE("You weld the turret's armor down."))
 
 					//The final step: create a full turret
 					var/obj/machinery/porta_turret/Turret = new target_type(loc)
+					transfer_fingerprints_to(Turret)
 					Turret.SetName(finish_name)
 					Turret.installation = installation
 					Turret.gun_charge = gun_charge
@@ -787,25 +754,26 @@ var/global/list/turret_icons
 					Turret.setup()
 
 					qdel(src) // qdel
+				return TRUE
 
 			else if(isCrowbar(I))
 				playsound(loc, 'sound/items/Crowbar.ogg', 75, 1)
 				to_chat(user, SPAN_NOTICE("You pry off the turret's exterior armor."))
 				new /obj/item/stack/material/steel(loc, 2)
 				build_step = 6
-				return
+				return TRUE
 
 	if(istype(I, /obj/item/pen))	//you can rename turrets like bots!
 		var/t = sanitizeSafe(input(user, "Enter new turret name", name, finish_name) as text, MAX_NAME_LEN)
 		if(!t)
-			return
+			return TRUE
 		if(!in_range(src, usr) && loc != usr)
-			return
+			return TRUE
 
 		finish_name = t
-		return
+		return TRUE
 
-	..()
+	return ..()
 
 
 /obj/machinery/porta_turret_construct/attack_hand(mob/user)

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -16,7 +16,7 @@
 	var/icon_state_idle = "recharger0" //also when unpowered
 	var/portable = 1
 
-/obj/machinery/recharger/attackby(obj/item/G as obj, mob/user as mob)
+/obj/machinery/recharger/use_tool(obj/item/G, mob/living/user, list/click_params)
 	var/allowed = 0
 	for (var/allowed_type in allowed_devices)
 		if (istype(G, allowed_type)) allowed = 1
@@ -24,31 +24,36 @@
 	if(allowed)
 		if(charging)
 			to_chat(user, SPAN_WARNING("\A [charging] is already charging here."))
-			return
+			return TRUE
 		// Checks to make sure he's not in space doing it, and that the area got proper power.
 		if(!powered())
-			to_chat(user, SPAN_WARNING("The [name] blinks red as you try to insert the item!"))
-			return
+			to_chat(user, SPAN_WARNING("\The [name] blinks red as you try to insert the item!"))
+			return TRUE
 		if (istype(G, /obj/item/gun/energy))
 			var/obj/item/gun/energy/E = G
 			if(E.self_recharge)
 				to_chat(user, SPAN_NOTICE("You can't find a charging port on \the [E]."))
-				return
+				return TRUE
 		if(!G.get_cell())
 			to_chat(user, "This device does not have a battery installed.")
-			return
+			return TRUE
 
 		if(user.unEquip(G))
 			G.forceMove(src)
 			charging = G
 			update_icon()
-	else if(portable && isWrench(G))
+			return TRUE
+
+	if (portable && isWrench(G))
 		if(charging)
 			to_chat(user, SPAN_WARNING("Remove [charging] first!"))
-			return
+			return TRUE
 		anchored = !anchored
 		to_chat(user, "You [anchored ? "attached" : "detached"] the recharger.")
 		playsound(loc, 'sound/items/Ratchet.ogg', 75, 1)
+		return TRUE
+
+	return ..()
 
 /obj/machinery/recharger/physical_attack_hand(mob/user)
 	if(charging)

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -188,31 +188,9 @@ var/global/list/obj/machinery/requests_console/allConsoles = list()
 		silent = !silent
 		return TOPIC_REFRESH
 
-					//err... hacking code, which has no reason for existing... but anyway... it was once supposed to unlock priority 3 messanging on that console (EXTREME priority...), but the code for that was removed.
-/obj/machinery/requests_console/attackby(obj/item/O as obj, mob/user as mob)
-	/*
-	if (istype(O, /obj/item/crowbar))
-		if(open)
-			open = 0
-			icon_state="req_comp0"
-		else
-			open = 1
-			if(hackState == 0)
-				icon_state="req_comp_open"
-			else if(hackState == 1)
-				icon_state="req_comp_rewired"
-	if (istype(O, /obj/item/screwdriver))
-		if(open)
-			if(hackState == 0)
-				hackState = 1
-				icon_state="req_comp_rewired"
-			else if(hackState == 1)
-				hackState = 0
-				icon_state="req_comp_open"
-		else
-			to_chat(user, "You can't do much with that.") */
-	if (istype(O, /obj/item/card/id))
-		if(inoperable() || GET_FLAGS(stat, MACHINE_STAT_MAINT)) return
+/obj/machinery/requests_console/use_tool(obj/item/O, mob/living/user, list/click_params)
+	if (isid(O))
+		if(inoperable() || GET_FLAGS(stat, MACHINE_STAT_MAINT)) return FALSE
 		if(screen == RCS_MESSAUTH)
 			var/obj/item/card/id/T = O
 			msgVerified = text(SPAN_COLOR("green", "<b>Verified by [T.registered_name] ([T.assignment])</b>"))
@@ -226,13 +204,17 @@ var/global/list/obj/machinery/requests_console/allConsoles = list()
 				reset_message()
 				to_chat(user, SPAN_WARNING("You are not authorized to send announcements."))
 			SSnano.update_uis(src)
+		return TRUE
+
 	if (istype(O, /obj/item/stamp))
-		if(inoperable() || GET_FLAGS(stat, MACHINE_STAT_MAINT)) return
+		if(inoperable() || GET_FLAGS(stat, MACHINE_STAT_MAINT)) return FALSE
 		if(screen == RCS_MESSAUTH)
 			var/obj/item/stamp/T = O
 			msgStamped = text(SPAN_COLOR("blue", "<b>Stamped with the [T.name]</b>"))
 			SSnano.update_uis(src)
-	return
+		return TRUE
+
+	return ..()
 
 /obj/machinery/requests_console/proc/reset_message(mainmenu = 0)
 	message = ""

--- a/code/game/machinery/robotics_fabricator.dm
+++ b/code/game/machinery/robotics_fabricator.dm
@@ -145,10 +145,10 @@
 		return SPAN_NOTICE("\The [src] is busy. Please wait for completion of previous operation.")
 	return ..()
 
-/obj/machinery/robotics_fabricator/attackby(obj/item/I, mob/user)
+/obj/machinery/robotics_fabricator/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if(busy)
 		to_chat(user, SPAN_NOTICE("\The [src] is busy. Please wait for completion of previous operation."))
-		return 1
+		return TRUE
 	if(!istype(I, /obj/item/stack/material))
 		return ..()
 
@@ -163,7 +163,7 @@
 
 	if(!(material in materials))
 		to_chat(user, SPAN_WARNING("\The [src] does not accept [stack_plural]!"))
-		return
+		return TRUE
 
 	if(materials[material] + amnt <= res_max_amount)
 		if(stack && stack.can_use(1))
@@ -180,6 +180,7 @@
 			update_busy()
 	else
 		to_chat(user, "The fabricator cannot hold more [stack_plural].")// use the plural form even if the given sheet is singular
+	return TRUE
 
 
 /obj/machinery/robotics_fabricator/emag_act(remaining_charges, mob/user)

--- a/code/game/machinery/seed_extractor.dm
+++ b/code/game/machinery/seed_extractor.dm
@@ -14,13 +14,13 @@
 	machine_name = "seed extractor"
 	machine_desc = "Extracts a number of growable seed packets from a provided plant sample. The sample is destroyed in the process."
 
-/obj/machinery/seed_extractor/attackby(obj/item/O, mob/user)
-	if((. = component_attackby(O, user)))
+/obj/machinery/seed_extractor/use_tool(obj/item/O, mob/living/user, list/click_params)
+	if ((. = ..()))
 		return
 	// Fruits and vegetables.
 	if(istype(O, /obj/item/reagent_containers/food/snacks/grown))
 		if(!user.unEquip(O))
-			return
+			return TRUE
 
 		var/obj/item/reagent_containers/food/snacks/grown/F = O
 		var/datum/seed/new_seed_type = SSplants.seeds[F.plantname]
@@ -36,17 +36,18 @@
 			to_chat(user, "[O] doesn't seem to have any usable seeds inside it.")
 
 		qdel(O)
+		return TRUE
 
 	//Grass.
-	else if(istype(O, /obj/item/stack/tile/grass))
+	if (istype(O, /obj/item/stack/tile/grass))
 		var/obj/item/stack/tile/grass/S = O
 		if (S.use(1))
 			to_chat(user, SPAN_NOTICE("You extract some seeds from the grass tile."))
 			new /obj/item/seeds/grassseed(loc)
+		return TRUE
 
-	else if(istype(O, /obj/item/fossil/plant)) // Fossils
+	if (istype(O, /obj/item/fossil/plant)) // Fossils
 		var/obj/item/seeds/random/R = new(get_turf(src))
 		to_chat(user, "\The [src] scans \the [O] and spits out \a [R].")
 		qdel(O)
-
-	return
+		return TRUE

--- a/code/game/machinery/self_destruct.dm
+++ b/code/game/machinery/self_destruct.dm
@@ -9,7 +9,7 @@
 	var/armed = 0
 	var/damaged = 0
 
-/obj/machinery/self_destruct/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/self_destruct/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(isWelder(W))
 		var/obj/item/weldingtool/WT = W
 		if(damaged && WT.can_use(5, user))
@@ -20,22 +20,23 @@
 			if(do_after(usr, (W.toolspeed * 10) SECONDS, src, DO_REPAIR_CONSTRUCT) && WT.remove_fuel(10, user))
 				damaged = 0
 				user.visible_message("[user] repairs [src].", "You repair [src].")
-				return
+			return TRUE
 	if(istype(W, /obj/item/nuclear_cylinder))
 		if(damaged)
-			to_chat(user, SPAN_WARNING("[src] is damaged, you cannot place the cylinder."))
-			return
+			to_chat(user, SPAN_WARNING("\The [src] is damaged, you cannot place the cylinder."))
+			return TRUE
 		if(cylinder)
 			to_chat(user, "There is already a cylinder here.")
-			return
-		user.visible_message("[user] begins to carefully place [W] onto the Inserter.", "You begin to carefully place [W] onto the Inserter.")
+			return TRUE
+		user.visible_message("\The [user] begins to carefully place \the [W] onto the Inserter.", "You begin to carefully place \the [W] onto the Inserter.")
 		if(do_after(user, 8 SECONDS, src, DO_PUBLIC_UNIQUE) && user.unEquip(W, src))
 			cylinder = W
 			set_density(TRUE)
 			user.visible_message("[user] places [W] onto the Inserter.", "You place [W] onto the Inserter.")
 			update_icon()
-			return
-	..()
+		return TRUE
+
+	return ..()
 
 /obj/machinery/self_destruct/physical_attack_hand(mob/user)
 	if(cylinder)

--- a/code/game/machinery/spaceheater.dm
+++ b/code/game/machinery/spaceheater.dm
@@ -58,23 +58,25 @@
 		cell.emp_act(severity)
 	..(severity)
 
-/obj/machinery/space_heater/attackby(obj/item/I, mob/user)
+/obj/machinery/space_heater/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if(istype(I, /obj/item/cell))
 		if(panel_open)
 			if(cell)
 				to_chat(user, "There is already a power cell inside.")
-				return
+				return TRUE
 			else
 				// insert cell
 				if(!user.unEquip(I, src))
-					return
+					return TRUE
 				cell = I
 				user.visible_message(SPAN_NOTICE("[user] inserts a power cell into [src]."), SPAN_NOTICE("You insert the power cell into [src]."))
 				power_change()
+				return TRUE
 		else
 			to_chat(user, "The hatch must be open to insert a power cell.")
-			return
-	else if(isScrewdriver(I))
+			return TRUE
+
+	if (isScrewdriver(I))
 		panel_open = !panel_open
 		user.visible_message(
 			SPAN_NOTICE("\The [user] [panel_open ? "opens" : "closes"] the hatch on \the [src]."),
@@ -84,9 +86,9 @@
 		if(!panel_open && user.machine == src)
 			show_browser(user, null, "window=spaceheater")
 			user.unset_machine()
-	else
-		..()
-	return
+		return TRUE
+
+	return ..()
 
 /obj/machinery/space_heater/interface_interact(mob/user)
 	if(panel_open)

--- a/code/game/machinery/suit_cycler.dm
+++ b/code/game/machinery/suit_cycler.dm
@@ -71,67 +71,62 @@
 	DROP_NULL(helmet)
 	return ..()
 
-/obj/machinery/suit_cycler/attackby(obj/item/I as obj, mob/user as mob)
-
+/obj/machinery/suit_cycler/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if(electrified != 0)
 		if(shock(user, 100))
-			return
+			return TRUE
 
 	//Hacking init.
 	if(isMultitool(I) || isWirecutter(I))
 		if(panel_open)
 			attack_hand(user)
-		return
+		return TRUE
 	//Other interface stuff.
-	else if(isScrewdriver(I))
-
+	if (isScrewdriver(I))
 		panel_open = !panel_open
 		to_chat(user, "You [panel_open ?  "open" : "close"] the maintenance panel.")
 		updateUsrDialog()
-		return
+		return TRUE
 
-	else if(istype(I,/obj/item/clothing/head/helmet/space) && !istype(I, /obj/item/clothing/head/helmet/space/rig))
-
+	if (istype(I,/obj/item/clothing/head/helmet/space) && !istype(I, /obj/item/clothing/head/helmet/space/rig))
 		if(locked)
 			to_chat(user, SPAN_DANGER("The suit cycler is locked."))
-			return
+			return TRUE
 
 		if(helmet)
 			to_chat(user, SPAN_DANGER("The cycler already contains a helmet."))
-			return
+			return TRUE
 
 		if(I.icon_override == CUSTOM_ITEM_MOB)
 			to_chat(user, "You cannot refit a customised voidsuit.")
-			return
+			return TRUE
 		if(!user.unEquip(I, src))
-			return
+			return TRUE
 		to_chat(user, "You fit \the [I] into the suit cycler.")
 		helmet = I
-
 		updateUsrDialog()
-		return
+		return TRUE
 
-	else if(istype(I,/obj/item/clothing/suit/space/void))
-
+	if (istype(I,/obj/item/clothing/suit/space/void))
 		if(locked)
 			to_chat(user, SPAN_DANGER("The suit cycler is locked."))
-			return
+			return TRUE
 
 		if(suit)
 			to_chat(user, SPAN_DANGER("The cycler already contains a voidsuit."))
-			return
+			return TRUE
 
 		if(I.icon_override == CUSTOM_ITEM_MOB)
 			to_chat(user, "You cannot refit a customised voidsuit.")
-			return
+			return TRUE
 		if(!user.unEquip(I, src))
-			return
+			return TRUE
 		to_chat(user, "You fit \the [I] into the suit cycler.")
 		suit = I
-
 		updateUsrDialog()
-		return
-	..()
+		return TRUE
+
+	return ..()
 
 /obj/machinery/suit_cycler/proc/move_target_inside(mob/target, mob/user)
 	visible_message(SPAN_NOTICE("\The [user] starts putting \the [target] into \the [src]."), range = 3)

--- a/code/game/machinery/suit_storage.dm
+++ b/code/game/machinery/suit_storage.dm
@@ -101,7 +101,10 @@
 				dump_everything()
 				qdel(src)
 
-/obj/machinery/suit_storage_unit/attackby(obj/item/I, mob/user)
+/obj/machinery/suit_storage_unit/use_tool(obj/item/I, mob/living/user, list/click_params)
+	if ((. = ..()))
+		return
+
 	if(isScrewdriver(I))
 		if(do_after(user, (I.toolspeed * 5) SECONDS, src, DO_REPAIR_CONSTRUCT))
 			panelopen = !panelopen
@@ -109,7 +112,8 @@
 			to_chat(user, SPAN_NOTICE("You [panelopen ? "open" : "close"] the unit's maintenance panel."))
 			SSnano.update_uis(src)
 			update_icon()
-		 return
+		 return TRUE
+
 	if(isCrowbar(I))
 		if(inoperable() && !islocked && !isopen)
 			to_chat(user, SPAN_NOTICE("You begin prying the unit open."))
@@ -120,7 +124,8 @@
 				update_icon()
 		else if(islocked)
 			to_chat(user, SPAN_WARNING("You can't pry the unit open, it's locked!"))
-		return
+		return TRUE
+
 	TRY_INSERT_SUIT_PIECE(suit, clothing/suit/space)
 	TRY_INSERT_SUIT_PIECE(helmet, clothing/head/helmet/space)
 	TRY_INSERT_SUIT_PIECE(boots, clothing/shoes/magboots)
@@ -128,6 +133,7 @@
 	TRY_INSERT_SUIT_PIECE(mask, clothing/mask)
 	update_icon()
 	SSnano.update_uis(src)
+	return TRUE
 
 /obj/machinery/suit_storage_unit/proc/move_target_inside(mob/target, mob/user)
 	visible_message(SPAN_WARNING("\The [user] starts putting \the [target] into \the [src]."))

--- a/code/game/machinery/supplybeacon.dm
+++ b/code/game/machinery/supplybeacon.dm
@@ -43,15 +43,15 @@
 	name = "supermatter supply beacon"
 	drop_type = "supermatter"
 
-/obj/machinery/power/supply_beacon/attackby(obj/item/W, mob/user)
+/obj/machinery/power/supply_beacon/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(!use_power && isWrench(W))
 		if(!anchored && !connect_to_network())
 			to_chat(user, SPAN_WARNING("This device must be placed over an exposed cable."))
-			return
+			return TRUE
 		anchored = !anchored
 		user.visible_message(SPAN_NOTICE("\The [user] [anchored ? "secures" : "unsecures"] \the [src]."))
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		return
+		return TRUE
 	return ..()
 
 /obj/machinery/power/supply_beacon/physical_attack_hand(mob/user)

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -128,26 +128,26 @@
 	else
 		to_chat(user, SPAN_DANGER("You need to screw the beacon to the floor first!"))
 
-/obj/machinery/power/singularity_beacon/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/power/singularity_beacon/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(isScrewdriver(W))
 		if(active)
 			to_chat(user, SPAN_DANGER("You need to deactivate the beacon first!"))
-			return
+			return TRUE
 
 		if(anchored)
 			anchored = FALSE
 			to_chat(user, SPAN_NOTICE("You unscrew the beacon from the floor."))
 			disconnect_from_network()
-			return
+			return TRUE
 		else
 			if(!connect_to_network())
 				to_chat(user, "This device must be placed over an exposed cable.")
-				return
+				return TRUE
 			anchored = TRUE
 			to_chat(user, SPAN_NOTICE("You screw the beacon to the floor and attach the cable."))
-			return
-	..()
-	return
+			return TRUE
+
+	return ..()
 
 
 /obj/machinery/power/singularity_beacon/Destroy()

--- a/code/game/machinery/telecomms/machine_interactions.dm
+++ b/code/game/machinery/telecomms/machine_interactions.dm
@@ -17,8 +17,7 @@
 	stat_immune = 0
 	maximum_component_parts = list(/obj/item/stock_parts = 15)
 
-/obj/machinery/telecomms/attackby(obj/item/P as obj, mob/user as mob)
-
+/obj/machinery/telecomms/use_tool(obj/item/P, mob/living/user, list/click_params)
 	// Using a multitool lets you access the receiver's interface
 	if(isMultitool(P))
 		interface_interact(user)
@@ -27,15 +26,15 @@
 	// REPAIRING: Use Nanopaste to repair 10-20 integrity points.
 	if(istype(P, /obj/item/stack/nanopaste))
 		var/obj/item/stack/nanopaste/T = P
-		if (integrity < 100)               								//Damaged, let's repair!
+		if (integrity < 100)
 			if (T.use(1))
 				integrity = clamp(integrity + rand(10, 20), 0, 100)
 				to_chat(usr, "You apply the Nanopaste to [src], repairing some of the damage.")
 		else
 			to_chat(usr, "This machine is already in perfect condition.")
-		return
+		return TRUE
 
-	return component_attackby(P, user)
+	return ..()
 
 /obj/machinery/telecomms/cannot_transition_to(state_path, mob/user)
 	. = ..()

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -85,18 +85,19 @@
 
 	return ..()
 
-/obj/machinery/turretid/attackby(obj/item/W, mob/user)
+/obj/machinery/turretid/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(MACHINE_IS_BROKEN(src))
-		return
+		return FALSE
 
 	if(istype(W, /obj/item/card/id)||istype(W, /obj/item/modular_computer))
-		if(src.allowed(usr))
+		if(allowed(usr))
 			if(emagged)
 				to_chat(user, SPAN_NOTICE("The turret control is unresponsive."))
 			else
 				locked = !locked
 				to_chat(user, SPAN_NOTICE("You [ locked ? "lock" : "unlock"] the panel."))
-		return
+		return TRUE
+
 	return ..()
 
 /obj/machinery/turretid/emag_act(remaining_charges, mob/user)

--- a/code/game/machinery/vending/_vending.dm
+++ b/code/game/machinery/vending/_vending.dm
@@ -201,7 +201,7 @@
 	return 1
 
 
-/obj/machinery/vending/attackby(obj/item/item, mob/living/user)
+/obj/machinery/vending/use_tool(obj/item/item, mob/living/user, list/click_params)
 	var/obj/item/card/id/id = item.GetIdCard()
 	var/static/list/simple_coins = subtypesof(/obj/item/material/coin) - typesof(/obj/item/material/coin/challenge)
 	if (currently_vending && vendor_account && !vendor_account.suspended)
@@ -222,6 +222,7 @@
 		else if (handled)
 			SSnano.update_uis(src)
 			return TRUE
+
 	if (id || istype(item, /obj/item/spacecash))
 		attack_hand(user)
 		return TRUE
@@ -240,6 +241,7 @@
 		to_chat(user, SPAN_NOTICE("You insert \the [item] into \the [src]."))
 		SSnano.update_uis(src)
 		return TRUE
+
 	if (istype(item, /obj/item/material/coin/challenge/syndie))
 		if (!LAZYLEN(antag))
 			to_chat(user, SPAN_WARNING("\The [src] does not have a secret compartment installed."))
@@ -252,10 +254,10 @@
 			return TRUE
 		ProcessAntag(item, user)
 		return TRUE
+
 	if ((user.a_intent == I_HELP) && attempt_to_stock(item, user))
 		return TRUE
-	if ((. = component_attackby(item, user)))
-		return
+
 	return ..()
 
 ///Proc that enables hidden antag items and replaces slogan list with anti-Sol slogans if any.

--- a/code/game/machinery/vending/_vending.dm
+++ b/code/game/machinery/vending/_vending.dm
@@ -159,7 +159,7 @@
 		icon_state = initial(icon_state)
 	else
 		spawn(rand(0, 15))
-			icon_state = "[initial(icon_state)]-off"
+		icon_state = "[initial(icon_state)]-off"
 	if (panel_open || IsShowingAntag())
 		AddOverlays(image(icon, "[initial(icon_state)]-panel"))
 	if (IsShowingAntag() && is_powered())

--- a/code/game/machinery/washing_machine.dm
+++ b/code/game/machinery/washing_machine.dm
@@ -127,7 +127,10 @@
 /obj/machinery/washing_machine/components_are_accessible(path)
 	return !(state & WASHER_STATE_RUNNING) && ..()
 
-/obj/machinery/washing_machine/attackby(obj/item/W, mob/user)
+/obj/machinery/washing_machine/use_tool(obj/item/W, mob/living/user, list/click_params)
+	if ((. = ..()))
+		return
+
 	if(!(state & WASHER_STATE_CLOSED))
 		if(!crayon && istype(W,/obj/item/pen/crayon))
 			if(!user.unEquip(W, src))
@@ -139,6 +142,7 @@
 				return
 			detergent = W
 			return TRUE
+
 	if(istype(W, /obj/item/holder)) // Mob holder
 		for(var/mob/living/doggy in W)
 			doggy.forceMove(src)
@@ -151,24 +155,21 @@
 		to_chat(user, SPAN_WARNING("\The [src] is currently running."))
 		return TRUE
 
-	else if (!(W.item_flags & ITEM_FLAG_WASHER_ALLOWED))
-		if (isScrewdriver(W) || isCrowbar(W) || isWrench(W) || can_add_component(W))
-			return ..()
-
+	if (!(W.item_flags & ITEM_FLAG_WASHER_ALLOWED))
 		to_chat(user, SPAN_WARNING("\The [W] can't be washed in \the [src]!"))
-		return
+		return TRUE
 
-	else
-		if (length(contents) < 5)
-			if (!(state & WASHER_STATE_CLOSED))
-				if (!user.unEquip(W, src))
-					return
-				state |= WASHER_STATE_FULL
-				update_icon()
-			else
-				to_chat(user, SPAN_NOTICE("You can't put the item in right now."))
+	if (length(contents) < 5)
+		if (!(state & WASHER_STATE_CLOSED))
+			if (!user.unEquip(W, src))
+				return
+			state |= WASHER_STATE_FULL
+			update_icon()
 		else
-			to_chat(user, SPAN_NOTICE("\The [src] is full."))
+			to_chat(user, SPAN_NOTICE("You can't put the item in right now."))
+	else
+		to_chat(user, SPAN_NOTICE("\The [src] is full."))
+	return TRUE
 
 
 /obj/machinery/washing_machine/physical_attack_hand(mob/user)

--- a/code/game/objects/items/devices/paint_sprayer.dm
+++ b/code/game/objects/items/devices/paint_sprayer.dm
@@ -112,9 +112,11 @@
 		GLOB.module_deselected_event.unregister(user, src, /obj/item/device/paint_sprayer/proc/remove_click_handler)
 		GLOB.module_deactivated_event.unregister(user, src, /obj/item/device/paint_sprayer/proc/remove_click_handler)
 
-/obj/item/device/paint_sprayer/use_after(atom/target, mob/living/user, click_parameters)
-	apply_paint(target, user, click_parameters)
-	return TRUE
+/obj/item/device/paint_sprayer/use_before(atom/target, mob/living/user, click_parameters)
+	if (apply_paint(target, user, click_parameters))
+		return TRUE
+
+	return ..()
 
 /obj/item/device/paint_sprayer/proc/pick_color(atom/A, mob/user)
 	if (!user.Adjacent(A) || user.incapacitated())
@@ -145,7 +147,6 @@
 		to_chat(user, SPAN_WARNING("\The [src] can only be used on floors, windows, walls, exosuits or certain airlocks."))
 		. = FALSE
 	if (.)
-		add_fingerprint(user)
 		playsound(get_turf(src), 'sound/effects/spray3.ogg', 30, 1, -6)
 	return .
 

--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -286,18 +286,17 @@ var/global/list/tape_roll_applications = list()
 		to_chat(usr, SPAN_NOTICE("You finish placing \the [src]."))
 		return
 
-/obj/item/taperoll/use_after(atom/A, mob/living/user, click_parameters)
+/obj/item/taperoll/use_before(atom/A, mob/living/user, click_parameters)
 	if (istype(A, /obj/machinery/door/airlock))
 		var/turf/T = get_turf(A)
 		var/obj/item/tape/P = new tape_type(T)
+		P.add_fingerprint(user)
 		P.update_icon()
 		P.layer = ABOVE_DOOR_LAYER
-		if (user)
-			to_chat(user, SPAN_NOTICE("You finish placing \the [src]."))
-			P.add_fingerprint(user)
+		to_chat(user, SPAN_NOTICE("You finish placing \the [src]."))
 		return TRUE
 
-	if (istype(A, /turf/simulated/floor) ||istype(A, /turf/unsimulated/floor))
+	if (istype(A, /turf/simulated/floor) || istype(A, /turf/unsimulated/floor))
 		var/turf/F = A
 		var/direction = user.loc == F ? user.dir : turn(user.dir, 180)
 		var/hazard_overlay = GLOB.hazard_overlays["[direction]"]
@@ -313,6 +312,8 @@ var/global/list/tape_roll_applications = list()
 			F.AddOverlays(hazard_overlay)
 			tape_roll_applications[F] |= direction
 		return TRUE
+
+	return ..()
 
 /obj/item/tape/proc/crumple()
 	if(!crumpled)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -289,6 +289,8 @@
 	. = ..()
 	if((obj_flags & OBJ_FLAG_ROTATABLE))
 		to_chat(user, SPAN_SUBTLE("Can be rotated with alt-click."))
+	if((obj_flags & OBJ_FLAG_ANCHORABLE))
+		to_chat(user, SPAN_SUBTLE("Can be [anchored? "unsecured from the floor" : "secured to the floor"] using a wrench."))
 
 /obj/proc/rotate(mob/user)
 	if(!CanPhysicallyInteract(user))

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -758,23 +758,29 @@
 		/obj/item/stock_parts/power/apc
 	)
 
-/obj/machinery/button/windowtint/attackby(obj/item/device/W as obj, mob/user as mob)
+/obj/machinery/button/windowtint/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(isMultitool(W))
-		var/t = sanitizeSafe(input(user, "Enter the ID for the button.", src.name, id), MAX_NAME_LEN)
+		var/t = sanitizeSafe(input(user, "Enter the ID for the button.", name, id), MAX_NAME_LEN)
 		if(user.incapacitated() && !user.Adjacent(src))
-			return
+			return TRUE
 		if (user.get_active_hand() != W)
-			return
+			to_chat(SPAN_WARNING("\The [W] needs to be in your active hand."))
+			return TRUE
 		if (!in_range(src, user) && src.loc != user)
-			return
+			return TRUE
 		t = sanitizeSafe(t, MAX_NAME_LEN)
 		if (t)
 			src.id = t
 			to_chat(user, SPAN_NOTICE("The new ID of the button is [id]"))
-		return
+		return TRUE
+
 	if(isScrewdriver(W))
-		new /obj/item/frame/light_switch/windowtint(user.loc, 1)
+		var/obj/item/frame/light_switch/windowtint/frame = new /obj/item/frame/light_switch/windowtint(user.loc, 1)
+		transfer_fingerprints_to(frame)
 		qdel(src)
+		return TRUE
+
+	return ..()
 
 /obj/machinery/button/windowtint/activate()
 	if(operating)

--- a/code/modules/atmospherics/atmospherics.dm
+++ b/code/modules/atmospherics/atmospherics.dm
@@ -62,11 +62,6 @@ Pipelines + Other Objects -> Pipe network
 	else
 		reset_plane_and_layer()
 
-/obj/machinery/atmospherics/attackby(atom/A, mob/user as mob)
-	if(istype(A, /obj/item/device/scanner/gas))
-		return
-	..()
-
 /obj/machinery/atmospherics/proc/add_underlay(turf/T, obj/machinery/atmospherics/node, direction, icon_connect_type)
 	if(node)
 		if(!T.is_plating() && node.level == ATOM_LEVEL_UNDER_TILE && istype(node, /obj/machinery/atmospherics/pipe))

--- a/code/modules/atmospherics/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/components/binary_devices/circulator.dm
@@ -93,7 +93,7 @@
 
 	return 1
 
-/obj/machinery/atmospherics/binary/circulator/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/binary/circulator/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(isWrench(W))
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
 		anchored = !anchored
@@ -127,9 +127,8 @@
 			node1 = null
 			node2 = null
 		update_icon()
-
-	else
-		..()
+		return TRUE
+	return ..()
 
 /obj/machinery/atmospherics/binary/circulator/verb/rotate_clockwise()
 	set category = "Object"

--- a/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
+++ b/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
@@ -49,40 +49,41 @@
 	. = ..()
 	to_chat(user,"Its outlet port is to the [dir2text(dir)]")
 
-/obj/machinery/atmospherics/binary/oxyregenerator/attackby(obj/item/O as obj, mob/user as mob)
-	if(component_attackby(O, user))
-		return TRUE
-	if(isWrench(O))
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-		anchored = !anchored
-		user.visible_message("[user.name] [anchored ? "secures" : "unsecures"] the bolts holding [src.name] to the floor.", \
-					"You [anchored ? "secure" : "unsecure"] the bolts holding [src] to the floor.", \
-					"You hear a ratchet")
+/obj/machinery/atmospherics/binary/oxyregenerator/use_tool(obj/item/O, mob/living/user, list/click_params)
+	if (!isWrench(O))
+		return ..()
 
-		if(anchored)
-			if(dir & (NORTH|SOUTH))
-				initialize_directions = NORTH|SOUTH
-			else if(dir & (EAST|WEST))
-				initialize_directions = EAST|WEST
+	playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
+	anchored = !anchored
+	user.visible_message("[user.name] [anchored ? "secures" : "unsecures"] the bolts holding [src.name] to the floor.", \
+				"You [anchored ? "secure" : "unsecure"] the bolts holding [src] to the floor.", \
+				"You hear a ratchet")
 
-			atmos_init()
-			build_network()
-			if (node1)
-				node1.atmos_init()
-				node1.build_network()
-			if (node2)
-				node2.atmos_init()
-				node2.build_network()
-		else
-			if(node1)
-				node1.disconnect(src)
-				qdel(network1)
-			if(node2)
-				node2.disconnect(src)
-				qdel(network2)
+	if(anchored)
+		if(dir & (NORTH|SOUTH))
+			initialize_directions = NORTH|SOUTH
+		else if(dir & (EAST|WEST))
+			initialize_directions = EAST|WEST
 
-			node1 = null
-			node2 = null
+		atmos_init()
+		build_network()
+		if (node1)
+			node1.atmos_init()
+			node1.build_network()
+		if (node2)
+			node2.atmos_init()
+			node2.build_network()
+	else
+		if(node1)
+			node1.disconnect(src)
+			qdel(network1)
+		if(node2)
+			node2.disconnect(src)
+			qdel(network2)
+
+		node1 = null
+		node2 = null
+	return TRUE
 
 /obj/machinery/atmospherics/binary/oxyregenerator/verb/rotate_clockwise()
 	set category = "Object"

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -235,27 +235,28 @@
 	src.add_fingerprint(usr)
 	return
 
-/obj/machinery/atmospherics/binary/passive_gate/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/binary/passive_gate/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(!isWrench(W))
 		return ..()
 	if (unlocked)
 		to_chat(user, SPAN_WARNING("You cannot unwrench \the [src], turn it off first."))
-		return 1
+		return TRUE
 	var/datum/gas_mixture/int_air = return_air()
 	var/datum/gas_mixture/env_air = loc.return_air()
 	if ((int_air.return_pressure()-env_air.return_pressure()) > 2*ONE_ATMOSPHERE)
 		to_chat(user, SPAN_WARNING("You cannot unwrench \the [src], it too exerted due to internal pressure."))
-		add_fingerprint(user)
-		return 1
+		return TRUE
 	playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 	to_chat(user, SPAN_NOTICE("You begin to unfasten \the [src]..."))
-	if (do_after(user, (W.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
-		user.visible_message( \
-			SPAN_NOTICE("\The [user] unfastens \the [src]."), \
-			SPAN_NOTICE("You have unfastened \the [src]."), \
-			"You hear ratchet.")
-		new /obj/item/pipe(loc, src)
-		qdel(src)
+	if (!do_after(user, (W.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
+		return TRUE
+	user.visible_message( \
+		SPAN_NOTICE("\The [user] unfastens \the [src]."), \
+		SPAN_NOTICE("You have unfastened \the [src]."), \
+		"You hear ratchet.")
+	new /obj/item/pipe(loc, src)
+	qdel(src)
+	return TRUE
 
 #undef REGULATE_NONE
 #undef REGULATE_INPUT

--- a/code/modules/atmospherics/components/omni_devices/omni_base.dm
+++ b/code/modules/atmospherics/components/omni_devices/omni_base.dm
@@ -76,7 +76,7 @@
 		return 0
 	return 1
 
-/obj/machinery/atmospherics/omni/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/omni/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(!isWrench(W))
 		return ..()
 
@@ -86,17 +86,18 @@
 	var/datum/gas_mixture/env_air = loc.return_air()
 	if ((int_pressure - env_air.return_pressure()) > 2*ONE_ATMOSPHERE)
 		to_chat(user, SPAN_WARNING("You cannot unwrench \the [src], it is too exerted due to internal pressure."))
-		add_fingerprint(user)
-		return 1
+		return TRUE
 	to_chat(user, SPAN_NOTICE("You begin to unfasten \the [src]..."))
 	playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-	if(do_after(user, (W.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
-		user.visible_message( \
-			SPAN_NOTICE("\The [user] unfastens \the [src]."), \
-			SPAN_NOTICE("You have unfastened \the [src]."), \
-			"You hear a ratchet.")
-		new /obj/item/pipe(loc, src)
-		qdel(src)
+	if (!do_after(user, (W.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
+		return TRUE
+	user.visible_message( \
+		SPAN_NOTICE("\The [user] unfastens \the [src]."), \
+		SPAN_NOTICE("You have unfastened \the [src]."), \
+		"You hear a ratchet.")
+	new /obj/item/pipe(loc, src)
+	qdel(src)
+	return TRUE
 
 /obj/machinery/atmospherics/omni/interface_interact(mob/user)
 	ui_interact(user)

--- a/code/modules/atmospherics/components/pipesparker.dm
+++ b/code/modules/atmospherics/components/pipesparker.dm
@@ -73,32 +73,25 @@
 	)
 	ignite()
 
-/obj/machinery/atmospherics/pipe/cap/sparker/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/pipe/cap/sparker/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if (isScrewdriver(W) && !signaler)
-		add_fingerprint(user)
 		disabled = !disabled
-		if (disabled)
-			user.visible_message(
-				SPAN_WARNING("\The [user] has disabled \the [src]!"),
-				SPAN_WARNING("You disable the connection to \the [src].")
-			)
-		else if (!disabled)
-			user.visible_message(
-				SPAN_NOTICE("\The [user] has reconnected wiring on \the [src]!"),
-				SPAN_NOTICE("You fix the wire connection on \the [src].")
-			)
+		user.visible_message(
+			SPAN_WARNING("\The [user] has [disabled ? "disabled" : "reconnected wiring on"] \the [src]."),
+			SPAN_WARNING("You [disabled ? "disable" : "fix"] the connection on \the [src].")
+		)
 		update_icon()
-		return
+		return TRUE
 
 	if (istype(W, /obj/item/device/assembly/signaler) && signaler == null)
 		if (disabled)
 			to_chat(user, SPAN_WARNING("\The [src] is disabled!"))
-			return
+			return TRUE
 		signaler = W
 		if (signaler.secured)
 			to_chat(user, SPAN_WARNING("\The [signaler] is secured!"))
 			signaler = null
-			return
+			return TRUE
 		signaler.mholder = src
 		user.unEquip(signaler)
 		signaler.forceMove(src)
@@ -107,7 +100,7 @@
 			SPAN_NOTICE("You connect \the [signaler] to \the [src].")
 		)
 		update_icon()
-		return
+		return TRUE
 
 	if (isScrewdriver(W) && signaler)
 		signaler.mholder = null
@@ -118,12 +111,13 @@
 		)
 		signaler = null
 		update_icon()
-		return
+		return TRUE
 
 	if (isWrench(W) && (signaler || disabled))
 		to_chat(user, SPAN_NOTICE("Remove signalers and check the wiring before unwrenching \the [src]."))
-		return
-	..()
+		return TRUE
+
+	return ..()
 
 /obj/machinery/atmospherics/pipe/cap/sparker/proc/process_activation()//the signaler calls this
 	ignite()

--- a/code/modules/atmospherics/components/portables_connector.dm
+++ b/code/modules/atmospherics/components/portables_connector.dm
@@ -130,26 +130,28 @@
 	return null
 
 
-/obj/machinery/atmospherics/portables_connector/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/portables_connector/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(!isWrench(W))
 		return ..()
+
 	if (connected_device)
 		to_chat(user, SPAN_WARNING("You cannot unwrench \the [src], dettach \the [connected_device] first."))
-		return 1
+		return TRUE
 	if (locate(/obj/machinery/portable_atmospherics, src.loc))
-		return 1
+		return TRUE
 	var/datum/gas_mixture/int_air = return_air()
 	var/datum/gas_mixture/env_air = loc.return_air()
 	if ((int_air.return_pressure()-env_air.return_pressure()) > 2*ONE_ATMOSPHERE)
 		to_chat(user, SPAN_WARNING("You cannot unwrench \the [src], it too exerted due to internal pressure."))
-		add_fingerprint(user)
-		return 1
+		return TRUE
 	playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 	to_chat(user, SPAN_NOTICE("You begin to unfasten \the [src]..."))
-	if (do_after(user, (W.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
-		user.visible_message( \
-			SPAN_NOTICE("\The [user] unfastens \the [src]."), \
-			SPAN_NOTICE("You have unfastened \the [src]."), \
-			"You hear a ratchet.")
-		new /obj/item/pipe(loc, src)
-		qdel(src)
+	if (!do_after(user, (W.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
+		return TRUE
+	user.visible_message( \
+		SPAN_NOTICE("\The [user] unfastens \the [src]."), \
+		SPAN_NOTICE("You have unfastened \the [src]."), \
+		"You hear a ratchet.")
+	new /obj/item/pipe(loc, src)
+	qdel(src)
+	return TRUE

--- a/code/modules/atmospherics/components/tvalve.dm
+++ b/code/modules/atmospherics/components/tvalve.dm
@@ -264,24 +264,26 @@
 
 	return null
 
-/obj/machinery/atmospherics/tvalve/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/tvalve/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(!isWrench(W))
 		return ..()
+
 	var/datum/gas_mixture/int_air = return_air()
 	var/datum/gas_mixture/env_air = loc.return_air()
 	if ((int_air.return_pressure()-env_air.return_pressure()) > 2*ONE_ATMOSPHERE)
-		to_chat(user, SPAN_CLASS("warnng", "You cannot unwrench \the [src], it too exerted due to internal pressure."))
-		add_fingerprint(user)
-		return 1
+		to_chat(user, SPAN_WARNING("You cannot unwrench \the [src], it too exerted due to internal pressure."))
+		return TRUE
 	playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 	to_chat(user, SPAN_NOTICE("You begin to unfasten \the [src]..."))
-	if (do_after(user, (W.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
-		user.visible_message( \
-			SPAN_NOTICE("\The [user] unfastens \the [src]."), \
-			SPAN_NOTICE("You have unfastened \the [src]."), \
-			"You hear a ratchet.")
-		new /obj/item/pipe(loc, src)
-		qdel(src)
+	if (!do_after(user, (W.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
+		return TRUE
+	user.visible_message( \
+		SPAN_NOTICE("\The [user] unfastens \the [src]."), \
+		SPAN_NOTICE("You have unfastened \the [src]."), \
+		"You hear a ratchet.")
+	new /obj/item/pipe(loc, src)
+	qdel(src)
+	return TRUE
 
 /singleton/public_access/public_variable/tvalve_state
 	expected_type = /obj/machinery/atmospherics/tvalve

--- a/code/modules/atmospherics/components/unary/heat_exchanger.dm
+++ b/code/modules/atmospherics/components/unary/heat_exchanger.dm
@@ -68,25 +68,27 @@
 	return 1
 
 
-/obj/machinery/atmospherics/unary/heat_exchanger/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/unary/heat_exchanger/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(!isWrench(W))
 		return ..()
-	var/turf/T = src.loc
+
+	var/turf/T = loc
 	if (level==ATOM_LEVEL_UNDER_TILE && isturf(T) && !T.is_plating())
 		to_chat(user, SPAN_WARNING("You must remove the plating first."))
-		return 1
+		return TRUE
 	var/datum/gas_mixture/int_air = return_air()
 	var/datum/gas_mixture/env_air = loc.return_air()
 	if ((int_air.return_pressure()-env_air.return_pressure()) > 2*ONE_ATMOSPHERE)
 		to_chat(user, SPAN_WARNING("You cannot unwrench \the [src], it is too exerted due to internal pressure."))
-		add_fingerprint(user)
-		return 1
+		return TRUE
 	playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 	to_chat(user, SPAN_NOTICE("You begin to unfasten \the [src]..."))
-	if (do_after(user, (W.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
-		user.visible_message( \
-			SPAN_NOTICE("\The [user] unfastens \the [src]."), \
-			SPAN_NOTICE("You have unfastened \the [src]."), \
-			"You hear a ratchet.")
-		new /obj/item/pipe(loc, src)
-		qdel(src)
+	if (!do_after(user, (W.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
+		return TRUE
+	user.visible_message( \
+		SPAN_NOTICE("\The [user] unfastens \the [src]."), \
+		SPAN_NOTICE("You have unfastened \the [src]."), \
+		"You hear a ratchet.")
+	new /obj/item/pipe(loc, src)
+	qdel(src)
+	return TRUE

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -202,15 +202,16 @@
 /obj/machinery/atmospherics/unary/outlet_injector/hide(i)
 	update_underlays()
 
-/obj/machinery/atmospherics/unary/outlet_injector/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/atmospherics/unary/outlet_injector/use_tool(obj/item/O, mob/living/user, list/click_params)
 	if(isMultitool(O))
 		var/datum/browser/popup = new (user, "Vent Configuration Utility", "[src] Configuration Panel", 600, 200)
 		popup.set_content(jointext(get_console_data(),"<br>"))
 		popup.open()
-		return
+		return TRUE
 
 	if(isWrench(O))
 		new /obj/item/pipe(loc, src)
 		qdel(src)
-		return
+		return TRUE
+
 	return ..()

--- a/code/modules/atmospherics/components/unary/tank.dm
+++ b/code/modules/atmospherics/components/unary/tank.dm
@@ -58,20 +58,24 @@
 /obj/machinery/atmospherics/unary/tank/return_air()
 	return air_contents
 
-/obj/machinery/atmospherics/unary/tank/attackby(obj/item/W as obj, mob/user as mob)
-	if(isWrench(W))
-		if (air_contents.return_pressure() > 2*ONE_ATMOSPHERE)
-			to_chat(user, SPAN_WARNING("You cannot unwrench \the [src], it is too exerted due to internal pressure."))
-			add_fingerprint(user)
-			return 1
+/obj/machinery/atmospherics/unary/tank/use_tool(obj/item/W, mob/living/user, list/click_params)
+	if(!isWrench(W))
+		return ..()
 
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		to_chat(user, SPAN_NOTICE("You begin to unfasten \the [src]..."))
+	if (air_contents.return_pressure() > 2*ONE_ATMOSPHERE)
+		to_chat(user, SPAN_WARNING("You cannot unwrench \the [src], it is too exerted due to internal pressure."))
+		return TRUE
 
-		if (do_after(user, (W.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
-			user.visible_message(SPAN_NOTICE("\The [user] unfastens \the [src]."), SPAN_NOTICE("You have unfastened \the [src]."), "You hear a ratchet.")
-			new /obj/item/pipe/tank(loc, src)
-			qdel(src)
+	playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+	to_chat(user, SPAN_NOTICE("You begin to unfasten \the [src]..."))
+
+	if (!do_after(user, (W.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
+		return TRUE
+
+	user.visible_message(SPAN_NOTICE("\The [user] unfastens \the [src]."), SPAN_NOTICE("You have unfastened \the [src]."), "You hear a ratchet.")
+	new /obj/item/pipe/tank(loc, src)
+	qdel(src)
+	return TRUE
 
 /obj/machinery/atmospherics/unary/tank/air
 	name = "Pressure Tank (Air)"

--- a/code/modules/atmospherics/components/unary/vent_pump.dm
+++ b/code/modules/atmospherics/components/unary/vent_pump.dm
@@ -312,10 +312,10 @@
 		to_chat(user, SPAN_NOTICE("Now welding \the [src]."))
 		playsound(src, 'sound/items/Welder.ogg', 50, 1)
 
-		if(!do_after(user, (W.toolspeed * 2) SECONDS, src, DO_REPAIR_CONSTRUCT) && !WT.remove_fuel(1, user))
+		if(!do_after(user, (W.toolspeed * 2) SECONDS, src, DO_REPAIR_CONSTRUCT))
 			return TRUE
 
-		if(!src)
+		if(!src || !WT.remove_fuel(1, user))
 			return TRUE
 
 		welded = !welded

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -203,39 +203,31 @@
 			return SPAN_WARNING("You cannot take this [src] apart, it too exerted due to internal pressure.")
 	return ..()
 
-/obj/machinery/atmospherics/unary/vent_scrubber/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/weldingtool))
-
+/obj/machinery/atmospherics/unary/vent_scrubber/use_tool(obj/item/W, mob/living/user, list/click_params)
+	if(isWelder(W))
 		var/obj/item/weldingtool/WT = W
 
-		if(!WT.isOn())
-			to_chat(user, SPAN_NOTICE("The welding tool needs to be on to start this task."))
-			return 1
 
 		if(!WT.can_use(1,user))
-			to_chat(user, SPAN_WARNING("You need more welding fuel to complete this task."))
-			return 1
+			return TRUE
 
 		to_chat(user, SPAN_NOTICE("Now welding \the [src]."))
 		playsound(src, 'sound/items/Welder.ogg', 50, 1)
 
-		if(!do_after(user, (W.toolspeed * 2) SECONDS, src, DO_REPAIR_CONSTRUCT))
-			to_chat(user, SPAN_NOTICE("You must remain close to finish this task."))
-			return 1
+		if(!do_after(user, (W.toolspeed * 2) SECONDS, src, DO_REPAIR_CONSTRUCT) && !WT.remove_fuel(1, user))
+			return TRUE
 
 		if(!src)
-			return 1
-
-		if(!WT.remove_fuel(1, user))
-			return 1
+			return TRUE
 
 		welded = !welded
 		update_icon()
 		playsound(src, 'sound/items/Welder2.ogg', 50, 1)
-		user.visible_message(SPAN_NOTICE("\The [user] [welded ? "welds \the [src] shut" : "unwelds \the [src]"]."), \
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [welded ? "welds \the [src] shut" : "unwelds \the [src]"]."), \
 			SPAN_NOTICE("You [welded ? "weld \the [src] shut" : "unweld \the [src]"]."), \
 			"You hear welding.")
-		return 1
+		return TRUE
 
 	return ..()
 

--- a/code/modules/atmospherics/components/unary/vent_scrubber.dm
+++ b/code/modules/atmospherics/components/unary/vent_scrubber.dm
@@ -214,10 +214,10 @@
 		to_chat(user, SPAN_NOTICE("Now welding \the [src]."))
 		playsound(src, 'sound/items/Welder.ogg', 50, 1)
 
-		if(!do_after(user, (W.toolspeed * 2) SECONDS, src, DO_REPAIR_CONSTRUCT) && !WT.remove_fuel(1, user))
+		if(!do_after(user, (W.toolspeed * 2) SECONDS, src, DO_REPAIR_CONSTRUCT))
 			return TRUE
 
-		if(!src)
+		if(!src || !WT.remove_fuel(1, user))
 			return TRUE
 
 		welded = !welded

--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -215,24 +215,25 @@
 
 	return null
 
-/obj/machinery/atmospherics/valve/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/atmospherics/valve/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if (!isWrench(W))
 		return ..()
 	var/datum/gas_mixture/int_air = return_air()
 	var/datum/gas_mixture/env_air = loc.return_air()
 	if ((int_air.return_pressure()-env_air.return_pressure()) > 2*ONE_ATMOSPHERE)
 		to_chat(user, SPAN_WARNING("You cannot unwrench \the [src], it is too exerted due to internal pressure."))
-		add_fingerprint(user)
-		return 1
+		return TRUE
 	playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
 	to_chat(user, SPAN_NOTICE("You begin to unfasten \the [src]..."))
-	if (do_after(user, (W.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
-		user.visible_message( \
-			SPAN_NOTICE("\The [user] unfastens \the [src]."), \
-			SPAN_NOTICE("You have unfastened \the [src]."), \
-			"You hear a ratchet.")
-		new /obj/item/pipe(loc, src)
-		qdel(src)
+	if (!do_after(user, (W.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
+		return TRUE
+	user.visible_message( \
+		SPAN_NOTICE("\The [user] unfastens \the [src]."), \
+		SPAN_NOTICE("You have unfastened \the [src]."), \
+		"You hear a ratchet.")
+	new /obj/item/pipe(loc, src)
+	qdel(src)
+	return TRUE
 
 /obj/machinery/atmospherics/valve/examine(mob/user)
 	. = ..()

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -101,46 +101,46 @@
 
 	. = ..()
 
-/obj/machinery/atmospherics/pipe/attackby(obj/item/W as obj, mob/user as mob)
-	if (istype(src, /obj/machinery/atmospherics/unary/tank))
-		return ..()
-	if (istype(src, /obj/machinery/atmospherics/pipe/vent))
+/obj/machinery/atmospherics/pipe/use_tool(obj/item/W, mob/living/user, list/click_params)
+	if (!isWrench(W))
 		return ..()
 
-	if(isWrench(W))
-		var/turf/T = src.loc
-		if (level==ATOM_LEVEL_UNDER_TILE && isturf(T) && !T.is_plating())
-			to_chat(user, SPAN_WARNING("You must remove the plating first."))
-			return 1
+	var/turf/T = src.loc
+	if (level==ATOM_LEVEL_UNDER_TILE && isturf(T) && !T.is_plating())
+		to_chat(user, SPAN_WARNING("You must remove the plating first."))
+		return TRUE
+	if (clamp)
+		to_chat(user, SPAN_WARNING("You must remove \the [clamp] first."))
+		return TRUE
 
-		if (clamp)
-			to_chat(user, SPAN_WARNING("You must remove \the [clamp] first."))
-			return TRUE
+	var/datum/gas_mixture/int_air = return_air()
+	var/datum/gas_mixture/env_air = loc.return_air()
 
-		var/datum/gas_mixture/int_air = return_air()
-		var/datum/gas_mixture/env_air = loc.return_air()
+	if ((int_air.return_pressure()-env_air.return_pressure()) > 2*ONE_ATMOSPHERE)
+		to_chat(user, SPAN_WARNING("You cannot unwrench \the [src], it is too exerted due to internal pressure."))
+		return TRUE
 
-		if ((int_air.return_pressure()-env_air.return_pressure()) > 2*ONE_ATMOSPHERE)
-			to_chat(user, SPAN_WARNING("You cannot unwrench \the [src], it is too exerted due to internal pressure."))
-			add_fingerprint(user)
-			return 1
+	playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+	to_chat(user, SPAN_NOTICE("You begin to unfasten \the [src]..."))
 
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		to_chat(user, SPAN_NOTICE("You begin to unfasten \the [src]..."))
+	if (!do_after(user, (W.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
+		return TRUE
 
-		if (do_after(user, (W.toolspeed * 4) SECONDS, src, DO_REPAIR_CONSTRUCT))
-			if (clamp)
-				to_chat(user, SPAN_WARNING("You must remove \the [clamp] first."))
-				return TRUE
+	if (clamp)
+		to_chat(user, SPAN_WARNING("You must remove \the [clamp] first."))
+		return TRUE
 
-			user.visible_message(SPAN_NOTICE("\The [user] unfastens \the [src]."), SPAN_NOTICE("You have unfastened \the [src]."), "You hear a ratchet.")
+	user.visible_message(
+		SPAN_NOTICE("\The [user] unfastens \the [src]."),
+		SPAN_NOTICE("You have unfastened \the [src]."),
+		"You hear a ratchet.")
 
-			new /obj/item/pipe(loc, src)
-
-			for (var/obj/machinery/meter/meter in T)
-				if (meter.target == src)
-					meter.dismantle()
-			qdel(src)
+	new /obj/item/pipe(loc, src)
+	for (var/obj/machinery/meter/meter in T)
+		if (meter.target == src)
+			meter.dismantle()
+	qdel(src)
+	return TRUE
 
 /obj/machinery/atmospherics/get_color()
 	return pipe_color

--- a/code/modules/codex/entries/tools.dm
+++ b/code/modules/codex/entries/tools.dm
@@ -98,3 +98,7 @@
 	associated_paths = list(/obj/item/device/drone_designator)
 	mechanics_text = "This device is used to retrieve items such as crates from away sites. You can use it on a drone pad to synchronize with its network. Use it while in an exterior area to mark an object for pickup."
 	lore_text = "Common throughout human space, short range transport drones are used for courier roles and to retrieve material shipments from remote areas. This designator can send telemetry data beyond orbit through the use of a compact subspace beacon."
+
+/datum/codex_entry/sample_kit
+	associated_paths = list(/obj/item/forensics/sample_kit, /obj/item/forensics/sample_kit/powder, /obj/item/swabber)
+	mechanics_text = "Used to collect fibers or fingerprints from any surface. Must be on a non-help intent to collect evidence."

--- a/code/modules/detectivework/microscope/dnascanner.dm
+++ b/code/modules/detectivework/microscope/dnascanner.dm
@@ -15,25 +15,28 @@
 	var/last_process_worldtime = 0
 	var/report_num = 0
 
-/obj/machinery/dnaforensics/attackby(obj/item/W, mob/user as mob)
+/obj/machinery/dnaforensics/use_tool(obj/item/W, mob/living/user, list/click_params)
+	if(!istype(W, /obj/item/forensics/swab))
+		return .. ()
 
+	var/obj/item/forensics/swab/swab = W
 	if(bloodsamp)
 		to_chat(user, SPAN_WARNING("There is already a sample in the machine."))
-		return
+		return TRUE
 
 	if(closed)
 		to_chat(user, SPAN_WARNING("Open the cover before inserting the sample."))
-		return
+		return TRUE
 
-	var/obj/item/forensics/swab/swab = W
 	if(istype(swab) && swab.is_used())
 		if(!user.unEquip(W, src))
-			return
-		src.bloodsamp = swab
+			return TRUE
+		bloodsamp = swab
 		to_chat(user, SPAN_NOTICE("You insert \the [W] into \the [src]."))
+		return TRUE
 	else
 		to_chat(user, SPAN_WARNING("\The [src] only accepts used swabs."))
-		return
+		return TRUE
 
 /obj/machinery/dnaforensics/ui_interact(mob/user, ui_key = "main",datum/nanoui/ui = null)
 	if(!is_powered()) return

--- a/code/modules/detectivework/microscope/microscope.dm
+++ b/code/modules/detectivework/microscope/microscope.dm
@@ -15,26 +15,28 @@
 		sample.dropInto(loc)
 	..()
 
-/obj/machinery/microscope/attackby(obj/item/W, mob/user)
-
+/obj/machinery/microscope/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(sample)
 		to_chat(user, SPAN_WARNING("There is already a slide in the microscope."))
-		return
+		return ..()
 
-	if(istype(W))
-		if(istype(W, /obj/item/evidencebag))
-			var/obj/item/evidencebag/B = W
-			if(B.stored_item)
-				to_chat(user, SPAN_NOTICE("You insert \the [B.stored_item] from \the [B] into the microscope."))
-				B.stored_item.forceMove(src)
-				sample = B.stored_item
-				B.empty()
-				return
-		if(!user.unEquip(W, src))
-			return
-		to_chat(user, SPAN_NOTICE("You insert \the [W] into the microscope."))
-		sample = W
-		update_icon()
+	if (istype(W, /obj/item/evidencebag))
+		var/obj/item/evidencebag/B = W
+		if (B.stored_item)
+			to_chat(user, SPAN_NOTICE("You insert \the [B.stored_item] from \the [B] into the microscope."))
+			B.stored_item.forceMove(src)
+			sample = B.stored_item
+			B.empty()
+		else
+			to_chat(user, SPAN_WARNING("\The [B] is empty!"))
+		return TRUE
+
+	if(!user.unEquip(W, src))
+		return TRUE
+	to_chat(user, SPAN_NOTICE("You insert \the [W] into the microscope."))
+	sample = W
+	update_icon()
+	return TRUE
 
 /obj/machinery/microscope/physical_attack_hand(mob/user)
 	. = TRUE

--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -151,17 +151,14 @@
 	var/obj/item/sample/S = new evidence_path(get_turf(user), supplied)
 	to_chat(user, SPAN_NOTICE("You transfer [length(S.evidence)] [length(S.evidence) > 1 ? "[evidence_type]s" : "[evidence_type]"] to \the [S]."))
 
-/obj/item/forensics/sample_kit/resolve_attackby(atom/A, mob/user, click_params)
-	if (user.a_intent != I_HELP) // Prevents putting sample kits in bags, on racks/tables, etc when trying to take samples
-		return FALSE
+/obj/item/forensics/sample_kit/use_before(atom/target, mob/living/user, click_parameters)
+	if (user.a_intent == I_HELP) // Prevents putting sample kits in bags, on racks/tables, etc when trying to take samples
+		return ..()
 
-	. = ..()
-
-/obj/item/forensics/sample_kit/use_after(atom/A, mob/living/user, click_parameters)
-	if(user.skill_check(SKILL_FORENSICS, SKILL_TRAINED) && can_take_sample(user, A))
-		take_sample(user,A)
+	if (user.skill_check(SKILL_FORENSICS, SKILL_TRAINED) && can_take_sample(user, target))
+		take_sample(user,target)
 	else
-		to_chat(user, SPAN_WARNING("You are unable to locate any [evidence_type]s on \the [A]."))
+		to_chat(user, SPAN_WARNING("You are unable to locate any [evidence_type]s on \the [target]."))
 	return TRUE
 
 /obj/item/forensics/sample_kit/MouseDrop(atom/over)

--- a/code/modules/detectivework/tools/swabs.dm
+++ b/code/modules/detectivework/tools/swabs.dm
@@ -5,9 +5,12 @@
 	icon_state = "swab"
 
 // This is pretty nasty but is a damn sight easier than trying to make swabs a stack item.
-/obj/item/swabber/use_after(atom/A, mob/living/user, click_parameters)
+/obj/item/swabber/use_before(atom/target, mob/living/user, click_parameters)
+	if (user.a_intent == I_HELP) // Prevents putting sample kits in bags, on racks/tables, etc when trying to take samples
+		return ..()
+
 	var/obj/item/forensics/swab/swab = new(user)
-	swab.resolve_attackby(A, user, click_parameters)
+	swab.resolve_attackby(target, user, click_parameters)
 	if(swab.is_used())
 		swab.dropInto(user.loc)
 	else

--- a/code/modules/economy/ATM.dm
+++ b/code/modules/economy/ATM.dm
@@ -68,7 +68,7 @@
 		return 1
 
 /obj/machinery/atm/use_tool(obj/item/I, mob/living/user, list/click_params)
-	if(istype(I, /obj/item/card/id))
+	if(isid(I))
 		if (emagged)
 			to_chat(user, "[icon2html(src, user)] [SPAN_WARNING("CARD READER ERROR. This system has been compromised!")]")
 			return TRUE

--- a/code/modules/economy/Accounts_DB.dm
+++ b/code/modules/economy/Accounts_DB.dm
@@ -31,18 +31,18 @@
 	machine_id = "[station_name()] Acc. DB #[num_financial_terminals++]"
 	..()
 
-/obj/machinery/computer/account_database/attackby(obj/O, mob/user)
-	if(!istype(O, /obj/item/card/id))
+/obj/machinery/computer/account_database/use_tool(obj/item/O, mob/living/user, list/click_params)
+	if(!isid(O))
 		return ..()
 
 	if(!held_card)
 		if(!user.unEquip(O, src))
-			return
+			return TRUE
 		held_card = O
-
 		SSnano.update_uis(src)
 
 	attack_hand(user)
+	return TRUE
 
 /obj/machinery/computer/account_database/interface_interact(mob/user)
 	ui_interact(user)

--- a/code/modules/fabrication/fabricator_intake.dm
+++ b/code/modules/fabrication/fabricator_intake.dm
@@ -70,8 +70,11 @@
 	else
 		to_chat(user, SPAN_WARNING("\The [src] cannot process \the [thing]."))
 
-/obj/machinery/fabricator/attackby(obj/item/O, mob/user)
-	if(component_attackby(O, user) || stat)
+/obj/machinery/fabricator/use_tool(obj/item/O, mob/living/user, list/click_params)
+	if ((. = ..()))
+		return
+	if(stat)
+		to_chat(user, SPAN_WARNING("\The [src] is not operating."))
 		return TRUE
 	if(panel_open && (isMultitool(O) || isWirecutter(O)))
 		attack_hand(user)
@@ -97,7 +100,6 @@
 			qdel(O)
 		updateUsrDialog()
 		return TRUE
-	. = ..()
 
 /obj/machinery/fabricator/physical_attack_hand(mob/user)
 	if(fab_status_flags & FAB_SHOCKED)

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -356,10 +356,6 @@
 /obj/machinery/readybutton/New()
 	..()
 
-
-/obj/machinery/readybutton/attackby(obj/item/W as obj, mob/user as mob)
-	to_chat(user, "The device is a solid button, there's nothing you can do with it!")
-
 /obj/machinery/readybutton/physical_attack_hand(mob/user)
 	currentarea = get_area(src)
 	if(!currentarea)

--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -209,17 +209,16 @@
 		return SPAN_NOTICE("You must wait for \the [src] to finish first!")
 	return ..()
 
-/obj/machinery/honey_extractor/attackby(obj/item/I, mob/user)
+/obj/machinery/honey_extractor/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if(processing)
 		to_chat(user, SPAN_NOTICE("\The [src] is currently spinning, wait until it's finished."))
-		return
-	if((. = component_attackby(I, user)))
-		return
+		return TRUE
+
 	if(istype(I, /obj/item/honey_frame))
 		var/obj/item/honey_frame/H = I
 		if(!H.honey)
 			to_chat(user, SPAN_NOTICE("\The [H] is empty, put it into a beehive."))
-			return
+			return TRUE
 		user.visible_message(SPAN_NOTICE("\The [user] loads \the [H] into \the [src] and turns it on."), SPAN_NOTICE("You load \the [H] into \the [src] and turn it on."))
 		processing = H.honey
 		icon_state = "centrifuge_moving"
@@ -230,16 +229,20 @@
 			honey += processing
 			processing = 0
 			icon_state = "centrifuge"
-	else if(istype(I, /obj/item/reagent_containers/glass))
+		return TRUE
+
+	if (istype(I, /obj/item/reagent_containers/glass))
 		if(!honey)
 			to_chat(user, SPAN_NOTICE("There is no honey in \the [src]."))
-			return
+			return TRUE
 		var/obj/item/reagent_containers/glass/G = I
 		var/transferred = min(G.reagents.maximum_volume - G.reagents.total_volume, honey)
 		G.reagents.add_reagent(/datum/reagent/nutriment/honey, transferred)
 		honey -= transferred
 		user.visible_message(SPAN_NOTICE("\The [user] collects honey from \the [src] into \the [G]."), SPAN_NOTICE("You collect [transferred] units of honey from \the [src] into \the [G]."))
-		return 1
+		return TRUE
+
+	return ..()
 
 /obj/item/bee_smoker
 	name = "bee smoker"

--- a/code/modules/hydroponics/beekeeping/beehive.dm
+++ b/code/modules/hydroponics/beekeeping/beehive.dm
@@ -6,6 +6,7 @@
 	density = TRUE
 	anchored = TRUE
 	layer = BELOW_OBJ_LAYER
+	obj_flags = OBJ_FLAG_ANCHORABLE
 
 	var/closed = 0
 	var/bee_count = 0 // Percent
@@ -45,71 +46,80 @@
 	if(!closed)
 		to_chat(user, "The lid is open.")
 
-/obj/machinery/beehive/attackby(obj/item/I, mob/user)
-	if(isCrowbar(I))
+/obj/machinery/beehive/use_tool(obj/item/I, mob/living/user, list/click_params)
+	if (isCrowbar(I))
 		closed = !closed
 		user.visible_message(
 			SPAN_NOTICE("\The [user] [closed ? "closes" : "opens"] \the [src]."),
 			SPAN_NOTICE("You [closed ? "close" : "open"] \the [src].")
 		)
 		update_icon()
-		return
-	else if(isWrench(I))
-		anchored = !anchored
-		user.visible_message(
-			SPAN_NOTICE("\The [user] [anchored ? "wrenches" : "unwrenches"] \the [src]."),
-			SPAN_NOTICE("You [anchored ? "wrench" : "unwrench"] \the [src].")
-		)
-		return
-	else if(istype(I, /obj/item/bee_smoker))
+		return TRUE
+
+	if (istype(I, /obj/item/bee_smoker))
 		if(closed)
 			to_chat(user, SPAN_NOTICE("You need to open \the [src] with a crowbar before smoking the bees."))
-			return
-		user.visible_message(SPAN_NOTICE("\The [user] smokes the bees in \the [src]."), SPAN_NOTICE("You smoke the bees in \the [src]."))
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] smokes the bees in \the [src]."),
+			SPAN_NOTICE("You smoke the bees in \the [src].")
+		)
 		smoked = 30
 		update_icon()
-		return
-	else if(istype(I, /obj/item/honey_frame))
+		return TRUE
+
+	if (istype(I, /obj/item/honey_frame))
 		if(closed)
 			to_chat(user, SPAN_NOTICE("You need to open \the [src] with a crowbar before inserting \the [I]."))
-			return
+			return TRUE
 		if(frames >= maxFrames)
 			to_chat(user, SPAN_NOTICE("There is no place for an another frame."))
-			return
+			return TRUE
 		var/obj/item/honey_frame/H = I
 		if(H.honey)
 			to_chat(user, SPAN_NOTICE("\The [I] is full with beeswax and honey, empty it in the extractor first."))
-			return
+			return TRUE
 		++frames
-		user.visible_message(SPAN_NOTICE("\The [user] loads \the [I] into \the [src]."), SPAN_NOTICE("You load \the [I] into \the [src]."))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] loads \the [I] into \the [src]."),
+			SPAN_NOTICE("You load \the [I] into \the [src].")
+		)
 		update_icon()
 		qdel(I)
-		return
-	else if(istype(I, /obj/item/bee_pack))
+		return TRUE
+
+	if (istype(I, /obj/item/bee_pack))
 		var/obj/item/bee_pack/B = I
 		if(B.full && bee_count)
 			to_chat(user, SPAN_NOTICE("\The [src] already has bees inside."))
-			return
+			return TRUE
 		if(!B.full && bee_count < 90)
 			to_chat(user, SPAN_NOTICE("\The [src] is not ready to split."))
-			return
+			return TRUE
 		if(!B.full && !smoked)
 			to_chat(user, SPAN_NOTICE("Smoke \the [src] first!"))
-			return
+			return TRUE
 		if(closed)
 			to_chat(user, SPAN_NOTICE("You need to open \the [src] with a crowbar before moving the bees."))
-			return
+			return TRUE
 		if(B.full)
-			user.visible_message(SPAN_NOTICE("\The [user] puts the queen and the bees from \the [I] into \the [src]."), SPAN_NOTICE("You put the queen and the bees from \the [I] into \the [src]."))
+			user.visible_message(
+				SPAN_NOTICE("\The [user] puts the queen and the bees from \the [I] into \the [src]."),
+				SPAN_NOTICE("You put the queen and the bees from \the [I] into \the [src].")
+			)
 			bee_count = 20
 			B.empty()
 		else
-			user.visible_message(SPAN_NOTICE("\The [user] puts bees and larvae from \the [src] into \the [I]."), SPAN_NOTICE("You put bees and larvae from \the [src] into \the [I]."))
+			user.visible_message(
+				SPAN_NOTICE("\The [user] puts bees and larvae from \the [src] into \the [I]."),
+				SPAN_NOTICE("You put bees and larvae from \the [src] into \the [I].")
+			)
 			bee_count /= 2
 			B.fill()
 		update_icon()
-		return
-	else if(istype(I, /obj/item/device/scanner/plant))
+		return TRUE
+
+	if (istype(I, /obj/item/device/scanner/plant))
 		to_chat(user, SPAN_NOTICE("Scan result of \the [src]..."))
 		to_chat(user, "Beehive is [bee_count ? "[round(bee_count)]% full" : "empty"].[bee_count > 90 ? " Colony is ready to split." : ""]")
 		if(frames)
@@ -120,18 +130,23 @@
 			to_chat(user, "No frames installed.")
 		if(smoked)
 			to_chat(user, "The hive is smoked.")
-		return 1
-	else if(isScrewdriver(I))
+		return TRUE
+
+	if (isScrewdriver(I))
 		if(bee_count)
 			to_chat(user, SPAN_NOTICE("You can't dismantle \the [src] with these bees inside."))
-			return
+			return TRUE
 		to_chat(user, SPAN_NOTICE("You start dismantling \the [src]..."))
 		playsound(loc, 'sound/items/Screwdriver.ogg', 50, 1)
-		if (do_after(user, (I.toolspeed * 3) SECONDS, src, DO_PUBLIC_UNIQUE))
-			user.visible_message(SPAN_NOTICE("\The [user] dismantles \the [src]."), SPAN_NOTICE("You dismantle \the [src]."))
-			new /obj/item/beehive_assembly(loc)
-			qdel(src)
-		return
+		if (!do_after(user, (I.toolspeed * 3) SECONDS, src, DO_PUBLIC_UNIQUE))
+			return TRUE
+
+		user.visible_message(SPAN_NOTICE("\The [user] dismantles \the [src]."), SPAN_NOTICE("You dismantle \the [src]."))
+		new /obj/item/beehive_assembly(loc)
+		qdel(src)
+		return TRUE
+
+	return ..()
 
 /obj/machinery/beehive/physical_attack_hand(mob/user)
 	if(!closed)

--- a/code/modules/hydroponics/seed_machines.dm
+++ b/code/modules/hydroponics/seed_machines.dm
@@ -65,51 +65,50 @@
 			visible_message("[icon2html(src, viewers(get_turf(src)))] [src] beeps and spits out [loaded_disk].")
 			loaded_disk = null
 
-/obj/machinery/botany/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/botany/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(istype(W,/obj/item/seeds))
 		if(seed)
 			to_chat(user, "There is already a seed loaded.")
-			return
+			return TRUE
 		var/obj/item/seeds/S =W
 		if(S.seed && S.seed.get_trait(TRAIT_IMMUTABLE) > 0)
 			to_chat(user, "That seed is not compatible with our genetics technology.")
 		else if(user.unEquip(W, src))
 			seed = W
 			to_chat(user, "You load [W] into [src].")
-		return
+		return TRUE
 
 	if(isScrewdriver(W))
 		open = !open
 		to_chat(user, SPAN_NOTICE("You [open ? "open" : "close"] the maintenance panel."))
-		return
+		return TRUE
 
-	if(open)
-		if(isCrowbar(W))
-			dismantle()
-			return
+	if(open && isCrowbar(W))
+		dismantle()
+		return TRUE
 
 	if(istype(W,/obj/item/disk/botany))
 		if(loaded_disk)
 			to_chat(user, "There is already a data disk loaded.")
-			return
+			return TRUE
+
+		var/obj/item/disk/botany/B = W
+		if (B.genes && length(B.genes))
+			if (!disk_needs_genes)
+				to_chat(user, "That disk already has gene data loaded.")
+				return TRUE
 		else
-			var/obj/item/disk/botany/B = W
+			if(disk_needs_genes)
+				to_chat(user, "That disk does not have any gene data loaded.")
+				return TRUE
 
-			if(B.genes && length(B.genes))
-				if(!disk_needs_genes)
-					to_chat(user, "That disk already has gene data loaded.")
-					return
-			else
-				if(disk_needs_genes)
-					to_chat(user, "That disk does not have any gene data loaded.")
-					return
-			if(!user.unEquip(W, src))
-				return
-			loaded_disk = W
-			to_chat(user, "You load [W] into [src].")
+		if(!user.unEquip(W, src))
+			return TRUE
+		loaded_disk = W
+		to_chat(user, "You load \the [W] into \the [src].")
+		return TRUE
 
-		return
-	..()
+	return ..()
 
 // Allows for a trait to be extracted from a seed packet, destroying that seed.
 /obj/machinery/botany/extractor

--- a/code/modules/hydroponics/seed_storage.dm
+++ b/code/modules/hydroponics/seed_storage.dm
@@ -25,6 +25,7 @@
 	density = TRUE
 	anchored = TRUE
 	idle_power_usage = 100
+	obj_flags = OBJ_FLAG_ANCHORABLE
 
 	var/list/datum/seed_pile/piles = list()
 	var/list/starting_seeds = list(
@@ -293,13 +294,14 @@
 			break
 	updateUsrDialog()
 
-/obj/machinery/seed_storage/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/seed_storage/use_tool(obj/item/O, mob/living/user, list/click_params)
 	if (istype(O, /obj/item/seeds))
 		add(O)
 		sort_piles()
 		user.visible_message("[user] puts \the [O.name] into \the [src].", "You put \the [O] into \the [src].")
-		return
-	else if (istype(O, /obj/item/storage/plants))
+		return TRUE
+
+	if (istype(O, /obj/item/storage/plants))
 		var/obj/item/storage/P = O
 		var/loaded = 0
 		for(var/obj/item/seeds/G in P.contents)
@@ -312,11 +314,8 @@
 			user.visible_message("[user] puts the seeds from \the [O.name] into \the [src].", "You put the seeds from \the [O.name] into \the [src].")
 		else
 			to_chat(user, SPAN_NOTICE("There are no seeds in \the [O.name]."))
-		return
-	else if(isWrench(O))
-		playsound(loc, 'sound/items/Ratchet.ogg', 50, 1)
-		anchored = !anchored
-		to_chat(user, "You [anchored ? "wrench" : "unwrench"] \the [src].")
+		return TRUE
+	return ..()
 
 /obj/machinery/seed_storage/proc/add(obj/item/seeds/O, bypass_removal = 0)
 	if(!bypass_removal)

--- a/code/modules/hydroponics/trays/tray_soil.dm
+++ b/code/modules/hydroponics/trays/tray_soil.dm
@@ -8,11 +8,11 @@
 	mechanical = 0
 	tray_light = 0
 
-/obj/machinery/portable_atmospherics/hydroponics/soil/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/portable_atmospherics/hydroponics/soil/use_tool(obj/item/O, mob/living/user, list/click_params)
 	if(istype(O,/obj/item/tank))
-		return
+		return FALSE
 	else
-		..()
+		return ..()
 
 /obj/machinery/portable_atmospherics/hydroponics/soil/New()
 	..()

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -67,19 +67,30 @@
 	icon_state = "binder"
 	anchored = TRUE
 	density = TRUE
+	var/binding
 
-/obj/machinery/bookbinder/attackby(obj/O as obj, mob/user as mob)
+/obj/machinery/bookbinder/use_tool(obj/item/O, mob/living/user, list/click_params)
 	if(istype(O, /obj/item/paper))
 		if(!user.unEquip(O, src))
-			return
-		user.visible_message("[user] loads some paper into [src].", "You load some paper into [src].")
-		src.visible_message("[src] begins to hum as it warms up its printing drums.")
+			return TRUE
+		if (binding)
+			to_chat(user, SPAN_WARNING("\The [src] is currently busy printing a book."))
+			return TRUE
+
+		user.visible_message(
+			SPAN_NOTICE("\The [user] loads some paper into \the [src]."),
+			SPAN_NOTICE("You load some paper into \the [src].")
+		)
+		visible_message(SPAN_NOTICE("\The [src] begins to hum as it warms up its printing drums."))
+		binding = TRUE
 		sleep(rand(200,400))
-		src.visible_message("[src] whirs as it prints and binds a new book.")
-		var/obj/item/book/b = new(src.loc)
+		visible_message(SPAN_NOTICE("\The [src] whirs as it prints and binds a new book."))
+		binding = FALSE
+		var/obj/item/book/b = new(loc)
 		b.dat = O:info
 		b.SetName("Print Job #" + "[rand(100, 999)]")
 		b.icon_state = "book[rand(1,7)]"
 		qdel(O)
-	else
-		..()
+		return TRUE
+
+	return ..()

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -16,10 +16,12 @@
 	density = TRUE
 	var/obj/item/book/cache		// Last scanned book
 
-/obj/machinery/libraryscanner/attackby(obj/O as obj, mob/user as mob)
+/obj/machinery/libraryscanner/use_tool(obj/item/O, mob/living/user, list/click_params)
 	if(istype(O, /obj/item/book))
-		if(!user.unEquip(O, src))
-			return
+		user.unEquip(O, src)
+		return TRUE
+
+	return ..()
 
 /obj/machinery/libraryscanner/interface_interact(mob/user)
 	interact(user)

--- a/code/modules/mechs/equipment/medical.dm
+++ b/code/modules/mechs/equipment/medical.dm
@@ -31,7 +31,7 @@
 
 /obj/item/mech_equipment/sleeper/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/reagent_containers/glass))
-		sleeper.attackby(I, user)
+		sleeper.use_tool(I, user)
 	else return ..()
 
 /obj/item/mech_equipment/sleeper/afterattack(atom/target, mob/living/user, inrange, params)

--- a/code/modules/mechs/equipment/medical.dm
+++ b/code/modules/mechs/equipment/medical.dm
@@ -80,16 +80,19 @@
 		S.passive_power_use = 0 //No passive power drain when the sleeper is empty. Set to 1.5 KW when patient is inside.
 
 //You cannot modify these, it'd probably end with something in nullspace. In any case basic meds are plenty for an ambulance
-/obj/machinery/sleeper/mounted/attackby(obj/item/I, mob/user)
+/obj/machinery/sleeper/mounted/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if(istype(I, /obj/item/reagent_containers/glass))
 		if(!user.unEquip(I, src))
-			return
+			return TRUE
 
 		if(beaker)
 			beaker.forceMove(get_turf(src))
 			user.visible_message(SPAN_NOTICE("\The [user] removes \the [beaker] from \the [src]."), SPAN_NOTICE("You remove \the [beaker] from \the [src]."))
 		beaker = I
 		user.visible_message(SPAN_NOTICE("\The [user] adds \a [I] to \the [src]."), SPAN_NOTICE("You add \a [I] to \the [src]."))
+		return TRUE
+
+	return ..()
 
 #define MEDIGEL_SALVE 1
 #define MEDIGEL_SCAN  2

--- a/code/modules/mining/drilling/drill.dm
+++ b/code/modules/mining/drilling/drill.dm
@@ -263,7 +263,7 @@
 	name = "mining drill brace"
 	desc = "A machinery brace for an industrial drill. It looks easily two feet thick."
 	icon_state = "mining_brace"
-	obj_flags = OBJ_FLAG_ROTATABLE
+	obj_flags = OBJ_FLAG_ROTATABLE | OBJ_FLAG_ANCHORABLE
 	interact_offline = 1
 
 	machine_name = "mining drill brace"
@@ -276,26 +276,20 @@
 		return SPAN_NOTICE("You can't work with the brace of a running drill!")
 	return ..()
 
-/obj/machinery/mining/brace/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/mining/brace/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(connected && connected.active)
 		to_chat(user, SPAN_NOTICE("You can't work with the brace of a running drill!"))
 		return TRUE
-	if(component_attackby(W, user))
-		return TRUE
-	if(isWrench(W))
 
-		if(istype(get_turf(src), /turf/space))
-			to_chat(user, SPAN_NOTICE("You can't anchor something to empty space. Idiot."))
-			return
+	return ..()
 
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-		to_chat(user, SPAN_NOTICE("You [anchored ? "un" : ""]anchor the brace."))
+/obj/machinery/mining/brace/post_anchor_change()
+	if (anchored)
+		connect()
+	else
+		disconnect()
 
-		anchored = !anchored
-		if(anchored)
-			connect()
-		else
-			disconnect()
+	..()
 
 /obj/machinery/mining/brace/proc/connect()
 

--- a/code/modules/modular_computers/computers/subtypes/dev_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_console.dm
@@ -76,7 +76,7 @@
 	var/obj/item/stock_parts/computer/P = path
 	return initial(P.external_slot)
 
-/obj/machinery/computer/modular/attackby(obj/item/I, mob/user)
+/obj/machinery/computer/modular/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if(istype(I, /obj/item/stock_parts/computer/hard_drive/portable))
 		if(portable_drive)
 			to_chat(user, SPAN_WARNING("There's already \a [portable_drive] plugged in."))

--- a/code/modules/modular_computers/laptop_vendor.dm
+++ b/code/modules/modular_computers/laptop_vendor.dm
@@ -269,8 +269,10 @@
 		ui.set_auto_update(1)
 
 
-/obj/machinery/lapvend/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/lapvend/use_tool(obj/item/W, mob/living/user, list/click_params)
 	var/obj/item/card/id/I = W.GetIdCard()
+	if (!I)
+		return ..()
 	// Awaiting payment state
 	if(state == 2)
 		if(process_payment(I,W))
@@ -293,8 +295,8 @@
 				fabricated_tablet = null
 			ping("Enjoy your new product!")
 			state = 3
-			return 1
-		return 0
+			return TRUE
+
 	return ..()
 
 

--- a/code/modules/overmap/contacts/contact_sensors.dm
+++ b/code/modules/overmap/contacts/contact_sensors.dm
@@ -193,22 +193,39 @@
 		addtimer(new Callback(record, .proc/ping), time_delay)
 
 /obj/machinery/shipsensors/use_tool(obj/item/tool, mob/living/user, list/click_params)
-	if (!isMultitool(tool))
-		return ..()
+	if (isMultitool(tool))
+		var/obj/item/device/multitool/mtool = tool
+		var/obj/item/ship_tracker/tracker = mtool.get_buffer()
+		if (!tracker || !istype(tracker))
+			return FALSE
 
-	var/obj/item/device/multitool/mtool = tool
-	var/obj/item/ship_tracker/tracker = mtool.get_buffer()
-	if (!tracker || !istype(tracker))
-		return
+		if (tracker in trackers)
+			trackers -= tracker
+			GLOB.destroyed_event.unregister(tracker, src, .proc/remove_tracker)
+			to_chat(user, SPAN_NOTICE("You unlink the tracker in \the [mtool]'s buffer from \the [src]"))
+			return TRUE
 
-	if (tracker in trackers)
-		trackers -= tracker
-		GLOB.destroyed_event.unregister(tracker, src, .proc/remove_tracker)
-		to_chat(user, SPAN_NOTICE("You unlink the tracker in \the [mtool]'s buffer from \the [src]"))
-		return
-	trackers += tracker
-	GLOB.destroyed_event.register(tracker, src, .proc/remove_tracker)
-	to_chat(user, SPAN_NOTICE("You link the tracker in \the [mtool]'s buffer to \the [src]"))
+		trackers += tracker
+		GLOB.destroyed_event.register(tracker, src, .proc/remove_tracker)
+		to_chat(user, SPAN_NOTICE("You link the tracker in \the [mtool]'s buffer to \the [src]"))
+		return TRUE
+
+	if (isWelder(tool))
+		var/damage = get_damage_value()
+		var/obj/item/weldingtool/WT = tool
+		if (!damage)
+			to_chat(user, SPAN_WARNING("\The [src] doesn't need any repairs."))
+			return TRUE
+		if (!WT.can_use(1, user))
+			return TRUE
+		to_chat(user, SPAN_NOTICE("You start repairing the damage to [src]."))
+		playsound(src, 'sound/items/Welder.ogg', 100, 1)
+		if (do_after(user, max(5, damage / 5), src, DO_REPAIR_CONSTRUCT) && WT.remove_fuel(1, user))
+			to_chat(user, SPAN_NOTICE("You finish repairing the damage to [src]."))
+			revive_health()
+		return TRUE
+
+	return ..()
 
 /obj/machinery/shipsensors/proc/remove_tracker(obj/item/ship_tracker/tracker)
 	trackers -= tracker

--- a/code/modules/overmap/disperser/disperser.dm
+++ b/code/modules/overmap/disperser/disperser.dm
@@ -12,16 +12,21 @@
 	if(panel_open)
 		to_chat(user, "The maintenance panel is open.")
 
-/obj/machinery/disperser/attackby(obj/item/I, mob/user)
+/obj/machinery/disperser/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if(isWrench(I))
 		if(panel_open)
-			user.visible_message(SPAN_NOTICE("\The [user] rotates \the [src] with \the [I]."), SPAN_NOTICE("You rotate \the [src] with \the [I]."))
+			user.visible_message(
+				SPAN_NOTICE("\The [user] rotates \the [src] with \the [I]."),
+				SPAN_NOTICE("You rotate \the [src] with \the [I].")
+			)
 			set_dir(turn(dir, 90))
 			playsound(src, 'sound/items/jaws_pry.ogg', 50, 1)
+			return TRUE
 		else
 			to_chat(user,SPAN_NOTICE("The maintenance panel must be screwed open for this!"))
-	else
-		return ..()
+			return TRUE
+
+	return ..()
 
 /obj/machinery/disperser/front
 	name = "obstruction field disperser beam generator"

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -270,26 +270,6 @@
 	..()
 	sensor_strength = clamp(total_component_rating_of_type(/obj/item/stock_parts/manipulator), 0, 5) * SENSORS_STRENGTH_COEFFICIENT
 
-
-/obj/machinery/shipsensors/attackby(obj/item/W, mob/user)
-	if (isWelder(W) && user.a_intent != I_HURT)
-		var/damage = get_damage_value()
-		var/obj/item/weldingtool/WT = W
-		if (!damage)
-			to_chat(user, SPAN_WARNING("\The [src] doesn't need any repairs."))
-			return TRUE
-		if (!WT.can_use(3,user))
-			return TRUE
-		to_chat(user, SPAN_NOTICE("You start repairing the damage to [src]."))
-		playsound(src, 'sound/items/Welder.ogg', 100, 1)
-		if (do_after(user, max(5, damage / 5), src, DO_REPAIR_CONSTRUCT) && WT.remove_fuel(3, user))
-			to_chat(user, SPAN_NOTICE("You finish repairing the damage to [src]."))
-			revive_health()
-		return TRUE
-
-	return ..()
-
-
 /obj/machinery/shipsensors/proc/in_vacuum()
 	var/turf/T=get_turf(src)
 	if (istype(T))

--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -51,47 +51,50 @@ GLOBAL_LIST_EMPTY(admin_departments)
 	. = ..()
 
 
-/obj/machinery/photocopier/faxmachine/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/photocopier/faxmachine/use_tool(obj/item/O, mob/living/user, list/click_params)
 	if(istype(O, /obj/item/paper))
 		var/obj/item/paper/P = O
 		if(!P.readable)
 			to_chat(user, SPAN_NOTICE("\The [src] beeps. Error, invalid document detected."))
-			return
-	if(istype(O, /obj/item/card/id))
+			return TRUE
+
+	if(isid(O))
 		if(!user.unEquip(O, src))
-			return
+			return TRUE
 		scan = O
 		to_chat(user, SPAN_NOTICE("You insert \the [O] into \the [src]."))
+		return TRUE
+
 	if (isMultitool(O))
 		to_chat(user, SPAN_NOTICE("\The [src]'s department tag is set to [department]."))
 		if (!emagged)
 			to_chat(user, SPAN_WARNING("\The [src]'s department configuration is vendor locked."))
-			return
+			return TRUE
 		var/list/option_list = GLOB.alldepartments.Copy() + GLOB.admin_departments.Copy() + "(Custom)" + "(Cancel)"
 		var/new_department = input(user, "Which department do you want to tag this fax machine as? Choose '(Custom)' to enter a custom department or '(Cancel) to cancel.", "Fax Machine Department Tag") as null|anything in option_list
 		if (!new_department || new_department == department || new_department == "(Cancel)" || !CanUseTopic(user) || !Adjacent(user))
-			return
+			return TRUE
 		if (new_department == "(Custom)")
 			new_department = input(user, "Which department do you want to tag this fax machine as?", "Fax Machine Department Tag", department) as text|null
 			if (!new_department || new_department == department || !CanUseTopic(user) || !Adjacent(user))
-				return
+				return TRUE
 		if (new_department == "Unknown" || new_department == "(Custom)" || new_department == "(Cancel)")
 			to_chat(user, SPAN_WARNING("Invalid department tag selected."))
-			return
+			return TRUE
 		department = new_department
 		to_chat(user, SPAN_NOTICE("You reconfigure \the [src]'s department tag to [department]."))
-		return
+		return TRUE
 
 	if (istype(O, /obj/item/modular_computer/pda))
 		if (LAZYISIN(linked_pdas, O))
 			unlink_pda(O)
 			to_chat(user, SPAN_NOTICE("You remove \the [O] from \the [src]'s notifications list."))
-			return
+			return TRUE
 		link_pda(O)
 		to_chat(user, SPAN_NOTICE("You add \the [O] to \the [src]'s notifications list. It will now be pinged whenever a fax is received."))
-		return
+		return TRUE
 
-	..()
+	return ..()
 
 /obj/machinery/photocopier/faxmachine/get_mechanics_info()
 	. = "<p>The fax machine can be used to transmit paper faxes to other fax machines on the map, or to off-ship organizations handled by server administration. To use the fax machine, you'll need to insert both a paper and your ID card, authenticate, select a destination, the transmit the fax.</p>"

--- a/code/modules/paperwork/papershredder.dm
+++ b/code/modules/paperwork/papershredder.dm
@@ -20,34 +20,35 @@
 		/obj/item/sample/print = 1
 		)
 
-/obj/machinery/papershredder/attackby(obj/item/W, mob/user)
-
+/obj/machinery/papershredder/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(istype(W, /obj/item/storage))
 		empty_bin(user, W)
-		return
+		return TRUE
+
+	var/paper_result
+	for(var/shred_type in shred_amounts)
+		if(istype(W, shred_type))
+			paper_result = shred_amounts[shred_type]
+
+	if(paper_result)
+		if(paperamount == max_paper)
+			to_chat(user, SPAN_WARNING("\The [src] is full; please empty it before you continue."))
+			return TRUE
+		paperamount += paper_result
+		qdel(W)
+		playsound(src.loc, 'sound/items/pshred.ogg', 75, 1)
+		if(paperamount > max_paper)
+			to_chat(user, SPAN_DANGER("\The [src] was too full, and shredded paper goes everywhere!"))
+			for(var/i=(paperamount-max_paper);i>0;i--)
+				var/obj/item/shreddedp/SP = get_shredded_paper()
+				SP.dropInto(loc)
+				SP.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),1,5)
+			paperamount = max_paper
+		update_icon()
+		return TRUE
 	else
-		var/paper_result
-		for(var/shred_type in shred_amounts)
-			if(istype(W, shred_type))
-				paper_result = shred_amounts[shred_type]
-		if(paper_result)
-			if(paperamount == max_paper)
-				to_chat(user, SPAN_WARNING("\The [src] is full; please empty it before you continue."))
-				return
-			paperamount += paper_result
-			qdel(W)
-			playsound(src.loc, 'sound/items/pshred.ogg', 75, 1)
-			if(paperamount > max_paper)
-				to_chat(user, SPAN_DANGER("\The [src] was too full, and shredded paper goes everywhere!"))
-				for(var/i=(paperamount-max_paper);i>0;i--)
-					var/obj/item/shreddedp/SP = get_shredded_paper()
-					SP.dropInto(loc)
-					SP.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),1,5)
-				paperamount = max_paper
-			update_icon()
-			return
-	..()
-	return
+		return ..()
+
 
 /obj/machinery/papershredder/verb/empty_contents()
 	set name = "Empty bin"

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -107,21 +107,23 @@
 		to_chat(user, SPAN_NOTICE("You take \the [copyitem] out of \the [src]."))
 		copyitem = null
 
-/obj/machinery/photocopier/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/photocopier/use_tool(obj/item/O, mob/living/user, list/click_params)
 	if(istype(O, /obj/item/paper) || istype(O, /obj/item/photo) || istype(O, /obj/item/paper_bundle) || istype(O, /obj/item/sample/print))
 		if(!copyitem)
 			if(!user.unEquip(O, src))
-				return
+				return TRUE
 			copyitem = O
 			to_chat(user, SPAN_NOTICE("You insert \the [O] into \the [src]."))
 			flick(insert_anim, src)
 			updateUsrDialog()
 		else
 			to_chat(user, SPAN_NOTICE("There is already something in \the [src]."))
-	else if(istype(O, /obj/item/device/toner))
+		return TRUE
+
+	if (istype(O, /obj/item/device/toner))
 		if(toner <= 10) //allow replacing when low toner is affecting the print darkness
 			if(!user.unEquip(O, src))
-				return
+				return TRUE
 			to_chat(user, SPAN_NOTICE("You insert the toner cartridge into \the [src]."))
 			var/obj/item/device/toner/T = O
 			toner += T.toner_amount
@@ -129,7 +131,9 @@
 			updateUsrDialog()
 		else
 			to_chat(user, SPAN_NOTICE("This cartridge is not yet ready for replacement! Use up the rest of the toner."))
-	else ..()
+		return TRUE
+
+	return ..()
 
 /obj/machinery/photocopier/ex_act(severity)
 	switch(severity)

--- a/code/modules/pointdefense/pointdefense.dm
+++ b/code/modules/pointdefense/pointdefense.dm
@@ -82,7 +82,7 @@
 	data["turrets"] = turrets
 	return data
 
-/obj/machinery/pointdefense_control/attackby(obj/item/thing, mob/user)
+/obj/machinery/pointdefense_control/use_tool(obj/item/thing, mob/living/user, list/click_params)
 	if(isMultitool(thing))
 		var/datum/extension/local_network_member/pointdefense = get_extension(src, /datum/extension/local_network_member)
 		pointdefense.get_new_tag(user)
@@ -92,7 +92,7 @@
 			var/list/pointdefense_controllers = lan.get_devices(/obj/machinery/pointdefense_control)
 			if(pointdefense_controllers && length(pointdefense_controllers) > 1)
 				lan.remove_device(src)
-		return
+		return TRUE
 	else
 		return ..()
 
@@ -128,11 +128,12 @@
 		var/datum/extension/local_network_member/pointdefense = get_extension(src, /datum/extension/local_network_member)
 		pointdefense.set_tag(null, initial_id_tag)
 
-/obj/machinery/pointdefense/attackby(obj/item/thing, mob/user)
+/obj/machinery/pointdefense/use_tool(obj/item/thing, mob/living/user, list/click_params)
 	if(isMultitool(thing))
 		var/datum/extension/local_network_member/pointdefense = get_extension(src, /datum/extension/local_network_member)
 		pointdefense.get_new_tag(user)
 		return TRUE
+
 	return ..()
 
 //Guns cannot shoot through hull or generally dense turfs.

--- a/code/modules/power/breaker_box.dm
+++ b/code/modules/power/breaker_box.dm
@@ -81,16 +81,15 @@
 	busy = 0
 	return TRUE
 
-/obj/machinery/power/breakerbox/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/power/breakerbox/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(isMultitool(W))
 		var/newtag = input(user, "Enter new RCON tag. Use \"NO_TAG\" to disable RCON or leave empty to cancel.", "SMES RCON system") as text
 		if(newtag)
 			RCon_tag = newtag
 			to_chat(user, SPAN_NOTICE("You changed the RCON tag to: [newtag]"))
+		return TRUE
 
-
-
-
+	return ..()
 
 /obj/machinery/power/breakerbox/proc/set_state(state)
 	on = state

--- a/code/modules/power/cell_rack.dm
+++ b/code/modules/power/cell_rack.dm
@@ -237,14 +237,16 @@
 		internal_cells -= C
 	return ..()
 
-/obj/machinery/power/smes/batteryrack/attackby(obj/item/W as obj, mob/user as mob)
-	if(..())
-		return TRUE
+/obj/machinery/power/smes/batteryrack/use_tool(obj/item/W, mob/living/user, list/click_params)
+	if((. = ..()))
+		return
+
 	if(istype(W, /obj/item/cell)) // ID Card, try to insert it.
 		if(insert_cell(W, user))
 			to_chat(user, "You insert \the [W] into \the [src].")
 		else
 			to_chat(user, "\The [src] has no empty slot for \the [W]")
+		return TRUE
 
 /obj/machinery/power/smes/batteryrack/interface_interact(mob/user)
 	ui_interact(user)

--- a/code/modules/power/fusion/consoles/_consoles.dm
+++ b/code/modules/power/fusion/consoles/_consoles.dm
@@ -18,13 +18,13 @@
 	var/datum/extension/local_network_member/fusion = get_extension(src, /datum/extension/local_network_member)
 	return fusion.get_local_network()
 
-/obj/machinery/computer/fusion/attackby(obj/item/thing, mob/user)
+/obj/machinery/computer/fusion/use_tool(obj/item/thing, mob/living/user, list/click_params)
 	if(isMultitool(thing))
 		var/datum/extension/local_network_member/fusion = get_extension(src, /datum/extension/local_network_member)
 		fusion.get_new_tag(user)
-		return
-	else
-		return ..()
+		return TRUE
+
+	return ..()
 
 /obj/machinery/computer/fusion/interface_interact(mob/user)
 	ui_interact(user)

--- a/code/modules/power/fusion/core/_core.dm
+++ b/code/modules/power/fusion/core/_core.dm
@@ -16,6 +16,7 @@
 	uncreated_component_parts = null
 	stat_immune = 0
 	base_type = /obj/machinery/power/fusion_core
+	obj_flags = OBJ_FLAG_ANCHORABLE
 
 	var/obj/fusion_em_field/owned_field
 	var/field_strength = 1//0.01
@@ -88,29 +89,15 @@
 		Shutdown()
 	return TRUE
 
-/obj/machinery/power/fusion_core/attackby(obj/item/W, mob/user)
-
+/obj/machinery/power/fusion_core/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(owned_field)
 		to_chat(user,SPAN_WARNING("Shut \the [src] off first!"))
-		return
+		return TRUE
 
 	if(isMultitool(W))
 		var/datum/extension/local_network_member/fusion = get_extension(src, /datum/extension/local_network_member)
 		fusion.get_new_tag(user)
-		return
-
-	else if(isWrench(W))
-		anchored = !anchored
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-		if(anchored)
-			user.visible_message("[user.name] secures [src.name] to the floor.", \
-				"You secure the [src.name] to the floor.", \
-				"You hear a ratchet")
-		else
-			user.visible_message("[user.name] unsecures [src.name] from the floor.", \
-				"You unsecure the [src.name] from the floor.", \
-				"You hear a ratchet")
-		return
+		return TRUE
 
 	return ..()
 

--- a/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_compressor.dm
@@ -25,7 +25,7 @@
 		return
 	return do_fuel_compression(target, user)
 
-/obj/machinery/fusion_fuel_compressor/attackby(obj/item/thing, mob/user)
+/obj/machinery/fusion_fuel_compressor/use_tool(obj/item/thing, mob/living/user, list/click_params)
 	return do_fuel_compression(thing, user) || ..()
 
 /obj/machinery/fusion_fuel_compressor/proc/do_fuel_compression(obj/item/thing, mob/user)

--- a/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
+++ b/code/modules/power/fusion/fuel_assembly/fuel_injector.dm
@@ -49,19 +49,18 @@
 		else
 			Inject()
 
-/obj/machinery/fusion_fuel_injector/attackby(obj/item/W, mob/user)
-
+/obj/machinery/fusion_fuel_injector/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(isMultitool(W))
 		var/datum/extension/local_network_member/fusion = get_extension(src, /datum/extension/local_network_member)
 		fusion.get_new_tag(user)
-		return
+		return TRUE
 
 	if(istype(W, /obj/item/fuel_assembly))
 		if(injecting)
 			to_chat(user, SPAN_WARNING("Shut \the [src] off before playing with the fuel rod!"))
-			return
+			return TRUE
 		if(!user.unEquip(W, src))
-			return
+			return TRUE
 		if(cur_assembly)
 			visible_message(SPAN_NOTICE("\The [user] swaps \the [src]'s [cur_assembly] for \a [W]."))
 		else
@@ -70,19 +69,19 @@
 			cur_assembly.dropInto(loc)
 			user.put_in_hands(cur_assembly)
 		cur_assembly = W
-		return
+		return TRUE
 
 	if(isWelder(W))
 		if(injecting)
 			to_chat(user, SPAN_WARNING("Shut \the [src] off first!"))
-			return
+			return TRUE
 		anchored = !anchored
 		playsound(src.loc, 'sound/items/Welder.ogg', 75, 1)
 		if(anchored)
 			user.visible_message("\The [user] secures \the [src] to the floor.")
 		else
 			user.visible_message("\The [user] unsecures \the [src] from the floor.")
-		return
+		return TRUE
 
 	return ..()
 

--- a/code/modules/power/fusion/gyrotron/gyrotron.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron.dm
@@ -55,11 +55,11 @@
 		AddOverlays(emissive_appearance(icon, "[icon_state]_lights"))
 		AddOverlays("[icon_state]_lights")
 
-/obj/machinery/power/emitter/gyrotron/attackby(obj/item/W, mob/user)
+/obj/machinery/power/emitter/gyrotron/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(isMultitool(W))
 		var/datum/extension/local_network_member/fusion = get_extension(src, /datum/extension/local_network_member)
 		fusion.get_new_tag(user)
-		return
+		return TRUE
 	return ..()
 
 #undef GYRO_POWER

--- a/code/modules/power/fusion/kinetic_harvester.dm
+++ b/code/modules/power/fusion/kinetic_harvester.dm
@@ -27,12 +27,13 @@
 	ui_interact(user)
 	return TRUE
 
-/obj/machinery/kinetic_harvester/attackby(obj/item/thing, mob/user)
+/obj/machinery/kinetic_harvester/use_tool(obj/item/thing, mob/living/user, list/click_params)
 	if(isMultitool(thing))
 		var/datum/extension/local_network_member/lanm = get_extension(src, /datum/extension/local_network_member)
 		if(lanm.get_new_tag(user))
 			find_core()
-		return
+		return TRUE
+
 	return ..()
 
 /obj/machinery/kinetic_harvester/proc/find_core()

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -5,6 +5,7 @@
 	icon_state = "teg-unassembled"
 	density = TRUE
 	anchored = FALSE
+	obj_flags = OBJ_FLAG_ANCHORABLE
 
 	use_power = POWER_USE_IDLE
 	idle_power_usage = 100 //Watts, I hope.  Just enough to do the computer and display things.
@@ -156,21 +157,9 @@
 		update_icon()
 	add_avail(effective_gen)
 
-/obj/machinery/power/generator/attackby(obj/item/W as obj, mob/user as mob)
-	if (isWrench(W))
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-		anchored = !anchored
-		user.visible_message("[user.name] [anchored ? "secures" : "unsecures"] the bolts holding [src.name] to the floor.", \
-					"You [anchored ? "secure" : "unsecure"] the bolts holding [src] to the floor.", \
-					"You hear a ratchet")
-		update_use_power(anchored)
-		if(anchored) // Powernet connection stuff.
-			connect_to_network()
-		else
-			disconnect_from_network()
-		reconnect()
-	else
-		..()
+/obj/machinery/power/generator/post_anchor_change()
+	reconnect()
+	..()
 
 /obj/machinery/power/generator/CanUseTopic(mob/user)
 	if(!anchored)

--- a/code/modules/power/power.dm
+++ b/code/modules/power/power.dm
@@ -65,6 +65,13 @@
 	else
 		return 0
 
+/obj/machinery/power/post_anchor_change()
+	if(anchored && !MACHINE_IS_BROKEN(src)) // Powernet connection stuff.
+		connect_to_network()
+	else
+		disconnect_from_network()
+	..()
+
 // connect the machine to a powernet if a node cable is present on the turf
 /obj/machinery/power/proc/connect_to_network()
 	var/turf/T = src.loc
@@ -87,14 +94,12 @@
 
 // attach a wire to a power machine - leads from the turf you are standing on
 //almost never called, overwritten by all power machines but terminal and generator
-/obj/machinery/power/attackby(obj/item/W, mob/user)
+/obj/machinery/power/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if((. = ..()))
 		return
 
 	if(isCoil(W))
-
 		var/obj/item/stack/cable_coil/coil = W
-
 		var/turf/T = user.loc
 
 		if(!T.is_plating() || !istype(T, /turf/simulated/floor))
@@ -105,6 +110,8 @@
 
 		coil.PlaceCableOnTurf(T, user)
 		return TRUE
+
+	return ..()
 
 ///////////////////////////////////////////
 // Powernet handling helpers

--- a/code/modules/power/singularity/generator.dm
+++ b/code/modules/power/singularity/generator.dm
@@ -7,6 +7,7 @@
 	anchored = FALSE
 	density = TRUE
 	use_power = POWER_USE_OFF
+	obj_flags = OBJ_FLAG_ANCHORABLE
 	var/energy = 0
 
 /obj/machinery/the_singularitygen/Process()
@@ -14,18 +15,3 @@
 	if(src.energy >= 200)
 		new /obj/singularity/(T, 50)
 		if(src) qdel(src)
-
-/obj/machinery/the_singularitygen/attackby(obj/item/W, mob/user)
-	if (isWrench(W))
-		anchored = !anchored
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-		if(anchored)
-			user.visible_message("[user.name] secures [src.name] to the floor.", \
-				"You secure the [src.name] to the floor.", \
-				"You hear a ratchet")
-		else
-			user.visible_message("[user.name] unsecures [src.name] from the floor.", \
-				"You unsecure the [src.name] from the floor.", \
-				"You hear a ratchet")
-		return
-	return ..()

--- a/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
+++ b/code/modules/power/singularity/particle_accelerator/particle_accelerator.dm
@@ -279,11 +279,12 @@ So, hopefully this is helpful if any more icons are to be added/changed/wonderin
 				to_chat(user, "\The [src] is assembled")
 
 
-/obj/machinery/particle_accelerator/attackby(obj/item/I, mob/user)
-	if (I?.istool())
+/obj/machinery/particle_accelerator/use_tool(obj/item/I, mob/living/user, list/click_params)
+	if (I.istool())
 		if (process_tool_hit(I, user))
-			return
-	..()
+			return TRUE
+
+	return ..()
 
 
 /obj/machinery/particle_accelerator/ex_act(severity)

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -241,9 +241,9 @@
 	ui_interact(user)
 	return TRUE
 
-/obj/machinery/power/smes/attackby(obj/item/W as obj, mob/user as mob)
-	if(component_attackby(W, user))
-		return TRUE
+/obj/machinery/power/smes/use_tool(obj/item/W, mob/living/user, list/click_params)
+	if((.= ..()))
+		return
 
 	if (!panel_open)
 		to_chat(user, SPAN_WARNING("You need to open the access hatch on \the [src] first!"))

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -330,23 +330,21 @@
 			return
 	..()
 
-// Proc: attackby()
-// Parameters: 2 (W - object that was used on this machine, user - person which used the object)
-// Description: Handles tool interaction. Allows deconstruction/upgrading/fixing.
-/obj/machinery/power/smes/buildable/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/power/smes/buildable/use_tool(obj/item/W, mob/living/user, list/click_params)
 	// No more disassembling of overloaded SMESs. You broke it, now enjoy the consequences.
 	if (failing)
 		to_chat(user, SPAN_WARNING("\The [src]'s screen is flashing with alerts. It seems to be overloaded! Touching it now is probably not a good idea."))
-		return
+		return TRUE
 
-	if (!..())
+	// Multitool - change RCON tag
+	if(isMultitool(W))
+		var/newtag = input(user, "Enter new RCON tag. Use \"NO_TAG\" to disable RCON or leave empty to cancel.", "SMES RCON system") as text
+		if(newtag)
+			RCon_tag = newtag
+			to_chat(user, SPAN_NOTICE("You changed the RCON tag to: [newtag]"))
+		return TRUE
 
-		// Multitool - change RCON tag
-		if(isMultitool(W))
-			var/newtag = input(user, "Enter new RCON tag. Use \"NO_TAG\" to disable RCON or leave empty to cancel.", "SMES RCON system") as text
-			if(newtag)
-				RCon_tag = newtag
-				to_chat(user, SPAN_NOTICE("You changed the RCON tag to: [newtag]"))
+	return ..()
 
 // Proc: toggle_input()
 // Parameters: None

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -62,7 +62,7 @@ var/global/solar_gen_rate = 1500
 
 
 
-/obj/machinery/power/solar/attackby(obj/item/W, mob/user)
+/obj/machinery/power/solar/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(isCrowbar(W))
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 		user.visible_message(SPAN_NOTICE("[user] begins to take the glass off the solar panel."))
@@ -76,7 +76,7 @@ var/global/solar_gen_rate = 1500
 			qdel(src)
 		return TRUE
 
-	. = ..()
+	return ..()
 
 /obj/machinery/power/solar/on_update_icon()
 	..()

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -56,8 +56,7 @@
 	if(powernet && (powernet == control.powernet)) //update if we're still in the same powernet
 		control.cdir = angle
 
-/obj/machinery/power/tracker/attackby(obj/item/W, mob/user)
-
+/obj/machinery/power/tracker/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(isCrowbar(W))
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 		user.visible_message(SPAN_NOTICE("[user] begins to take the glass off the solar tracker."))
@@ -69,8 +68,9 @@
 			playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 			user.visible_message(SPAN_NOTICE("[user] takes the glass off the tracker."))
 			qdel(src)
-		return
-	..()
+		return TRUE
+
+	return ..()
 
 // Tracker Electronic
 

--- a/code/modules/reagents/Chemistry-Grinder.dm
+++ b/code/modules/reagents/Chemistry-Grinder.dm
@@ -119,20 +119,22 @@
 		icon_state = "[initial(icon_state)]"
 
 
-/obj/machinery/reagentgrinder/attackby(obj/item/I, mob/user)
-	if((. = component_attackby(I, user)))
+/obj/machinery/reagentgrinder/use_tool(obj/item/I, mob/living/user, list/click_params)
+	if((. = ..()))
 		detach()
 		eject()
+		return
 
-	else if (is_type_in_list(I, allowed_containers) && !is_type_in_list(I, banned_containers))
+	if (is_type_in_list(I, allowed_containers) && !is_type_in_list(I, banned_containers))
 		if (container)
 			to_chat(user, SPAN_WARNING("\The [src] already has \a [container]."))
 		else if (user.unEquip(I, src))
 			container = I
 			update_icon()
 			updateDialog()
+		return TRUE
 
-	else if (is_type_in_list(I, storage_types))
+	if (is_type_in_list(I, storage_types))
 		var/obj/item/storage/S = I
 		if (!length(S.contents))
 			to_chat(user, SPAN_WARNING("\The [S] is empty."))
@@ -160,22 +162,24 @@
 				updateDialog()
 			else
 				to_chat(user, SPAN_WARNING("Nothing more in \the [S] will go into \the [src]."))
+		return TRUE
 
-	else if (I.w_class > max_item_size)
+	if (I.w_class > max_item_size)
 		to_chat(user, SPAN_WARNING("\The [I] is too large for \the [src]."))
+		return TRUE
 
-	else if (length(items) >= max_items)
+	if (length(items) >= max_items)
 		to_chat(user, SPAN_WARNING("\The [src] is full."))
+		return TRUE
 
-	else if (is_type_in_list(I, banned_items) || !grindable(I))
+	if (is_type_in_list(I, banned_items) || !grindable(I))
 		to_chat(user, SPAN_WARNING("\The [src] cannot grind \the [I]."))
+		return TRUE
 
-	else if (user.unEquip(I, src))
+	if (user.unEquip(I, src))
 		items += I
 		updateUsrDialog()
-
-	return TRUE
-
+		return TRUE
 
 /obj/machinery/reagentgrinder/interface_interact(mob/user)
 	interact(user)

--- a/code/modules/reagents/Chemistry-Machinery.dm
+++ b/code/modules/reagents/Chemistry-Machinery.dm
@@ -71,29 +71,31 @@
 				qdel(src)
 				return
 
-/obj/machinery/chem_master/attackby(obj/item/B as obj, mob/user as mob)
-
+/obj/machinery/chem_master/use_tool(obj/item/B, mob/living/user, list/click_params)
 	if(istype(B, /obj/item/reagent_containers/glass) || istype(B, /obj/item/reagent_containers/ivbag))
-
 		if(beaker)
 			to_chat(user, "A container is already loaded into the machine.")
-			return
+			return TRUE
 		if(!user.unEquip(B, src))
-			return
+			return TRUE
 		beaker = B
-		to_chat(user, "You add the container to the machine!")
+		to_chat(user, SPAN_NOTICE("You add \the [B] to \the [src]!"))
 		atom_flags |= ATOM_FLAG_OPEN_CONTAINER
+		update_icon()
+		return TRUE
 
-	else if(istype(B, /obj/item/storage/pill_bottle))
-
+	if (istype(B, /obj/item/storage/pill_bottle))
 		if(loaded_pill_bottle)
-			to_chat(user, "A pill bottle is already loaded into the machine.")
-			return
+			to_chat(user, "A pill bottle is already loaded into \the [src].")
+			return TRUE
 		if(!user.unEquip(B, src))
-			return
+			return TRUE
 		loaded_pill_bottle = B
-		to_chat(user, "You add the pill bottle into the dispenser slot!")
-	update_icon()
+		to_chat(user, SPAN_NOTICE("You add \the [B] into \the [src]'s dispenser slot!"))
+		update_icon()
+		return TRUE
+
+	return ..()
 
 /obj/machinery/chem_master/proc/eject_beaker(mob/user)
 	if(!beaker)

--- a/code/modules/reagents/Chemistry-Sublimator.dm
+++ b/code/modules/reagents/Chemistry-Sublimator.dm
@@ -100,10 +100,12 @@
 	update_icon()
 	return TRUE
 
-/obj/machinery/portable_atmospherics/reagent_sublimator/attackby(obj/item/thing, mob/user)
+/obj/machinery/portable_atmospherics/reagent_sublimator/use_tool(obj/item/thing, mob/living/user, list/click_params)
 	if(istype(thing, /obj/item/tank))
 		to_chat(user, SPAN_WARNING("\The [src] has no socket for a gas tank."))
-	else if(istype(thing, /obj/item/reagent_containers))
+		return TRUE
+
+	if (istype(thing, /obj/item/reagent_containers))
 		if(container)
 			to_chat(user, SPAN_WARNING("\The [src] is already loaded with \the [container]."))
 		else if(user.unEquip(thing, src))
@@ -111,8 +113,9 @@
 			user.visible_message(SPAN_NOTICE("\The [user] loads \the [thing] into \the [src]."))
 			verbs |= /obj/machinery/portable_atmospherics/reagent_sublimator/proc/remove_container
 		update_icon()
-	else
-		. = ..()
+		return TRUE
+
+	return ..()
 
 /obj/machinery/portable_atmospherics/reagent_sublimator/Process()
 

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -71,42 +71,43 @@
 	cartridges -= label
 	SSnano.update_uis(src)
 
-/obj/machinery/chemical_dispenser/attackby(obj/item/W, mob/user)
-	if(istype(W, /obj/item/reagent_containers/chem_disp_cartridge))
+/obj/machinery/chemical_dispenser/use_tool(obj/item/W, mob/living/user, list/click_params)
+	if (istype(W, /obj/item/reagent_containers/chem_disp_cartridge))
 		add_cartridge(W, user)
+		return TRUE
 
-	else if(isScrewdriver(W))
+	if (isScrewdriver(W))
 		var/label = input(user, "Which cartridge would you like to remove?", "Chemical Dispenser") as null|anything in cartridges
-		if(!label) return
+		if(!label) return TRUE
 		var/obj/item/reagent_containers/chem_disp_cartridge/C = remove_cartridge(label)
 		if(C)
 			to_chat(user, SPAN_NOTICE("You remove \the [C] from \the [src]."))
 			C.dropInto(loc)
+		return TRUE
 
-	else if(istype(W, /obj/item/reagent_containers/glass) || istype(W, /obj/item/reagent_containers/food) || istype(W, /obj/item/reagent_containers/ivbag))
+	if (istype(W, /obj/item/reagent_containers/glass) || istype(W, /obj/item/reagent_containers/food) || istype(W, /obj/item/reagent_containers/ivbag))
 		if(container)
 			to_chat(user, SPAN_WARNING("There is already \a [container] on \the [src]!"))
-			return
+			return TRUE
 
 		var/obj/item/reagent_containers/RC = W
 
 		if(!accept_drinking && istype(RC,/obj/item/reagent_containers/food))
 			to_chat(user, SPAN_WARNING("This machine only accepts beakers and IV bags!"))
-			return
+			return TRUE
 
 		if(!RC.is_open_container())
 			to_chat(user, SPAN_WARNING("You don't see how \the [src] could dispense reagents into \the [RC]."))
-			return
+			return TRUE
 		if(!user.unEquip(RC, src))
-			return
+			return TRUE
 		container =  RC
 		update_icon()
 		to_chat(user, SPAN_NOTICE("You set \the [RC] on \the [src]."))
 		SSnano.update_uis(src) // update all UIs attached to src
+		return TRUE
 
-	else
-		..()
-	return
+	return ..()
 
 /obj/machinery/chemical_dispenser/proc/eject_beaker(mob/user)
 	if(!container)

--- a/code/modules/reagents/heat_sources/thermal_regulator.dm
+++ b/code/modules/reagents/heat_sources/thermal_regulator.dm
@@ -8,7 +8,7 @@
 	icon = 'icons/obj/machines/medical/thermal_regulator.dmi'
 	icon_state = "regulator"
 	atom_flags = ATOM_FLAG_CLIMBABLE
-	obj_flags = OBJ_FLAG_CAN_TABLE
+	obj_flags = OBJ_FLAG_CAN_TABLE | OBJ_FLAG_ANCHORABLE
 	anchored = TRUE
 	idle_power_usage = 0
 	active_power_usage = 1.2 KILOWATTS
@@ -89,14 +89,9 @@
 		return TRUE // Don't kill this processing loop unless we're not powered.
 	. = ..()
 
-/obj/machinery/reagent_temperature/attackby(obj/item/thing, mob/user)
-	if(isWrench(thing))
-		if(use_power == POWER_USE_ACTIVE)
-			to_chat(user, SPAN_WARNING("Turn \the [src] off first!"))
-		else
-			anchored = !anchored
-			visible_message(SPAN_NOTICE("\The [user] [anchored ? "secured" : "unsecured"] \the [src]."))
-			playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
+/obj/machinery/reagent_temperature/use_tool(obj/item/thing, mob/living/user, list/click_params)
+	if(isWrench(thing) && use_power == POWER_USE_ACTIVE)
+		to_chat(user, SPAN_WARNING("Turn \the [src] off first!"))
 		return TRUE
 
 	if(thing.reagents)
@@ -111,6 +106,8 @@
 					update_icon()
 				return TRUE
 		to_chat(user, SPAN_WARNING("\The [src] cannot accept \the [thing]."))
+		return TRUE
+
 	return ..()
 
 /obj/machinery/reagent_temperature/on_update_icon()

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -95,7 +95,10 @@
 			step(A,movedir)
 
 // attack with item, place item on conveyor
-/obj/machinery/conveyor/attackby(obj/item/I, mob/user)
+/obj/machinery/conveyor/use_tool(obj/item/I, mob/living/user, list/click_params)
+	if ((. = ..()))
+		return
+
 	if(isCrowbar(I))
 		if(!MACHINE_IS_BROKEN(src))
 			var/obj/item/conveyor_construct/C = new/obj/item/conveyor_construct(src.loc)
@@ -103,8 +106,11 @@
 			transfer_fingerprints_to(C)
 		to_chat(user, SPAN_NOTICE("You remove the conveyor belt."))
 		qdel(src)
-		return
-	user.unequip_item(get_turf(src))
+		return TRUE
+
+	else
+		user.unequip_item(get_turf(src))
+		return TRUE
 
 // attack with hand, move pulled object onto conveyor
 /obj/machinery/conveyor/physical_attack_hand(mob/user)
@@ -232,13 +238,16 @@
 		last_pos = position
 		position = 0
 
-/obj/machinery/conveyor_switch/attackby(obj/item/I, mob/user, params)
+/obj/machinery/conveyor_switch/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if(isCrowbar(I))
 		var/obj/item/conveyor_switch_construct/C = new/obj/item/conveyor_switch_construct(src.loc)
 		C.id = id
 		transfer_fingerprints_to(C)
 		to_chat(user, SPAN_NOTICE("You deattach the conveyor switch."))
 		qdel(src)
+		return TRUE
+
+	return ..()
 
 /obj/machinery/conveyor_switch/oneway
 	var/convdir = 1 //Set to 1 or -1 depending on which way you want the convayor to go. (In other words keep at 1 and set the proper dir on the belts.)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -592,22 +592,19 @@
 	update_icon()
 	return
 
-/obj/machinery/disposal/deliveryChute/attackby(obj/item/I, mob/user)
-	if(!I || !user)
-		return
-
+/obj/machinery/disposal/deliveryChute/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if(isScrewdriver(I))
 		if(c_mode==0)
 			c_mode=1
 			playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 			to_chat(user, "You remove the screws around the power connection.")
-			return
+			return TRUE
 		else if(c_mode==1)
 			c_mode=0
 			playsound(src.loc, 'sound/items/Screwdriver.ogg', 50, 1)
 			to_chat(user, "You attach the screws around the power connection.")
-			return
-	else if(isWelder(I) && c_mode==1)
+			return TRUE
+	if (isWelder(I) && c_mode==1)
 		var/obj/item/weldingtool/W = I
 		if(W.can_use(1,user))
 			to_chat(user, "You start slicing the floorweld off the delivery chute.")
@@ -618,10 +615,12 @@
 				var/obj/structure/disposalconstruct/C = new (loc, src)
 				C.update()
 				qdel(src)
-			return
+			return TRUE
 		else
 			to_chat(user, "You need more welding fuel to complete this task.")
-			return
+			return TRUE
+
+	return ..()
 
 /obj/machinery/disposal/deliveryChute/Destroy()
 	if(trunk)

--- a/code/modules/research/circuitprinter.dm
+++ b/code/modules/research/circuitprinter.dm
@@ -99,31 +99,32 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 		return SPAN_NOTICE("\The [src] is busy. Please wait for completion of previous operation.")
 	return ..()
 
-/obj/machinery/r_n_d/circuit_imprinter/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/r_n_d/circuit_imprinter/use_tool(obj/item/O, mob/living/user, list/click_params)
 	if(busy)
 		to_chat(user, SPAN_NOTICE("\The [src] is busy. Please wait for completion of previous operation."))
-		return 1
-	if(component_attackby(O, user))
 		return TRUE
+	if ((. = ..()))
+		return
 	if(panel_open)
 		to_chat(user, SPAN_NOTICE("You can't load \the [src] while it's opened."))
-		return 1
+		return TRUE
 	if(!linked_console)
 		to_chat(user, "\The [src] must be linked to an R&D console first.")
-		return 1
+		return TRUE
 	if(O.is_open_container())
-		return 0
+		return FALSE
 	if(is_robot_module(O))
-		return 0
+		return FALSE
 	if(!istype(O, /obj/item/stack/material))
-		to_chat(user, SPAN_NOTICE("You cannot insert this item into \the [src]!"))
-		return 0
+		to_chat(user, SPAN_WARNING("You cannot insert this item into \the [src]!"))
+		return TRUE
 	if(inoperable())
-		return 1
+		to_chat(user, SPAN_WARNING("\The [src] is not working properly."))
+		return TRUE
 
 	if(TotalMaterials() + SHEET_MATERIAL_AMOUNT > max_material_storage)
-		to_chat(user, SPAN_NOTICE("\The [src]'s material bin is full. Please remove material before adding more."))
-		return 1
+		to_chat(user, SPAN_WARNING("\The [src]'s material bin is full. Please remove material before adding more."))
+		return TRUE
 
 	var/obj/item/stack/material/stack = O
 	var/amount = min(stack.get_amount(), round((max_material_storage - TotalMaterials()) / SHEET_MATERIAL_AMOUNT))
@@ -139,6 +140,7 @@ using metal and glass, it uses glass and reagents (usually sulphuric acid).
 				materials[t] += amount * SHEET_MATERIAL_AMOUNT
 	busy = 0
 	updateUsrDialog()
+	return TRUE
 
 /obj/machinery/r_n_d/circuit_imprinter/proc/addToQueue(datum/design/D)
 	queue += D

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -54,32 +54,32 @@ Note: Must be placed within 3 tiles of the R&D Console
 		return SPAN_NOTICE("There is something already loaded into \the [src]. You must remove it first.")
 	return ..()
 
-/obj/machinery/r_n_d/destructive_analyzer/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/r_n_d/destructive_analyzer/use_tool(obj/item/O, mob/living/user, list/click_params)
 	if(busy)
 		to_chat(user, SPAN_NOTICE("\The [src] is busy right now."))
-		return
-	if(component_attackby(O, user))
 		return TRUE
+	if((. = ..()))
+		return
 	if(loaded_item)
 		to_chat(user, SPAN_NOTICE("There is something already loaded into \the [src]."))
-		return 1
+		return TRUE
 	if(panel_open)
 		to_chat(user, SPAN_NOTICE("You can't load \the [src] while it's opened."))
-		return 1
+		return TRUE
 	if(!linked_console)
 		to_chat(user, SPAN_NOTICE("\The [src] must be linked to an R&D console first."))
-		return
+		return TRUE
 	if(!loaded_item)
 		if(isrobot(user)) //Don't put your module items in there!
-			return
+			return FALSE
 		if(!O.origin_tech)
 			to_chat(user, SPAN_NOTICE("This doesn't seem to have a tech origin."))
-			return
+			return TRUE
 		if(length(O.origin_tech) == 0 || O.holographic)
 			to_chat(user, SPAN_NOTICE("You cannot deconstruct this item."))
-			return
+			return TRUE
 		if(!user.unEquip(O, src))
-			return
+			return TRUE
 		busy = 1
 		loaded_item = O
 		to_chat(user, SPAN_NOTICE("You add \the [O] to \the [src]."))
@@ -91,5 +91,4 @@ Note: Must be placed within 3 tiles of the R&D Console
 			if (linked_console.quick_deconstruct)
 				linked_console.deconstruct(weakref(user))
 
-		return 1
-	return
+		return TRUE

--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -96,31 +96,31 @@
 		return SPAN_NOTICE("\The [src] is busy. Please wait for completion of previous operation.")
 	return ..()
 
-/obj/machinery/r_n_d/protolathe/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/r_n_d/protolathe/use_tool(obj/item/O, mob/living/user, list/click_params)
 	if(busy)
 		to_chat(user, SPAN_NOTICE("\The [src] is busy. Please wait for completion of previous operation."))
-		return 1
-	if(component_attackby(O, user))
 		return TRUE
+	if((. = ..()))
+		return
 	if(O.is_open_container())
-		return 1
+		return TRUE
 	if(panel_open)
 		to_chat(user, SPAN_NOTICE("You can't load \the [src] while it's opened."))
-		return 1
+		return TRUE
 	if(!linked_console)
 		to_chat(user, SPAN_NOTICE("\The [src] must be linked to an R&D console first!"))
-		return 1
+		return TRUE
 	if(is_robot_module(O))
-		return 0
+		return FALSE
 	if(!istype(O, /obj/item/stack/material))
 		to_chat(user, SPAN_NOTICE("You cannot insert this item into \the [src]!"))
-		return 0
+		return TRUE
 	if(inoperable())
-		return 1
+		return TRUE
 
 	if(TotalMaterials() + SHEET_MATERIAL_AMOUNT > max_material_storage)
 		to_chat(user, SPAN_NOTICE("\The [src]'s material bin is full. Please remove material before adding more."))
-		return 1
+		return TRUE
 
 	var/obj/item/stack/material/stack = O
 
@@ -140,6 +140,7 @@
 			materials[stack.material.name] += amount * SHEET_MATERIAL_AMOUNT
 	busy = 0
 	updateUsrDialog()
+	return TRUE
 
 /obj/machinery/r_n_d/protolathe/proc/addToQueue(datum/design/D)
 	queue += D

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -131,29 +131,26 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	SyncRDevices()
 	. = ..()
 
-/obj/machinery/computer/rdconsole/attackby(obj/item/D as obj, mob/user as mob)
-	//Loading a disk into it.
+/obj/machinery/computer/rdconsole/use_tool(obj/item/D, mob/living/user, list/click_params)
 	if(istype(D, /obj/item/disk))
 		if(t_disk || d_disk)
 			to_chat(user, "A disk is already loaded into the machine.")
-			return
+			return TRUE
 		if(!user.canUnEquip(D))
-			return
+			return TRUE
 		if(istype(D, /obj/item/disk/tech_disk))
 			t_disk = D
 		else if (istype(D, /obj/item/disk/design_disk))
 			d_disk = D
 		else
 			to_chat(user, SPAN_NOTICE("Machine cannot accept disks in that format."))
-			return
+			return TRUE
 		user.drop_from_inventory(D, src)
 		to_chat(user, SPAN_NOTICE("You add \the [D] to the machine."))
-	else
-		//The construction/deconstruction of the console code.
-		..()
+		updateUsrDialog()
+		return TRUE
 
-	src.updateUsrDialog()
-	return
+	return ..()
 
 /obj/machinery/computer/rdconsole/emag_act(remaining_charges, mob/user)
 	if(!emagged)

--- a/code/modules/security levels/keycard authentication.dm
+++ b/code/modules/security levels/keycard authentication.dm
@@ -23,11 +23,12 @@
 	to_chat(user, SPAN_WARNING("A firewall prevents you from interfacing with this device!"))
 	return
 
-/obj/machinery/keycard_auth/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/keycard_auth/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(inoperable())
 		to_chat(user, "This device is not powered.")
-		return
-	if(istype(W,/obj/item/card/id))
+		return TRUE
+
+	if (isid(W))
 		var/obj/item/card/id/ID = W
 		if(access_keycard_auth in ID.access)
 			if(active == 1)
@@ -40,6 +41,9 @@
 			else if(screen == 2)
 				event_triggered_by = usr
 				broadcast_request() //This is the device making the initial event request. It needs to broadcast to other devices
+		return TRUE
+
+	return ..()
 
 //icon_state gets set everwhere besides here, that needs to be fixed sometime
 /obj/machinery/keycard_auth/on_update_icon()

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -210,11 +210,11 @@
 		return SPAN_NOTICE("Wait until \the [src] cools down from emergency shutdown first!")
 	return ..()
 
-/obj/machinery/power/shield_generator/attackby(obj/item/O as obj, mob/user as mob)
+/obj/machinery/power/shield_generator/use_tool(obj/item/O, mob/living/user, list/click_params)
 	if(panel_open && (isMultitool(O) || isWirecutter(O)))
 		attack_hand(user)
 		return TRUE
-	return component_attackby(O, user)
+	return ..()
 
 /obj/machinery/power/shield_generator/proc/energy_failure()
 	if(running == SHIELD_DISCHARGING)

--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -195,7 +195,7 @@
 		update_icon()
 		return 1
 
-/obj/machinery/shieldgen/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/shieldgen/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(isScrewdriver(W))
 		playsound(src.loc, 'sound/items/Screwdriver.ogg', 100, 1)
 		if(is_open)
@@ -217,27 +217,9 @@
 				to_chat(user, SPAN_NOTICE("You repair the [src]!"))
 		return TRUE
 
-	else if(istype(W, /obj/item/wrench))
-		if(locked)
-			to_chat(user, "The bolts are covered, unlocking this would retract the covers.")
-			return TRUE
-		if(anchored)
-			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-			to_chat(user, SPAN_NOTICE("'You unsecure the [src] from the floor!"))
-			if(active)
-				to_chat(user, SPAN_NOTICE("The [src] shuts off!"))
-				src.shields_down()
-			anchored = FALSE
-		else
-			if(istype(get_turf(src), /turf/space)) return //No wrenching these in space!
-			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-			to_chat(user, SPAN_NOTICE("You secure the [src] to the floor!"))
-			anchored = TRUE
-		return TRUE
-
-	else if(istype(W, /obj/item/card/id) || istype(W, /obj/item/modular_computer/pda))
-		if(src.allowed(user))
-			src.locked = !src.locked
+	if (istype(W, /obj/item/card/id) || istype(W, /obj/item/modular_computer/pda))
+		if(allowed(user))
+			locked = !locked
 			to_chat(user, "The controls are now [src.locked ? "locked." : "unlocked."]")
 		else
 			to_chat(user, SPAN_WARNING("Access denied."))
@@ -245,6 +227,16 @@
 
 	return ..()
 
+/obj/machinery/shieldgen/can_anchor(obj/item/tool, mob/user, silent)
+	if(locked)
+		to_chat(user, "The bolts are covered, unlocking this would retract the covers.")
+		return FALSE
+	return ..()
+
+/obj/machinery/shieldgen/post_anchor_change()
+	if (!anchored && active)
+		shields_down()
+	..()
 
 /obj/machinery/shieldgen/on_update_icon()
 	if(active && is_powered())

--- a/code/modules/shieldgen/shieldwallgen.dm
+++ b/code/modules/shieldgen/shieldwallgen.dm
@@ -12,7 +12,7 @@
 	var/locked = 1
 	var/max_range = 8
 	var/storedpower = 0
-	obj_flags = OBJ_FLAG_CONDUCTIBLE
+	obj_flags = OBJ_FLAG_CONDUCTIBLE | OBJ_FLAG_ANCHORABLE
 	//There have to be at least two posts, so these are effectively doubled
 	var/power_draw = 30 KILOWATTS //30 kW. How much power is drawn from powernet. Increase this to allow the generator to sustain longer shields, at the cost of more power draw.
 	var/max_stored_power = 50 KILOWATTS //50 kW
@@ -194,37 +194,22 @@
 		var/obj/machinery/shieldwall/CF = new(T, src, G) //(ref to this gen, ref to connected gen)
 		CF.set_dir(field_dir)
 
+/obj/machinery/shieldwallgen/can_anchor(obj/item/tool, mob/user, silent)
+	if (active)
+		to_chat(user, SPAN_WARNING("Turn off \the [src] first."))
+		return FALSE
+	..()
 
-/obj/machinery/shieldwallgen/attackby(obj/item/W, mob/user)
-	if(isWrench(W))
-		if(active)
-			to_chat(user, "Turn off the field generator first.")
-			return
-
-		else if(!anchored)
-			playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-			to_chat(user, "You secure the external reinforcing bolts to the floor.")
-			src.anchored = TRUE
-			return
-
-		else if(anchored)
-			playsound(src.loc, 'sound/items/Ratchet.ogg', 75, 1)
-			to_chat(user, "You undo the external reinforcing bolts.")
-			src.anchored = FALSE
-			return
-
+/obj/machinery/shieldwallgen/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(istype(W, /obj/item/card/id)||istype(W, /obj/item/modular_computer))
-		if (src.allowed(user))
-			src.locked = !src.locked
+		if (allowed(user))
+			locked = !locked
 			to_chat(user, "Controls are now [src.locked ? "locked." : "unlocked."]")
 		else
 			to_chat(user, SPAN_WARNING("Access denied."))
-		return
+		return TRUE
 
-	else
-		src.add_fingerprint(user)
-		..()
-
+	return ..()
 
 /obj/machinery/shieldwallgen/proc/cleanup(NSEW)
 	var/obj/machinery/shieldwall/F
@@ -290,13 +275,14 @@
 	update_nearby_tiles()
 	..()
 
-/obj/machinery/shieldwall/attackby(obj/item/I, mob/user)
+/obj/machinery/shieldwall/use_weapon(obj/item/I, mob/living/user, list/click_params)
 	var/obj/machinery/shieldwallgen/G = prob(50) ? gen_primary : gen_secondary
 	G.storedpower -= I.force*2500
 	user.visible_message(SPAN_DANGER("\The [user] hits \the [src] with \the [I]!"))
-	user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
+	user.setClickCooldown(user.get_attack_speed(I))
 	user.do_attack_animation(src)
 	playsound(loc, 'sound/weapons/smash.ogg', 75, 1)
+	return TRUE || ..()
 
 /obj/machinery/shieldwall/Process()
 	if(needs_power)

--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -166,9 +166,9 @@
 		emagged = TRUE
 		return 1
 
-/obj/machinery/computer/shuttle_control/emergency/attackby(obj/item/W as obj, mob/user as mob)
+/obj/machinery/computer/shuttle_control/emergency/use_tool(obj/item/W, mob/living/user, list/click_params)
 	read_authorization(W)
-	..()
+	return ..()
 
 /obj/machinery/computer/shuttle_control/emergency/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
 	var/data[0]

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -511,7 +511,7 @@
 		ui.set_auto_update(1)
 
 
-/obj/machinery/power/supermatter/attackby(obj/item/W as obj, mob/living/user as mob)
+/obj/machinery/power/supermatter/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(istype(W, /obj/item/tape_roll))
 		to_chat(user, SPAN_NOTICE("You repair some of the damage to \the [src] with \the [W]."))
 		damage = max(damage - 10, 0)
@@ -523,10 +523,11 @@
 		SPAN_WARNING("For a brief moment, you hear an oppressive, unnatural silence.")
 	)
 
+	user.apply_damage(150, DAMAGE_RADIATION, damage_flags = DAMAGE_FLAG_DISPERSED)
 	if (user.drop_from_inventory(W))
 		Consume(W)
-
-	user.apply_damage(150, DAMAGE_RADIATION, damage_flags = DAMAGE_FLAG_DISPERSED)
+		return TRUE
+	else return ..()
 
 
 /obj/machinery/power/supermatter/Bumped(atom/AM as mob|obj)

--- a/code/modules/xenoarcheaology/artifacts/artifact.dm
+++ b/code/modules/xenoarcheaology/artifacts/artifact.dm
@@ -107,7 +107,7 @@
 	visible_message("[user] touches \the [src].")
 	check_triggers(/datum/artifact_trigger/proc/on_touch, user)
 
-/obj/machinery/artifact/attackby(obj/item/W, mob/living/user)
+/obj/machinery/artifact/use_tool(obj/item/W, mob/living/user, list/click_params)
 	. = ..()
 	check_triggers(/datum/artifact_trigger/proc/on_hit, W, user)
 

--- a/code/modules/xenoarcheaology/artifacts/replicator.dm
+++ b/code/modules/xenoarcheaology/artifacts/replicator.dm
@@ -123,11 +123,15 @@
 
 	show_browser(user, dat, "window=alien_replicator")
 
-/obj/machinery/replicator/attackby(obj/item/W as obj, mob/living/user as mob)
-	if(!user.unEquip(W, src))
+/obj/machinery/replicator/use_tool(obj/item/W, mob/living/user, list/click_params)
+	if ((. = ..()))
 		return
+
+	if(!user.unEquip(W, src))
+		return TRUE
 	stored_materials.Add(W)
-	src.visible_message(SPAN_NOTICE("\The [user] inserts \the [W] into \the [src]."))
+	visible_message(SPAN_NOTICE("\The [user] inserts \the [W] into \the [src]."))
+	return TRUE
 
 /obj/machinery/replicator/OnTopic(user, href_list)
 	if(href_list["activate"])

--- a/code/modules/xenoarcheaology/tools/artifact_harvester.dm
+++ b/code/modules/xenoarcheaology/tools/artifact_harvester.dm
@@ -19,18 +19,19 @@
 	if(!owned_scanner)
 		owned_scanner = locate(/obj/machinery/artifact_scanpad) in orange(1, src)
 
-/obj/machinery/artifact_harvester/attackby(obj/I as obj, mob/user as mob)
+/obj/machinery/artifact_harvester/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if(istype(I,/obj/item/anobattery))
 		if(!inserted_battery)
 			if(!user.unEquip(I, src))
-				return
+				return TRUE
 			to_chat(user, SPAN_NOTICE("You insert [I] into [src]."))
 			src.inserted_battery = I
 			updateDialog()
+			return TRUE
 		else
 			to_chat(user, SPAN_WARNING("There is already a battery in [src]."))
-	else
-		return..()
+			return TRUE
+	return..()
 
 /obj/machinery/artifact_harvester/attack_hand(mob/user as mob)
 	..()

--- a/code/modules/xenoarcheaology/tools/geosample_scanner.dm
+++ b/code/modules/xenoarcheaology/tools/geosample_scanner.dm
@@ -63,41 +63,48 @@
 	ui_interact(user)
 	return TRUE
 
-/obj/machinery/radiocarbon_spectrometer/attackby(obj/I as obj, mob/user as mob)
+/obj/machinery/radiocarbon_spectrometer/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if(scanning)
 		to_chat(user, SPAN_WARNING("You can't do that while [src] is scanning!"))
-	else
-		if(istype(I, /obj/item/stack/nanopaste))
-			var/choice = alert("What do you want to do with the nanopaste?","Radiometric Scanner","Scan nanopaste","Fix seal integrity")
-			if(choice == "Fix seal integrity")
-				var/obj/item/stack/nanopaste/N = I
-				var/amount_used = min(N.get_amount(), 10 - scanner_seal_integrity / 10)
-				N.use(amount_used)
-				scanner_seal_integrity = round(scanner_seal_integrity + amount_used * 10)
-				return
-		if(istype(I, /obj/item/reagent_containers/glass))
-			var/choice = alert("What do you want to do with the container?","Radiometric Scanner","Add coolant","Empty coolant","Scan container")
-			if(choice == "Add coolant")
-				var/obj/item/reagent_containers/glass/G = I
-				var/amount_transferred = min(src.reagents.maximum_volume - src.reagents.total_volume, G.reagents.total_volume)
-				G.reagents.trans_to(src, amount_transferred)
-				to_chat(user, SPAN_INFO("You empty [amount_transferred]u of coolant into [src]."))
-				update_coolant()
-				return
-			else if(choice == "Empty coolant")
-				var/obj/item/reagent_containers/glass/G = I
-				var/amount_transferred = min(G.reagents.maximum_volume - G.reagents.total_volume, src.reagents.total_volume)
-				src.reagents.trans_to(G, amount_transferred)
-				to_chat(user, SPAN_INFO("You remove [amount_transferred]u of coolant from [src]."))
-				update_coolant()
-				return
-		if(scanned_item)
-			to_chat(user, SPAN_WARNING("\The [src] already has \a [scanned_item] inside!"))
-			return
-		if(!user.unEquip(I, src))
-			return
-		scanned_item = I
-		to_chat(user, SPAN_NOTICE("You put \the [I] into \the [src]."))
+		return TRUE
+
+	if ((. = ..()))
+		return
+
+	if (istype(I, /obj/item/stack/nanopaste))
+		var/choice = alert("What do you want to do with the nanopaste?","Radiometric Scanner","Scan nanopaste","Fix seal integrity")
+		if(choice == "Fix seal integrity")
+			var/obj/item/stack/nanopaste/N = I
+			var/amount_used = min(N.get_amount(), 10 - scanner_seal_integrity / 10)
+			N.use(amount_used)
+			scanner_seal_integrity = round(scanner_seal_integrity + amount_used * 10)
+			return TRUE
+
+	if (istype(I, /obj/item/reagent_containers/glass))
+		var/choice = alert("What do you want to do with the container?","Radiometric Scanner","Add coolant","Empty coolant","Scan container")
+		if(choice == "Add coolant")
+			var/obj/item/reagent_containers/glass/G = I
+			var/amount_transferred = min(reagents.maximum_volume - reagents.total_volume, G.reagents.total_volume)
+			G.reagents.trans_to(src, amount_transferred)
+			to_chat(user, SPAN_INFO("You empty [amount_transferred]u of coolant into \the [src]."))
+			update_coolant()
+			return TRUE
+		else if(choice == "Empty coolant")
+			var/obj/item/reagent_containers/glass/G = I
+			var/amount_transferred = min(G.reagents.maximum_volume - G.reagents.total_volume, src.reagents.total_volume)
+			reagents.trans_to(G, amount_transferred)
+			to_chat(user, SPAN_INFO("You remove [amount_transferred]u of coolant from \the [src]."))
+			update_coolant()
+			return TRUE
+
+	if (scanned_item)
+		to_chat(user, SPAN_WARNING("\The [src] already has \a [scanned_item] inside!"))
+		return TRUE
+	if (!user.unEquip(I, src))
+		return TRUE
+	scanned_item = I
+	to_chat(user, SPAN_NOTICE("You put \the [I] into \the [src]."))
+	return TRUE
 
 /obj/machinery/radiocarbon_spectrometer/proc/update_coolant()
 	var/total_purity = 0

--- a/code/modules/xenoarcheaology/tools/suspension_generator.dm
+++ b/code/modules/xenoarcheaology/tools/suspension_generator.dm
@@ -11,6 +11,7 @@
 	machine_name = "suspension generator"
 	machine_desc = "Projects a pacifying energy field, used to hold xenofauna (among other things) for safe study."
 	var/obj/suspension_field/suspension_field
+	obj_flags = OBJ_FLAG_ANCHORABLE
 
 /obj/machinery/suspension_gen/Process()
 	if(suspension_field)
@@ -90,23 +91,20 @@
 		return SPAN_NOTICE("Turn \the [src] off first.")
 	return ..()
 
-/obj/machinery/suspension_gen/attackby(obj/item/W, mob/user)
-	if(component_attackby(W, user))
-		return TRUE
-	else if(isWrench(W))
-		if(!suspension_field)
-			anchored = !anchored
-			to_chat(user, SPAN_INFO("You wrench the stabilising bolts [anchored ? "into place" : "loose"]."))
-			if(anchored)
-				desc = "Its tracks are securely held in place with securing bolts."
-				icon_state = "suspension_wrenched"
-			else
-				desc = "It has stubby bolts bolted up against its tracks for stabilizing."
-				icon_state = "suspension"
-			playsound(loc, 'sound/items/Ratchet.ogg', 40)
-			update_icon()
-		else
-			to_chat(user, SPAN_WARNING("You are unable to secure [src] while it is active!"))
+/obj/machinery/suspension_gen/can_anchor(obj/item/tool, mob/user, silent)
+	if (suspension_field)
+		to_chat(user, SPAN_WARNING("You are unable to wrench \the [src] while it is active!"))
+		return FALSE
+	return ..()
+
+/obj/machinery/suspension_gen/post_anchor_change()
+	if (anchored)
+		desc = "Its tracks are securely held in place with securing bolts."
+		icon_state = "suspension_wrenched"
+	else
+		desc = "It has stubby bolts bolted up against its tracks for stabilizing."
+		icon_state = "suspension"
+	..()
 
 //checks for whether the machine can be activated or not should already have occurred by this point
 /obj/machinery/suspension_gen/proc/activate()

--- a/code/modules/xenoarcheaology/tools/transport_drone.dm
+++ b/code/modules/xenoarcheaology/tools/transport_drone.dm
@@ -264,9 +264,9 @@
 			to_chat(user, SPAN_NOTICE("\The [tool] was synchronized with the [transport.id_tag] network."))
 			designator.network = transport.id_tag
 			playsound(src.loc, 'sound/machines/twobeep.ogg', 50, 1, -3)
+		update_icon()
 		return TRUE
 
-	update_icon()
 	return ..()
 
 /obj/machinery/drone_pad/RefreshParts()

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -57,7 +57,7 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 7 "uses of .len" '\.len\b' -P
-exactly 375 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 210 "attackby() override" '\/attackby\((.*)\)'  -P
 exactly 15 "uses of examine()" '[.|\s]examine\(' -P # If this fails it's likely because you used '/atom/proc/examine(mob)' instead of '/proc/examinate(mob, atom)' - Exception: An examine()-proc may call other examine()-procs
 exactly 7 "direct modifications of overlays list" '\boverlays((\s*[|^=+&-])|(\.(Cut)|(Add)|(Copy)|(Remove)|(Remove)))' -P
 exactly 0 "new/list list instantiations" 'new\s*/list' -P


### PR DESCRIPTION
🆑 emmanuelbassil
tweak: Microwaves no longer accept solutions that contain forbidden ingredients. Feedback now given on which ingredient is incompatible.
bugfix: Un/Re-Anchoring a machine now properly updates machine's power usage.
/🆑 

So I know I said I'm going to try to avoid test merges but this is sadly an exception that will require one.


Some other things I did:
- Removed a bunch of attackby code governing wrenching/unwrenching anchored objects that was exactly similar to obj/use_tool. Now that it's handled by obj/use_tool; all you need to do is set the OBJ_ANCHORABLE flag to get this behavior. Tested the instances I did this. Did NOT add new behavior to any items.
- Small notice when examining an object that can be anchored/unanchored that it is possible to do so.
- attackby for newcaster handled damaging it. Axed this completely and made it use existing standardized health; works like a charm.
- Removed alot of 'add fingerprints' and 'add components'. These are handled by post_use_item and the parent obj/machinery/use_tool respectively; no need for repetition.
- Fixed as much styling as I could; some of this code is really old.
- Fixed an oversight on post_anchor_change where equipment power use did not change.
- Effectively moved alot of wrenching code out to post_anchor_change(). Did this for items with existing wrench/unwrench behavior under attackby() and no construction steps otherwise. No new behavior, all backend.
- Fixed oversight where pipe dispensers could work while unanchored and did not consume idle power.