### PR TITLE
Chem Quantities: Alky/Imi

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -174,7 +174,6 @@
 	result = /datum/reagent/kelotane
 	required_reagents = list(/datum/reagent/silicon = 1, /datum/reagent/carbon = 1)
 	result_amount = 2
-	log_is_important = 1
 
 /datum/chemical_reaction/peridaxon
 	name = "Peridaxon"
@@ -208,7 +207,7 @@
 	name = "Alkysine"
 	result = /datum/reagent/alkysine
 	required_reagents = list(/datum/reagent/acid/hydrochloric = 1, /datum/reagent/ammonia = 1, /datum/reagent/dylovene = 1)
-	result_amount = 2
+	result_amount = 3
 
 /datum/chemical_reaction/dexalin
 	name = "Dexalin"
@@ -298,7 +297,7 @@
 	name = "Imidazoline"
 	result = /datum/reagent/imidazoline
 	required_reagents = list(/datum/reagent/carbon = 1, /datum/reagent/hydrazine = 1, /datum/reagent/dylovene = 1)
-	result_amount = 2
+	result_amount = 3
 
 /datum/chemical_reaction/ethylredoxrazine
 	name = "Ethylredoxrazine"


### PR DESCRIPTION
:cl: TheNightingale
tweak: Alkysine and imidazoline recipes now produce the same amount of output as input, rather than turning 3 units of input into 2 units of output.
tweak: Kelotane no longer messages admins every time it's created.
/:cl:

Chemicals with a smaller output than input are typically restricted to especially strong chems like chloral hydrate, or hard-to-make chems like peridaxon. Alkysine and imidazoline really have no reason other than a very, very mild inconvenience to be the way they are.

(Also, kelotane _really_ isn't 'hey, ping staff whenever someone makes this' worthy...)