### PR TITLE
Industrial suit access restriction

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -5011,7 +5011,9 @@
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/northright{
-	name = "suit storage"
+	name = "suit storage";
+	req_access = list("ACCESS_MINING");
+	autoset_access = 0
 	},
 /obj/item/rig/industrial/equipped,
 /obj/structure/window/reinforced{


### PR DESCRIPTION
:cl:
tweak: The industrial RIG is locked behind the mining access.
/:cl:

Apparently, the explorers think that everything in the hangar that isn't locked belongs to them.

Remade the PR because screw git.