### PR TITLE
fixes rotation of soda machine in deck five aft ladderwell

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -6743,7 +6743,7 @@
 	dir = 6
 	},
 /obj/machinery/vending/cola{
-	dir = 4
+	dir = 8
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/hallway/primary/fifthdeck/aft)


### PR DESCRIPTION
🆑
tweak: shuttle pilot's soda machine rotation is fixed
/🆑

Words fail me.

![(null)scrnshot1](https://github.com/Baystation12/Baystation12/assets/44277885/0d9279e6-960d-421b-b511-6cd5db4f5d71)

You people are the architects of a dystopian future within my soul, constructing towering skyscrapers of despair within my chambers. These pelagic depths threaten to swallow me. They should swallow you, but you will all sink your own ships in time enough.

Peh.