### PR TITLE
Make Headshots Dangerous

### DIFF
--- a/code/modules/mob/grab/normal/grab_normal.dm
+++ b/code/modules/mob/grab/normal/grab_normal.dm
@@ -273,7 +273,7 @@
 
 	var/total_damage = 0
 	for(var/i in 1 to 3)
-		var/damage = min(W.force*2.5, 30)*damage_mod
+		var/damage = min(W.force*2, 30)*damage_mod
 		affecting.apply_damage(damage, W.damtype, BP_HEAD, damage_flags, armor_pen = 100, used_weapon=W)
 		total_damage += damage
 

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -167,7 +167,7 @@
 	organ_hit_chance = min(organ_hit_chance, 100)
 	if(prob(organ_hit_chance))
 		var/obj/item/organ/internal/victim = pickweight(victims)
-		damage_amt -= max(damage_amt*victim.damage_reduction, 0)
+		damage_amt -= damage_amt*victim.damage_reduction
 		victim.take_internal_damage(damage_amt)
 		return TRUE
 

--- a/code/modules/organs/internal/brain.dm
+++ b/code/modules/organs/internal/brain.dm
@@ -13,7 +13,7 @@
 	origin_tech = list(TECH_BIO = 3)
 	attack_verb = list("attacked", "slapped", "whacked")
 	relative_size = 85
-	damage_reduction = 0
+	damage_reduction = -1 //being hit in the brain is generally pretty bad for you, so deal extra damage
 	can_be_printed = FALSE
 
 	var/can_use_mmi = TRUE


### PR DESCRIPTION
:cl: karljohansson
tweak: Makes headshots, especially without armour, more dangerous
/:cl:

### Karl, Why?

1. Headshots currently are in a strange niche where they're hard to achieve and not very effective
2. This results in immersion-breaking events such as being shot in the back of the head and still being able to sprint away
3. This is a draft because I'm not certain on exact values or balancing
4. Making headshots more deadly also discourages non-combat personnel from getting involved in firefights because there's a real chance of being downed or even killed outright
5. Helmets are also made more useful
6. Also allows blunt objects to be used to knock out other players, although the amount of hits required means that it isn't just a cheap instant knockout

### Problems

1. Throat slitting may be too powerful now. This could be tweaked if needed.


### Can you stop?
Okay. I'll close this if I'm asked.

### Bugs?
Not that I'm aware of. It is still a draft, though, just in case.