### PR TITLE
You can trim grass

### DIFF
--- a/code/game/turfs/flooring/flooring.dm
+++ b/code/game/turfs/flooring/flooring.dm
@@ -66,6 +66,9 @@
 	wall_smooth = SMOOTH_ALL
 	space_smooth = SMOOTH_NONE
 
+/singleton/flooring/grass/cut
+	floor_smooth = SMOOTH_ALL
+
 /singleton/flooring/dirt
 	name = "dirt"
 	desc = "Extra dirty."

--- a/code/game/turfs/flooring/flooring_premade.dm
+++ b/code/game/turfs/flooring/flooring_premade.dm
@@ -78,6 +78,16 @@
 	icon_state = "grass0"
 	initial_flooring = /singleton/flooring/grass
 
+/turf/simulated/floor/grass/use_tool(obj/item/I, mob/user)
+	if(I.IsWirecutter())
+		user.visible_message(SPAN_NOTICE("\The [user] trims \the [src] with \the [I]."), SPAN_NOTICE("You trim \the [src] with \the [I]."))
+		ChangeTurf(/turf/simulated/floor/grass/cut)
+		return TRUE
+	return ..()
+
+/turf/simulated/floor/grass/cut
+	initial_flooring = /singleton/flooring/grass/cut
+
 /turf/simulated/floor/carpet
 	name = "brown carpet"
 	icon = 'icons/turf/flooring/carpet.dmi'

--- a/maps/away/abandoned_hotel/abandoned_hotel-1.dmm
+++ b/maps/away/abandoned_hotel/abandoned_hotel-1.dmm
@@ -21,7 +21,7 @@
 /area/abandoned_hotel/buffet)
 "ak" = (
 /obj/structure/window/reinforced,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "al" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -62,7 +62,7 @@
 /area/abandoned_hotel/lobby)
 "aB" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "aD" = (
 /obj/structure/window/reinforced{
@@ -100,7 +100,7 @@
 "aS" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "aV" = (
 /turf/simulated/floor/plating,
@@ -113,7 +113,7 @@
 /area/abandoned_hotel/pool)
 "aX" = (
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "bd" = (
 /obj/structure/cable{
@@ -215,7 +215,7 @@
 "bI" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "bK" = (
 /obj/decal/cleanable/cobweb2{
@@ -469,12 +469,12 @@
 "eV" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/buffet)
 "eX" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/buffet)
 "fq" = (
 /obj/structure/bed/chair/comfy/green{
@@ -500,16 +500,16 @@
 "fB" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/buffet)
 "fD" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/buffet)
 "fE" = (
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/buffet)
 "fF" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -562,7 +562,7 @@
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/buffet)
 "gf" = (
 /turf/simulated/floor/tiled/old_tile,
@@ -671,7 +671,7 @@
 /area/abandoned_hotel/lobby)
 "gZ" = (
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/buffet)
 "ha" = (
 /obj/machinery/smartfridge/foods,
@@ -700,7 +700,7 @@
 "hg" = (
 /obj/structure/flora/ausbushes/reedbush,
 /obj/structure/window/reinforced,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/lobby)
 "hh" = (
 /obj/decal/cleanable/cobweb{
@@ -827,21 +827,21 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/buffet)
 "hP" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/flora/bush,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/buffet)
 "hQ" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/buffet)
 "hR" = (
 /obj/floor_decal/spline/fancy/black{
@@ -876,12 +876,12 @@
 "io" = (
 /obj/structure/flora/ausbushes/genericbush,
 /obj/structure/window/reinforced,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/lobby)
 "ip" = (
 /obj/structure/flora/ausbushes/sparsegrass,
 /obj/structure/window/reinforced,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/lobby)
 "iu" = (
 /obj/structure/firedoor_assembly,
@@ -890,29 +890,29 @@
 "ix" = (
 /obj/structure/flora/ausbushes/pointybush,
 /obj/structure/window/reinforced,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/lobby)
 "iF" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "iG" = (
 /obj/structure/flora/ausbushes/ywflowers,
 /obj/structure/window/reinforced,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/lobby)
 "iH" = (
 /obj/structure/flora/bush,
 /obj/structure/window/reinforced,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/lobby)
 "iI" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/structure/window/reinforced,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/lobby)
 "iJ" = (
 /obj/floor_decal/spline/fancy/black{
@@ -925,14 +925,14 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/lobby)
 "iL" = (
 /obj/structure/window/reinforced{
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/lavendergrass,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/lobby)
 "iN" = (
 /obj/structure/flora/pottedplant/orientaltree,
@@ -999,7 +999,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/lobby)
 "jV" = (
 /obj/structure/safe,
@@ -1504,7 +1504,7 @@
 "qt" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "qB" = (
 /obj/structure/cable{
@@ -1597,7 +1597,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/lobby)
 "rV" = (
 /obj/structure/bed/chair/comfy/green{
@@ -1819,7 +1819,7 @@
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/lobby)
 "vB" = (
 /obj/structure/closet/crate/freezer{
@@ -2315,7 +2315,7 @@
 "Dv" = (
 /obj/structure/window/reinforced,
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "Dw" = (
 /obj/decal/cleanable/dirt,
@@ -2473,7 +2473,7 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "FQ" = (
 /obj/structure/table/woodentable/walnut,
@@ -2591,7 +2591,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/lobby)
 "Hr" = (
 /obj/decal/cleanable/dirt,
@@ -2621,7 +2621,7 @@
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/lobby)
 "It" = (
 /obj/machinery/light,
@@ -2781,7 +2781,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/buffet)
 "KE" = (
 /obj/machinery/washing_machine,
@@ -2862,7 +2862,7 @@
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "Lv" = (
 /obj/structure/table/standard,
@@ -2965,7 +2965,7 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/sparsegrass,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/lobby)
 "MA" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -3051,7 +3051,7 @@
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/lobby)
 "Ol" = (
 /obj/structure/largecrate,
@@ -3117,7 +3117,7 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "Pn" = (
 /obj/decal/cleanable/dirt,
@@ -3178,7 +3178,7 @@
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "Qk" = (
 /obj/structure/cable{
@@ -3245,7 +3245,7 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "Ru" = (
 /obj/floor_decal/corner/black/diagonal,
@@ -3378,7 +3378,7 @@
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "Tk" = (
 /obj/structure/cable{
@@ -3406,7 +3406,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/grassybush,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "TX" = (
 /obj/machinery/door/airlock,
@@ -3522,7 +3522,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "VI" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -3539,7 +3539,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "VL" = (
 /turf/simulated/floor/tiled/old_cargo,
@@ -3644,7 +3644,7 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/buffet)
 "Xg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -3674,7 +3674,7 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/lobby)
 "Xs" = (
 /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers{
@@ -3745,7 +3745,7 @@
 	dir = 8
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/pool)
 "Yc" = (
 /obj/machinery/power/apc{

--- a/maps/away/abandoned_hotel/abandoned_hotel-2.dmm
+++ b/maps/away/abandoned_hotel/abandoned_hotel-2.dmm
@@ -336,7 +336,7 @@
 /obj/machinery/power/apc{
 	pixel_y = -25
 	},
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/rooms)
 "cU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -443,7 +443,7 @@
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/rooms)
 "dR" = (
 /obj/machinery/atmospherics/unary/tank/air,
@@ -657,7 +657,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/northright,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/rooms)
 "fV" = (
 /obj/structure/window/reinforced{
@@ -666,7 +666,7 @@
 /obj/structure/window/reinforced{
 	dir = 1
 	},
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/rooms)
 "fW" = (
 /obj/structure/curtain/open/shower,
@@ -1014,7 +1014,7 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/rooms)
 "iu" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
@@ -1061,7 +1061,7 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/ywflowers,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/rooms)
 "iI" = (
 /obj/structure/lattice,
@@ -1510,7 +1510,7 @@
 	dir = 1
 	},
 /obj/structure/flora/ausbushes/genericbush,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/rooms)
 "qw" = (
 /obj/floor_decal/corner/white{
@@ -1592,7 +1592,7 @@
 "rT" = (
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/item/material/shard,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/rooms)
 "rW" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
@@ -2012,7 +2012,7 @@
 "zn" = (
 /obj/structure/flora/ausbushes/grassybush,
 /obj/item/material/shard,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/rooms)
 "zF" = (
 /obj/decal/cleanable/dirt,
@@ -2893,7 +2893,7 @@
 	dir = 1
 	},
 /obj/structure/flora/bush,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/rooms)
 "QQ" = (
 /turf/simulated/floor/wood,
@@ -2959,7 +2959,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/rooms)
 "Su" = (
 /obj/structure/bookcase,
@@ -3217,7 +3217,7 @@
 	dir = 4
 	},
 /obj/structure/flora/ausbushes/fullgrass,
-/turf/simulated/floor/grass,
+/turf/simulated/floor/grass/cut,
 /area/abandoned_hotel/rooms)
 "XC" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{


### PR DESCRIPTION
## Hello comrades! 
I made so an old grass turf can be trimmed so it can exist with floor decals and be used in different places and maps. 

* New grass/cut turf for mapping 
* You can trim the old /grass with wirecutter to make it grass/cut
* Author of abandoned hotel bam4000 requested this grass change on his map so I also did it


### Video

https://github.com/Baystation12/Baystation12/assets/105150564/b977e81a-acb5-4fff-8c88-f3d2f34dd768


### Changelog
🆑 cuddleandtea
rscadd: players can trim grass with wirecutters
/🆑 