### PR TITLE
Allow using outfits for setting up chameleon appearance

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -358,6 +358,7 @@
 #include "code\datums\observation\destroyed.dm"
 #include "code\datums\observation\dir_set.dm"
 #include "code\datums\observation\dismembered.dm"
+#include "code\datums\observation\empd.dm"
 #include "code\datums\observation\entered.dm"
 #include "code\datums\observation\equipped.dm"
 #include "code\datums\observation\exited.dm"

--- a/code/datums/extensions/chameleon.dm
+++ b/code/datums/extensions/chameleon.dm
@@ -2,10 +2,13 @@
 	base_type = /datum/extension/chameleon
 	expected_type = /obj/item
 	flags = EXTENSION_FLAG_IMMEDIATE
-	var/list/chameleon_choices
 	var/static/list/chameleon_choices_by_type
+	var/chameleon_choices
 	var/atom/atom_holder
-	var/chameleon_verb
+	var/static/chameleon_verbs = list(
+		/obj/item/proc/ChameleonFlexibleAppearance,
+		/obj/item/proc/ChameleonOutfitAppearanceSingle,
+		/obj/item/proc/ChameleonOutfitAppearanceAll)
 
 /datum/extension/chameleon/New(datum/holder, base_type)
 	..()
@@ -13,35 +16,24 @@
 	if (!chameleon_choices)
 		var/chameleon_type = base_type || holder.parent_type
 		chameleon_choices = LAZYACCESS(chameleon_choices_by_type, chameleon_type)
-		if(!chameleon_choices)
-			chameleon_choices = generate_chameleon_choices(chameleon_type)
-			LAZYSET(chameleon_choices_by_type, chameleon_type, chameleon_choices)
-	else
-		var/list/choices = list()
-		for(var/path in chameleon_choices)
-			add_chameleon_choice(choices, path)
-		chameleon_choices = sortAssoc(choices)
+		if (!chameleon_choices)
+			chameleon_choices = GenerateChameleonChoices(chameleon_type)
 
 	atom_holder = holder
-	chameleon_verb = /atom/proc/chameleon_appearance
-	atom_holder.verbs += chameleon_verb
+	atom_holder.verbs += chameleon_verbs
 
 /datum/extension/chameleon/Destroy()
 	. = ..()
-	atom_holder.verbs -= chameleon_verb
+	atom_holder.verbs -= chameleon_verbs
 	atom_holder = null
 
-/datum/extension/chameleon/proc/disguise(newtype, mob/user, newname, newdesc)
-	var/obj/item/copy = new newtype(null) //initial() does not handle lists well
+/datum/extension/chameleon/proc/Disguise(newtype, mob/user, newname, newdesc)
+	SHOULD_NOT_OVERRIDE(TRUE) // Subtypes should override OnDisguise
+
+	var/obj/item/copy = new newtype(null) // initial() does not handle lists well
 	var/obj/item/C = atom_holder
-	if (newname)
-		C.name = newname
-	else
-		C.name = copy.name
-	if (newdesc)
-		C.desc = newdesc
-	else
-		C.desc = copy.desc
+	C.name = newname || copy.name
+	C.desc = newdesc || copy.desc
 	C.icon = copy.icon
 	C.color = copy.color
 	C.icon_state = copy.icon_state
@@ -53,32 +45,23 @@
 	C.item_state_slots = copy.item_state_slots
 	C.sprite_sheets = copy.sprite_sheets
 
-	OnDisguise(copy)
+	OnDisguise(user, holder, copy)
 	qdel(copy)
 
-/datum/extension/chameleon/proc/OnDisguise(obj/item/copy)
+/datum/extension/chameleon/proc/OnDisguise(mob/user, obj/item/holder, obj/item/copy)
+	return
 
-/datum/extension/chameleon/clothing
-	expected_type = /obj/item/clothing
+/datum/extension/chameleon/proc/GetItemDisguiseType(singleton/hierarchy/outfit/outfit)
+	return null
 
-/datum/extension/chameleon/clothing/accessory
-	expected_type = /obj/item/clothing/accessory
+/datum/extension/chameleon/proc/GenerateChameleonChoices(basetype)
+	var/choices = list()
+	var/types = islist(basetype) ? basetype : typesof(basetype)
+	for (var/path in types)
+		AddChameleonChoice(choices, path)
+	return sortAssoc(choices)
 
-/datum/extension/chameleon/clothing/accessory/OnDisguise(obj/item/clothing/accessory/copy)
-	..()
-	var/obj/item/clothing/accessory/A = holder
-
-	A.slot = copy.slot
-	A.parent = copy.parent
-	A.inv_overlay = copy.inv_overlay
-	A.mob_overlay = copy.mob_overlay
-	A.overlay_state = copy.overlay_state
-	A.accessory_icons = copy.accessory_icons
-	A.on_rolled_down = copy.on_rolled_down
-	A.on_rolled_sleeves = copy.on_rolled_sleeves
-	A.accessory_flags = copy.accessory_flags
-
-/datum/extension/chameleon/proc/add_chameleon_choice(list/target, path)
+/datum/extension/chameleon/proc/AddChameleonChoice(list/target, path)
 	var/obj/item/I = path
 	if (initial(I.icon) && initial(I.icon_state) && !(initial(I.item_flags) & ITEM_FLAG_INVALID_FOR_CHAMELEON))
 		var/name = initial(I.name)
@@ -92,78 +75,184 @@
 		else
 			target[name] = path
 
-/datum/extension/chameleon/proc/generate_chameleon_choices(basetype)
-	var/choices = list()
-	var/types = islist(basetype) ? basetype : typesof(basetype)
-	for (var/path in types)
-		add_chameleon_choice(choices, path)
-	return sortAssoc(choices)
-
 /**
- * Verb to handle changing the appearance of atoms that have the chameleon extension.
+ * Verbs to handle changing the appearance of atoms that have the chameleon extension.
  */
-/atom/proc/chameleon_appearance()
-	set name = "Change Appearance"
+/obj/item/proc/ChameleonFlexibleAppearance()
+	set name = "Change Appearance - Flexible"
 	set desc = "Activate the holographic appearance changing module."
 	set category = "Object"
 
-	if (!CanPhysicallyInteract(usr))
+	if (!CanPhysicallyInteractWith(usr, src))
 		return
-	if (has_extension(src,/datum/extension/chameleon))
-		var/datum/extension/chameleon/C = get_extension(src, /datum/extension/chameleon)
-		C.change(usr)
+
+	var/datum/extension/chameleon/C = get_extension(src, /datum/extension/chameleon)
+	if (C)
+		C.ChangeGeneral(usr)
 	else
-		src.verbs -= /atom/proc/chameleon_appearance
+		src.verbs -= C.chameleon_verbs
 
-/datum/extension/chameleon/proc/change(mob/user)
+/datum/extension/chameleon/proc/ChangeGeneral(mob/user)
 	var/choice = input(user, "Select a new appearance", "Select appearance") as null|anything in chameleon_choices
-	if (choice)
-		var/newname = input(user, "Choose a new name, or leave blank to use the default", "Choose item name") as null|text
-		var/newdesc = input(user, "Choose a new description, or leave blank to use the default", "Choose item description") as null|text
-		if (QDELETED(user) || QDELETED(holder))
-			return
-		if(user.incapacitated() || !(holder in user))
-			to_chat(user, SPAN_WARNING("You can't reach \the [holder]."))
-			return
-		disguise(chameleon_choices[choice], user, newname, newdesc)
-		OnChange(user,holder)
+	if (!choice)
+		return
 
-/datum/extension/chameleon/proc/OnChange(mob/user, obj/item/clothing/C) //contains icon updates
-	if (istype(C))
-		C.update_clothing_icon()
+	var/newname = input(user, "Choose a new name, or leave blank to use the default", "Choose item name") as null|text
+	var/newdesc = input(user, "Choose a new description, or leave blank to use the default", "Choose item description") as null|text
+	if(!CanPhysicallyInteractWith(user, holder))
+		to_chat(user, SPAN_WARNING("You can't reach \the [holder]."))
+		return
+	Disguise(chameleon_choices[choice], user, newname, newdesc)
 
+/obj/item/proc/ChameleonOutfitAppearanceSingle()
+	set name = "Change Appearance - Outfit (Single)"
+	set desc = "Activate the holographic appearance changing module."
+	set category = "Object"
+
+	if (!CanPhysicallyInteractWith(usr, src))
+		return
+
+	var/datum/extension/chameleon/C = get_extension(src, /datum/extension/chameleon)
+	if (C)
+		C.ChangeOutfitSingle(usr)
+	else
+		src.verbs -= C.chameleon_verbs
+
+/datum/extension/chameleon/proc/ChangeOutfitSingle(mob/user)
+	var/choice = input(user, "Select a new appearance for the selected chameleon item", "Select appearance") as null|anything in outfits()
+	if (!choice)
+		return
+	if(!CanPhysicallyInteractWith(user, holder))
+		to_chat(user, SPAN_WARNING("You can't reach \the [holder]."))
+		return
+	SetOutfitAppearance(user, list(src), choice)
+
+/obj/item/proc/ChameleonOutfitAppearanceAll()
+	set name = "Change Appearance - Outfit (All)"
+	set desc = "Activate the holographic appearance changing module."
+	set category = "Object"
+
+	if (!CanPhysicallyInteractWith(usr, src))
+		return
+
+	var/datum/extension/chameleon/C = get_extension(src, /datum/extension/chameleon)
+	if (C)
+		C.ChangeOutfitAll(usr)
+	else
+		src.verbs -= C.chameleon_verbs
+
+/datum/extension/chameleon/proc/ChangeOutfitAll(mob/user)
+	var/choice = input(usr, "Select a new appearance for the selected chameleon item", "Select appearance") as null|anything in outfits()
+	if (!choice)
+		return
+	if(!CanPhysicallyInteractWith(user, holder))
+		to_chat(usr, SPAN_WARNING("You can't reach \the [holder]."))
+		return
+
+	var/list/extensions = list()
+	for (var/obj/item/I as anything in user.get_equipped_items(TRUE))
+		var/extension = get_extension(I, /datum/extension/chameleon)
+		if (extension)
+			extensions += extension
+	extensions |= src
+	SetOutfitAppearance(user, extensions, choice)
+
+/datum/extension/chameleon/proc/SetOutfitAppearance(mob/user, list/chameleon_extensions, singleton/hierarchy/outfit/outfit)
+	for (var/datum/extension/chameleon/chameleon_extension as anything in chameleon_extensions)
+		var/outfit_type = chameleon_extension.GetItemDisguiseType(outfit)
+		if (outfit_type)
+			to_chat(user, SPAN_NOTICE("The outfit '[outfit]' appearance was applied to \the [chameleon_extension.holder]."));
+			chameleon_extension.Disguise(outfit_type)
+		else
+			to_chat(user, SPAN_WARNING("The outfit '[outfit]' had no suitable appearance for \the [chameleon_extension.holder]."));
+
+/********************
+* Subtype overrides *
+********************/
 /datum/extension/chameleon/backpack
 	expected_type = /obj/item/storage/backpack
 
-/datum/extension/chameleon/backpack/OnChange(mob/user, obj/item/storage/backpack/C)
-	if (ismob(C.loc))
-		var/mob/M = C.loc
+/datum/extension/chameleon/backpack/OnDisguise(obj/item/storage/backpack/holder, obj/item/copy)
+	if (ismob(holder.loc))
+		var/mob/M = holder.loc
 		M.update_inv_back()
 
-/datum/extension/chameleon/headset
-	expected_type = /obj/item/device/radio/headset
+/datum/extension/chameleon/backpack/GetItemDisguiseType(singleton/hierarchy/outfit/outfit)
+	return outfit.back
 
-/datum/extension/chameleon/headset/OnChange(mob/user, obj/item/device/radio/headset/C)
-	if (ismob(C.loc))
-		var/mob/M = C.loc
-		M.update_inv_ears()
+/datum/extension/chameleon/clothing
+	expected_type = /obj/item/clothing
 
-/datum/extension/chameleon/gun
-	expected_type = /obj/item/gun
+/datum/extension/chameleon/clothing/OnDisguise(mob/user, obj/item/clothing/holder, obj/item/copy)
+	SHOULD_CALL_PARENT(TRUE)
+	..()
+	if (istype(holder))
+		holder.update_clothing_icon()
 
-/datum/extension/chameleon/gun/OnChange(mob/user, obj/item/gun/C)
-	if (ismob(C.loc))
-		var/mob/M = C.loc
-		M.update_inv_r_hand()
-		M.update_inv_l_hand()
+/datum/extension/chameleon/clothing/accessory
+	expected_type = /obj/item/clothing/accessory
 
-/datum/extension/chameleon/gun/OnDisguise(obj/item/gun/copy)
-	var/obj/item/gun/G = atom_holder
+/datum/extension/chameleon/clothing/accessory/OnDisguise(mob/user, obj/item/clothing/accessory/holder, obj/item/clothing/accessory/copy)
+	holder.slot = copy.slot
+	holder.parent = copy.parent
+	holder.inv_overlay = copy.inv_overlay
+	holder.mob_overlay = copy.mob_overlay
+	holder.overlay_state = copy.overlay_state
+	holder.accessory_icons = copy.accessory_icons
+	holder.on_rolled_down = copy.on_rolled_down
+	holder.on_rolled_sleeves = copy.on_rolled_sleeves
+	holder.accessory_flags = copy.accessory_flags
+	..()
 
-	G.flags_inv = copy.flags_inv
-	G.fire_sound = copy.fire_sound
-	G.fire_sound_text = copy.fire_sound_text
-	G.icon = copy.icon
+/datum/extension/chameleon/clothing/glasses
+	expected_type = /obj/item/clothing/glasses
+
+/datum/extension/chameleon/clothing/glasses/GetItemDisguiseType(singleton/hierarchy/outfit/outfit)
+	if (ispath(outfit.glasses, expected_type))
+		return outfit.glasses
+
+/datum/extension/chameleon/clothing/gloves
+	expected_type = /obj/item/clothing/gloves
+
+/datum/extension/chameleon/clothing/gloves/GetItemDisguiseType(singleton/hierarchy/outfit/outfit)
+	if (ispath(outfit.gloves, expected_type))
+		return outfit.gloves
+
+/datum/extension/chameleon/clothing/head
+	expected_type = /obj/item/clothing/head
+
+/datum/extension/chameleon/clothing/head/GetItemDisguiseType(singleton/hierarchy/outfit/outfit)
+	if (ispath(outfit.head, expected_type))
+		return outfit.head
+
+/datum/extension/chameleon/clothing/mask
+	expected_type = /obj/item/clothing/mask
+
+/datum/extension/chameleon/clothing/mask/GetItemDisguiseType(singleton/hierarchy/outfit/outfit)
+	if (ispath(outfit.mask, expected_type))
+		return outfit.mask
+
+/datum/extension/chameleon/clothing/shoes
+	expected_type = /obj/item/clothing/shoes
+
+/datum/extension/chameleon/clothing/shoes/GetItemDisguiseType(singleton/hierarchy/outfit/outfit)
+	..()
+	if (ispath(outfit.shoes, expected_type))
+		return outfit.shoes
+
+/datum/extension/chameleon/clothing/suit
+	expected_type = /obj/item/clothing/suit
+
+/datum/extension/chameleon/clothing/suit/GetItemDisguiseType(singleton/hierarchy/outfit/outfit)
+	if (ispath(outfit.suit, expected_type))
+		return outfit.suit
+
+/datum/extension/chameleon/clothing/under
+	expected_type = /obj/item/clothing/under
+
+/datum/extension/chameleon/clothing/under/GetItemDisguiseType(singleton/hierarchy/outfit/outfit)
+	if (ispath(outfit.uniform, expected_type))
+		return outfit.uniform
 
 /datum/extension/chameleon/emag
 	expected_type = /obj/item/card
@@ -175,3 +264,36 @@
 		/obj/item/card/data/disk,
 		/obj/item/card/id
 	)
+
+/datum/extension/chameleon/emag/GetItemDisguiseType(singleton/hierarchy/outfit/outfit)
+	if (length(outfit.id_types) > 0)
+		var/id_path = outfit.id_types[0]
+		if (ispath(id_path, expected_type))
+			return id_path
+
+/datum/extension/chameleon/gun
+	expected_type = /obj/item/gun
+
+/datum/extension/chameleon/gun/OnDisguise(mob/user, obj/item/gun/holder, obj/item/gun/copy)
+	holder.flags_inv = copy.flags_inv
+	holder.fire_sound = copy.fire_sound
+	holder.fire_sound_text = copy.fire_sound_text
+
+	if (ismob(holder.loc))
+		var/mob/M = holder.loc
+		M.update_inv_r_hand()
+		M.update_inv_l_hand()
+
+/datum/extension/chameleon/headset
+	expected_type = /obj/item/device/radio/headset
+
+/datum/extension/chameleon/headset/OnDisguise(mob/user, obj/item/holder, obj/item/copy)
+	if (ismob(holder.loc))
+		var/mob/M = holder.loc
+		M.update_inv_ears()
+
+/datum/extension/chameleon/headset/GetItemDisguiseType(singleton/hierarchy/outfit/outfit)
+	if (ispath(outfit.l_ear, expected_type))
+		return outfit.l_ear
+	if (ispath(outfit.r_ear, expected_type))
+		return outfit.r_ear

--- a/code/datums/observation/empd.dm
+++ b/code/datums/observation/empd.dm
@@ -1,0 +1,13 @@
+//	Observer Pattern Implementation: EMPd
+//		Registration type: /atom
+//
+//		Raised when: A /atom instance is EMPd.
+//
+//		Arguments that the called proc should expect:
+//			/atom/empd_instance: The instance that was EMPd.
+//			severity: The EMP severity
+
+GLOBAL_DATUM_INIT(empd_event, /singleton/observ/empd, new)
+
+/singleton/observ/empd
+	name = "EMPd"

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -246,7 +246,6 @@
 /atom/proc/HasProximity(atom/movable/AM as mob|obj)
 	return
 
-
 /**
  * Called when the atom is affected by an EMP.
  *
@@ -254,10 +253,12 @@
  * - `severity` Integer. The strength of the EMP, ranging from 1 to 3. NOTE: Lower numbers are stronger.
  */
 /atom/proc/emp_act(severity)
+	SHOULD_CALL_PARENT(TRUE)
 	if (get_max_health())
 		// No hitsound here - Doesn't make sense for EMPs.
 		// Generalized - 75-125 damage at max, 38-63 at medium, 25-42 at minimum severities.
 		damage_health(rand(75, 125) / severity, DAMAGE_EMP, severity = severity)
+	GLOB.empd_event.raise_event(src, severity)
 
 
 /**

--- a/code/game/machinery/barrier.dm
+++ b/code/game/machinery/barrier.dm
@@ -86,6 +86,7 @@
 	return 1
 
 /obj/machinery/barrier/emp_act(severity)
+	SHOULD_CALL_PARENT(FALSE)
 	if (severity > EMP_ACT_LIGHT)
 		return
 	locked = FALSE
@@ -94,6 +95,7 @@
 	if (severity > EMP_ACT_HEAVY)
 		return
 	sparks(3, 1, src)
+	GLOB.empd_event.raise_event(src, severity)
 	emag_act()
 
 /obj/machinery/barrier/on_death()

--- a/code/game/machinery/stasis_cage.dm
+++ b/code/game/machinery/stasis_cage.dm
@@ -260,6 +260,7 @@ var/global/const/STASISCAGE_WIRE_LOCK      = 4
 
 
 /obj/machinery/stasis_cage/emp_act(severity)
+	SHOULD_CALL_PARENT(FALSE)
 	if (health_dead())
 		return
 	if (inoperable())
@@ -280,7 +281,7 @@ var/global/const/STASISCAGE_WIRE_LOCK      = 4
 		cell.emp_act(severity)
 
 	update_icon()
-
+	GLOB.empd_event.raise_event(src, severity)
 
 /obj/machinery/stasis_cage/on_update_icon()
 	ClearOverlays()

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -180,6 +180,7 @@ var/global/list/all_gps_units = list()
 	update_icon()
 
 /obj/item/device/gps/emp_act(severity)
+	SHOULD_CALL_PARENT(FALSE)
 	if(emped) // Without a fancy callback system, this will have to do.
 		return
 	if(tracking)
@@ -190,6 +191,7 @@ var/global/list/all_gps_units = list()
 	emped = TRUE
 	update_icon()
 	addtimer(new Callback(src, .proc/reset_emp), duration)
+	GLOB.empd_event.raise_event(src, severity)
 
 /obj/item/device/gps/proc/reset_emp()
 	emped = FALSE

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -323,8 +323,10 @@
 		M.show_message(SPAN_NOTICE("\The [src] flashes a message across its screen, \"Additional personalities available for download.\""), 3, SPAN_NOTICE("\The [src] bleeps electronically."), 2)
 
 /obj/item/device/paicard/emp_act(severity)
+	SHOULD_CALL_PARENT(FALSE)
 	for(var/mob/M in src)
 		M.emp_act(severity)
+	GLOB.empd_event.raise_event(src, severity)
 
 /obj/item/device/paicard/ex_act(severity)
 	if(pai)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -179,7 +179,7 @@ var/global/const/NO_EMAG_ACT = -50
 
 /obj/item/card/emag/Initialize()
 	. = ..()
-	set_extension(src,/datum/extension/chameleon/emag)
+	set_extension(src, /datum/extension/chameleon/emag)
 
 /obj/item/card/emag/get_antag_info()
 	. = ..()

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -105,6 +105,7 @@
 
 
 /obj/item/melee/energy/emp_act(severity)
+	SHOULD_CALL_PARENT(FALSE)
 	if (!active)
 		return
 	if (damaged)
@@ -124,6 +125,7 @@
 		deactivate()
 	update_icon()
 	damaged = TRUE
+	GLOB.empd_event.raise_event(src, severity)
 
 
 /obj/item/melee/energy/get_storage_cost()

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -270,6 +270,7 @@
 
 
 /obj/item/shield/energy/emp_act(severity)
+	SHOULD_CALL_PARENT(FALSE)
 	if (!active)
 		return
 	if (damaged)
@@ -289,6 +290,7 @@
 	else
 		deactivate()
 	update_icon()
+	GLOB.empd_event.raise_event(src, severity)
 
 
 /obj/item/shield/energy/proc/UpdateSoundLoop()

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -9,7 +9,7 @@
 
 /obj/item/clothing/under/chameleon/Initialize()
 	. = ..()
-	set_extension(src,/datum/extension/chameleon/clothing)
+	set_extension(src,/datum/extension/chameleon/clothing/under)
 
 /obj/item/clothing/head/chameleon
 	name = "cap"
@@ -21,7 +21,7 @@
 
 /obj/item/clothing/head/chameleon/Initialize()
 	. = ..()
-	set_extension(src,/datum/extension/chameleon/clothing)
+	set_extension(src, /datum/extension/chameleon/clothing/head)
 
 /obj/item/clothing/suit/chameleon
 	name = "armor"
@@ -33,7 +33,7 @@
 
 /obj/item/clothing/suit/chameleon/Initialize()
 	. = ..()
-	set_extension(src,/datum/extension/chameleon/clothing)
+	set_extension(src, /datum/extension/chameleon/clothing/suit)
 
 /obj/item/clothing/shoes/chameleon
 	name = "shoes"
@@ -45,7 +45,7 @@
 
 /obj/item/clothing/shoes/chameleon/Initialize()
 	. = ..()
-	set_extension(src,/datum/extension/chameleon/clothing)
+	set_extension(src, /datum/extension/chameleon/clothing/shoes)
 
 /obj/item/storage/backpack/chameleon
 	name = "backpack"
@@ -69,7 +69,7 @@
 
 /obj/item/clothing/gloves/chameleon/Initialize()
 	. = ..()
-	set_extension(src,/datum/extension/chameleon/clothing)
+	set_extension(src, /datum/extension/chameleon/clothing/gloves)
 
 /obj/item/clothing/mask/chameleon
 	name = "mask"
@@ -81,7 +81,7 @@
 
 /obj/item/clothing/mask/chameleon/Initialize()
 	. = ..()
-	set_extension(src,/datum/extension/chameleon/clothing,/obj/item/clothing/mask)
+	set_extension(src, /datum/extension/chameleon/clothing/mask)
 
 /obj/item/clothing/glasses/chameleon
 	name = "goggles"
@@ -93,7 +93,7 @@
 
 /obj/item/clothing/glasses/chameleon/Initialize()
 	. = ..()
-	set_extension(src,/datum/extension/chameleon/clothing)
+	set_extension(src, /datum/extension/chameleon/clothing/glasses)
 
 /obj/item/device/radio/headset/chameleon
 	name = "radio headset"

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -41,8 +41,10 @@
 	activators = list("on toggle" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/input/toggle_button/emp_act()
-	return // This is a mainly physical thing, not affected by electricity
+// This is a mainly physical thing, not affected by electricity
+/obj/item/integrated_circuit/input/toggle_button/emp_act(severity)
+	SHOULD_CALL_PARENT(FALSE)
+	GLOB.empd_event.raise_event(src, severity)
 
 /obj/item/integrated_circuit/input/toggle_button/get_topic_data(mob/user)
 	return list("Toggle [get_pin_data(IC_OUTPUT, 1) ? "Off" : "On"]" = "toggle=1")

--- a/code/modules/organs/internal/species/vox.dm
+++ b/code/modules/organs/internal/species/vox.dm
@@ -193,6 +193,7 @@
 		to_chat(user, SPAN_NOTICE("The integrity light on [src] is off. It is empty and lifeless."))
 
 /obj/item/organ/internal/voxstack/emp_act()
+	SHOULD_CALL_PARENT(FALSE)
 	return
 
 /obj/item/organ/internal/voxstack/getToxLoss()

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -83,6 +83,7 @@
 	else
 		to_chat(usr, SPAN_NOTICE("The generator is off."))
 /obj/machinery/power/port_gen/emp_act(severity)
+	SHOULD_CALL_PARENT(FALSE)
 	if(!active)
 		return
 	var/duration
@@ -95,6 +96,7 @@
 			if(prob(25)) set_broken(TRUE)
 			if(prob(10)) explode()
 			else duration = 30 SECONDS
+	GLOB.empd_event.raise_event(src, severity)
 
 	if(duration)
 		set_stat(MACHINE_STAT_EMPED, TRUE)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -138,6 +138,7 @@
 	efficiency *= 1 + (rand() - 1) * skill_modifier //subtract off between 0.8 and 0, depending on skill and luck.
 
 /obj/machinery/power/emitter/emp_act(severity)
+	SHOULD_CALL_PARENT(FALSE)
 	return
 
 /obj/machinery/power/emitter/Process()

--- a/code/modules/power/singularity/field_generator.dm
+++ b/code/modules/power/singularity/field_generator.dm
@@ -158,6 +158,7 @@ field_generator power level display
 
 
 /obj/machinery/field_generator/emp_act()
+	SHOULD_CALL_PARENT(FALSE)
 	return
 
 /obj/machinery/field_generator/bullet_act(obj/item/projectile/Proj)

--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -124,4 +124,5 @@
 	return
 
 /obj/machinery/computer/shuttle_control/emp_act()
+	SHOULD_CALL_PARENT(FALSE)
 	return

--- a/code/modules/xenoarcheaology/anomaly_container.dm
+++ b/code/modules/xenoarcheaology/anomaly_container.dm
@@ -145,12 +145,14 @@
 	..()
 
 /obj/machinery/anomaly_container/emp_act(severity)
+	SHOULD_CALL_PARENT(FALSE)
 	if(health_dead)
 		return
 	if(contained)
 		visible_message(SPAN_DANGER("\The [src]'s latches break loose, freeing the contents!"))
 		playsound(loc, 'sound/mecha/hydraulic.ogg', 40)
 		release()
+	GLOB.empd_event.raise_event(src, severity)
 
 
 /obj/machinery/anomaly_container/attackby(obj/item/P, mob/user)

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dm
@@ -116,6 +116,7 @@
 
 
 /mob/living/simple_animal/hostile/retaliate/malf_drone/hydro/emp_act(severity)
+	SHOULD_CALL_PARENT(FALSE)
 	if (status_flags & GODMODE)
 		return
 	health -= rand(5, 10) * (severity + 1)
@@ -125,6 +126,7 @@
 	destroy_surroundings = TRUE
 	projectiletype = initial(projectiletype)
 	walk(src, 0)
+	GLOB.empd_event.raise_event(src, severity)
 
 
 /datum/say_list/malf_drone/hydro/speak = list(


### PR DESCRIPTION
🆑
add: Added the verb "Change Appearance - Outfit (Selected Only)" to chameleon items. This allows selecting a predefined outfit and if the outfit has a relevant appearance setup for the item it's applied. Most of the outfits relevant for Torch are prefixed with "Job - ".
add: Added the verb "Change Appearance - Outfit (All Equipped)". Does the same as above but for all equipped chameleon items.
tweak: The old verb is renamed to "Change Appearance - Flexible"
add: Chameleon items can again be affected by EMP, both at impact and for some time after. Unlike the old behavior a random appearance is selected, rather than flashing rainbow colors.
/🆑

And a quick example on the "Change Appearance - Outfit (All Equipped)"-verb can quickly turn someone suspicious into someone not at all suspicious.
![image](https://github.com/Baystation12/Baystation12/assets/496895/82d0b22c-8fce-4734-8b1c-fac6ec7ae621)

Or another quick change and the removal of a few items and you've got yourself an engineer.
![image](https://github.com/Baystation12/Baystation12/assets/496895/a5f21843-1a43-4ac3-bc4c-21d939229d12) ![image](https://github.com/Baystation12/Baystation12/assets/496895/f00cfff7-65be-4061-9587-20bc2301e64d)

Only your imagination (and what's in the code) is your limitation.