### PR TITLE
new ghost verb

### DIFF
--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -469,6 +469,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	updateghostsight()
 	to_chat(src, "You [(ghostvision?"now":"no longer")] have ghost vision.")
 
+/mob/observer/ghost/verb/set_ghost_alpha()
+	set name = "Set Ghost Alpha"
+	set desc = "Giving you option to enter value for custom ghost transparency"
+	set category = "Ghost"
+	alpha = alpha == 127 ? 0 : 127
+	mouse_opacity = alpha ? 1 : 0
+
 /mob/observer/ghost/verb/toggle_darkness()
 	set name = "Toggle Darkness"
 	set category = "Ghost"


### PR DESCRIPTION
## Hello comrades! 
Made new verb for ghosts to switch their alpha so you can hide not only other ghosts by "toggle ghost vision" but also yourself.
So you can have clean screenshots and videos from ghosts. 
(Other players still will be able to see your ghost with your turned alpha if their ghost vision is enabled)

![image](https://github.com/Baystation12/Baystation12/assets/105150564/e2897034-8d66-4aa1-a8ed-e7db20f73449)
![image](https://github.com/Baystation12/Baystation12/assets/105150564/f97d4c28-a67e-410e-b4cf-d72f133dfa53)


### Changelog
🆑 cuddleandtea
rscadd: players ghost mob now can be hidden for your screen
/🆑 