### PR TITLE
no free merc ofd charges + add charges to uplink

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -509,6 +509,7 @@
 #include "code\datums\uplink\services.dm"
 #include "code\datums\uplink\stealth_and_camouflage_items.dm"
 #include "code\datums\uplink\stealthy_and_inconspicuous_weapons.dm"
+#include "code\datums\uplink\structures_and_vehicles.dm"
 #include "code\datums\uplink\telecrystals.dm"
 #include "code\datums\uplink\uplink_categories.dm"
 #include "code\datums\uplink\uplink_items.dm"

--- a/code/datums/uplink/structures_and_vehicles.dm
+++ b/code/datums/uplink/structures_and_vehicles.dm
@@ -1,0 +1,34 @@
+/datum/uplink_item/item/structures_and_vehicles
+	category = /datum/uplink_category/structures_and_vehicles
+
+
+/datum/uplink_item/item/structures_and_vehicles/ofd_charge_fire
+	name = "FR1-ENFER charge"
+	desc = "An obstruction field disperser charge that causes a localised fire."
+	antag_roles = list(MODE_MERCENARY)
+	item_cost = 80
+	path = /obj/structure/ship_munition/disperser_charge/fire
+
+
+/datum/uplink_item/item/structures_and_vehicles/ofd_charge_emp
+	name = "EM2-QUASAR charge"
+	desc = "An obstruction field disperser charge that emits an electromagnetic pulse."
+	antag_roles = list(MODE_MERCENARY)
+	item_cost = 80
+	path = /obj/structure/ship_munition/disperser_charge/emp
+
+
+/datum/uplink_item/item/structures_and_vehicles/ofd_charge_explosive
+	name = "XP4-INDARRA charge"
+	desc = "An obstruction field disperser charge that explodes."
+	antag_roles = list(MODE_MERCENARY)
+	item_cost = 80
+	path = /obj/structure/ship_munition/disperser_charge/explosive
+
+
+/datum/uplink_item/item/structures_and_vehicles/ofd_charge_mining
+	name = "MN3-BERGBAU charge"
+	desc = "An obstruction field disperser charge that extracts ore."
+	antag_roles = list(MODE_MERCENARY)
+	item_cost = 80
+	path = /obj/structure/ship_munition/disperser_charge/mining

--- a/code/datums/uplink/uplink_categories.dm
+++ b/code/datums/uplink/uplink_categories.dm
@@ -48,5 +48,8 @@
 /datum/uplink_category/badassery
 	name = "Badassery"
 
+/datum/uplink_category/structures_and_vehicles
+	name = "Structures & Vehicles"
+
 /datum/uplink_category/telecrystals
 	name = "Telecrystal Materialization"

--- a/maps/antag_spawn/mercenary/mercenary_base.dmm
+++ b/maps/antag_spawn/mercenary/mercenary_base.dmm
@@ -467,7 +467,6 @@
 /obj/machinery/disperser/back{
 	dir = 1
 	},
-/obj/structure/ship_munition/disperser_charge/emp,
 /turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
 "eR" = (
@@ -1922,11 +1921,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/map_template/merc_shuttle)
-"vZ" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/map_template/merc_shuttle)
 "wd" = (
 /obj/machinery/sleeper{
 	dir = 4
@@ -2295,11 +2289,11 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "Bj" = (
-/obj/floor_decal/industrial/outline/red,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/ship_munition/disperser_charge/explosive,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/merc_shuttle)
 "Bn" = (
@@ -5646,7 +5640,7 @@ tY
 kZ
 BA
 ew
-vZ
+uq
 qA
 AF
 xc


### PR DESCRIPTION
:cl:
maptweak: Removed the free OFD charges from the mercenary ship.
tweak: Added the "Structures & Vehicles" uplink category, containing 80tc OFD charges for mercenaries.
/:cl:

Might be too expensive initially but we'll see.

closes #34355 as a more moderate alternative