### PR TITLE
Fixes lipstick oversight

### DIFF
--- a/code/game/objects/items/weapons/cosmetics.dm
+++ b/code/game/objects/items/weapons/cosmetics.dm
@@ -37,8 +37,7 @@
 	else
 		icon_state = initial(icon_state)
 
-/obj/item/lipstick/use_before(atom/A, mob/living/user as mob)
-	. = FALSE
+/obj/item/lipstick/use_after(atom/A, mob/living/user, click_parameters)
 	if (!open)
 		to_chat(user, SPAN_NOTICE("You need to uncap \the [src] first!"))
 		return TRUE


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: Fixes being unable to place lipstick in storage
/🆑 

Did the entire move storage before use_after thing and forgot to move lipstick there. Genius.