### PR TITLE
Makes collection mode toggleable oversight

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -281,14 +281,10 @@
 
 	if(istype(W, /obj/item/storage))
 		var/obj/item/storage/S = W
-		if(S.use_to_pickup)
-			if(S.collection_mode) //Mode is set to collect all items
-				if(isturf(src.loc))
-					S.gather_all(src.loc, user)
-					return TRUE
-			else if (S.can_be_inserted(src, user))
-				S.handle_item_insertion(src)
-				return TRUE
+		if (S.collection_mode && isturf(loc)) //Mode is set to collect all items
+			S.gather_all(loc, user)
+			return TRUE
+
 	return ..()
 
 ///Eventually should be deleted in favor of use_tool; keeping duplicate until downstream attackbys are replaced.
@@ -298,14 +294,10 @@
 
 	if(istype(W, /obj/item/storage))
 		var/obj/item/storage/S = W
-		if(S.use_to_pickup)
-			if(S.collection_mode) //Mode is set to collect all items
-				if(isturf(src.loc))
-					S.gather_all(src.loc, user)
-					return TRUE
-			else if (S.can_be_inserted(src, user))
-				S.handle_item_insertion(src)
-				return TRUE
+		if (S.collection_mode && isturf(loc)) //Mode is set to collect all items
+			S.gather_all(loc, user)
+			return TRUE
+
 	return ..()
 
 /obj/item/can_embed()

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -46,7 +46,7 @@
 	if (!worn_access && usr?.isEquipped(src, slot_back))
 		to_chat(usr, SPAN_WARNING("You can't insert \the [W] while \the [src] is on your back."))
 		return
-	..()
+	return ..()
 
 /obj/item/storage/backpack/open(mob/user)
 	if (!worn_access && user.isEquipped(src, slot_back))

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -2,9 +2,9 @@
 	Represents flexible bags that expand based on the size of their contents.
 */
 /obj/item/storage/bag
-	allow_quick_gather = 1
-	allow_quick_empty = 1
-	use_to_pickup = 1
+	allow_quick_gather = TRUE
+	allow_quick_empty = TRUE
+	collection_mode = TRUE
 	slot_flags = SLOT_BELT
 
 /obj/item/storage/bag/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -465,7 +465,8 @@
 	icon_state = "light"
 	desc = "This box is shaped on the inside so that only light tubes and bulbs fit."
 	item_state = "syringe_kit"
-	use_to_pickup = 1 // for picking up broken bulbs, not that most people will try
+	allow_quick_gather = TRUE
+	collection_mode = TRUE
 
 
 /obj/item/storage/box/lights/Initialize()

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -211,7 +211,8 @@
 	max_w_class = ITEM_SIZE_NORMAL
 	w_class = ITEM_SIZE_LARGE
 	max_storage_space = DEFAULT_LARGEBOX_STORAGE
-	use_to_pickup = TRUE
+	allow_quick_gather = TRUE
+	collection_mode = TRUE
 	temperature = -16 CELSIUS
 	matter = list(MATERIAL_PLASTIC = 350)
 	origin_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2)

--- a/code/game/objects/items/weapons/storage/laundry_basket.dm
+++ b/code/game/objects/items/weapons/storage/laundry_basket.dm
@@ -14,10 +14,9 @@
 	max_w_class = ITEM_SIZE_HUGE
 	max_storage_space = DEFAULT_BACKPACK_STORAGE //20 for clothes + a bit of additional space for non-clothing items that were worn on body
 	storage_slots = 14
-	use_to_pickup = 1
-	allow_quick_empty = 1
-	allow_quick_gather = 1
-	collection_mode = 1
+	allow_quick_empty = TRUE
+	allow_quick_gather = TRUE
+	collection_mode = TRUE
 	var/linked
 
 
@@ -79,7 +78,8 @@
 	icon = 'icons/obj/weapons/other.dmi'
 	icon_state = "offhand"
 	name = "second hand"
-	use_to_pickup = 0
+	collection_mode = FALSE
+	allow_quick_gather = FALSE
 
 /obj/item/storage/laundry_basket/offhand/dropped(mob/user as mob)
 	..()

--- a/code/game/objects/items/weapons/storage/pill_bottle.dm
+++ b/code/game/objects/items/weapons/storage/pill_bottle.dm
@@ -8,20 +8,21 @@
 	max_w_class = ITEM_SIZE_TINY
 	max_storage_space = 21
 	can_hold = list(/obj/item/reagent_containers/pill,/obj/item/dice,/obj/item/paper)
-	allow_quick_gather = 1
-	use_to_pickup = 1
+	allow_quick_gather = TRUE
+	allow_quick_empty = TRUE
+	collection_mode = TRUE
 	use_sound = 'sound/effects/storage/pillbottle.ogg'
 	matter = list(MATERIAL_PLASTIC = 250)
 	var/wrapper_color
 	var/label
 
 
-/obj/item/storage/pill_bottle/use_after(atom/target, mob/living/user)
-	if (!length(contents))
-		to_chat(user, SPAN_WARNING("It's empty!"))
-		return TRUE
-
+/obj/item/storage/pill_bottle/use_before(atom/target, mob/living/user)
 	if (istype(user) && target == user && user.can_eat())
+		if (!length(contents))
+			to_chat(user, SPAN_WARNING("\The [src] is empty!"))
+			return TRUE
+
 		user.visible_message(SPAN_NOTICE("[user] pops a pill from \the [src]."))
 		playsound(get_turf(src), 'sound/effects/peelz.ogg', 50)
 		var/list/peelz = filter_list(contents,/obj/item/reagent_containers/pill)
@@ -32,6 +33,9 @@
 			return TRUE
 
 	if (isobj(target) && target.is_open_container() && target.reagents)
+		if (!length(contents))
+			to_chat(user, SPAN_WARNING("\The [src] is empty!"))
+			return TRUE
 		if (!target.reagents.total_volume)
 			to_chat(user, SPAN_NOTICE("[target] is empty. Can't dissolve a pill."))
 			return TRUE
@@ -42,6 +46,8 @@
 			remove_from_storage(P)
 			P.use_after(target, user)
 			return TRUE
+
+	else return FALSE
 
 
 /obj/item/storage/pill_bottle/attack_self(mob/living/user)

--- a/code/game/objects/items/weapons/storage/specialized.dm
+++ b/code/game/objects/items/weapons/storage/specialized.dm
@@ -12,7 +12,7 @@
 	)
 	allow_quick_gather = TRUE
 	allow_quick_empty = TRUE
-	use_to_pickup = TRUE
+	collection_mode = TRUE
 
 
 /obj/item/storage/evidence
@@ -33,7 +33,7 @@
 	)
 	allow_quick_gather = TRUE
 	allow_quick_empty = TRUE
-	use_to_pickup = TRUE
+	collection_mode = TRUE
 
 
 /obj/item/storage/plants
@@ -52,7 +52,7 @@
 	)
 	allow_quick_gather = TRUE
 	allow_quick_empty = TRUE
-	use_to_pickup = TRUE
+	collection_mode = TRUE
 
 
 /obj/item/storage/sheetsnatcher
@@ -63,7 +63,8 @@
 	storage_ui = /datum/storage_ui/default/sheetsnatcher
 	w_class = ITEM_SIZE_NORMAL
 	storage_slots = 7
-	use_to_pickup = TRUE
+	collection_mode = TRUE
+	allow_quick_gather = TRUE
 	virtual = TRUE
 	var/max_sheets = 300
 	var/cur_sheets = 0

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -1,5 +1,5 @@
 // To clarify:
-// For use_to_pickup and allow_quick_gather functionality,
+// For allow_quick_gather functionality,
 // see item/attackby() (/game/objects/items.dm)
 // Do not remove this functionality without good reason, cough reagent_containers cough.
 // -Sayu
@@ -16,12 +16,11 @@
 	var/max_storage_space = null //Total storage cost of items this can hold. Will be autoset based on storage_slots if left null.
 	var/storage_slots = null //The number of storage slots in this container.
 
-	var/use_to_pickup	//Set this to make it possible to use this item in an inverse way, so you can have the item in your hand and click items on the floor to pick them up.
 	var/allow_quick_empty	//Set this variable to allow the object to have the 'empty' verb, which dumps all the contents on the floor.
 	var/allow_quick_gather	//Set this variable to allow the object to have the 'toggle mode' verb, which quickly collects all items from a tile.
 	///Allows dumping the contents of storage after a duration
 	var/allow_slow_dump
-	var/collection_mode = 1;  //0 = pick one at a time, 1 = pick all on tile
+	var/collection_mode //0 = pick one at a time, 1 = pick all on tile
 	var/use_sound = "rustle"	//sound played when used. null for no sound.
 
 	///If true, will not permit use of the storage UI
@@ -282,33 +281,35 @@
 
 //This proc is called when you want to place an item into the storage item.
 /obj/item/storage/use_tool(obj/item/W, mob/living/user, list/click_params)
-	if ((. = ..())) //if the item was used as a crafting component, just return
+	if (SSfabrication.try_craft_with(src, W, user))
 		return TRUE
 
-	if(isrobot(user) && (W == user.get_active_hand()))
+	if (isrobot(user) && (W == user.get_active_hand()))
 		return //Robots can't store their modules.
 
-	if(!can_be_inserted(W, user))
-		return
+	if (!can_be_inserted(W, user))
+		return TRUE
 
-	W.add_fingerprint(user)
-	handle_item_insertion(W)
-	return TRUE
+	if (handle_item_insertion(W))
+		return TRUE
+
+	return ..()
 
 ///Eventually should be deleted in favor of use_tool; keeping duplicate until downstream attackbys are replaced.
 /obj/item/storage/attackby(obj/item/W, mob/living/user, click_params)
-	if ((. = ..())) //if the item was used as a crafting component, just return
+	if (SSfabrication.try_craft_with(src, W, user))
 		return TRUE
 
-	if(isrobot(user) && (W == user.get_active_hand()))
+	if (isrobot(user) && (W == user.get_active_hand()))
 		return //Robots can't store their modules.
 
-	if(!can_be_inserted(W, user))
-		return
+	if (!can_be_inserted(W, user))
+		return TRUE
 
-	W.add_fingerprint(user)
-	handle_item_insertion(W)
-	return TRUE
+	if (handle_item_insertion(W))
+		return TRUE
+
+	return ..()
 
 /obj/item/storage/attack_hand(mob/user as mob)
 	if(ishuman(user))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -137,7 +137,7 @@
 /turf/attackby(obj/item/W as obj, mob/user as mob)
 	if(istype(W, /obj/item/storage))
 		var/obj/item/storage/S = W
-		if(S.use_to_pickup && S.collection_mode)
+		if(S.collection_mode)
 			S.gather_all(src, user)
 	return ..()
 

--- a/code/modules/research/part_replacer.dm
+++ b/code/modules/research/part_replacer.dm
@@ -7,10 +7,9 @@
 	w_class = ITEM_SIZE_HUGE
 	can_hold = list(/obj/item/stock_parts)
 	storage_slots = 50
-	use_to_pickup = 1
-	allow_quick_gather = 1
-	allow_quick_empty = 1
-	collection_mode = 1
+	allow_quick_gather = TRUE
+	allow_quick_empty = TRUE
+	collection_mode = TRUE
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = 100
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 3)

--- a/code/modules/xenoarcheaology/tools/tools_pickaxe.dm
+++ b/code/modules/xenoarcheaology/tools/tools_pickaxe.dm
@@ -179,7 +179,9 @@
 	can_hold = list(/obj/item/pickaxe/xeno)
 	max_storage_space = 18
 	max_w_class = ITEM_SIZE_NORMAL
-	use_to_pickup = 1
+	allow_quick_gather = TRUE
+	allow_quick_empty = TRUE
+	collection_mode = TRUE
 	startswith = list(
 		/obj/item/pickaxe/xeno/brush,
 		/obj/item/pickaxe/xeno/one_pick,
@@ -190,8 +192,9 @@
 		/obj/item/pickaxe/xeno/six_pick)
 
 /obj/item/storage/excavation/handle_item_insertion()
-	..()
-	sort_picks()
+	. = ..()
+	if (.)
+		sort_picks()
 
 /obj/item/storage/excavation/proc/sort_picks()
 	var/list/obj/item/pickaxe/xeno/picksToSort = list()


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: Fixes oversight where some storage items that could collect all items off a turf could not have that mode toggled off.
bugfix: Fixes being unable to use pill bottles on a storage object or reagent container
tweak: Removed behavior where clicking on a storage item on the floor with another storage item sometimes led to picking up the item off the floor.
tweak: Can now quickly empty pill bottles and the excavation pick set.
/🆑 

Fixes #34323 

use_to_pickup was redundant and served no good purpose. 
