### PR TITLE
Fixes #34407

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -181,11 +181,13 @@
 	..()
 
 /obj/machinery/door/attack_hand(mob/user)
+	if ((. = ..()))
+		return
+
 	if (MUTATION_FERAL in user.mutations)
 		attack_generic(user, 15)
 		return
 
-	..()
 	if (allowed(user) && operable())
 		if (density)
 			open()


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: Using wirecutters/multitool on a door with an exposed panel no longer opens the door.
/🆑 

So turns out the same misplaced parent call was causing this bug on dev too; unrelated to refactor.
Pulled it out from the zombiefix PR and will do it as standalone PR. Up to devs if they want to wait for the zombiefix PR to minimize conflict resolution nonsense

Fixes #34407