### PR TITLE
make firedoors check up/down, add to maint openspaces

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -497,14 +497,23 @@
 	return mixedcolor
 
 /**
-* Gets the highest and lowest pressures from the tiles in cardinal directions
+* Gets the highest and lowest pressures from the tiles in cardinal directions (including up/down)
 * around us, then checks the difference.
 */
 /proc/getOPressureDifferential(turf/loc)
 	var/minp=16777216;
 	var/maxp=0;
-	for(var/dir in GLOB.cardinal)
-		var/turf/simulated/T=get_turf(get_step(loc,dir))
+	for(var/dir in GLOB.cardinalz)
+		var/turf/simulated/T
+		var/turf/simulated/up = get_turf_above(loc)
+		var/turf/simulated/down = get_turf_below(loc)
+		if (dir == UP && istype(up, /turf/simulated/open))
+			T = up
+		else if (dir == DOWN && istype(down, /turf/simulated/open))
+			T = down
+		else
+			T=get_turf(get_step(loc,dir))
+
 		var/cp=0
 		if(T && istype(T) && T.zone)
 			var/datum/gas_mixture/environment = T.return_air()
@@ -514,6 +523,7 @@
 				continue
 		if(cp<minp)minp=cp
 		if(cp>maxp)maxp=cp
+
 	return abs(minp-maxp)
 
 /proc/convert_k2c(temp)
@@ -524,8 +534,8 @@
 
 /proc/getCardinalAirInfo(turf/loc, list/stats=list("temperature"))
 	RETURN_TYPE(/list)
-	var/list/temps = new(4)
-	for(var/dir in GLOB.cardinal)
+	var/list/temps = new(6)
+	for(var/dir in GLOB.cardinalz)
 		var/direction
 		switch(dir)
 			if(NORTH)
@@ -536,7 +546,21 @@
 				direction = 3
 			if(WEST)
 				direction = 4
-		var/turf/simulated/T=get_turf(get_step(loc,dir))
+			if (UP)
+				direction = 5
+			if (DOWN)
+				direction = 6
+
+		var/turf/simulated/T
+		if (direction >= 5)
+			if (dir == UP)
+				var/turf/simulated/up = get_turf_above(loc)
+				T = up
+			else if (dir == DOWN)
+				var/turf/simulated/down = get_turf_below(loc)
+				T = down
+		else
+			T = get_turf(get_step(loc,dir))
 		var/list/rstats = new(length(stats))
 		if(T && istype(T) && T.zone)
 			var/datum/gas_mixture/environment = T.return_air()

--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -236,3 +236,16 @@
 			continue
 		result += locate(x, y, z)
 	return result
+
+/proc/get_turf_above(turf/T)
+	var/turf/target = locate(T.x, T.y, (T.z + 1))
+	if (target)
+		return target
+
+/proc/get_turf_below(turf/T)
+	if ((T.z - 1) < 0)
+		return
+
+	var/turf/target = locate(T.x, T.y, (T.z - 1))
+	if (target)
+		return target

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -48,8 +48,8 @@
 	power_channel = ENVIRON
 	idle_power_usage = 5
 
-	var/list/tile_info[4]
-	var/list/dir_alerts[4] // 4 dirs, bitflags
+	var/list/tile_info[6]
+	var/list/dir_alerts[6] // 4 dirs, bitflags
 
 	turf_hand_priority = 2 //Lower priority than normal doors to prevent interference
 
@@ -113,6 +113,10 @@
 				o += "EAST: "
 			if(4)
 				o += "WEST: "
+			if (5)
+				o += "UP: "
+			if (6)
+				o += "DOWN: "
 		if(tile_info[index] == null)
 			o += SPAN_WARNING("DATA UNAVAILABLE")
 			to_chat(user, o)
@@ -340,7 +344,7 @@
 
 		tile_info = getCardinalAirInfo(loc,list("temperature", "pressure"))
 		var/old_alerts = dir_alerts
-		for(var/index = 1; index <= 4; index++)
+		for(var/index = 1; index <= 6; index++)
 			var/list/tileinfo = tile_info[index]
 			if(tileinfo == null)
 				continue // Bad data.

--- a/code/unit_tests/map_tests.dm
+++ b/code/unit_tests/map_tests.dm
@@ -843,7 +843,7 @@
 		else
 			var/is_bad_door = FALSE
 			for(var/L in D.locs)
-				if(istype(L, /turf/simulated/open) || isspaceturf(L))
+				if(isspaceturf(L))
 					is_bad_door = TRUE
 					log_bad("Invalid door turf: [log_info_line(L)]]")
 			if(is_bad_door)

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -1234,6 +1234,7 @@
 	dir = 8;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/fourthdeck/starboard)
 "ec" = (
@@ -2043,6 +2044,7 @@
 /obj/machinery/atmospherics/pipe/zpipe/up/cyan{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/fourthdeck/port)
 "gY" = (
@@ -2334,6 +2336,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/structure/lattice,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/fourthdeck/starboard)
 "hE" = (
@@ -11192,6 +11195,7 @@
 	dir = 8;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/fourthdeck/port)
 "Mr" = (
@@ -11501,6 +11505,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/structure/railing/mapped,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/hallway/primary/fourthdeck/fore)
 "Ng" = (
@@ -12046,6 +12051,7 @@
 	dir = 8;
 	pixel_x = 32
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/hallway/primary/fourthdeck/fore)
 "OI" = (

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -857,6 +857,7 @@
 /area/maintenance/thirddeck/starboard)
 "ck" = (
 /obj/structure/railing/mapped,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/thirddeck/starboard)
 "cl" = (
@@ -3425,6 +3426,7 @@
 /obj/structure/railing/mapped,
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/thirddeck/port)
 "hK" = (
@@ -3436,6 +3438,7 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/hallway/primary/thirddeck/fore)
 "hL" = (
@@ -4147,20 +4150,9 @@
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "jk" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/cable/green{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
-/area/maintenance/thirddeck/port)
+/area/hallway/primary/thirddeck/fore)
 "jl" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
@@ -5597,6 +5589,7 @@
 /area/maintenance/thirddeck/forestarboard)
 "mG" = (
 /obj/structure/railing/mapped,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/thirddeck/aftstarboard)
 "mH" = (
@@ -6341,6 +6334,7 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/thirddeck/starboard)
 "oI" = (
@@ -6419,6 +6413,7 @@
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/hallway/primary/thirddeck/fore)
 "oU" = (
@@ -14467,6 +14462,7 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/thirddeck/port)
 "JM" = (
@@ -15911,6 +15907,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/thirddeck/aftport)
 "Nf" = (
@@ -16659,6 +16656,7 @@
 	dir = 8;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/thirddeck/port)
 "Pl" = (
@@ -17428,6 +17426,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 9
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/thirddeck/aftport)
 "Rs" = (
@@ -17793,6 +17792,7 @@
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/zpipe/down/supply,
 /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/thirddeck/aftstarboard)
 "Su" = (
@@ -17904,6 +17904,7 @@
 	dir = 1
 	},
 /obj/structure/lattice,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/thirddeck/port)
 "SJ" = (
@@ -18208,7 +18209,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
 /obj/structure/catwalk,
-/turf/simulated/open,
+/turf/simulated/floor/plating,
 /area/maintenance/thirddeck/port)
 "TC" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
@@ -18510,6 +18511,7 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/thirddeck/starboard)
 "Uw" = (
@@ -19290,6 +19292,7 @@
 /obj/machinery/atmospherics/valve/shutoff/fuel{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/thirddeck/aftport)
 "Ws" = (
@@ -19415,6 +19418,7 @@
 "WL" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/thirddeck/port)
 "WN" = (
@@ -19512,6 +19516,7 @@
 	},
 /obj/structure/lattice,
 /obj/structure/railing/mapped,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/thirddeck/starboard)
 "Xa" = (
@@ -19980,6 +19985,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/structure/railing/mapped,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/thirddeck/port)
 "Yk" = (
@@ -33848,7 +33854,7 @@ mi
 MD
 VU
 hK
-pO
+jk
 SE
 sc
 tp
@@ -39119,7 +39125,7 @@ UZ
 Hd
 Pj
 Yj
-jk
+CE
 JL
 Hf
 Hf

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -1907,6 +1907,7 @@
 	dir = 8;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/seconddeck/aftstarboard)
 "dO" = (
@@ -1920,6 +1921,7 @@
 /area/vacant/chapel)
 "dP" = (
 /obj/structure/railing/mapped,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/seconddeck/forestarboard)
 "dQ" = (
@@ -2284,6 +2286,7 @@
 	dir = 8;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/seconddeck/aftstarboard)
 "ev" = (
@@ -2992,11 +2995,13 @@
 /turf/simulated/floor/plating,
 /area/vacant/chapel)
 "gb" = (
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/seconddeck/forestarboard)
 "gc" = (
 /obj/structure/disposalpipe/down,
 /obj/structure/lattice,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/seconddeck/forestarboard)
 "gd" = (
@@ -3394,6 +3399,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/lattice,
 /obj/structure/railing/mapped,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/seconddeck/forestarboard)
 "gQ" = (
@@ -5149,6 +5155,7 @@
 	dir = 4;
 	icon_state = "tube1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/hallway/primary/seconddeck/center)
 "lr" = (
@@ -5493,6 +5500,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/structure/railing/mapped,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/hallway/primary/seconddeck/center)
 "mo" = (
@@ -7625,6 +7633,7 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/seconddeck/aftstarboard)
 "rD" = (
@@ -10335,6 +10344,7 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/seconddeck/aftstarboard)
 "zT" = (
@@ -11441,6 +11451,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 1
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/seconddeck/aftport)
 "CP" = (
@@ -11644,6 +11655,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 5
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/seconddeck/aftport)
 "Do" = (
@@ -13316,6 +13328,7 @@
 	dir = 8;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/seconddeck/aftport)
 "Ib" = (
@@ -13966,6 +13979,7 @@
 /obj/machinery/atmospherics/pipe/zpipe/up/fuel{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/seconddeck/aftport)
 "JX" = (
@@ -14085,6 +14099,7 @@
 	dir = 8;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/seconddeck/aftport)
 "Ko" = (
@@ -15909,6 +15924,7 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/seconddeck/aftport)
 "QC" = (

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -5909,6 +5909,7 @@
 /turf/simulated/open,
 /area/maintenance/firstdeck/centralstarboard)
 "ann" = (
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/firstdeck/centralstarboard)
 "anp" = (
@@ -5916,6 +5917,7 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/firstdeck/centralstarboard)
 "anq" = (
@@ -6075,6 +6077,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/structure/lattice,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/firstdeck/centralstarboard)
 "aom" = (
@@ -12029,6 +12032,7 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 6
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/firstdeck/aftport)
 "aRf" = (
@@ -12498,6 +12502,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/machinery/atmospherics/valve/shutoff/fuel,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/firstdeck/aftport)
 "aSf" = (
@@ -12505,6 +12510,7 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/firstdeck/aftport)
 "aSh" = (
@@ -16081,6 +16087,7 @@
 /obj/machinery/atmospherics/valve/shutoff/fuel{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/firstdeck/aftport)
 "dJb" = (
@@ -16634,6 +16641,11 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"etk" = (
+/obj/structure/lattice,
+/obj/machinery/door/firedoor,
+/turf/simulated/open,
+/area/maintenance/firstdeck/centralstarboard)
 "etI" = (
 /obj/floor_decal/techfloor{
 	dir = 6
@@ -28012,6 +28024,7 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/fuel{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/firstdeck/aftport)
 "tgT" = (
@@ -28861,6 +28874,7 @@
 /obj/machinery/atmospherics/pipe/zpipe/down/fuel{
 	dir = 8
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/firstdeck/aftport)
 "uJd" = (
@@ -44965,7 +44979,7 @@ rhO
 wNX
 aeg
 amn
-anm
+etk
 anm
 auN
 aqn

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -8008,6 +8008,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/lattice,
 /obj/structure/railing/mapped,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
 "ut" = (
@@ -8696,6 +8697,7 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
 "wl" = (
@@ -9073,6 +9075,7 @@
 	pixel_x = -23
 	},
 /obj/structure/railing/mapped,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
 "xb" = (
@@ -9272,6 +9275,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/structure/lattice,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
 "xs" = (
@@ -9296,6 +9300,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/structure/lattice,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
 "xx" = (
@@ -9389,6 +9394,7 @@
 	dir = 8;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
 "xN" = (
@@ -9396,6 +9402,7 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/bridge/forestarboard)
 "xP" = (
@@ -9616,6 +9623,7 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
 "yA" = (
@@ -9881,6 +9889,7 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
 "zT" = (
@@ -10333,6 +10342,7 @@
 	icon_state = "railing0-1"
 	},
 /obj/structure/lattice,
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
 "BI" = (
@@ -11401,6 +11411,7 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
 "GU" = (
@@ -11997,6 +12008,14 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
+"Iw" = (
+/obj/structure/railing/mapped{
+	dir = 1;
+	icon_state = "railing0-1"
+	},
+/obj/structure/grille,
+/turf/simulated/floor/plating,
+/area/maintenance/bridge/forestarboard)
 "Ix" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12736,6 +12755,7 @@
 	dir = 1;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/bridge/foreport)
 "Mb" = (
@@ -13004,6 +13024,7 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/bridge/aftport)
 "Nr" = (
@@ -15539,6 +15560,7 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
+/obj/machinery/door/firedoor,
 /turf/simulated/open,
 /area/maintenance/bridge/forestarboard)
 "YN" = (
@@ -25167,7 +25189,7 @@ af
 af
 YI
 VB
-JF
+Iw
 aO
 Zs
 co


### PR DESCRIPTION
:cl: Mucker
rscadd: Firedoors now check atmosphere on turfs above and below them.
rscadd: Added firedoors over openspaces in maintenance to prevent multideck decompression. 
/:cl:

I'm not happy with this currently for the single reason that I think the firedoors, even when open, ruin the aesthetic of maint. We could potentially make a subtype that is invisible when not deployed, but that still might not be great. Open to suggestions on how to improve on that front, or alternative ways we can stop the hell that is multi-deck decompression in the tunnels.