### PR TITLE
EMP Damage Scaling

### DIFF
--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -154,11 +154,16 @@
 		return
 
 	var/burn_damage = 0
+	var/rand_modifier = rand(1,3)
 	switch (severity)
 		if (EMP_ACT_HEAVY)
-			burn_damage = 30
+			burn_damage = 10 * rand_modifier
 		if (EMP_ACT_LIGHT)
-			burn_damage = 15
+			burn_damage = 4 * rand_modifier
+
+	/// Ions can't be aimed like conventional weaponry. This way damage is more even between center mass and limbs based on their total health relative to each other.
+	if(!(src.body_part & FULL_TORSO))
+		burn_damage *= 0.5
 
 	var/mult = 1 + !!(BP_IS_ASSISTED(src)) // This macro returns (large) bitflags.
 	burn_damage *= mult/species.get_burn_mod(owner) //ignore burn mod for EMP damage
@@ -174,9 +179,6 @@
 
 	if(owner && limb_flags & ORGAN_FLAG_CAN_GRASP)
 		owner.grasp_damage_disarm(src)
-
-	if(owner && limb_flags & ORGAN_FLAG_CAN_STAND)
-		owner.stance_damage_prone(src)
 
 	..()
 

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -191,9 +191,10 @@
 /obj/item/organ/internal/emp_act(severity)
 	if(!BP_IS_ROBOTIC(src))
 		return
+	var/rand_modifier = rand(1, 3)
 	switch (severity)
 		if (EMP_ACT_HEAVY)
-			take_internal_damage(16)
+			take_internal_damage(5 * rand_modifier)
 		if (EMP_ACT_LIGHT)
-			take_internal_damage(9)
+			take_internal_damage(2 * rand_modifier)
 	..()

--- a/code/modules/organs/internal/species/fbp.dm
+++ b/code/modules/organs/internal/species/fbp.dm
@@ -56,6 +56,7 @@
 	if(!checked_use(cost) && owner.isSynthetic())
 		if(!owner.lying && !owner.buckled)
 			to_chat(owner, SPAN_WARNING("You don't have enough energy to function!"))
+		owner.Weaken(3)
 		owner.Paralyse(3)
 	if(percent() < 10 && prob(1))
 		to_chat(owner, SPAN_WARNING("Your internal battery beeps an alert code, it is low on charge!"))

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -30,6 +30,7 @@
 	one_hand_penalty = 0
 	charge_cost = 40
 	max_shots = 3
+	fire_delay = 30
 	projectile_type = /obj/item/projectile/ion/small
 
 /obj/item/gun/energy/ionrifle/mounted


### PR DESCRIPTION
:cl:
tweak: EMP damage is now calculated with a 1 to 3 multiplicative modifier with 3 being the pre-change damage.
tweak: The ion pistol now has half the fire delay it had before to differentiate it from the ion rifle.
tweak: EMP damage to limbs has been reduced by 50%. Torso damage remains the same.
tweak: EMP damage to robotic legs and feet no longer immediately weaken the victim.
tweak: FBPs and IPCs first fall over before being paralyzed when their battery is dead or destroyed.
/:cl:
(I hate balancing)

This PR aims to reduce the effectiveness of ion weaponry as an instant win against humanoid synthetics, while still keeping them a viable option against antagonists and those with synthetic parts.

- EMP damage now is applied with a random modifier that on average reduces the total damage to humanoid prosthetics and augments. Ion rifles retain their original firing speed, but the firing speed on the ion pistol has been increased as the damage on it is very unlikely to disable an IPC in a single magazine. Across the board, limb damage has been reduced by 50%. Additionally, ion damage is applied in random "steps" of 33%:

| WEAPON  | Rifle Damage | Pistol Damage |
| ------------- | ------------- | ------------- |
| 33% Chance | 10 External, 5 Internal  | 4 External, 2 Internal  |
| 33% Chance  | 20 External, 10 Internal | 8 External, 4 Internal  |
| 33% Chance  | 30 External, 15 Internal  | 12 External, 6 Internal  |

- Ion hits are calculated for each robotic limb the victim has. For an IPC, this was over 100 damage per hit to the entire body. It was impossible to survive 2 consecutive hits and the 1st hit was guaranteed to floor due to leg malfunction.

- For context, the original calculation was a flat 30 burn damage to every limb on an ion rifle hit, with a flat 15 damage to every organ. The ion pistol was a flat 15 damage externally and 9 damage internally. After testing these weapons are still very viable against IPCs and FBPs because they ignore armor, but are not guaranteed stuns like before and require consecutive hits to add up damage.

- EMP damage to limbs (arms, legs, hands, feet) has been reduced by 50% and flooring stun has been removed to prevent instant immobilization when someone is hit by an ion or EMP. Torsos have much higher health than limbs and damage to synthetic legs will still start to floor them after the 2nd or 3rd direct hit by an ion pulse. This way ions can still be used against a heavily armored synthetic but are not effective without hitting the person multiple times.

_None of this affects mechs or hardsuits._ Hardsuits and mech damage calculations are unchanged and function just as before.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->