### PR TITLE
Reduce survival pod spawn rate, remove bearcat radio beacon and holopad

### DIFF
--- a/maps/away/bearcat/bearcat-1.dmm
+++ b/maps/away/bearcat/bearcat-1.dmm
@@ -2514,6 +2514,8 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/item/rcd_ammo,
+/obj/item/rcd_ammo,
 /turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/storage)
 "eI" = (

--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -146,7 +146,6 @@
 "av" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/hologram/holopad/longrange/remoteship,
 /obj/structure/cable/green{
 	d1 = 2;
 	d2 = 8;
@@ -174,8 +173,7 @@
 "ay" = (
 /obj/machinery/light,
 /obj/machinery/computer/modular/preset/engineering{
-	dir = 1;
-	icon_state = "console"
+	dir = 1
 	},
 /obj/item/device/radio/intercom/map_preset/bearcat{
 	dir = 4;
@@ -196,8 +194,7 @@
 "aA" = (
 /obj/machinery/light,
 /obj/machinery/computer/modular/preset/cardslot/command{
-	dir = 1;
-	icon_state = "console"
+	dir = 1
 	},
 /obj/machinery/alarm{
 	dir = 8;
@@ -5081,6 +5078,7 @@
 	},
 /obj/floor_decal/corner/red/diagonal,
 /obj/structure/window/reinforced,
+/obj/item/rcd,
 /turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/atmos)
 "je" = (
@@ -5693,9 +5691,9 @@
 /turf/simulated/floor,
 /area/ship/scrap/hidden)
 "PZ" = (
-/obj/machinery/radio_beacon,
-/turf/simulated/floor/bluegrid,
-/area/ship/scrap/comms)
+/obj/item/stock_parts/circuitboard/radio_beacon,
+/turf/simulated/floor,
+/area/ship/scrap/maintenance/engine/aft)
 "Qd" = (
 /obj/structure/cable/green{
 	d1 = 4;
@@ -12419,7 +12417,7 @@ Yv
 Yv
 ed
 ar
-PZ
+aH
 aO
 aX
 Yv
@@ -12704,7 +12702,7 @@ iV
 jg
 jt
 jG
-jF
+PZ
 jV
 jX
 jU

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -6,10 +6,10 @@ GLOBAL_LIST_INIT(crashed_pod_areas, new)
 	description = "A crashed survival pod from a destroyed ship."
 	suffixes = list("crashed_pod/crashed_pod.dmm")
 	spawn_cost = 1.5
-	player_cost = 2
+	player_cost = 4
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	ruin_tags = RUIN_HUMAN|RUIN_WRECK
-	spawn_weight = 0.33
+	spawn_weight = 0.25
 
 /area/map_template/crashed_pod
 	name = "\improper Crashed Survival Pod"


### PR DESCRIPTION
:cl: Mucker
tweak: Removed Bearcat's holopad and distress beacon. Added a radio beacon circuit board and a RCD.
tweak: Reduced Survival Pod's spawn rate so Exploration isn't constantly stuck doing rescues.
/:cl:

Should hopefully force survivors and Bearcat people to fend for themselves more often, and solve the headache of the Torch having to respond to these on a majority of round.