### PR TITLE
Surgery fixes

### DIFF
--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -59,6 +59,7 @@
 	name = "Set bone"
 	allowed_tools = list(
 		/obj/item/bonesetter = 100,
+		/obj/item/swapper/power_drill = 100,
 		/obj/item/wrench = 75
 	)
 	min_duration = 60

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -735,6 +735,7 @@
 /singleton/surgery_step/robone/realign_support
 	name = "Realign support"
 	allowed_tools = list(
+		/obj/item/swapper/power_drill = 100,
 		/obj/item/wrench = 70,
 		/obj/item/bonesetter = 50
 	)


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: Can now use welders to fix external dents on IPCs on an operating table
bugfix: Fixed oversight where you could not use swappers for surgical steps.
bugfix: Fixed oversight where welding tool lit up and damage your  eyes even if no actual surgical step occured.
/🆑 

So keep in mind, swappers in existing behavior don't actually check which head is equipped before allowing the surgery. Given I am not that comfortable with surgery code yet, I did not fix it in the scope of this PR. Mechanically it's not a big problem if the swapper doesn't actually check since it's a click away anyways.

I also sadly had to reintroduce the 'check if surgeries are possible' bit to allow welding tools to work on surgical tables.
The rest of the 'welders harm your eyes for no reason' oversight is fixed in my other open PR.