### PR TITLE
added typesof_real and subtypesof_real

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -131,6 +131,7 @@
 #include "code\_helpers\tools.dm"
 #include "code\_helpers\turfs.dm"
 #include "code\_helpers\type2type.dm"
+#include "code\_helpers\types.dm"
 #include "code\_helpers\unsorted.dm"
 #include "code\_helpers\vector.dm"
 #include "code\_helpers\washing.dm"

--- a/code/_helpers/types.dm
+++ b/code/_helpers/types.dm
@@ -1,0 +1,40 @@
+/// `typesof()` without the type of thing (or thing if it is a type) included.
+/proc/subtypesof(datum/thing)
+	RETURN_TYPE(/list)
+	if (ispath(thing))
+		return typesof(thing) - thing
+	if (istype(thing))
+		return typesof(thing) - thing.type
+	return list()
+
+
+/// `typesof()` without abstract types included.
+/proc/typesof_real(datum/thing)
+	RETURN_TYPE(/list)
+	var/static/list/cache = list()
+	if (!ispath(thing))
+		if (!istype(thing))
+			return list()
+		thing = thing.type
+	var/list/result = cache[thing]
+	if (!result)
+		result = list()
+		for (var/path in typesof(thing))
+			if (!is_abstract(path))
+				result += path
+		if (!length(result))
+			result = TRUE
+		cache[thing] = result
+	if (result == TRUE)
+		return list()
+	return result.Copy()
+
+
+/// `subtypesof()` without abstract types included.
+/proc/subtypesof_real(datum/thing)
+	RETURN_TYPE(/list)
+	if (!ispath(thing))
+		if (!istype(thing))
+			return list()
+		thing = thing.type
+	return typesof_real(thing) - thing

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -1,15 +1,3 @@
-/*
- * A large number of misc global procs.
- */
-
-/proc/subtypesof(datum/thing)
-	RETURN_TYPE(/list)
-	if (ispath(thing))
-		return typesof(thing) - thing
-	if (istype(thing))
-		return typesof(thing) - thing.type
-	return list()
-
 //Checks if all high bits in req_mask are set in bitfield
 #define BIT_TEST_ALL(bitfield, req_mask) ((~(bitfield) & (req_mask)) == 0)
 


### PR DESCRIPTION
closes #34266

Versions of typesof and subtypesof that don't include abstract types in their result lists. These alternatives to the other PR's `types_of_real_objects` and `subtypes_of_real_objects` are more performant and have behavior consistent with typesof when the passed thing is unexpected. Also put them in their own file along with subtypesof.
