### PR TITLE
Fixes C4 and runtime

### DIFF
--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -35,22 +35,27 @@
 
 /obj/item/plastique/attack_self(mob/user as mob)
 	var/newtime = input(usr, "Please set the timer.", "Timer", 10) as num
-	if(user.get_active_hand() == src)
+	if (newtime < 10)
+		to_chat(user, SPAN_WARNING("You cannot set the timer to be less than 10 seconds."))
+		return
+
+	if (user.get_active_hand() == src)
 		newtime = clamp(newtime, 10, 60000)
 		timer = newtime
 		to_chat(user, "Timer set for [timer] seconds.")
 
-/obj/item/plastique/use_after(atom/target, mob/living/user, click_parameters)
-	if (ismob(target) || istype(target, /turf/unsimulated) || istype(target, /turf/simulated/shuttle) || istype(target, /obj/item/storage) || istype(target, /obj/item/clothing/accessory/storage) || istype(target, /obj/item/clothing/under))
+/obj/item/plastique/use_after(atom/clicked, mob/living/user, click_parameters)
+	if (ismob(clicked) || istype(clicked, /turf/unsimulated) || istype(clicked, /turf/simulated/shuttle) || istype(clicked, /obj/item/clothing/accessory/storage) || istype(clicked, /obj/item/clothing/under))
 		return FALSE
 
 	to_chat(user, "Planting explosives...")
-	user.do_attack_animation(target)
+	user.do_attack_animation(clicked)
 
-	if(do_after(user, 5 SECONDS, target, DO_DEFAULT | DO_USER_UNIQUE_ACT) && in_range(user, target))
+	if(do_after(user, 5 SECONDS, clicked, DO_DEFAULT | DO_USER_UNIQUE_ACT) && in_range(user, clicked))
 		if(!user.unequip_item())
+			FEEDBACK_UNEQUIP_FAILURE(user, src)
 			return TRUE
-		target = target
+		target = clicked
 		forceMove(null)
 
 		if (ismob(target))

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -105,8 +105,7 @@
 /obj/item/melee/baton/throw_impact(atom/hit_atom, datum/thrownthing/TT)
 	if(istype(hit_atom,/mob/living))
 		apply_hit_effect(hit_atom, hit_zone = ran_zone(TT.target_zone, 30))//more likely to hit the zone you target!
-	else
-		..()
+	..()
 
 /obj/item/melee/baton/proc/set_status(newstatus, mob/user)
 	if(bcell && bcell.charge >= hitcost)

--- a/code/modules/mob/living/living_health.dm
+++ b/code/modules/mob/living/living_health.dm
@@ -57,7 +57,10 @@
 		if (DAMAGE_BRAIN)
 			adjustBrainLoss(damage)
 		else
-			apply_damage(damage, damage_type, def_zone, damage_flags, used_weapon, used_weapon.armor_penetration, TRUE)
+			if (used_weapon)
+				apply_damage(damage, damage_type, def_zone, damage_flags, used_weapon, used_weapon.armor_penetration, TRUE)
+			else
+				apply_damage(damage, damage_type, def_zone, damage_flags, silent = TRUE)
 	return prior_death_state != health_dead()
 
 


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: Fixes C4/Plastique. It now explodes again.
runtime: Fixes runtime when blob attacks people
/🆑 

At the moment; general_health_adjustment is never called with a used_weapon; so technically this runtime could also be fixed by just calling apply_damage() at the end without used_weapon and used_weapon.armorpenetration. Did it this way in case someone decides to call it with a weapon down the road; your call how you want it fixed.

Also fixed oversight in stun baton's throw impact proc.
Added better feedback to C4.