### PR TITLE
Readds access to the industrial rig

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -63,6 +63,8 @@
 	boot_type = /obj/item/clothing/shoes/magboots/rig/industrial
 	glove_type = /obj/item/clothing/gloves/rig/industrial
 
+	req_access = list(access_mining)
+
 /obj/item/clothing/head/helmet/space/rig/industrial
 	light_overlay = "helmet_light_wide"
 	camera = /obj/machinery/camera/network/helmet

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -5011,7 +5011,9 @@
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/northright{
-	name = "suit storage"
+	name = "suit storage";
+	req_access = list("ACCESS_MINING");
+	autoset_access = 0
 	},
 /obj/item/rig/industrial/equipped,
 /obj/structure/window/reinforced{


### PR DESCRIPTION
:cl:
tweak: The industrial RIG is locked behind the mining access.
/:cl:

Apparently, the explorers think that everything in the hangar that isn't locked belongs to them.