### PR TITLE
Fixes hardsuit modules

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -124,9 +124,8 @@
 	if(!target.Adjacent(holder.wearer))
 		return 0
 
-	var/resolved = target.attackby(device,holder.wearer)
-	if(!resolved && device && target)
-		device.afterattack(target,holder.wearer,1)
+	var/mob/user = holder.wearer
+	device.resolve_attackby(target, user)
 	return 1
 
 


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: Fixes mounted hardsuit scanners, RCD, and defibrillator. They now work when you click on target using your preferred key combination
/🆑 

Fixes #34409

This was calling attackby. Some of these devices no longer have attackbys for starters. And even if they did, correct thing is to call resolve_attackby() at this point.

I noticed some QI/QoL stuff that can be done on hardsuit modules, added it to my list for the future.