### PR TITLE
Prevent Cultists from summoning nar-sie on shuttles or off-ship.

### DIFF
--- a/code/game/antagonist/station/cultist.dm
+++ b/code/game/antagonist/station/cultist.dm
@@ -51,6 +51,8 @@ GLOBAL_DATUM_INIT(cult, /datum/antagonist/cultist, new)
 	var/list/cult_rating_bounds = list(CULT_RUNES_1, CULT_RUNES_2, CULT_RUNES_3, CULT_GHOSTS_1, CULT_GHOSTS_2, CULT_GHOSTS_3)
 	var/max_cult_rating = 0
 	var/conversion_blurb = "You catch a glimpse of the Realm of Nar-Sie, the Geometer of Blood. You now see how flimsy the world is, you see that it should be open to the knowledge of That Which Waits. Assist your new compatriots in their dark dealings. Their goals are yours, and yours are theirs. You serve the Dark One above all else. Bring It back."
+	var/station_summon_only = TRUE
+	var/no_shuttle_summon = TRUE
 
 	faction = "cult"
 

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -781,6 +781,12 @@
 /obj/rune/tearreality/cast(mob/living/user)
 	if(!GLOB.cult.allow_narsie)
 		return
+	if (GLOB.cult.station_summon_only && !(get_z(user) in GLOB.using_map.station_levels))
+		to_chat(user, SPAN_OCCULT("Nar-Sie cannot be summoned here."))
+		return
+	if (GLOB.cult.no_shuttle_summon && istype(get_area(user), /area/shuttle))
+		to_chat(user, SPAN_OCCULT("Nar-Sie cannot be summoned on a shuttle."))
+		return
 	if(the_end_comes)
 		to_chat(user, SPAN_OCCULT("You are already summoning! Be patient!"))
 		return


### PR DESCRIPTION
:cl: Mucker
tweak: Cult members can no longer summon Nar-Sie offship or on shuttles. 
/:cl: