### PR TITLE
Add emissives to air alarms, lights, and switches

### DIFF
--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -355,7 +355,10 @@
 			new_color = COLOR_SUN
 		if (2)
 			new_color = COLOR_RED_LIGHT
-	AddOverlays(overlay_image(icon, "alarm[icon_level]", plane = EFFECTS_ABOVE_LIGHTING_PLANE, layer = ABOVE_LIGHTING_LAYER))
+	AddOverlays(list(
+		emissive_appearance(icon, "alarm[icon_level]"),
+		image(icon, "alarm[icon_level]")
+	))
 
 	pixel_x = 0
 	pixel_y = 0

--- a/code/game/machinery/lightswitch.dm
+++ b/code/game/machinery/lightswitch.dm
@@ -12,7 +12,6 @@
 	var/on = 0
 	var/area/connected_area = null
 	var/other_area = null
-	var/image/overlay
 
 /obj/machinery/light_switch/Initialize()
 	. = ..()
@@ -28,20 +27,18 @@
 	update_icon()
 
 /obj/machinery/light_switch/on_update_icon()
-	if(!overlay)
-		overlay = image(icon, "light1-overlay")
-		overlay.plane = EFFECTS_ABOVE_LIGHTING_PLANE
-		overlay.layer = ABOVE_LIGHTING_LAYER
-
 	ClearOverlays()
 	if(inoperable())
 		icon_state = "light-p"
 		set_light(0)
 	else
 		icon_state = "light[on]"
-		overlay.icon_state = "light[on]-overlay"
-		AddOverlays(overlay)
-		set_light(2, 0.25, on ? "#82ff4c" : "#f86060")
+		var/color = on ? "#82ff4c" : "#f86060"
+		AddOverlays(list(
+			emissive_appearance(icon, "light[on]-overlay"),
+			overlay_image(icon, "light[on]-overlay", color)
+		))
+		set_light(2, 0.25, color)
 
 /obj/machinery/light_switch/examine(mob/user, distance)
 	. = ..()

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -297,12 +297,9 @@
 			on = FALSE
 
 	if(istype(lightbulb, /obj/item/light))
-		var/image/I = image(icon, src, _state)
-		I.color = get_mode_color()
 		if (on)
-			I.plane = EFFECTS_ABOVE_LIGHTING_PLANE
-			I.layer = ABOVE_LIGHTING_LAYER
-		AddOverlays(I)
+			AddOverlays(emissive_appearance(icon, _state))
+		AddOverlays(overlay_image(icon, _state, color))
 
 	if(on)
 


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
tweak: Lights, switches, and air alarms now use emissive overlays.
/:cl: