### PR TITLE
IPC Antennae Fixes

### DIFF
--- a/code/modules/sprite_accessories/accessory_ipc.dm
+++ b/code/modules/sprite_accessories/accessory_ipc.dm
@@ -383,12 +383,11 @@
 	abstract_type = /datum/sprite_accessory/hair/ipc
 	icon = 'icons/mob/human_races/species/ipc/hair.dmi'
 	species_allowed = list(SPECIES_IPC)
-	gender = NEUTER
-	do_coloration = FALSE
 
 /datum/sprite_accessory/hair/ipc/ipc_bald
 	name = "None"
 	icon_state = "null"
+	do_coloration = FALSE
 
 /datum/sprite_accessory/hair/ipc/ipc_antennae
 	name = "Antennae"

--- a/code/modules/sprite_accessories/accessory_ipc.dm
+++ b/code/modules/sprite_accessories/accessory_ipc.dm
@@ -386,6 +386,10 @@
 	gender = NEUTER
 	do_coloration = FALSE
 
+/datum/sprite_accessory/hair/ipc/ipc_bald
+	name = "None"
+	icon_state = "null"
+
 /datum/sprite_accessory/hair/ipc/ipc_antennae
 	name = "Antennae"
 	icon_state = "antennae"


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Fixes IPC antennae rendering full-black instead of having their intended colors.
rscadd: Adds a `None` option to IPC hairs.
/:cl:

## Bug Fixes
- Fixes #34383