### PR TITLE
Adds NTNRC Notifications and NT Relay Chat to PDA defaults

### DIFF
--- a/code/modules/modular_computers/computers/subtypes/preset_pda.dm
+++ b/code/modules/modular_computers/computers/subtypes/preset_pda.dm
@@ -13,6 +13,7 @@
 	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
 	if(os)
 		os.create_file(new/datum/computer_file/program/email_client())
+		os.create_file(new/datum/computer_file/program/chatclient())
 		os.create_file(new/datum/computer_file/program/crew_manifest())
 		os.create_file(new/datum/computer_file/program/wordprocessor())
 		os.create_file(new/datum/computer_file/program/records())

--- a/nano/templates/ntnet_chat.tmpl
+++ b/nano/templates/ntnet_chat.tmpl
@@ -4,13 +4,13 @@
 
 {{if data.title}}
 	<div class="itemLabel">
-		Current channel: 
+		Current channel:
 	</div>
 	<div class="itemContent">
 		{{:data.title}}
 	</div>
 	<div class="itemLabel">
-		Operator access: 
+		Operator access:
 	</div>
 	<div class="itemContent">
 		{{if data.is_operator}}
@@ -20,12 +20,13 @@
 		{{/if}}
 	</div>
 	<div class="itemLabel">
-		Controls: 
+		Controls:
 	</div>
 	<div class="itemContent">
 		<table>
 			<tr><td>{{:helper.link("Send message", null, {'PRG_speak' : 1})}}
 			<tr><td>{{:helper.link("Change nickname", null, {'PRG_changename' : 1})}}
+			<tr><td>{{:helper.link("Toggle notifications", null, {'PRG_mutenotif' : 1})}}
 			<tr><td>{{:helper.link("Toggle administration mode", null, {'PRG_toggleadmin' : 1})}}
 			<tr><td>{{:helper.link("Leave channel", null, {'PRG_leavechannel' : 1})}}
 			<tr><td>{{:helper.link("Save log to local drive", null, {'PRG_savelog' : 1})}}
@@ -35,7 +36,7 @@
 				<tr><td>{{:helper.link("Delete channel", null, {'PRG_deletechannel' : 1})}}
 			{{/if}}
 		</table>
-	</div>		
+	</div>
 	<b>Chat Window</b>
         <div class="statusDisplay" style="overflow: auto;">
 		<div class="item">
@@ -45,7 +46,7 @@
 				{{/for}}
 			</div>
 		</div>
-        </div>	
+        </div>
  	<b>Connected Users</b><br>
 	{{for data.clients}}
 		{{:value.name}}<br>
@@ -59,7 +60,7 @@
 	</table>
 	<b>Available channels:</b>
 	<table>
-	{{for data.all_channels}}		
+	{{for data.all_channels}}
 		<tr><td>{{:helper.link(value.chan, null, {'PRG_joinchannel' : value.id})}}<br>
 	{{/for}}
 	</table>


### PR DESCRIPTION
:cl:
rscadd: Added toggleable NRC notifications for join, leave, and message events.
tweak: The NRC program is 2GQ and installed on PDAs by default.
bugfix: Held computers can connect to NRC channels properly.
/🆑 

NTNet Relay Chat now alerts connected channel users to new users, users leaving, and new messages while minimized or while the PDA is in your pocket/bag/ID slot. For sanity's sake, there is a mute button you can use to toggle this on or off.

You do not receive notifications if someone with admin privileges toggled on joins or leaves a server. They're still a ghost who gets to spy on you!

Also adds NTNet Relay Chat to ship PDAs to encourage texting each other as much as emailing each other. Reduces the size of the chat client to 2 GQ because it shouldn't be 8 times the size of an email client.

![image](https://github.com/Baystation12/Baystation12/assets/67706292/921b809b-fd8e-4305-b3d2-628540c4936d)


<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->