### PR TITLE
Changes afterattacks to use_after

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -56,7 +56,7 @@
 	The most common are:
 	* mob/UnarmedAttack(atom,adjacent) - used here only when adjacent, with no item in hand; in the case of humans, checks gloves
 	* atom/resolve_attackby(item,user) - used only when adjacent
-	* item/afterattack(atom,user,adjacent,params) - used both ranged and adjacent
+	* item/afterattack(atom,user,adjacent,params) - used for ranged; called when resolve_attackby returns FALSE.
 	* mob/RangedAttack(atom,params) - used only ranged, only used for tk and laser eyes but could be changed
 */
 /mob/proc/ClickOn(atom/A, params)

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -398,8 +398,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 
 /**
  * Called when the item is in the active hand and another atom is clicked and `resolve_attackby()` returns FALSE. This is generally called by `ClickOn()`.
- * Use this similar to how attack() is used; but for non-mob targets. Whenever you want specific behavior at the item level.
- * Also works on ranged targets, unlike attack()
+ * Works on ranged targets, unlike resolve_attackby()
  *
  * **Parameters**:
  * - `target` - The atom that was clicked on.

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -53,9 +53,9 @@
 		to_chat(user, "You see strange symbols on the paper. Are they supposed to mean something?")
 
 
-/obj/item/paper/talisman/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+/obj/item/paper/talisman/use_after(atom/target, mob/living/user, click_parameters)
 	if (!can_invoke(target, user))
-		return
+		return TRUE
 
 	// Null rods block the talisman's effect but still consume it
 	var/obj/item/nullrod/nullrod = locate() in target
@@ -77,6 +77,7 @@
 	if (talisman_sound)
 		playsound(src, talisman_sound, 100, 1)
 	qdel(src)
+	return TRUE
 
 
 /**

--- a/code/game/machinery/atmoalter/clamp.dm
+++ b/code/game/machinery/atmoalter/clamp.dm
@@ -148,25 +148,24 @@
 	icon_state = "pclamp0"
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_MAGNET = 4)
 
-/obj/item/clamp/afterattack(atom/A, mob/user as mob, proximity)
-	if(!proximity)
-		return
-
+/obj/item/clamp/use_after(atom/A, mob/living/user, click_parameters)
 	if (istype(A, /obj/machinery/atmospherics/pipe/simple))
 		var/obj/machinery/atmospherics/pipe/simple/P = A
 		if (P.clamp)
 			to_chat(user, SPAN_WARNING("There is already \a [P.clamp] attached to \the [P]."))
-			return
+			return TRUE
 
 		to_chat(user, SPAN_NOTICE("You begin to attach \the [src] to \the [A]..."))
 		if (do_after(user, 3 SECONDS, A, DO_REPAIR_CONSTRUCT))
 			if (QDELETED(P))
-				return
+				return TRUE
 			if (P.clamp)
 				to_chat(user, SPAN_WARNING("There is already \a [P.clamp] attached to \the [P]."))
-				return
+				return TRUE
 			if(!user.unEquip(src))
-				return
+				return TRUE
 			to_chat(user, SPAN_NOTICE("You have attached \the [src] to \the [A]."))
 			new/obj/machinery/clamp(A.loc, A)
 			qdel(src)
+		return TRUE
+	else return FALSE

--- a/code/game/machinery/pipe/construction.dm
+++ b/code/game/machinery/pipe/construction.dm
@@ -40,12 +40,10 @@ Buildable meters
 	constructed_path = P.type
 
 //called when a turf is attacked with a pipe item
-/obj/item/pipe/afterattack(turf/simulated/floor/target, mob/user, proximity)
-	if(!proximity) return
-	if(istype(target))
+/obj/item/pipe/use_after(atom/target, mob/living/user, click_parameters)
+	if (istype(target))
 		user.unEquip(src, target)
-	else
-		return ..()
+		return TRUE
 
 /obj/item/pipe/rotate(mob/user)
 	. = ..()

--- a/code/game/objects/effects/decals/contraband.dm
+++ b/code/game/objects/effects/decals/contraband.dm
@@ -31,27 +31,22 @@
 	return ..()
 
 //Places the poster on a wall
-/obj/item/contraband/poster/afterattack(atom/A, mob/user, adjacent, clickparams)
-	if (!adjacent)
-		return
-
-	//must place on a wall and user must not be inside a closet/exosuit/whatever
-	var/turf/W = A
+/obj/item/contraband/poster/use_after(turf/W, mob/living/user, click_parameters)
 	if(!isturf(W))
-		return
+		return FALSE
 
 	if (!W.is_wall() || !isturf(user.loc))
 		to_chat(user, SPAN_WARNING("You can't place this here!"))
-		return
+		return TRUE
 
 	var/placement_dir = get_dir(user, W)
 	if (!(placement_dir in GLOB.cardinal))
 		to_chat(user, SPAN_WARNING("You must stand directly in front of the wall you wish to place that on."))
-		return
+		return TRUE
 
 	if (ArePostersOnWall(W))
 		to_chat(user, SPAN_NOTICE("There is already a poster there!"))
-		return
+		return TRUE
 
 	user.visible_message(SPAN_NOTICE("\The [user] starts placing a poster on \the [W]."),SPAN_NOTICE("You start placing the poster on \the [W]."))
 
@@ -64,6 +59,7 @@
 	else
 		// We cannot rely on user being on the appropriate turf when placement fails
 		P.roll_and_drop(get_step(W, turn(placement_dir, 180)))
+	return TRUE
 
 /obj/item/contraband/poster/proc/ArePostersOnWall(turf/W, placed_poster)
 	//just check if there is a poster on or adjacent to the wall

--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -82,8 +82,7 @@
 	shadeColour = input(user, "Please select the shade colour.", "Crayon colour") as color
 	return
 
-/obj/item/pen/crayon/afterattack(atom/target, mob/user as mob, proximity)
-	if(!proximity) return
+/obj/item/pen/crayon/use_after(atom/target, mob/user)
 	if(istype(target,/turf/simulated/floor))
 		var/drawtype = input("Choose what you'd like to draw.", "Crayon scribbles") in list("graffiti","rune","letter","arrow", "defector graffiti")
 		switch(drawtype)
@@ -108,7 +107,7 @@
 				if(!uses)
 					to_chat(user, SPAN_WARNING("You used up your crayon!"))
 					qdel(src)
-	return
+		return TRUE
 
 /obj/item/pen/crayon/use_before(mob/living/carbon/M as mob, mob/user as mob)
 	if(istype(M) && M == user)

--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -28,8 +28,7 @@
 /obj/item/device/chameleon/attack_self()
 	toggle()
 
-/obj/item/device/chameleon/afterattack(atom/target, mob/user , proximity)
-	if(!proximity) return
+/obj/item/device/chameleon/use_after(atom/target, mob/living/user, click_parameters)
 	if(!active_dummy)
 		if(istype(target,/obj/item) && !istype(target, /obj/item/disk/nuclear))
 			playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, 1, -6)
@@ -38,6 +37,7 @@
 			saved_icon = target.icon
 			saved_icon_state = target.icon_state
 			saved_overlays = target.overlays.Copy()
+			return TRUE
 
 /obj/item/device/chameleon/proc/toggle()
 	if(!can_use || !saved_item) return

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -321,10 +321,11 @@
 		update_icon()
 		START_PROCESSING(SSobj, src)
 
-/obj/item/device/flashlight/flare/afterattack(obj/O, mob/user, proximity)
-	if(proximity && istype(O) && on)
+/obj/item/device/flashlight/flare/use_after(obj/O, mob/living/user)
+	if(istype(O) && on)
 		O.HandleObjectHeating(src, user, 500)
-	..()
+		return TRUE
+	return ..()
 
 /obj/item/device/flashlight/flare/proc/activate(mob/user)
 	if(istype(user))

--- a/code/game/objects/items/devices/inducer.dm
+++ b/code/game/objects/items/devices/inducer.dm
@@ -38,9 +38,11 @@
 	if(cell)
 		cell.emp_act(severity)
 
-/obj/item/inducer/afterattack(obj/O, mob/living/carbon/user, proximity)
-	if (!proximity || user.a_intent == I_HURT || CannotUse(user) || !recharge(O, user))
-		return ..()
+/obj/item/inducer/use_after(obj/O, mob/living/user, click_parameters)
+	if (!istype(O))
+		return FALSE
+	if (CannotUse(user) || !recharge(O, user))
+		return TRUE
 
 /obj/item/inducer/proc/CannotUse(mob/user)
 	var/obj/item/cell/my_cell = get_cell()

--- a/code/game/objects/items/devices/modkit.dm
+++ b/code/game/objects/items/devices/modkit.dm
@@ -15,17 +15,14 @@
 		/obj/item/clothing/suit/space/void
 		)
 
-/obj/item/device/modkit/afterattack(obj/O, mob/user as mob, proximity)
-	if(!proximity)
-		return
-
+/obj/item/device/modkit/use_after(obj/O, mob/living/user, click_parameters)
 	if (!target_species)
-		return	//it shouldn't be null, okay?
+		return	FALSE
 
 	if(!parts)
 		to_chat(user, SPAN_WARNING("This kit has no parts for this modification left."))
 		qdel(src)
-		return
+		return TRUE
 
 	var/allowed = 0
 	for (var/permitted_type in permitted_types)
@@ -35,22 +32,23 @@
 	var/obj/item/clothing/I = O
 	if (!istype(I) || !allowed)
 		to_chat(user, SPAN_NOTICE("[src] is unable to modify that."))
-		return
+		return TRUE
 
 	var/excluding = ("exclude" in I.species_restricted)
 	var/in_list = (target_species in I.species_restricted)
 	if (excluding ^ in_list)
 		to_chat(user, SPAN_NOTICE("[I] is already modified."))
-		return
+		return TRUE
 
 	if(!isturf(O.loc))
 		to_chat(user, SPAN_WARNING("[O] must be safely placed on the ground for modification."))
-		return
+		return TRUE
 
 	playsound(user.loc, 'sound/items/Screwdriver.ogg', 100, 1)
-
-	user.visible_message(SPAN_NOTICE("\The [user] opens \the [src] and modifies \the [O]."),SPAN_NOTICE("You open \the [src] and modify \the [O]."))
-
+	user.visible_message(
+		SPAN_NOTICE("\The [user] opens \the [src] and modifies \the [O]."),
+		SPAN_NOTICE("You open \the [src] and modify \the [O].")
+	)
 	I.refit_for_species(target_species)
 
 	if (istype(I, /obj/item/clothing/head/helmet))
@@ -60,6 +58,7 @@
 
 	if(!parts)
 		qdel(src)
+	return TRUE
 
 /obj/item/device/modkit/examine(mob/user)
 	. = ..(user)

--- a/code/game/objects/items/devices/oxycandle.dm
+++ b/code/game/objects/items/devices/oxycandle.dm
@@ -20,10 +20,10 @@
 	..()
 	update_icon()
 
-/obj/item/device/oxycandle/afterattack(obj/O, mob/user, proximity)
-	if(proximity && istype(O) && on)
+/obj/item/device/oxycandle/use_after(obj/O, mob/living/user, click_parameters)
+	if(istype(O) && on)
 		O.HandleObjectHeating(src, user, 500)
-	..()
+		return TRUE
 
 /obj/item/device/oxycandle/attack_self(mob/user)
 	if(!on)

--- a/code/game/objects/items/devices/paint_sprayer.dm
+++ b/code/game/objects/items/devices/paint_sprayer.dm
@@ -112,10 +112,9 @@
 		GLOB.module_deselected_event.unregister(user, src, /obj/item/device/paint_sprayer/proc/remove_click_handler)
 		GLOB.module_deactivated_event.unregister(user, src, /obj/item/device/paint_sprayer/proc/remove_click_handler)
 
-/obj/item/device/paint_sprayer/afterattack(atom/A, mob/user, proximity, params)
-	if (!proximity)
-		return
-	apply_paint(A, user, params)
+/obj/item/device/paint_sprayer/use_after(atom/target, mob/living/user, click_parameters)
+	apply_paint(target, user, click_parameters)
+	return TRUE
 
 /obj/item/device/paint_sprayer/proc/pick_color(atom/A, mob/user)
 	if (!user.Adjacent(A) || user.incapacitated())

--- a/code/game/objects/items/glassjar.dm
+++ b/code/game/objects/items/glassjar.dm
@@ -17,9 +17,11 @@
 	..()
 	update_icon()
 
-/obj/item/glass_jar/afterattack(atom/A, mob/user, proximity)
-	if(!proximity || contains)
-		return
+/obj/item/glass_jar/use_after(atom/A, mob/living/user, click_parameters)
+	if(contains)
+		to_chat(user, SPAN_WARNING("\The [src] is full and cannot accept further items."))
+		return TRUE
+
 	if(istype(A, /mob))
 		var/accept = 0
 		for(var/D in accept_mobs)
@@ -27,21 +29,22 @@
 				accept = 1
 		if(!accept)
 			to_chat(user, "[A] doesn't fit into \the [src].")
-			return
+			return TRUE
 		var/mob/L = A
 		user.visible_message(SPAN_NOTICE("[user] scoops [L] into \the [src]."), SPAN_NOTICE("You scoop [L] into \the [src]."))
 		L.forceMove(src)
 		contains = 2
 		update_icon()
-		return
-	else if(istype(A, /obj/spider/spiderling))
+		return TRUE
+
+	if (istype(A, /obj/spider/spiderling))
 		var/obj/spider/spiderling/S = A
 		user.visible_message(SPAN_NOTICE("[user] scoops [S] into \the [src]."), SPAN_NOTICE("You scoop [S] into \the [src]."))
 		S.forceMove(src)
 		STOP_PROCESSING(SSobj, S) // No growing inside jars
 		contains = 3
 		update_icon()
-		return
+		return TRUE
 
 /obj/item/glass_jar/attack_self(mob/user)
 	switch(contains)

--- a/code/game/objects/items/holosign_creator.dm
+++ b/code/game/objects/items/holosign_creator.dm
@@ -21,36 +21,33 @@
 	signs.Cut()
 	. = ..()
 
-/obj/item/holosign_creator/afterattack(atom/target, mob/user, flag)
-	. = ..()
-	if(flag)
-		var/turf/T = get_turf(target)
-		if(!T)
-			return // Some objs qdel on attackby (notably, holosigns), which happens before this.
-		var/obj/structure/holosign/H = locate(holosign_type) in T
-		if(H)
-			return
+/obj/item/holosign_creator/use_after(atom/target, mob/living/user, click_parameters)
+	var/turf/T = get_turf(target)
+	if (!T) return FALSE
+	var/obj/structure/holosign/H = locate(holosign_type) in T
+	if (H) return FALSE
+
+	if (!is_blocked_turf(T, TRUE)) //can't put holograms on a tile that has dense stuff
+		if (holocreator_busy)
+			to_chat(user, SPAN_NOTICE("[src] is busy creating a hologram."))
+			return TRUE
+		if (length(signs) < max_signs)
+			playsound(src.loc, 'sound/machines/click.ogg', 20, 1)
+			if(creation_time)
+				holocreator_busy = TRUE
+				if(!do_after(user, creation_time, target, DO_BOTH_UNIQUE_ACT))
+					holocreator_busy = FALSE
+					return TRUE
+				holocreator_busy = FALSE
+				if(length(signs) >= max_signs)
+					return TRUE
+				if(is_blocked_turf(T, TRUE)) //don't try to sneak dense stuff on our tile during the wait.
+					return TRUE
+			H = new holosign_type(get_turf(target), src)
+			to_chat(user, SPAN_NOTICE("You create \a [H] with [src]."))
 		else
-			if(!is_blocked_turf(T, TRUE)) //can't put holograms on a tile that has dense stuff
-				if(holocreator_busy)
-					to_chat(user, SPAN_NOTICE("[src] is busy creating a hologram."))
-					return
-				if(length(signs) < max_signs)
-					playsound(src.loc, 'sound/machines/click.ogg', 20, 1)
-					if(creation_time)
-						holocreator_busy = TRUE
-						if(!do_after(user, creation_time, target, DO_BOTH_UNIQUE_ACT))
-							holocreator_busy = FALSE
-							return
-						holocreator_busy = FALSE
-						if(length(signs) >= max_signs)
-							return
-						if(is_blocked_turf(T, TRUE)) //don't try to sneak dense stuff on our tile during the wait.
-							return
-					H = new holosign_type(get_turf(target), src)
-					to_chat(user, SPAN_NOTICE("You create \a [H] with [src]."))
-				else
-					to_chat(user, SPAN_NOTICE("[src] is projecting at max capacity!"))
+			to_chat(user, SPAN_NOTICE("[src] is projecting at max capacity!"))
+		return TRUE
 
 /obj/item/holosign_creator/attack_self(mob/user)
 	if(length(signs))

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -9,16 +9,16 @@
 	item_flags = ITEM_FLAG_NO_BLUDGEON
 	origin_tech = list(TECH_MATERIAL = 6, TECH_BLUESPACE = 4)
 
-/obj/item/stack/telecrystal/afterattack(obj/item/I as obj, mob/user as mob, proximity)
-	if(!proximity)
-		return
-	if(istype(I, /obj/item))
-		if(I.hidden_uplink && I.hidden_uplink.active) //No metagaming by using this on every PDA around just to see if it gets used up.
-			I.hidden_uplink.uses += amount
-			I.hidden_uplink.update_nano_data()
-			SSnano.update_uis(I.hidden_uplink)
-			use(amount)
-			to_chat(user, SPAN_NOTICE("You slot \the [src] into \the [I] and charge its internal uplink."))
+/obj/item/stack/telecrystal/use_after(obj/item/I, mob/living/user, click_parameters)
+	if (!istype(I))
+		return FALSE
+	if (I.hidden_uplink && I.hidden_uplink.active) //No metagaming by using this on every PDA around just to see if it gets used up.
+		I.hidden_uplink.uses += amount
+		I.hidden_uplink.update_nano_data()
+		SSnano.update_uis(I.hidden_uplink)
+		use(amount)
+		to_chat(user, SPAN_NOTICE("You slot \the [src] into \the [I] and charge its internal uplink."))
+		return TRUE
 
 /obj/item/stack/telecrystal/attack_self(mob/user)
 	if(use(ceil(DEFAULT_TELECRYSTAL_AMOUNT/20)))

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -44,14 +44,13 @@
 	create_reagents(10)
 	..()
 
-/obj/item/toy/water_balloon/afterattack(atom/A as mob|obj, mob/user as mob, proximity)
-	if(!proximity) return
+/obj/item/toy/water_balloon/use_after(atom/A, mob/living/user, click_parameters)
 	if (istype(A, /obj/structure/reagent_dispensers/watertank) && get_dist(src,A) <= 1)
 		A.reagents.trans_to_obj(src, 10)
 		to_chat(user, SPAN_NOTICE("You fill the balloon with the contents of [A]."))
-		src.desc = "A translucent balloon with some form of liquid sloshing around in it."
-		src.update_icon()
-	return
+		desc = "A translucent balloon with some form of liquid sloshing around in it."
+		update_icon()
+		return TRUE
 
 /obj/item/toy/water_balloon/attackby(obj/O as obj, mob/user as mob)
 	if(istype(O, /obj/item/reagent_containers/glass))
@@ -161,13 +160,13 @@
 			to_chat(usr, SPAN_WARNING("It's already fully loaded."))
 
 
-/obj/item/toy/crossbow/afterattack(atom/target as mob|obj|turf|area, mob/user as mob, flag)
-	if(!isturf(target.loc) || target == user) return
-	if(flag) return
+/obj/item/toy/crossbow/use_after(atom/target, mob/living/user, click_parameters)
+	if(!isturf(target.loc) || target == user) return FALSE
 
-	if (locate (/obj/structure/table, src.loc))
-		return
-	else if (bullets)
+	if (locate (/obj/structure/table, loc))
+		return FALSE
+
+	if (bullets)
 		var/turf/trg = get_turf(target)
 		var/obj/foam_dart_dummy/D = new/obj/foam_dart_dummy(get_turf(src))
 		bullets--
@@ -187,7 +186,7 @@
 						O.show_message(SPAN_WARNING("\The [M] was hit by the foam dart!"), 1)
 					new /obj/item/toy/ammo/crossbow(M.loc)
 					qdel(D)
-					return
+					return TRUE
 
 				for(var/atom/A in D.loc)
 					if(A == user) continue
@@ -201,12 +200,13 @@
 			if(D)
 				new /obj/item/toy/ammo/crossbow(D.loc)
 				qdel(D)
+		return TRUE
 
-		return
 	else if (bullets == 0)
 		user.Weaken(5)
 		for(var/mob/O in viewers(world.view, user))
 			O.show_message(SPAN_WARNING("\The [user] realized they were out of ammo and starting scrounging for some!"), 1)
+		return TRUE
 
 
 /obj/item/toy/crossbow/use_before(mob/M as mob, mob/user as mob)
@@ -1009,7 +1009,7 @@
 /obj/item/toy/eightball/attack_self(mob/user)
 	user.visible_message(SPAN_NOTICE("\The [user] shakes \the [src] for a moment, and it says, \"[pick(possible_answers) ].\""))
 
-/obj/item/toy/eightball/afterattack(obj/O, mob/user, proximity)
-	. = ..()
-	if (proximity)
+/obj/item/toy/eightball/use_after(atom/O, mob/living/user, click_parameters)
+	if (isobj(O))
 		visible_message(SPAN_WARNING("\The [src] says, \"[pick(possible_answers) ]\" as it hits \the [O]!"))
+		return TRUE

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -121,14 +121,14 @@
 	playsound(src.loc, 'sound/effects/pop.ogg', 50, 0)
 	if(prob(20)) src.spark_system.start()
 
-/obj/item/rcd/afterattack(atom/A, mob/user, proximity)
-	if(!proximity) return
+/obj/item/rcd/use_after(atom/A, mob/living/user, click_parameters)
 	if(disabled && !isrobot(user))
-		return 0
+		return FALSE
 	if(istype(get_area(A),/area/shuttle)||istype(get_area(A),/turf/space/transit))
-		return 0
+		return FALSE
 	work_id++
 	work_mode.do_work(src, A, user)
+	return TRUE
 
 /obj/item/rcd/proc/useResource(amount, mob/user)
 	if(stored_matter < amount)

--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -131,11 +131,10 @@ GLOBAL_LIST_INIT(rpd_pipe_selection_skilled, list(
 	if(popup)
 		popup.close()
 
-/obj/item/rpd/afterattack(atom/A, mob/user, proximity)
-	if (!proximity || istype(A, /obj/item/storage))
-		return
+/obj/item/rpd/use_after(atom/A, mob/living/user, click_parameters)
 	if (istype(A, /obj/item/pipe))
 		recycle(A,user)
+		return TRUE
 	else
 		if (user.skill_fail_prob(SKILL_ATMOS, 80, SKILL_TRAINED))
 			var/C = pick(GLOB.rpd_pipe_selection)
@@ -143,17 +142,18 @@ GLOBAL_LIST_INIT(rpd_pipe_selection_skilled, list(
 			user.visible_message(SPAN_WARNING("\The [user] cluelessly fumbles with \the [src]."))
 		var/turf/T = get_turf(A)
 		if (!T.Adjacent(loc))
-			return
+			return TRUE
 
 		playsound(get_turf(user), 'sound/machines/click.ogg', 50, 1)
 		if (T.is_wall())
 			if (!do_after(user, 3 SECONDS, T, DO_PUBLIC_UNIQUE))
-				return
+				return TRUE
 			playsound (get_turf(user), 'sound/items/Deconstruct.ogg', 50, 1)
 
 		P.Build(P, T, pipe_colors[pipe_color])
 		if (prob(20))
 			spark_system.start()
+		return TRUE
 
 /obj/item/rpd/examine(mob/user, distance)
 	. = ..()

--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -59,20 +59,19 @@ RSF
 		to_chat(user, "Changed dispensing mode to 'Cigarette'")
 		return
 
-/obj/item/rsf/afterattack(atom/A, mob/user as mob, proximity)
-
-	if(!proximity) return
-
+/obj/item/rsf/use_after(atom/A, mob/living/user, click_parameters)
 	if(istype(user,/mob/living/silicon/robot))
 		var/mob/living/silicon/robot/R = user
 		if(R.stat || !R.cell || R.cell.charge <= 0)
-			return
+			to_chat(user, SPAN_WARNING("You are unable to use \the [src]."))
+			return TRUE
 	else
 		if(stored_matter <= 0)
-			return
+			to_chat(user, SPAN_WARNING("\The [src] is empty!"))
+			return TRUE
 
 	if(!istype(A, /obj/structure/table) && !istype(A, /turf/simulated/floor))
-		return
+		return FALSE
 
 	playsound(src.loc, 'sound/machines/click.ogg', 10, 1)
 	var/used_energy = 0
@@ -105,3 +104,4 @@ RSF
 	else
 		stored_matter--
 		to_chat(user, "The RSF now holds [stored_matter]/30 fabrication-units.")
+	return TRUE

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -174,14 +174,13 @@
 		timeofdeath = null
 		to_chat(user, SPAN_NOTICE("A new patient has been registered. Purging data for previous patient."))
 
-/obj/item/autopsy_scanner/afterattack(obj/item/organ/external/target, mob/user, proximity_flag, click_parameters)
-	if(!proximity_flag)
-		return
+/obj/item/autopsy_scanner/use_after(obj/item/organ/external/target, mob/living/user, click_parameters)
 	if(!istype(target))
-		return
+		return FALSE
 
 	set_target(target, user)
 	add_data(target)
+	return TRUE
 
 /obj/item/autopsy_scanner/attack_self(mob/user)
 	print_data(user)

--- a/code/game/objects/items/weapons/beachball.dm
+++ b/code/game/objects/items/weapons/beachball.dm
@@ -14,4 +14,4 @@
 
 /obj/item/beach_ball/afterattack(atom/target as mob|obj|turf|area, mob/user as mob)
 	if(user.unequip_item())
-		src.throw_at(target, throw_range, throw_speed, user)
+		throw_at(target, throw_range, throw_speed, user)

--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -21,13 +21,13 @@
 /obj/item/card/id/syndicate/prevent_tracking()
 	return electronic_warfare
 
-/obj/item/card/id/syndicate/afterattack(obj/item/O as obj, mob/user as mob, proximity)
-	if(!proximity) return
+/obj/item/card/id/syndicate/use_after(atom/O, mob/living/user, click_parameters)
 	if(istype(O, /obj/item/card/id))
 		var/obj/item/card/id/I = O
-		src.access |= I.access
+		access |= I.access
 		if(player_is_antag(user.mind))
 			to_chat(user, SPAN_NOTICE("The microscanner activates as you pass it over the ID, copying its access."))
+		return TRUE
 
 /obj/item/card/id/syndicate/attack_self(mob/user as mob)
 	// We use the fact that registered_name is not unset should the owner be vaporized, to ensure the id doesn't magically become unlocked.

--- a/code/game/objects/items/weapons/electric_welder.dm
+++ b/code/game/objects/items/weapons/electric_welder.dm
@@ -23,12 +23,12 @@
 	else
 		to_chat(user, (distance == 0 ? "It has [get_fuel()] [welding_resource] remaining. " : "") + "[cell] is attached.")
 
-/obj/item/weldingtool/electric/afterattack(obj/O, mob/user, proximity)
-	if(proximity && istype(O, /obj/structure/reagent_dispensers/fueltank))
+/obj/item/weldingtool/electric/use_after(obj/O, mob/living/user)
+	if(istype(O, /obj/structure/reagent_dispensers/fueltank))
 		if(!welding)
 			to_chat(user, SPAN_WARNING("\The [src] runs on an internal charge and does not need to be refuelled."))
-		return
-	. = ..()
+		return TRUE
+	return ..()
 
 /obj/item/weldingtool/electric/get_cell()
 	if(cell)

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -40,18 +40,17 @@
 		timer = newtime
 		to_chat(user, "Timer set for [timer] seconds.")
 
-/obj/item/plastique/afterattack(atom/movable/target, mob/user, flag)
-	if (!flag)
-		return
+/obj/item/plastique/use_after(atom/target, mob/living/user, click_parameters)
 	if (ismob(target) || istype(target, /turf/unsimulated) || istype(target, /turf/simulated/shuttle) || istype(target, /obj/item/storage) || istype(target, /obj/item/clothing/accessory/storage) || istype(target, /obj/item/clothing/under))
-		return
+		return FALSE
+
 	to_chat(user, "Planting explosives...")
 	user.do_attack_animation(target)
 
 	if(do_after(user, 5 SECONDS, target, DO_DEFAULT | DO_USER_UNIQUE_ACT) && in_range(user, target))
 		if(!user.unequip_item())
-			return
-		src.target = target
+			return TRUE
+		target = target
 		forceMove(null)
 
 		if (ismob(target))
@@ -65,6 +64,7 @@
 		target.AddOverlays(image_overlay)
 		to_chat(user, "Bomb has been planted. Timer counting down from [timer].")
 		run_timer()
+	return TRUE
 
 /obj/item/plastique/proc/explode(location)
 	if(!target)

--- a/code/game/objects/items/weapons/flame.dm
+++ b/code/game/objects/items/weapons/flame.dm
@@ -3,10 +3,10 @@
 	waterproof = FALSE
 	var/lit = 0
 
-/obj/item/flame/afterattack(obj/O, mob/user, proximity)
-	..()
-	if(proximity && lit && istype(O))
+/obj/item/flame/use_after(obj/O, mob/living/user, click_parameters)
+	if(lit && istype(O))
 		O.HandleObjectHeating(src, user, 700)
+		return TRUE
 
 /obj/item/flame/proc/extinguish(mob/user, no_message)
 	lit = 0

--- a/code/game/objects/items/weapons/implants/implants/compressed.dm
+++ b/code/game/objects/items/weapons/implants/implants/compressed.dm
@@ -58,23 +58,22 @@
 		return TRUE
 	else return ..()
 
-/obj/item/implanter/compressed/afterattack(obj/item/A, mob/user as mob, proximity)
-	if(!proximity)
-		return
+/obj/item/implanter/compressed/use_after(obj/item/A, mob/living/user, click_parameters)
 	if(istype(A) && imp)
 		var/obj/item/implant/compressed/c = imp
 		if (c.scanned)
 			if (!istype(A,/obj/item/storage))
 				to_chat(user, SPAN_WARNING("Something is already compressed inside the implant!"))
-			return
+			return TRUE
 		else if(safe)
 			if (!istype(A,/obj/item/storage))
 				to_chat(user, SPAN_WARNING("The matter compressor safeties prevent you from doing that."))
-			return
+			return TRUE
 		if(istype(A.loc,/mob/living/carbon/human))
 			var/mob/living/carbon/human/H = A.loc
 			if(!H.unEquip(A))
-				return
+				FEEDBACK_UNEQUIP_FAILURE(user, A)
+				return TRUE
 		else if(istype(A.loc,/obj/item/storage))
 			var/obj/item/storage/S = A.loc
 			S.remove_from_storage(A)
@@ -83,6 +82,7 @@
 		safe = 2
 		desc = "It currently contains some matter."
 		update_icon()
+		return TRUE
 
 /obj/item/implanter/compressed/attack_self(mob/user)
 	if(!imp || safe == 2)

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -163,12 +163,12 @@
 	user.visible_message(SPAN_CLASS("rose", "You hear a quiet click, as [user] shuts off [src] without even looking at what they're doing."))
 	playsound(src.loc, 'sound/items/zippo_close.ogg', 100, 1, -4)
 
-/obj/item/flame/lighter/zippo/afterattack(obj/O, mob/user, proximity)
-	if(!proximity) return
+/obj/item/flame/lighter/zippo/use_after(atom/O, mob/living/user, click_parameters)
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank) && !lit)
 		O.reagents.trans_to_obj(src, max_fuel)
 		to_chat(user, SPAN_NOTICE("You refuel [src] from \the [O]"))
 		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
+		return TRUE
 
 /obj/item/flame/lighter/zippo/black
 	color = COLOR_DARK_GRAY

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -85,18 +85,23 @@
 	worth_multiplier = 31
 	base_parry_chance = 15
 
-/obj/item/material/twohanded/fireaxe/afterattack(atom/A as mob|obj|turf|area, mob/user as mob, proximity)
-	if(!proximity) return
-	..()
-	if(A && wielded)
-		if(istype(A,/obj/structure/window))
-			var/obj/structure/window/W = A
-			W.shatter()
-		else if(istype(A,/obj/structure/grille))
-			qdel(A)
-		else if(istype(A,/obj/vine))
-			var/obj/vine/P = A
-			P.kill_health()
+/obj/item/material/twohanded/fireaxe/use_before(atom/A, mob/living/user, click_parameters)
+	if(!wielded || user.a_intent == I_HELP || !isobj(A))
+		return FALSE
+
+	if(istype(A,/obj/structure/window))
+		var/obj/structure/window/W = A
+		W.shatter()
+		return TRUE
+
+	if(istype(A,/obj/structure/grille))
+		qdel(A)
+		return TRUE
+
+	if(istype(A,/obj/vine))
+		var/obj/vine/P = A
+		P.kill_health()
+		return TRUE
 
 /obj/item/material/twohanded/fireaxe/IsHatchet()
 	return TRUE
@@ -184,21 +189,22 @@
 	else
 		return ..()
 
-/obj/item/material/twohanded/baseballbat/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
-	. = ..()
-	var/obj/O = target
-	if(istype(O))
-		if(is_held_twohanded(user) && !O.anchored && proximity_flag && isturf(O.loc) && O.w_class <= ITEM_SIZE_SMALL)
-			if(!prob(user.skill_fail_chance(SKILL_HAULING, 20, SKILL_EXPERIENCED)))
-				var/skill = 0.25 + (user.get_skill_value(SKILL_HAULING) - SKILL_MIN)/(SKILL_MAX - SKILL_MIN)
-				var/dist = O.throw_range * skill
-				O.throw_at(get_ranged_target_turf(user, user.dir, dist), dist, O.throw_speed * skill, user, TRUE)
-				visible_message(SPAN_NOTICE("\The [user] hits \the [O], sending it flying!"))
-				playsound(src, pick('sound/items/baseball/baseball_hit_01.wav', 'sound/items/baseball/baseball_hit_02.wav'), 75, 1)
-			else
-				playsound(src, 'sound/items/baseball/swing_woosh.wav', 75, 1)
-				visible_message(SPAN_NOTICE("\The [user] tries to bat \the [O] but misses!"))
-			user.do_attack_animation(target)
+/obj/item/material/twohanded/baseballbat/use_before(obj/O, mob/living/user, click_parameters)
+	if(!istype(O))
+		return FALSE
+
+	if(is_held_twohanded(user) && !O.anchored && isturf(O.loc) && O.w_class <= ITEM_SIZE_SMALL)
+		if(!prob(user.skill_fail_chance(SKILL_HAULING, 20, SKILL_EXPERIENCED)))
+			var/skill = 0.25 + (user.get_skill_value(SKILL_HAULING) - SKILL_MIN)/(SKILL_MAX - SKILL_MIN)
+			var/dist = O.throw_range * skill
+			O.throw_at(get_ranged_target_turf(user, user.dir, dist), dist, O.throw_speed * skill, user, TRUE)
+			visible_message(SPAN_NOTICE("\The [user] hits \the [O], sending it flying!"))
+			playsound(src, pick('sound/items/baseball/baseball_hit_01.wav', 'sound/items/baseball/baseball_hit_02.wav'), 75, 1)
+		else
+			playsound(src, 'sound/items/baseball/swing_woosh.wav', 75, 1)
+			visible_message(SPAN_NOTICE("\The [user] tries to bat \the [O] but misses!"))
+		user.do_attack_animation(O)
+		return TRUE
 
 //Predefined materials go here.
 /obj/item/material/twohanded/baseballbat/metal/New(newloc)

--- a/code/game/objects/items/weapons/material/urn.dm
+++ b/code/game/objects/items/weapons/material/urn.dm
@@ -8,15 +8,16 @@
 	w_class = ITEM_SIZE_SMALL
 	default_material = MATERIAL_WOOD
 
-/obj/item/material/urn/afterattack(obj/A, mob/user, proximity)
+/obj/item/material/urn/use_after(obj/A, mob/living/user, click_parameters)
 	if(!istype(A, /obj/decal/cleanable/ash))
-		return ..()
-	else if(proximity)
-		if(length(contents))
-			to_chat(user, SPAN_WARNING("\The [src] is already full!"))
-			return
-		user.visible_message("\The [user] scoops \the [A] into \the [src], securing the lid.", "You scoop \the [A] into \the [src], securing the lid.")
-		A.forceMove(src)
+		return FALSE
+	if(length(contents))
+		to_chat(user, SPAN_WARNING("\The [src] is already full!"))
+		return TRUE
+
+	user.visible_message("\The [user] scoops \the [A] into \the [src], securing the lid.", "You scoop \the [A] into \the [src], securing the lid.")
+	A.forceMove(src)
+	return TRUE
 
 /obj/item/material/urn/attack_self(mob/user)
 	if(!length(contents))

--- a/code/game/objects/items/weapons/mop.dm
+++ b/code/game/objects/items/weapons/mop.dm
@@ -22,10 +22,7 @@
 	. = ..()
 	create_reagents(30)
 
-/obj/item/mop/afterattack(atom/A, mob/user, proximity)
-	if(!proximity)
-		return
-
+/obj/item/mop/use_after(atom/A, mob/living/user, click_parameters)
 	var/moppable
 	if(istype(A, /turf))
 		var/turf/T = A
@@ -41,7 +38,7 @@
 					else
 						qdel(F)
 						to_chat(user, SPAN_NOTICE("You have finished mopping!"))
-			return
+			return TRUE
 		moppable = TRUE
 
 	else if(is_type_in_list(A,moppable_types))
@@ -50,10 +47,10 @@
 	if(moppable)
 		if(reagents.total_volume < 1)
 			to_chat(user, SPAN_NOTICE("Your mop is dry!"))
-			return
+			return TRUE
 		var/turf/T = get_turf(A)
 		if(!T)
-			return
+			return TRUE
 
 		user.visible_message(SPAN_WARNING("\The [user] begins to clean \the [T]."))
 
@@ -61,6 +58,7 @@
 			if(T)
 				T.clean(src, user)
 			to_chat(user, SPAN_NOTICE("You have finished mopping!"))
+		return TRUE
 
 
 /obj/item/mop/advanced

--- a/code/game/objects/items/weapons/paint.dm
+++ b/code/game/objects/items/weapons/paint.dm
@@ -18,8 +18,7 @@ var/global/list/cached_icons = list()
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	var/paint_hex = "#fe191a"
 
-/obj/item/reagent_containers/glass/paint/afterattack(turf/simulated/target, mob/user, proximity)
-	if(!proximity) return
+/obj/item/reagent_containers/glass/paint/use_after(turf/simulated/target, mob/living/user, click_parameters)
 	if(istype(target) && reagents.total_volume > 5)
 		if (reagents.should_admin_log())
 			var/contained = reagentlist()
@@ -29,8 +28,7 @@ var/global/list/cached_icons = list()
 				admin_attacker_log(user, "Used \the [name] containing [contained] to splash \the [target]")
 		user.visible_message(SPAN_WARNING("\The [target] has been splashed with something by [user]!"))
 		reagents.trans_to_turf(target, 5)
-	else
-		return ..()
+		return TRUE
 
 /obj/item/reagent_containers/glass/paint/Initialize()
 	. = ..()

--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -27,7 +27,7 @@ GLOBAL_LIST(hazard_overlays)
 			return
 		var/obj/machinery/door/airlock/airlock = locate(/obj/machinery/door/airlock) in T
 		if(airlock)
-			afterattack(airlock, null, TRUE)
+			use_after(airlock, null)
 		return INITIALIZE_HINT_QDEL
 
 var/global/list/tape_roll_applications = list()
@@ -286,17 +286,16 @@ var/global/list/tape_roll_applications = list()
 		to_chat(usr, SPAN_NOTICE("You finish placing \the [src]."))
 		return
 
-/obj/item/taperoll/afterattack(atom/A, mob/user as mob, proximity)
-	if(!proximity)
-		return
-
+/obj/item/taperoll/use_after(atom/A, mob/living/user, click_parameters)
 	if (istype(A, /obj/machinery/door/airlock))
 		var/turf/T = get_turf(A)
 		var/obj/item/tape/P = new tape_type(T)
-		P.add_fingerprint(user)
 		P.update_icon()
 		P.layer = ABOVE_DOOR_LAYER
-		to_chat(user, SPAN_NOTICE("You finish placing \the [src]."))
+		if (user)
+			to_chat(user, SPAN_NOTICE("You finish placing \the [src]."))
+			P.add_fingerprint(user)
+		return TRUE
 
 	if (istype(A, /turf/simulated/floor) ||istype(A, /turf/unsimulated/floor))
 		var/turf/F = A
@@ -313,7 +312,7 @@ var/global/list/tape_roll_applications = list()
 			user.visible_message("\The [user] applied \the [src] on \the [F] to create area markings.", "You apply \the [src] on \the [F] to create area markings.")
 			F.AddOverlays(hazard_overlay)
 			tape_roll_applications[F] |= direction
-		return
+		return TRUE
 
 /obj/item/tape/proc/crumple()
 	if(!crumpled)

--- a/code/game/objects/items/weapons/soap.dm
+++ b/code/game/objects/items/weapons/soap.dm
@@ -118,8 +118,7 @@
 			return
 		AM.slip("the [src.name]",3)
 
-/obj/item/soap/afterattack(atom/target, mob/user as mob, proximity)
-	if(!proximity) return
+/obj/item/soap/use_after(atom/target, mob/living/user, click_parameters)
 	//I couldn't feasibly  fix the overlay bugs caused by cleaning items we are wearing.
 	//So this is a workaround. This also makes more sense from an IC standpoint. ~Carn
 	var/cleaned = FALSE
@@ -136,7 +135,7 @@
 	else if(istype(target,/turf) || istype(target, /obj/structure/catwalk))
 		var/turf/T = get_turf(target)
 		if(!T)
-			return
+			return TRUE
 		user.visible_message(SPAN_WARNING("[user] starts scrubbing \the [T]."))
 		T.clean(src, user, 80, SPAN_NOTICE("You scrub \the [target.name] clean."))
 		cleaned = TRUE
@@ -156,6 +155,7 @@
 
 	if(cleaned)
 		user.update_personal_goal(/datum/goal/clean, 1)
+	return TRUE
 
 //attack_as_weapon
 /obj/item/soap/use_before(mob/living/target, mob/living/user)

--- a/code/game/objects/items/weapons/storage/bible.dm
+++ b/code/game/objects/items/weapons/storage/bible.dm
@@ -79,14 +79,14 @@
 				to_chat(M, "Nothing happened.")
 		return TRUE
 
-/obj/item/storage/bible/afterattack(atom/A, mob/user as mob, proximity)
-	if(!proximity) return
+/obj/item/storage/bible/use_after(atom/A, mob/living/user, click_parameters)
 	if(user.mind && istype(user.mind.assigned_job, /datum/job/chaplain))
-		if(A.reagents && A.reagents.has_reagent(/datum/reagent/water)) //blesses all the water in the holder
-			to_chat(user, SPAN_NOTICE("You bless \the [A].")) // I wish it was this easy in nethack
+		if(A.reagents && A.reagents.has_reagent(/datum/reagent/water))
+			to_chat(user, SPAN_NOTICE("You bless \the [A]."))
 			var/water2holy = A.reagents.get_reagent_amount(/datum/reagent/water)
 			A.reagents.del_reagent(/datum/reagent/water)
 			A.reagents.add_reagent(/datum/reagent/water/holywater,water2holy)
+			return TRUE
 
 /obj/item/storage/bible/attackby(obj/item/W as obj, mob/user as mob)
 	if (src.use_sound)

--- a/code/game/objects/items/weapons/storage/pill_bottle.dm
+++ b/code/game/objects/items/weapons/storage/pill_bottle.dm
@@ -40,7 +40,7 @@
 		if (length(peelz))
 			var/obj/item/reagent_containers/pill/P = pick(peelz)
 			remove_from_storage(P)
-			P.afterattack(target, user, TRUE)
+			P.use_after(target, user)
 			return TRUE
 
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -169,7 +169,7 @@
 		return FALSE
 
 	// Don't allow insertion of unsafed compressed matter implants
-	// Since they are sucking something up now, their afterattack will delete the storage
+	// Since they are sucking something up now, their use_after will delete the storage
 	if(istype(W, /obj/item/implanter/compressed))
 		var/obj/item/implanter/compressed/impr = W
 		if(!impr.safe)

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -121,10 +121,9 @@
 	stuck = null
 	qdel(src)
 
-/obj/item/ducttape/afterattack(A, mob/user, flag, params)
-
+/obj/item/ducttape/use_after(atom/A, mob/living/user, click_parameters)
 	if(!in_range(user, A) || istype(A, /obj/machinery/door) || !stuck)
-		return
+		return FALSE
 
 	var/turf/target_turf = get_turf(A)
 	var/turf/source_turf = get_turf(user)
@@ -133,26 +132,27 @@
 	if(target_turf != source_turf)
 		dir_offset = get_dir(source_turf, target_turf)
 		if(!(dir_offset in GLOB.cardinal))
-			to_chat(user, "You cannot reach that from here.")// can only place stuck papers in cardinal directions, to
-			return											// reduce papers around corners issue.
+			to_chat(user, "You cannot reach that from here.")
+			return TRUE
 
 	if(!user.unEquip(src, source_turf))
-		return
-	playsound(src, 'sound/effects/tape.ogg',25)
+		FEEDBACK_UNEQUIP_FAILURE(user, src)
+		return TRUE
 
+	playsound(src, 'sound/effects/tape.ogg',25)
 	layer = ABOVE_WINDOW_LAYER
 
-	if(params)
-		var/list/mouse_control = params2list(params)
-		if(mouse_control["icon-x"])
-			pixel_x = text2num(mouse_control["icon-x"]) - 16
+	if(click_parameters)
+		if(click_parameters["icon-x"])
+			pixel_x = text2num(click_parameters["icon-x"]) - 16
 			if(dir_offset & EAST)
 				pixel_x += 32
 			else if(dir_offset & WEST)
 				pixel_x -= 32
-		if(mouse_control["icon-y"])
-			pixel_y = text2num(mouse_control["icon-y"]) - 16
+		if(click_parameters["icon-y"])
+			pixel_y = text2num(click_parameters["icon-y"]) - 16
 			if(dir_offset & NORTH)
 				pixel_y += 32
 			else if(dir_offset & SOUTH)
 				pixel_y -= 32
+	return TRUE

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -117,21 +117,18 @@
 		if((!waterproof && submerged()) || !remove_fuel(0.05))
 			setWelding(0)
 
-/obj/item/weldingtool/afterattack(obj/O, mob/user, proximity)
-	if(!proximity)
-		return
-
+/obj/item/weldingtool/use_after(obj/O, mob/living/user)
 	if(istype(O, /obj/structure/reagent_dispensers/fueltank) && get_dist(src,O) <= 1 && !welding)
 		if(!tank)
 			to_chat(user, SPAN_WARNING("\The [src] has no tank attached!"))
-			return
+			return TRUE
 		if (!tank.can_refuel)
 			to_chat(user, SPAN_WARNING("\The [tank] does not have a refuelling port."))
-			return
+			return TRUE
 		O.reagents.trans_to_obj(tank, tank.max_fuel)
 		to_chat(user, SPAN_NOTICE("You refuel \the [tank]."))
 		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
-		return
+		return TRUE
 
 	if(welding)
 		var/turf/location = get_turf(user)
@@ -278,25 +275,34 @@
 		playsound(src, 'sound/items/welderdeactivate.ogg', 10, 1)
 		update_icon()
 
-/obj/item/weldingtool/use_after(mob/living/M, mob/living/user)
-	if (ishuman(M))
-		var/target_zone = user.zone_sel.selecting
-		var/mob/living/carbon/human/H = M
-		var/obj/item/organ/external/S = H.organs_by_name[target_zone]
+/obj/item/weldingtool/use_before(mob/living/target, mob/living/user, click_parameters)
+	if (!ishuman(target))
+		return FALSE
 
-		if (!S || !BP_IS_ROBOTIC(S) || user.a_intent != I_HELP)
+	var/target_zone = user.zone_sel.selecting
+	var/mob/living/carbon/human/H = target
+	var/obj/item/organ/external/S = H.organs_by_name[target_zone]
+
+	if (!S || !BP_IS_ROBOTIC(S) || user.a_intent != I_HELP)
+		return FALSE
+
+	var/list/all_surgeries = GET_SINGLETON_SUBTYPE_MAP(/singleton/surgery_step)
+	for (var/singleton in all_surgeries)
+		var/singleton/surgery_step/step = all_surgeries[singleton]
+		if (step.name && step.tool_quality(src) && step.can_use(user, H, target_zone, src))
 			return FALSE
 
-		if (BP_IS_BRITTLE(S))
-			to_chat(user, SPAN_WARNING("\The [M]'s [S.name] is hard and brittle - \the [src]  cannot repair it."))
-			return TRUE
+	if (BP_IS_BRITTLE(S))
+		to_chat(user, SPAN_WARNING("\The [target]'s [S.name] is hard and brittle - \the [src] cannot repair it."))
+		return TRUE
 
-		if (!can_use(2, user, "to patch the damage on [M]'s [S.name]"))
-			return TRUE
+	if (!can_use(2, user, silent = TRUE)) //The surgery check above already returns can_use's feedback.
+		return TRUE
 
-		if (S.robo_repair(15, DAMAGE_BRUTE, "some dents", src, user))
-			remove_fuel(2, user)
-			return TRUE
+	if (S.robo_repair(15, DAMAGE_BRUTE, "some dents", src, user))
+		remove_fuel(2, user)
+		return TRUE
+
 	else return FALSE
 
 /obj/item/weldingtool/IsFlameSource()
@@ -341,16 +347,15 @@
 	reagents.add_reagent(/datum/reagent/fuel, max_fuel)
 	. = ..()
 
-/obj/item/welder_tank/afterattack(obj/O as obj, mob/user as mob, proximity)
-	if (!proximity)
-		return
+/obj/item/welder_tank/use_after(obj/O, mob/living/user, click_parameters)
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank) && get_dist(src, O) <= 1)
 		if (!can_refuel)
 			to_chat(user, SPAN_DANGER("\The [src] does not have a refuelling port."))
-			return
+			return TRUE
 		O.reagents.trans_to_obj(src, max_fuel)
 		to_chat(user, SPAN_NOTICE("You refuel \the [src]."))
 		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
+		return TRUE
 
 /obj/item/welder_tank/mini
 	name = "small welding fuel tank"

--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -61,17 +61,15 @@
 
 	else return ..()
 
-/obj/item/storage/backpack/weldpack/afterattack(obj/O as obj, mob/user as mob, proximity)
-	if(!proximity) // this replaces and improves the get_dist(src,O) <= 1 checks used previously
-		return
+/obj/item/storage/backpack/weldpack/use_after(obj/O, mob/living/user, click_parameters)
 	if (istype(O, /obj/structure/reagent_dispensers/fueltank) && src.reagents.total_volume < max_fuel)
 		O.reagents.trans_to_obj(src, max_fuel)
 		to_chat(user, SPAN_NOTICE("You crack the cap off the top of \the [src] and fill it back up again from the tank."))
 		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
-		return
+		return TRUE
 	else if (istype(O, /obj/structure/reagent_dispensers/fueltank) && src.reagents.total_volume == max_fuel)
 		to_chat(user, SPAN_WARNING("The pack is already full!"))
-		return
+		return TRUE
 
 /obj/item/storage/backpack/weldpack/examine(mob/user)
 	. = ..()

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -6,7 +6,7 @@
 	health_min_damage = 10
 	var/deploy_path = null
 
-/obj/item/inflatable/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
+/obj/item/inflatable/use_after(atom/target, mob/living/user, click_parameters)
 	if(!deploy_path)
 		return
 	if (loc != user)
@@ -16,11 +16,11 @@
 		return
 	if (isspaceturf(T) || isopenspace(T))
 		to_chat(user, SPAN_WARNING("You cannot use \the [src] in open space."))
-		return
+		return TRUE
 	var/obstruction = T.get_obstruction()
 	if (obstruction)
 		to_chat(user, SPAN_WARNING("\The [english_list(obstruction)] is blocking that spot."))
-		return
+		return TRUE
 	user.visible_message(
 		SPAN_ITALIC("\The [user] starts inflating \an [src]."),
 		SPAN_ITALIC("You start inflating \the [src]."),
@@ -28,11 +28,11 @@
 		range = 5
 	)
 	if (!do_after(user, 1 SECOND, target, DO_PUBLIC_UNIQUE) || QDELETED(src))
-		return
+		return TRUE
 	obstruction = T.get_obstruction()
 	if (obstruction)
 		to_chat(user, SPAN_WARNING("\The [english_list(obstruction)] is blocking that spot."))
-		return
+		return TRUE
 	user.visible_message(
 		SPAN_ITALIC("\The [user] finishes inflating \an [src]."),
 		SPAN_NOTICE("You inflate \the [src]."),
@@ -44,6 +44,7 @@
 	R.add_fingerprint(user)
 	copy_health(src, R)
 	qdel(src)
+	return TRUE
 
 /obj/item/inflatable/wall
 	name = "inflatable wall"

--- a/code/modules/blob/blob.dm
+++ b/code/modules/blob/blob.dm
@@ -425,9 +425,7 @@ regen() will cover update_icon() for this proc
 				color = COLOR_AMBER
 				origin_tech = list(TECH_POWER = 2)
 
-/obj/item/blob_tendril/afterattack(obj/O, mob/user, proximity)
-	if(!proximity)
-		return
+/obj/item/blob_tendril/use_after(obj/O, mob/living/user, click_parameters)
 	if(is_tendril && prob(50))
 		force--
 		if(force <= 0)
@@ -435,6 +433,7 @@ regen() will cover update_icon() for this proc
 			user.drop_from_inventory(src)
 			new /obj/decal/cleanable/ash(src.loc)
 			qdel(src)
+		return TRUE
 
 
 /obj/item/blob_tendril/IsHeatSource()

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -343,22 +343,22 @@
 		return TRUE
 	return ..()
 
-/obj/item/clothing/mask/smokable/cigarette/afterattack(obj/item/reagent_containers/glass/glass, mob/user, proximity)
-	..()
-	if(!proximity)
-		return
-	if(istype(glass)) //you can dip cigarettes into beakers
-		if(!glass.is_open_container())
-			to_chat(user, SPAN_NOTICE("You need to take the lid off first."))
-			return
-		var/transfered = glass.reagents.trans_to_obj(src, chem_volume)
-		if(transfered)	//if reagents were transfered, show the message
-			to_chat(user, SPAN_NOTICE("You dip \the [src] into \the [glass]."))
-		else			//if not, either the beaker was empty, or the cigarette was full
-			if(!glass.reagents.total_volume)
-				to_chat(user, SPAN_NOTICE("[glass] is empty."))
-			else
-				to_chat(user, SPAN_NOTICE("[src] is full."))
+/obj/item/clothing/mask/smokable/cigarette/use_after(obj/item/reagent_containers/glass/glass, mob/living/user, click_parameters)
+	if(!istype(glass))
+		return FALSE
+	if(!glass.is_open_container())
+		to_chat(user, SPAN_NOTICE("You need to take the lid off first."))
+		return TRUE
+
+	var/transfered = glass.reagents.trans_to_obj(src, chem_volume)
+	if(transfered)
+		to_chat(user, SPAN_NOTICE("You dip \the [src] into \the [glass]."))
+	else
+		if(!glass.reagents.total_volume)
+			to_chat(user, SPAN_NOTICE("[glass] is empty."))
+		else
+			to_chat(user, SPAN_NOTICE("[src] is full."))
+	return TRUE
 
 /obj/item/clothing/mask/smokable/cigarette/attack_self(mob/user)
 	if(lit == 1)

--- a/code/modules/clothing/underwear/base.dm
+++ b/code/modules/clothing/underwear/base.dm
@@ -4,10 +4,9 @@
 	var/required_slot_flags
 	var/required_free_body_parts
 
-/obj/item/underwear/afterattack(atom/target, mob/user, proximity)
-	if(!proximity)
-		return // Might as well check
+/obj/item/underwear/use_after(atom/target, mob/living/user, click_parameters)
 	DelayedEquipUnderwear(user, target)
+	return TRUE
 
 /obj/item/underwear/MouseDrop(atom/target)
 	DelayedEquipUnderwear(usr, target)

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -185,26 +185,24 @@
 		to_chat(user, SPAN_WARNING("\The [src] is too dry to use on \the [target]!"))
 		return TRUE
 
-/obj/item/reagent_containers/glass/rag/afterattack(atom/A as obj|turf|area, mob/user as mob, proximity)
-	if(!proximity)
-		return
-
+/obj/item/reagent_containers/glass/rag/use_after(atom/A, mob/living/user, click_parameters)
 	if(istype(A, /obj/structure/reagent_dispensers))
 		if(!reagents.get_free_space())
 			to_chat(user, SPAN_WARNING("\The [src] is already soaked."))
-			return
+			return TRUE
 
 		if(A.reagents && A.reagents.trans_to_obj(src, reagents.maximum_volume))
 			user.visible_message(SPAN_NOTICE("\The [user] soaks [src] using [A]."), SPAN_NOTICE("You soak [src] using [A]."))
 			update_name()
-		return
+			return TRUE
 
 	if(!on_fire && istype(A) && (src in user))
 		if(A.is_open_container() && !(A in user))
 			remove_contents(user, A)
+			return TRUE
 		else if(!ismob(A)) //mobs are handled in attack() - this prevents us from wiping down people while smothering them.
 			wipe_down(A, user)
-		return
+			return TRUE
 
 /obj/item/reagent_containers/glass/rag/fire_act(datum/gas_mixture/air, exposed_temperature, exposed_volume)
 	if(exposed_temperature >= 50 + T0C)

--- a/code/modules/detectivework/tools/sample_kits.dm
+++ b/code/modules/detectivework/tools/sample_kits.dm
@@ -157,19 +157,16 @@
 
 	. = ..()
 
-/obj/item/forensics/sample_kit/afterattack(atom/A, mob/user, proximity)
-	if(!proximity)
-		return
+/obj/item/forensics/sample_kit/use_after(atom/A, mob/living/user, click_parameters)
 	if(user.skill_check(SKILL_FORENSICS, SKILL_TRAINED) && can_take_sample(user, A))
 		take_sample(user,A)
-		. = 1
 	else
 		to_chat(user, SPAN_WARNING("You are unable to locate any [evidence_type]s on \the [A]."))
-		. = ..()
+	return TRUE
 
 /obj/item/forensics/sample_kit/MouseDrop(atom/over)
-	if(ismob(src.loc) && CanMouseDrop(over))
-		afterattack(over, usr, TRUE)
+	if(ismob(loc) && CanMouseDrop(over))
+		use_after(over, usr)
 
 /obj/item/forensics/sample_kit/powder
 	name = "fingerprint powder"

--- a/code/modules/detectivework/tools/swabs.dm
+++ b/code/modules/detectivework/tools/swabs.dm
@@ -5,16 +5,14 @@
 	icon_state = "swab"
 
 // This is pretty nasty but is a damn sight easier than trying to make swabs a stack item.
-/obj/item/swabber/afterattack(atom/A, mob/user, proximity, params)
-	if(proximity)
-		var/obj/item/forensics/swab/swab = new(user)
-		var/resolved = swab.resolve_attackby(A, user, params)
-		if(!resolved && A && !QDELETED(A))
-			swab.afterattack(A, user, TRUE, params)
-		if(swab.is_used())
-			swab.dropInto(user.loc)
-		else
-			qdel(swab)
+/obj/item/swabber/use_after(atom/A, mob/living/user, click_parameters)
+	var/obj/item/forensics/swab/swab = new(user)
+	swab.resolve_attackby(A, user, click_parameters)
+	if(swab.is_used())
+		swab.dropInto(user.loc)
+	else
+		qdel(swab)
+	return TRUE
 
 /obj/item/forensics/swab
 	name = "swab"
@@ -73,7 +71,7 @@
 			return TRUE
 		var/obj/C = H.get_covering_equipped_item_by_zone(zone)
 		if (C)
-			afterattack(C, user, 1) //Lazy but this would work
+			use_after(C, user) //Lazy but this would work
 			return TRUE
 		user.visible_message("[user] swabs [H]'s [O.name] for a sample.")
 		sample_type = "gunshot_residue"
@@ -82,16 +80,10 @@
 		set_used(sample_type, H)
 	return TRUE
 
-/obj/item/forensics/swab/afterattack(atom/A, mob/user, proximity)
-
-	if(!proximity || istype(A, /obj/machinery/dnaforensics))
-		return
-
+/obj/item/forensics/swab/use_after(atom/A, mob/living/user, click_parameters)
 	if(is_used())
 		to_chat(user, SPAN_WARNING("This swab has already been used."))
-		return
-
-	add_fingerprint(user)
+		return TRUE
 
 	var/list/choices = list()
 	if(A.blood_DNA)
@@ -104,20 +96,20 @@
 	var/choice
 	if(!length(choices))
 		to_chat(user, SPAN_WARNING("There is no evidence on \the [A]."))
-		return
+		return TRUE
 	else if(length(choices) == 1)
 		choice = choices[1]
 	else
 		choice = input("What kind of evidence are you looking for?","Evidence Collection") as null|anything in choices
 
 	if(!choice)
-		return
+		return TRUE
 
 	var/sample_type
 	if(choice == "Blood")
 		if(!A.blood_DNA || !length(A.blood_DNA))
 			to_chat(user, SPAN_WARNING("There is no blood on \the [A]."))
-			return
+			return TRUE
 		dna = A.blood_DNA.Copy()
 		sample_type = "blood"
 
@@ -125,7 +117,7 @@
 		var/obj/item/clothing/B = A
 		if(!istype(B) || !B.gunshot_residue)
 			to_chat(user, SPAN_WARNING("There is no residue on \the [A]."))
-			return
+			return TRUE
 		gunshot_residue_sample = B.gunshot_residue.Copy()
 		sample_type = "residue"
 
@@ -133,13 +125,14 @@
 		var/obj/item/I = A
 		if(!istype(I) || !I.trace_DNA)
 			to_chat(user, SPAN_WARNING("There is no non-blood DNA on \the [A]."))
-			return
+			return TRUE
 		trace_dna = I.trace_DNA.Copy()
 		sample_type = "trace DNA"
 
 	if(sample_type)
 		user.visible_message("\The [user] swabs \the [A] for a sample.", "You swab \the [A] for a sample.")
 		set_used(sample_type, A)
+		return TRUE
 
 /obj/item/forensics/swab/proc/set_used(sample_str, atom/source)
 	SetName("[initial(name)] ([sample_str] - [source])")

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -785,9 +785,10 @@
 	max_complexity = IC_COMPLEXITY_BASE * 2
 	health_max = 40
 
-/obj/item/device/electronic_assembly/wallmount/afterattack(atom/a, mob/user, proximity)
-	if(proximity && istype(a ,/turf) && a.density)
-		mount_assembly(a,user)
+/obj/item/device/electronic_assembly/wallmount/use_after(atom/target, mob/living/user, click_parameters)
+	if(istype(target ,/turf) && target.density)
+		mount_assembly(target,user)
+		return TRUE
 
 /obj/item/device/electronic_assembly/wallmount/heavy
 	name = "heavy wall-mounted electronic assembly"

--- a/code/modules/integrated_electronics/core/debugger.dm
+++ b/code/modules/integrated_electronics/core/debugger.dm
@@ -37,14 +37,14 @@
 			data_to_write = null
 			to_chat(user, SPAN_NOTICE("You set \the [src]'s memory to absolutely nothing."))
 
-/obj/item/device/integrated_electronics/debugger/afterattack(atom/target, mob/living/user, proximity)
-	. = ..()
-	if(accepting_refs && proximity)
+/obj/item/device/integrated_electronics/debugger/use_after(atom/target, mob/living/user, click_parameters)
+	if (accepting_refs)
 		data_to_write = weakref(target)
 		visible_message(SPAN_NOTICE("[user] slides \a [src]'s over \the [target]."))
 		to_chat(user, SPAN_NOTICE("You set \the [src]'s memory to a reference to [target.name] \[Ref\].  The ref scanner is \
 		now off."))
 		accepting_refs = FALSE
+		return TRUE
 
 /obj/item/device/integrated_electronics/debugger/proc/write_data(datum/integrated_io/io, mob/user)
 	if(io.io_type == DATA_CHANNEL)

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -266,7 +266,7 @@ a creative player the means to solve many problems.  Circuits are held inside an
 		if(istype(held_item, /obj/item/device/integrated_electronics/debugger))
 			var/obj/item/device/integrated_electronics/debugger/D = held_item
 			if(D.accepting_refs)
-				D.afterattack(src, usr, TRUE)
+				D.use_after(src, usr)
 				. = IC_TOPIC_REFRESH
 			else
 				to_chat(usr, SPAN_WARNING("The debugger's 'ref scanner' needs to be on."))

--- a/code/modules/integrated_electronics/subtypes/memory.dm
+++ b/code/modules/integrated_electronics/subtypes/memory.dm
@@ -129,12 +129,12 @@
 			O.data = null
 			to_chat(user, SPAN_NOTICE("You set \the [src]'s memory to absolutely nothing."))
 
-/obj/item/integrated_circuit/memory/constant/afterattack(atom/target, mob/living/user, proximity)
-	. = ..()
-	if(accepting_refs && proximity)
+/obj/item/integrated_circuit/memory/constant/use_after(atom/target, mob/living/user, click_parameters)
+	if (accepting_refs)
 		var/datum/integrated_io/O = outputs[1]
 		O.data = weakref(target)
 		visible_message(SPAN_NOTICE("[user] slides \a [src]'s over \the [target]."))
 		to_chat(user, SPAN_NOTICE("You set \the [src]'s memory to a reference to [O.display_data(O.data)].  The ref scanner is \
 		now off."))
 		accepting_refs = FALSE
+		return TRUE

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -339,44 +339,43 @@
 	var/datum/matter_synth/wood = null
 	var/datum/matter_synth/plastic = null
 
-/obj/item/matter_decompiler/afterattack(atom/target as mob|obj|turf|area, mob/living/user as mob|obj, proximity, params)
-
-	if(!proximity) return //Not adjacent.
-
+/obj/item/matter_decompiler/use_after(atom/target, mob/living/user, click_parameters)
 	//We only want to deal with using this on turfs. Specific items aren't important.
 	var/turf/T = get_turf(target)
 	if(!istype(T))
-		return
+		return FALSE
 
 	//Used to give the right message.
 	var/grabbed_something = 0
 
 	for(var/mob/M in T)
 		if(istype(M,/mob/living/simple_animal/passive/lizard) || istype(M,/mob/living/simple_animal/passive/mouse))
-			src.loc.visible_message(SPAN_DANGER("[src.loc] sucks [M] into its decompiler. There's a horrible crunching noise."),SPAN_DANGER("It's a bit of a struggle, but you manage to suck [M] into your decompiler. It makes a series of visceral crunching noises."))
+			loc.visible_message(
+				SPAN_DANGER("\The [loc] sucks \the [M] into its decompiler. There's a horrible crunching noise."),
+				SPAN_DANGER("It's a bit of a struggle, but you manage to suck \the [M] into your decompiler. It makes a series of visceral crunching noises.")
+			)
 			new/obj/decal/cleanable/blood/splatter(get_turf(src))
 			qdel(M)
 			if(wood)
 				wood.add_charge(2000)
 			if(plastic)
 				plastic.add_charge(2000)
-			return
+			return TRUE
 
 		else if(istype(M,/mob/living/silicon/robot/drone) && !M.client)
-
-			var/mob/living/silicon/robot/D = src.loc
+			var/mob/living/silicon/robot/D = loc
 
 			if(!istype(D))
-				return
+				return TRUE
 
-			to_chat(D, SPAN_DANGER("You begin decompiling [M]."))
+			to_chat(D, SPAN_DANGER("You begin decompiling \the [M]."))
 
 			if(!do_after(D, 5 SECONDS, M, DO_PUBLIC_UNIQUE))
-				return
+				return TRUE
 
-			if(!M || !D) return
+			if(!M || !D) return TRUE
 
-			to_chat(D, SPAN_DANGER("You carefully and thoroughly decompile [M], storing as much of its resources as you can within yourself."))
+			to_chat(D, SPAN_DANGER("You carefully and thoroughly decompile \the [M], storing as much of its resources as you can within yourself."))
 			qdel(M)
 			new/obj/decal/cleanable/blood/oil(get_turf(src))
 
@@ -388,7 +387,7 @@
 				wood.add_charge(2000)
 			if(plastic)
 				plastic.add_charge(1000)
-			return
+			return TRUE
 		else
 			continue
 
@@ -460,7 +459,7 @@
 		to_chat(user, SPAN_NOTICE("You deploy your decompiler and clear out the contents of \the [T]."))
 	else
 		to_chat(user, SPAN_DANGER("Nothing on \the [T] is useful to you."))
-	return
+	return TRUE
 
 //PRETTIER TOOL LIST.
 /mob/living/silicon/robot/drone/installed_modules()

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -87,9 +87,8 @@
 		if(print)
 			return print
 
-/obj/item/organ/external/afterattack(atom/A, mob/user, proximity)
-	..()
-	if(proximity && get_fingerprint())
+/obj/item/organ/external/use_after(atom/A, mob/living/user, click_parameters)
+	if(get_fingerprint())
 		A.add_partial_print(get_fingerprint())
 
 /obj/item/organ/external/New(mob/living/carbon/holder)

--- a/code/modules/paperwork/paper_sticky.dm
+++ b/code/modules/paperwork/paper_sticky.dm
@@ -106,10 +106,9 @@
 /obj/item/paper/sticky/can_bundle()
 	return FALSE // Would otherwise lead to buggy interaction
 
-/obj/item/paper/sticky/afterattack(A, mob/user, flag, params)
-
-	if(!in_range(user, A) || istype(A, /obj/machinery/door) || istype(A, /obj/item/storage) || icon_state == "scrap")
-		return
+/obj/item/paper/sticky/use_after(atom/A, mob/living/user, click_parameters)
+	if(!in_range(user, A) || istype(A, /obj/machinery/door) || icon_state == "scrap")
+		return FALSE
 
 	var/turf/target_turf = get_turf(A)
 	var/turf/source_turf = get_turf(user)
@@ -119,21 +118,21 @@
 		dir_offset = get_dir(source_turf, target_turf)
 		if(!(dir_offset in GLOB.cardinal))
 			to_chat(user, SPAN_WARNING("You cannot reach that from here."))
-			return
+			return TRUE
 
 	if(user.unEquip(src, source_turf))
 		SSpersistence.track_value(src, /datum/persistent/paper/sticky)
-		if(params)
-			var/list/mouse_control = params2list(params)
-			if(mouse_control["icon-x"])
-				pixel_x = text2num(mouse_control["icon-x"]) - 16
+		if(click_parameters)
+			if(click_parameters["icon-x"])
+				pixel_x = text2num(click_parameters["icon-x"]) - 16
 				if(dir_offset & EAST)
 					pixel_x += 32
 				else if(dir_offset & WEST)
 					pixel_x -= 32
-			if(mouse_control["icon-y"])
-				pixel_y = text2num(mouse_control["icon-y"]) - 16
+			if(click_parameters["icon-y"])
+				pixel_y = text2num(click_parameters["icon-y"]) - 16
 				if(dir_offset & NORTH)
 					pixel_y += 32
 				else if(dir_offset & SOUTH)
 					pixel_y -= 32
+		return TRUE

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -425,7 +425,7 @@
 	if (istype(user, /mob/living/silicon) && get_dist(src,user)>1)
 		return attack_robot(user)
 	if(istype(W, /obj/item/inducer))
-		return FALSE // inducer.dm afterattack handles this
+		return FALSE // inducer.dm use_after handles this
 
 	if(isCrowbar(W) && user.a_intent != I_HURT)//bypass when on harm intend to actually make use of the cover hammer off check further down.
 		if(opened) // Closes or removes board.

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -838,15 +838,13 @@
 
 // shatter light, unless it was an attempt to put it in a light socket
 // now only shatter if the intent was harm
-/obj/item/light/afterattack(atom/target, mob/user, proximity)
-	if(!proximity)
-		return
+/obj/item/light/use_after(atom/target, mob/living/user, click_parameters)
 	if(istype(target, /obj/machinery/light))
-		return
+		return FALSE
 	if(user.a_intent != I_HURT)
-		return
-
+		return FALSE
 	shatter()
+	return TRUE
 
 /// Handles updating the light's `status`.
 /obj/item/light/proc/set_status(new_status)

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -73,18 +73,13 @@
 		list(mode_name="induce specific mutations", projectile_type=/obj/item/projectile/energy/floramut/gene, modifystate="floramut"),
 		)
 
-/obj/item/gun/energy/floragun/resolve_attackby(atom/A)
-	if(istype(A,/obj/machinery/portable_atmospherics/hydroponics))
-		return FALSE // do afterattack, i.e. fire, at pointblank at trays.
-	return ..()
+/obj/item/gun/energy/floragun/use_before(atom/target, mob/living/user, click_parameters)
+	if (!istype(target, /obj/machinery/portable_atmospherics/hydroponics))
+		return FALSE
 
-/obj/item/gun/energy/floragun/afterattack(obj/target, mob/user, adjacent_flag)
-	//allow shooting into adjacent hydrotrays regardless of intent
-	if(adjacent_flag && istype(target,/obj/machinery/portable_atmospherics/hydroponics))
-		user.visible_message(SPAN_DANGER("\The [user] fires \the [src] into \the [target]!"))
-		Fire(target,user)
-		return
-	..()
+	user.visible_message(SPAN_DANGER("\The [user] fires \the [src] into \the [target]!"))
+	Fire(target,user)
+	return TRUE
 
 /obj/item/gun/energy/floragun/verb/select_gene()
 	set name = "Select Gene"

--- a/code/modules/reagents/dispenser/cartridge.dm
+++ b/code/modules/reagents/dispenser/cartridge.dm
@@ -66,36 +66,32 @@
 		to_chat(usr, SPAN_NOTICE("You take the cap off \the [src]."))
 		atom_flags |= ATOM_FLAG_OPEN_CONTAINER
 
-/obj/item/reagent_containers/chem_disp_cartridge/afterattack(obj/target, mob/user , flag)
-	if (!is_open_container() || !flag)
-		return
+/obj/item/reagent_containers/chem_disp_cartridge/use_after(atom/target, mob/living/user, click_parameters)
+	if (!is_open_container())
+		to_chat(user, SPAN_WARNING("\The [src] is covered with a cap."))
+		return TRUE
 
-	else if(istype(target, /obj/structure/reagent_dispensers)) //A dispenser. Transfer FROM it TO us.
-		target.add_fingerprint(user)
-
+	if(istype(target, /obj/structure/reagent_dispensers)) //A dispenser. Transfer FROM it TO us.
 		if(!target.reagents.total_volume && target.reagents)
 			to_chat(user, SPAN_WARNING("\The [target] is empty."))
-			return
+			return TRUE
 
 		if(reagents.total_volume >= reagents.maximum_volume)
 			to_chat(user, SPAN_WARNING("\The [src] is full."))
-			return
+			return TRUE
 
 		var/trans = target.reagents.trans_to(src, target:amount_per_transfer_from_this)
 		to_chat(user, SPAN_NOTICE("You fill \the [src] with [trans] units of the contents of \the [target]."))
+		return TRUE
 
-	else if(target.is_open_container() && target.reagents) //Something like a glass. Player probably wants to transfer TO it.
-
+	if(target.is_open_container() && target.reagents) //Something like a glass. Player probably wants to transfer TO it.
 		if(!reagents.total_volume)
 			to_chat(user, SPAN_WARNING("\The [src] is empty."))
-			return
-
+			return TRUE
 		if(target.reagents.total_volume >= target.reagents.maximum_volume)
 			to_chat(user, SPAN_WARNING("\The [target] is full."))
-			return
+			return TRUE
 
 		var/trans = src.reagents.trans_to(target, amount_per_transfer_from_this)
 		to_chat(user, SPAN_NOTICE("You transfer [trans] units of the solution to \the [target]."))
-
-	else
-		return ..()
+		return TRUE

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -39,9 +39,6 @@
 /obj/item/reagent_containers/attack_self(mob/user as mob)
 	return
 
-/obj/item/reagent_containers/afterattack(obj/target, mob/user, flag)
-	return
-
 /obj/item/reagent_containers/proc/reagentlist() // For attack logs
 	if(reagents)
 		return reagents.get_reagents()
@@ -65,7 +62,7 @@
 	else
 		SetName("[initial(name)] ([label_text])")
 
-/obj/item/reagent_containers/proc/standard_dispenser_refill(mob/user, obj/structure/reagent_dispensers/target) // This goes into afterattack
+/obj/item/reagent_containers/proc/standard_dispenser_refill(mob/user, obj/structure/reagent_dispensers/target) // This goes into use_after()
 	if(!istype(target))
 		return 0
 
@@ -81,7 +78,7 @@
 	to_chat(user, SPAN_NOTICE("You fill [src] with [trans] units of the contents of [target]."))
 	return 1
 
-/obj/item/reagent_containers/proc/standard_splash_mob(mob/user, mob/target) // This goes into afterattack
+/obj/item/reagent_containers/proc/standard_splash_mob(mob/user, mob/target) // This goes into use_after()
 	if(!istype(target))
 		return
 
@@ -172,7 +169,7 @@
 	return TRUE
 
 
-/obj/item/reagent_containers/proc/standard_pour_into(mob/user, atom/target) // This goes into afterattack and yes, it's atom-level
+/obj/item/reagent_containers/proc/standard_pour_into(mob/user, atom/target) // This goes into use_after() and yes, it's atom-level
 	if(!target.reagents)
 		return 0
 

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -252,22 +252,21 @@
 /obj/item/reagent_containers/borghypo/service/use_before(mob/M, mob/user)
 	return FALSE //We don't want the service borg to be able to inject alcohol into blood.
 
-/obj/item/reagent_containers/borghypo/service/afterattack(obj/target, mob/user, proximity)
-	if(!proximity)
-		return
-
-	if(!target.is_open_container() || !target.reagents)
-		return
-
+/obj/item/reagent_containers/borghypo/service/use_after(obj/target, mob/living/user, click_parameters)
+	if (!target.reagents)
+		return FALSE
+	if(!target.is_open_container())
+		to_chat(user, SPAN_WARNING("\The [target] is capped."))
+		return TRUE
 	if(!target.reagents.get_free_space())
-		to_chat(user, SPAN_WARNING("[target] is full."))
-		return
+		to_chat(user, SPAN_WARNING("\The [target] is full."))
+		return TRUE
 
 	if (mode)
 		var/datum/reagent/R = reagent_ids[mode]
 		if(!reagent_volumes[R])
-			to_chat(user, SPAN_WARNING("[src] is out of this reagent, give it some time to refill."))
-			return
+			to_chat(user, SPAN_WARNING("\The [src] is out of this reagent, give it some time to refill."))
+			return TRUE
 		var/transferred = min(amount_per_transfer_from_this, reagent_volumes[R])
 		target.reagents.add_reagent(R, transferred)
 		reagent_volumes[R] -= transferred
@@ -276,12 +275,13 @@
 		var/obj/item/reagent_containers/container = dispense.resolve()
 		if (!valid_container(user, container))
 			to_chat(user, SPAN_WARNING("Can't find the container to dispense from."))
-			return
+			return TRUE
 		var/datum/reagents/R = container.reagents
 		if (!R || !R.total_volume)
 			to_chat(user, SPAN_WARNING("\The [container] is empty."))
 		var/transferred = R.trans_to_holder(target.reagents, amount_per_transfer_from_this)
 		to_chat(user, "You transfer [transferred] units of the solution to [target].")
+	return TRUE
 
 
 /obj/item/robot_rack/bottle

--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -207,10 +207,11 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 		else continue
 		side = "right"
 
-/obj/item/reagent_containers/food/drinks/glass2/afterattack(obj/target, mob/user, proximity)
-	if (!proximity || standard_dispenser_refill(user, target) || standard_pour_into(user, target))
+/obj/item/reagent_containers/food/drinks/glass2/use_after(obj/target, mob/living/user, click_parameters)
+	if (standard_dispenser_refill(user, target) || standard_pour_into(user, target))
 		return TRUE
 	splashtarget(target, user)
+	return TRUE
 
 /obj/item/reagent_containers/food/drinks/glass2/attackby(obj/item/W, mob/user)
 	if(istype(W, /obj/item/material/kitchen/utensil/spoon))

--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -12,30 +12,29 @@
 	slot_flags = SLOT_EARS
 	volume = 5
 
-/obj/item/reagent_containers/dropper/afterattack(obj/target, mob/user, proximity)
-	if(!target.reagents || !proximity) return
+/obj/item/reagent_containers/dropper/use_after(obj/target, mob/living/user, click_parameters)
+	if(!target.reagents)
+		return FALSE
 
 	if(reagents.total_volume)
-
 		if(!target.reagents.get_free_space())
 			to_chat(user, SPAN_NOTICE("[target] is full."))
-			return
-
+			return TRUE
 		if(!target.is_open_container() && !ismob(target) && !istype(target, /obj/item/reagent_containers/food) && !istype(target, /obj/item/clothing/mask/smokable/cigarette)) //You can inject humans and food but you can't remove the shit.
 			to_chat(user, SPAN_NOTICE("You cannot directly fill this object."))
-			return
+			return TRUE
 
 		var/trans = 0
 
 		if(ismob(target))
 			if(user.a_intent == I_HELP)
-				return
+				return TRUE
 
 			var/time = 20 //2/3rds the time of a syringe
 			user.visible_message(SPAN_WARNING("[user] is trying to squirt something into [target]'s eyes!"))
 
 			if(!do_after(user, time, target, DO_MEDICAL))
-				return
+				return TRUE
 
 			if(istype(target, /mob/living/carbon/human))
 				var/mob/living/carbon/human/victim = target
@@ -54,7 +53,7 @@
 				if(safe_thing)
 					trans = reagents.splash(safe_thing, amount_per_transfer_from_this, max_spill=30)
 					user.visible_message(SPAN_WARNING("[user] tries to squirt something into [target]'s eyes, but fails!"), SPAN_NOTICE("You transfer [trans] units of the solution."))
-					return
+					return TRUE
 
 			var/mob/living/M = target
 			if (reagents.should_admin_log())
@@ -65,29 +64,25 @@
 			trans += reagents.splash(target, reagents.total_volume/2, max_spill = spill_amt)
 			trans += reagents.trans_to_mob(target, reagents.total_volume/2, CHEM_BLOOD) //I guess it gets into the bloodstream through the eyes or something
 			user.visible_message(SPAN_WARNING("[user] squirts something into [target]'s eyes!"), SPAN_NOTICE("You transfer [trans] units of the solution."))
-
-
-			return
+			return TRUE
 
 		else
 			trans = reagents.splash(target, amount_per_transfer_from_this, max_spill=0) //sprinkling reagents on generic non-mobs. Droppers are very precise
 			to_chat(user, SPAN_NOTICE("You transfer [trans] units of the solution."))
+			return TRUE
 
 	else // Taking from something
 
 		if(!target.is_open_container() && !istype(target,/obj/structure/reagent_dispensers))
 			to_chat(user, SPAN_NOTICE("You cannot directly remove reagents from [target]."))
-			return
-
+			return TRUE
 		if(!target.reagents || !target.reagents.total_volume)
 			to_chat(user, SPAN_NOTICE("[target] is empty."))
-			return
+			return TRUE
 
 		var/trans = target.reagents.trans_to_obj(src, amount_per_transfer_from_this)
-
 		to_chat(user, SPAN_NOTICE("You fill the dropper with [trans] units of the solution."))
-
-	return
+		return TRUE
 
 /obj/item/reagent_containers/dropper/on_reagent_change()
 	update_icon()

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -48,28 +48,21 @@
 	if (standard_feed_mob(user, M))
 		return TRUE
 
-/obj/item/reagent_containers/food/condiment/afterattack(obj/target, mob/user, proximity)
-	if(!proximity)
-		return
-
-	if(standard_dispenser_refill(user, target))
-		return
-	if(standard_pour_into(user, target))
-		return
+/obj/item/reagent_containers/food/condiment/use_after(obj/target, mob/living/user, click_parameters)
+	if(standard_dispenser_refill(user, target) || standard_pour_into(user, target))
+		return TRUE
 
 	if(istype(target, /obj/item/reagent_containers/food/snacks)) // These are not opencontainers but we can transfer to them
 		if(!reagents || !reagents.total_volume)
 			to_chat(user, SPAN_NOTICE("There is no condiment left in \the [src]."))
-			return
-
+			return TRUE
 		if(!target.reagents.get_free_space())
 			to_chat(user, SPAN_NOTICE("You can't add more condiment to \the [target]."))
-			return
+			return TRUE
 
 		var/trans = reagents.trans_to_obj(target, amount_per_transfer_from_this)
 		to_chat(user, SPAN_NOTICE("You add [trans] units of the condiment to \the [target]."))
-	else
-		..()
+		return TRUE
 
 /obj/item/reagent_containers/food/condiment/feed_sound(mob/user)
 	playsound(user.loc, 'sound/items/drink.ogg', rand(10, 50), 1)

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -39,14 +39,9 @@
 	if(standard_feed_mob(user, M))
 		return TRUE
 
-/obj/item/reagent_containers/food/drinks/afterattack(obj/target, mob/user, proximity)
-	if(!proximity) return
-
-	if(standard_dispenser_refill(user, target))
-		return
-	if(standard_pour_into(user, target))
-		return
-	return ..()
+/obj/item/reagent_containers/food/drinks/use_after(obj/target, mob/living/user, click_parameters)
+	if (standard_dispenser_refill(user, target) || standard_pour_into(user, target))
+		return TRUE
 
 /obj/item/reagent_containers/food/drinks/standard_feed_mob(mob/user, mob/target)
 	if(!is_open_container())

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -231,22 +231,22 @@
 			something.dropInto(loc)
 	. = ..()
 
-/obj/item/reagent_containers/food/snacks/afterattack(obj/item/reagent_containers/food/drinks/glass2/glass, mob/user, proximity)
-	..()
-	if(!proximity)
-		return
-	if(istype(glass))
-		if(w_class != ITEM_SIZE_TINY)
-			to_chat(user, SPAN_NOTICE("\The [src] is too big to properly dip in \the [glass]."))
-			return
-		var/transfered = glass.reagents.trans_to_obj(src, volume)
-		if(transfered)	//if reagents were transfered, show the message
-			to_chat(user, SPAN_NOTICE("You dip \the [src] into \the [glass]."))
-		else			//if not, either the glass was empty, or the food was full
-			if(!glass.reagents.total_volume)
-				to_chat(user, SPAN_NOTICE("\The [glass] is empty."))
-			else
-				to_chat(user, SPAN_NOTICE("\The [src] is full."))
+/obj/item/reagent_containers/food/snacks/use_after(obj/item/reagent_containers/food/drinks/glass2/glass, mob/user)
+	if(!istype(glass))
+		return FALSE
+	if(w_class != ITEM_SIZE_TINY)
+		to_chat(user, SPAN_NOTICE("\The [src] is too big to properly dip in \the [glass]."))
+		return TRUE
+
+	var/transfered = glass.reagents.trans_to_obj(src, volume)
+	if(transfered)	//if reagents were transfered, show the message
+		to_chat(user, SPAN_NOTICE("You dip \the [src] into \the [glass]."))
+	else			//if not, either the glass was empty, or the food was full
+		if(!glass.reagents.total_volume)
+			to_chat(user, SPAN_NOTICE("\The [glass] is empty."))
+		else
+			to_chat(user, SPAN_NOTICE("\The [src] is full."))
+	return TRUE
 
 ////////////////////////////////////////////////////////////////////////////////
 /// FOOD END
@@ -322,14 +322,15 @@
 	.=..()
 	reagents.add_reagent(/datum/reagent/nutriment/protein/egg, 3)
 
-/obj/item/reagent_containers/food/snacks/egg/afterattack(obj/O as obj, mob/user as mob, proximity)
+/obj/item/reagent_containers/food/snacks/egg/use_after(obj/O, mob/living/user, click_parameters)
 	if(istype(O,/obj/machinery/microwave))
-		return ..()
-	if(!(proximity && O.is_open_container()))
-		return
+		return FALSE
+	if(!O.is_open_container())
+		return TRUE
 	to_chat(user, "You crack \the [src] into \the [O].")
 	reagents.trans_to(O, reagents.total_volume)
 	qdel(src)
+	return TRUE
 
 /obj/item/reagent_containers/food/snacks/egg/throw_impact(atom/hit_atom)
 	if(QDELETED(src))

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -122,10 +122,11 @@
 			)
 		playsound(src.loc, "sound/effects/Glasshit.ogg", 50)
 
-/obj/item/reagent_containers/glass/afterattack(obj/target, mob/user, proximity)
-	if (!proximity || (target.type in can_be_placed_into) || standard_dispenser_refill(user, target) || standard_pour_into(user, target))
+/obj/item/reagent_containers/glass/use_after(obj/target, mob/living/user, click_parameters)
+	if ((target.type in can_be_placed_into) || standard_dispenser_refill(user, target) || standard_pour_into(user, target))
 		return TRUE
 	splashtarget(target, user)
+	return TRUE
 
 
 /obj/item/reagent_containers/glass/beaker

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -141,9 +141,7 @@
 		return
 	..()
 
-/obj/item/reagent_containers/hypospray/vial/afterattack(obj/target, mob/user, proximity) // hyposprays can be dumped into, why not out? uses standard_pour_into helper checks.
-	if(!proximity)
-		return
+/obj/item/reagent_containers/hypospray/vial/use_after(obj/target, mob/living/user, click_parameters) // hyposprays can be dumped into, why not out? uses standard_pour_into helper checks.
 	if (!reagents.total_volume && istype(target, /obj/item/reagent_containers/glass))
 		var/good_target = is_type_in_list(target, list(
 			/obj/item/reagent_containers/glass/beaker,
@@ -153,14 +151,16 @@
 			return
 		if (!target.is_open_container())
 			to_chat(user, SPAN_ITALIC("\The [target] is closed."))
-			return
+			return TRUE
 		if (!target.reagents?.total_volume)
 			to_chat(user, SPAN_ITALIC("\The [target] is empty."))
-			return
+			return TRUE
 		var/trans = target.reagents.trans_to_obj(src, amount_per_transfer_from_this)
 		to_chat(user, SPAN_NOTICE("You fill \the [src] with [trans] units of the solution."))
-		return
-	standard_pour_into(user, target)
+		return TRUE
+	else
+		standard_pour_into(user, target)
+		return TRUE
 
 /obj/item/reagent_containers/hypospray/autoinjector
 	name = "autoinjector"

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -54,22 +54,22 @@
 		qdel(src)
 		return TRUE
 
-/obj/item/reagent_containers/pill/afterattack(obj/target, mob/user, proximity)
-	if(!proximity) return
+/obj/item/reagent_containers/pill/use_after(atom/target, mob/living/user, click_parameters)
+	if (target.is_open_container() && target.reagents)
+		if (!target.reagents.total_volume)
+			to_chat(user, SPAN_NOTICE("\The [target] is empty. Can't dissolve \the [src]."))
+			return TRUE
 
-	if(target.is_open_container() && target.reagents)
-		if(!target.reagents.total_volume)
-			to_chat(user, SPAN_NOTICE("[target] is empty. Can't dissolve \the [src]."))
-			return
-		to_chat(user, SPAN_NOTICE("You dissolve \the [src] in [target]."))
+		to_chat(user, SPAN_NOTICE("You dissolve \the [src] in \the [target]."))
 
 		if (reagents.should_admin_log())
 			admin_attacker_log(user, "spiked \a [target] with a pill. Reagents: [reagentlist()]")
 		reagents.trans_to(target, reagents.total_volume)
 		for(var/mob/O in viewers(2, user))
-			O.show_message(SPAN_WARNING("[user] puts something in \the [target]."), 1)
+			O.show_message(SPAN_WARNING("\The [user] puts something in \the [target]."), 1)
 		qdel(src)
-	return
+		return TRUE
+	else return FALSE
 
 ////////////////////////////////////////////////////////////////////////////////
 /// Pills. END

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -54,26 +54,24 @@
 	..()
 	update_icon()
 
-/obj/item/reagent_containers/syringe/afterattack(obj/target, mob/user, proximity)
-	if(!proximity)
-		return
-
+/obj/item/reagent_containers/syringe/use_after(obj/target, mob/living/user, click_parameters)
 	if(mode == SYRINGE_BROKEN)
 		to_chat(user, SPAN_WARNING("This syringe is broken."))
-		return
+		return TRUE
 
 	if(istype(target, /obj/structure/closet/body_bag))
 		handleBodyBag(target, user)
-		return
+		return TRUE
 
 	if(!target.reagents)
-		return
+		return FALSE
 
 	if((user.a_intent == I_HURT) && ismob(target))
 		syringestab(target, user)
-		return
+		return TRUE
 
 	handleTarget(target, user)
+	return TRUE
 
 /obj/item/reagent_containers/syringe/on_update_icon()
 	ClearOverlays()

--- a/code/modules/recycling/conveyor2.dm
+++ b/code/modules/recycling/conveyor2.dm
@@ -270,21 +270,22 @@
 		var/obj/item/conveyor_switch_construct/C = I
 		id = C.id
 
-/obj/item/conveyor_construct/afterattack(atom/A, mob/user, proximity)
-	if(!proximity || !istype(A, /turf/simulated/floor) || istype(A, /area/shuttle) || user.incapacitated())
-		return
+/obj/item/conveyor_construct/use_after(atom/A, mob/living/user, click_parameters)
+	if(!istype(A, /turf/simulated/floor) || istype(A, /area/shuttle) || user.incapacitated())
+		return FALSE
 	var/cdir = get_dir(A, user)
 	if(!(cdir in GLOB.cardinal) || A == user.loc)
-		return
+		return TRUE
 	for(var/obj/machinery/conveyor/CB in A)
 		if(CB.dir == cdir || CB.dir == turn(cdir,180))
-			return
+			return TRUE
 		cdir |= CB.dir
 		qdel(CB)
 	var/obj/machinery/conveyor/C = new/obj/machinery/conveyor(A,cdir)
 	C.id = id
 	transfer_fingerprints_to(C)
 	qdel(src)
+	return TRUE
 
 /obj/item/conveyor_switch_construct
 	name = "conveyor switch assembly"
@@ -300,9 +301,9 @@
 	..()
 	id = rand() //this couldn't possibly go wrong
 
-/obj/item/conveyor_switch_construct/afterattack(atom/A, mob/user, proximity)
-	if(!proximity || !istype(A, /turf/simulated/floor) || istype(A, /area/shuttle) || user.incapacitated())
-		return
+/obj/item/conveyor_switch_construct/use_after(atom/A, mob/living/user, click_parameters)
+	if(!istype(A, /turf/simulated/floor) || istype(A, /area/shuttle) || user.incapacitated())
+		return FALSE
 	var/found = 0
 	for(var/obj/machinery/conveyor/C in view())
 		if(C.id == src.id)
@@ -310,18 +311,19 @@
 			break
 	if(!found)
 		to_chat(user, "[icon2html(src, user)][SPAN_NOTICE("The conveyor switch did not detect any linked conveyor belts in range.")]")
-		return
+		return TRUE
 	var/obj/machinery/conveyor_switch/NC = new /obj/machinery/conveyor_switch(A, id)
 	transfer_fingerprints_to(NC)
 	qdel(src)
+	return TRUE
 
 /obj/item/conveyor_switch_construct/oneway
 	name = "one-way conveyor switch assembly"
 	desc = "An one-way conveyor control switch assembly."
 
-/obj/item/conveyor_switch_construct/oneway/afterattack(atom/A, mob/user, proximity)
-	if(!proximity || !istype(A, /turf/simulated/floor) || istype(A, /area/shuttle) || user.incapacitated())
-		return
+/obj/item/conveyor_switch_construct/oneway/use_after(atom/A, mob/living/user, click_parameters)
+	if(!istype(A, /turf/simulated/floor) || istype(A, /area/shuttle) || user.incapacitated())
+		return FALSE
 	var/found = 0
 	for(var/obj/machinery/conveyor/C in view())
 		if(C.id == src.id)
@@ -329,7 +331,8 @@
 			break
 	if(!found)
 		to_chat(user, "[icon2html(src, user)][SPAN_NOTICE("The conveyor switch did not detect any linked conveyor belts in range.")]")
-		return
+		return TRUE
 	var/obj/machinery/conveyor_switch/oneway/NC = new /obj/machinery/conveyor_switch/oneway(A, id)
 	transfer_fingerprints_to(NC)
 	qdel(src)
+	return TRUE

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -562,9 +562,9 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 	else
 		id_tag = "ds[sequential_id(/obj/item/disposal_switch_construct)]"
 
-/obj/item/disposal_switch_construct/afterattack(atom/A, mob/user, proximity)
-	if(!proximity || !istype(A, /turf/simulated/floor) || istype(A, /area/shuttle) || user.incapacitated() || !id_tag)
-		return
+/obj/item/disposal_switch_construct/use_after(atom/A, mob/living/user, click_parameters)
+	if(!istype(A, /turf/simulated/floor) || istype(A, /area/shuttle) || user.incapacitated() || !id_tag)
+		return FALSE
 	var/found = 0
 	for(var/obj/structure/disposalpipe/diversion_junction/D in world)
 		if(D.id_tag == src.id_tag)
@@ -572,10 +572,11 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 			break
 	if(!found)
 		to_chat(user, "[icon2html(src, user)][SPAN_NOTICE("\The [src] is not linked to any junctions!")]")
-		return
+		return TRUE
 	var/obj/machinery/disposal_switch/NC = new/obj/machinery/disposal_switch(A, id_tag)
 	transfer_fingerprints_to(NC)
 	qdel(src)
+	return TRUE
 
 // the disposal outlet machine
 


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: Fixes being unable to place pills into beakers placed on a table/turf
bugfix: Fixes duct-taped and sticky papers not properly offsetting
/🆑 


The only afterattacks that will remain are the rare ones that actually handle ranged behavior. No changes in this PR other than changing afterattack to use_after; dropping the proximity flag check, and returning TRUE where needed.
Beyond that, at most there are styling changes. Any bugs I fix on the way are listed on the changelog.

Kept afterattacks for guns, sprays, and magic spells as these have a ranged use.
Also kept them for mech_equipment, as the after_attacks there do not EXPLICITLY check for proximity so I'm not touching it just in case.

Updated documentation as needed.