### PR TITLE
Fix EMP event unregistration and inconsistent /emp_act() override

### DIFF
--- a/code/datums/extensions/chameleon.dm
+++ b/code/datums/extensions/chameleon.dm
@@ -27,7 +27,7 @@
 /datum/extension/chameleon/Destroy()
 	if (emp_amount)
 		STOP_PROCESSING(SSobj, src)
-	GLOB.empd_event.unregister(item_holder)
+	GLOB.empd_event.unregister(item_holder, src)
 	item_holder.verbs -= chameleon_verbs
 	item_holder = null
 	return ..()

--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -44,7 +44,7 @@
 // This is a mainly physical thing, not affected by electricity
 /obj/item/integrated_circuit/input/toggle_button/emp_act(severity)
 	SHOULD_CALL_PARENT(FALSE)
-	GLOB.empd_event.raise_event(src, severity)
+	return
 
 /obj/item/integrated_circuit/input/toggle_button/get_topic_data(mob/user)
 	return list("Toggle [get_pin_data(IC_OUTPUT, 1) ? "Off" : "On"]" = "toggle=1")


### PR DESCRIPTION
Adds missing argument to `GLOB.empd_event.unregister()`
`/obj/item/integrated_circuit/input/toggle_button/emp_act(severity)` now also doesn't raise the EMPd event while otherwise ignoring being EMPd, same as other similar overrides.