### PR TITLE
Fixes setOxyLoss() for humanoids

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -143,19 +143,18 @@
 
 // Defined here solely to take species flags into account without having to recast at mob/living level.
 /mob/living/carbon/human/getOxyLoss()
-	if(!need_breathe())
+	if (!need_breathe())
 		return 0
-	else
-		var/obj/item/organ/internal/lungs/breathe_organ = internal_organs_by_name[species.breathing_organ]
-		if(!breathe_organ)
-			return maxHealth/2
-		return breathe_organ.get_oxygen_deprivation()
+	var/obj/item/organ/internal/lungs/lungs = internal_organs_by_name[species.breathing_organ]
+	if (!lungs)
+		return 100
+	return lungs.get_oxygen_deprivation()
 
 /mob/living/carbon/human/setOxyLoss(amount)
-	if(!need_breathe())
-		return 0
-	else
-		adjustOxyLoss(getOxyLoss()-amount)
+	if (!need_breathe())
+		return
+	amount = clamp(amount, 0, 100) / 100
+	adjustOxyLoss(amount * species.total_health)
 
 /mob/living/carbon/human/adjustOxyLoss(amount)
 	if(!need_breathe())


### PR DESCRIPTION
For humanoids, getOxyLoss() returns a percentage of oxygen_deprivation, and adjustOxyLoss() adjusts the raw value. In every place it's called, setOxyLoss() is given a percentage value even though it just calls adjustOxyLoss(). It also increases oxygen_deprivation when it should decrease it because of a misordered subtraction. Neither of these problems are relevant when setting oxygen_deprivation from 0 to 0, which is probably why they've gone unnoticed for so long. 
To avoid sweeping changes, this PR just makes humans' setOxyLoss() convert percentage oxyLoss to raw oxygen_deprivation when calling adjustOxyLoss().

:cl:
bugfix: Rescuscitating an asystolic suffocation victim won't cause their oxygenation to plummet.
/:cl: