### PR TITLE
makes sugar-iron use glucose

### DIFF
--- a/code/game/objects/items/weapons/storage/pill_bottle.dm
+++ b/code/game/objects/items/weapons/storage/pill_bottle.dm
@@ -189,7 +189,7 @@
 
 /obj/item/storage/pill_bottle/sugariron
 	name = "pill bottle (Sugar-Iron)"
-	desc = "A fifty-fifty mix of iron and sugar, used for encouraging the body's natural blood regeneration."
+	desc = "A fifty-fifty mix of iron and glucose, used for encouraging the body's natural blood regeneration."
 	startswith = list(/obj/item/reagent_containers/pill/sugariron = 14)
 	wrapper_color = COLOR_RED_GRAY
 

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -346,7 +346,7 @@
 /obj/item/reagent_containers/pill/sugariron/New()
 	..()
 	reagents.add_reagent(/datum/reagent/iron, 5)
-	reagents.add_reagent(/datum/reagent/sugar, 5)
+	reagents.add_reagent(/datum/reagent/nutriment/glucose, 5)
 	color = reagents.get_color()
 
 /obj/item/reagent_containers/pill/detergent


### PR DESCRIPTION
:cl:
tweak: Sugar-iron pills contain glucose instead of sucrose, improving their ability to replenish blood.
/:cl: