### PR TITLE
Fix chameleon stuff

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -677,7 +677,8 @@ GLOBAL_LIST_INIT(duplicate_object_disallowed_vars, list(
 	"key",
 	"group",
 	"ai_holder",
-	"natural_weapon"
+	"natural_weapon",
+	"extensions"
 ))
 
 

--- a/code/datums/datum.dm
+++ b/code/datums/datum.dm
@@ -26,8 +26,7 @@
 				qdel(extension)
 		extensions = null
 	GLOB.destroyed_event && GLOB.destroyed_event.raise_event(src)
-	if (!isturf(src))
-		cleanup_events(src)
+	cleanup_events(src)
 	var/list/machines = global.state_machines["\ref[src]"]
 	if (length(machines))
 		for (var/base_type in machines)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -115,7 +115,7 @@
 				set_extension(src, armor_type, armor, armor_degradation_speed)
 				break
 	if (item_flags & ITEM_FLAG_IS_CHAMELEON_ITEM)
-		SetupChameleonExtension(TRUE)
+		SetupChameleonExtension(CHAMELEON_FLEXIBLE_OPTIONS_EXTENSION, FALSE, TRUE)
 
 /obj/item/Destroy()
 	QDEL_NULL(hidden_uplink)

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -281,7 +281,7 @@
 	for(var/obj/holo_obj in holographic_objs)
 		holo_obj.alpha *= 0.8 //give holodeck objs a slight transparency
 		holo_obj.holographic = TRUE
-		holo_obj.SetupChameleonExtension()
+		holo_obj.SetupChameleonExtension(CHAMELEON_FLEXIBLE_OPTIONS_PARENT_TYPE, TRUE, FALSE)
 
 	if(HP.ambience)
 		linkedholodeck.forced_ambience = HP.ambience.Copy()


### PR DESCRIPTION
Two performance enhancements:
* The chameleon extension didn't actually cache the list of chameleon choices, this has been fixed.
* When using the auto-setup, instances that only match the base /extension/chameleon-type are excluded. The reason being that generating all possible options for `/obj/item` cause an hefty initial lag spike before being cached.

The `SetupChameleonExtension()`-proc has been made more flexible and thus able of covering more use-cases.

Fixes holo-items having extensions with incorrect `holder`-references by simply not cloning extensions.