### PR TITLE
Voice changers work on tapes now!

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -112,14 +112,18 @@
 		to_chat(user, SPAN_NOTICE("The wires are exposed."))
 
 /obj/item/device/taperecorder/hear_talk(mob/living/M as mob, msg, verb="says", datum/language/speaking=null)
+	var/speaker = null
 	if(mytape && recording)
-
+		if (istype(M, /mob/living/carbon/human))
+			speaker = M.GetVoice()
+		else
+			speaker = M.name
 		if(speaking)
 			if(!speaking.machine_understands)
 				msg = speaking.scramble(msg)
-			mytape.record_speech("[M.name] [speaking.format_message_plain(msg, verb)]")
+			mytape.record_speech("[speaker] [speaking.format_message_plain(msg, verb)]")
 		else
-			mytape.record_speech("[M.name] [verb], \"[msg]\"")
+			mytape.record_speech("[speaker] [verb], \"[msg]\"")
 
 
 /obj/item/device/taperecorder/see_emote(mob/M as mob, text, emote_type)
@@ -371,7 +375,7 @@
 	usr.put_in_hands(P)
 	playsound(src, "sound/machines/dotprinter.ogg", 30)
 	canprint = 0
-	sleep(300)
+	sleep(150)
 	canprint = 1
 
 
@@ -400,7 +404,7 @@
 
 /obj/item/device/tape
 	name = "tape"
-	desc = "A magnetic tape that can hold up to ten minutes of content."
+	desc = "A magnetic tape that can hold up to twenty minutes of content."
 	icon = 'icons/obj/tools/tape_recorder.dmi'
 	icon_state = "tape_white"
 	item_state = "analyzer"
@@ -408,7 +412,7 @@
 	matter = list(MATERIAL_PLASTIC=20, MATERIAL_STEEL=5, MATERIAL_GLASS=5)
 	force = 1
 	throwforce = 0
-	var/max_capacity = 600
+	var/max_capacity = 1200
 	var/used_capacity = 0
 	var/list/storedinfo = list()
 	var/list/timestamp = list()


### PR DESCRIPTION
:cl: TheNightingale
bugfix: Voice changers now work to fool tape recorders.
tweak: Tapes now have a maximum length of twenty minutes, up from ten.
tweak: Lowered the cooldown for printing transcripts on tape recorders.
/:cl:

first one is a bugfix, second one is a minor QOL so you don't have to swap tapes constantly (ten minutes works for LRP servers but we like to write actual fucking essays to each other apparently)