### PR TITLE
Move punitelli to safer spawns

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -5007,9 +5007,9 @@
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/door/window/northright{
+	autoset_access = 0;
 	name = "suit storage";
-	req_access = list("ACCESS_MINING");
-	autoset_access = 0
+	req_access = list("ACCESS_MINING")
 	},
 /obj/item/rig/industrial/equipped,
 /obj/structure/window/reinforced{
@@ -8724,8 +8724,8 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
-	name = "Canister Storage";
 	autoset_access = 0;
+	name = "Canister Storage";
 	req_access = list("ACCESS_TOX_STORAGE")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
@@ -8785,8 +8785,8 @@
 "tj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/research{
-	name = "Canister Storage";
 	autoset_access = 0;
+	name = "Canister Storage";
 	req_access = list("ACCESS_TOX_STORAGE")
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden{

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -1093,6 +1093,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/random_multi/single_item/punitelli,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/head/deck4)
 "dI" = (
@@ -4100,6 +4101,7 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 4
 	},
+/obj/random_multi/single_item/punitelli,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/laundry)
 "nZ" = (
@@ -4390,6 +4392,11 @@
 /obj/random/soap,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/laundry)
+"pj" = (
+/obj/structure/table/standard,
+/obj/random_multi/single_item/punitelli,
+/turf/simulated/floor/tiled,
+/area/crew_quarters/diplomatic_office)
 "pl" = (
 /obj/floor_decal/industrial/outline/grey,
 /obj/machinery/suit_storage_unit/standard_unit,
@@ -5213,6 +5220,7 @@
 	},
 /obj/floor_decal/industrial/outline/yellow,
 /obj/catwalk_plated,
+/obj/random_multi/single_item/punitelli,
 /turf/simulated/floor/plating,
 /area/storage/primary)
 "sw" = (
@@ -7327,8 +7335,8 @@
 	},
 /obj/structure/table/woodentable/walnut,
 /obj/item/storage/box/silverware{
-	pixel_y = 10;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 10
 	},
 /obj/item/storage/box/silverware{
 	pixel_x = -3;
@@ -16326,12 +16334,12 @@
 	},
 /obj/structure/table/woodentable/walnut,
 /obj/item/reagent_containers/food/drinks/bottle/premiumwine{
-	pixel_y = 15;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = 15
 	},
 /obj/item/reagent_containers/food/drinks/bottle/tadmorwine{
-	pixel_y = 15;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 15
 	},
 /obj/item/reagent_containers/food/drinks/bottle/champagne{
 	pixel_x = -6;
@@ -29173,7 +29181,7 @@ tv
 tv
 LZ
 PY
-PY
+pj
 PY
 Ct
 Oh

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -405,6 +405,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 10
 	},
+/obj/random_multi/single_item/punitelli,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/gym)
 "bx" = (
@@ -5164,6 +5165,7 @@
 	},
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/hologram/holopad,
+/obj/random_multi/single_item/punitelli,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/thirddeck)
 "lE" = (
@@ -8106,6 +8108,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
+/obj/random_multi/single_item/punitelli,
 /turf/simulated/floor/lino,
 /area/crew_quarters/office)
 "sI" = (
@@ -9607,6 +9610,7 @@
 	dir = 8;
 	pixel_x = 21
 	},
+/obj/random_multi/single_item/punitelli,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/sleep/bunk)
 "wY" = (
@@ -12076,6 +12080,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/random_multi/single_item/punitelli,
 /turf/simulated/floor/tiled/dark,
 /area/crew_quarters/service_break_room)
 "DU" = (
@@ -13869,34 +13874,52 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/hallway/primary/thirddeck/fore)
 "ID" = (
-/obj/random_multi/single_item/punitelly,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/random_multi/single_item/punitelli,
 /turf/simulated/floor/tiled,
-/area/vacant/brig)
+/area/crew_quarters/gym)
 "IE" = (
-/obj/random_multi/single_item/punitelly,
-/turf/simulated/floor/plating,
-/area/maintenance/thirddeck/starboard)
+/obj/random_multi/single_item/punitelli,
+/turf/simulated/floor/carpet,
+/area/crew_quarters/recreation)
 "IF" = (
 /obj/structure/sign/poster/torch,
 /turf/simulated/wall/prepainted,
 /area/crew_quarters/recreation)
 "IH" = (
-/obj/structure/table/steel,
-/obj/random_multi/single_item/punitelly,
-/turf/simulated/floor/tiled/dark,
-/area/vacant/cabin)
+/obj/random_multi/single_item/punitelli,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/head)
 "II" = (
-/obj/random_multi/single_item/punitelly,
-/turf/simulated/floor/tiled/dark,
-/area/vacant/cabin)
-"IJ" = (
-/obj/random_multi/single_item/punitelly,
-/obj/structure/railing/mapped{
-	dir = 4;
-	icon_state = "railing0-1"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/turf/simulated/floor/plating,
-/area/maintenance/thirddeck/aftport)
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/random_multi/single_item/punitelli,
+/turf/simulated/floor/tiled/dark,
+/area/chapel/main)
+"IJ" = (
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/disposalpipe/segment,
+/obj/random_multi/single_item/punitelli,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/cryo)
 "IK" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -16149,7 +16172,6 @@
 /turf/simulated/floor/tiled,
 /area/hallway/primary/thirddeck/fore)
 "NO" = (
-/obj/random_multi/single_item/punitelly,
 /obj/decal/cleanable/dirt,
 /turf/simulated/floor/plating,
 /area/vacant/mess)
@@ -16262,12 +16284,12 @@
 	pixel_y = 10
 	},
 /obj/item/reagent_containers/glass/rag{
-	pixel_y = 4;
-	pixel_x = -3
+	pixel_x = -3;
+	pixel_y = 4
 	},
 /obj/item/reagent_containers/glass/rag{
-	pixel_y = 4;
-	pixel_x = 3
+	pixel_x = 3;
+	pixel_y = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -16325,6 +16347,7 @@
 	},
 /obj/structure/table/standard,
 /obj/random_multi/single_item/runtime,
+/obj/random_multi/single_item/punitelli,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/mess)
 "Om" = (
@@ -17133,7 +17156,6 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/random_multi/single_item/punitelly,
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /obj/floor_decal/industrial/outline/grey,
 /turf/simulated/floor/tiled/techfloor,
@@ -18388,6 +18410,7 @@
 	dir = 4
 	},
 /obj/random/date_based/christmas/tree/fountain,
+/obj/random_multi/single_item/punitelli,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/observation)
 "Ui" = (
@@ -31203,7 +31226,7 @@ mS
 pF
 zj
 pH
-jb
+ID
 Wb
 jb
 ur
@@ -32631,7 +32654,7 @@ CF
 CF
 My
 qu
-qu
+IE
 qu
 uC
 IF
@@ -37487,7 +37510,7 @@ vW
 yd
 yW
 vW
-vW
+IJ
 vW
 vW
 Dd
@@ -39706,7 +39729,7 @@ cV
 uU
 fo
 YK
-YK
+IH
 gK
 TZ
 hL
@@ -41492,18 +41515,18 @@ ae
 aq
 ao
 We
-ID
+ae
 ag
 az
 ag
 ag
 aE
-IE
+aY
 aY
 PP
 cl
 dd
-IE
+aY
 cl
 da
 dD
@@ -42141,7 +42164,7 @@ Ov
 JV
 ub
 ED
-II
+Fj
 FN
 ub
 ko
@@ -43958,7 +43981,7 @@ Do
 DZ
 ub
 Fk
-IH
+FN
 Gm
 GO
 ub
@@ -44567,7 +44590,7 @@ ED
 ub
 ub
 ub
-IJ
+Tk
 Tk
 jZ
 jZ
@@ -44757,7 +44780,7 @@ vn
 Eh
 Mj
 uq
-Mj
+II
 XY
 WA
 ZW

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -2736,7 +2736,6 @@
 /area/maintenance/seconddeck/forestarboard)
 "fw" = (
 /obj/floor_decal/corner/yellow/diagonal,
-/obj/random_multi/single_item/punitelly,
 /turf/simulated/floor/tiled/freezer,
 /area/maintenance/seconddeck/forestarboard)
 "fx" = (
@@ -12289,10 +12288,6 @@
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/foyer)
-"EQ" = (
-/obj/random_multi/single_item/punitelly,
-/turf/simulated/floor/plating,
-/area/vacant/chapel)
 "ES" = (
 /obj/machinery/atmospherics/pipe/manifold/visible/cyan{
 	dir = 4
@@ -15648,15 +15643,6 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck)
-"PO" = (
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/random_multi/single_item/punitelly,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/seconddeck/forestarboard)
 "PP" = (
 /obj/machinery/door/blast/regular/escape_pod{
 	dir = 4
@@ -15983,10 +15969,6 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
-"QR" = (
-/obj/random_multi/single_item/punitelly,
-/turf/simulated/floor/plating,
-/area/maintenance/seconddeck/forestarboard)
 "QT" = (
 /obj/structure/sign/warning/vent_port{
 	dir = 1
@@ -30804,7 +30786,7 @@ JX
 fd
 bd
 bd
-QR
+bd
 bd
 GY
 Gs
@@ -31609,7 +31591,7 @@ JX
 JX
 dO
 dq
-EQ
+dq
 dq
 dr
 dq
@@ -34027,7 +34009,7 @@ JX
 JX
 JX
 bc
-PO
+vH
 ch
 cL
 cN

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -14032,6 +14032,7 @@
 /area/space)
 "aXh" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
+/obj/random_multi/single_item/punitelli,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/firstdeck)
 "aYj" = (
@@ -15422,6 +15423,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/random_multi/single_item/punitelli,
 /turf/simulated/floor/tiled/techfloor,
 /area/crew_quarters/safe_room/medical)
 "cHj" = (
@@ -16974,6 +16976,7 @@
 /obj/floor_decal/scglogo{
 	dir = 8
 	},
+/obj/random_multi/single_item/punitelli,
 /turf/simulated/floor/tiled/dark,
 /area/command/conference)
 "eVQ" = (
@@ -17921,6 +17924,10 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/exam_room)
+"gSl" = (
+/obj/random_multi/single_item/punitelli,
+/turf/simulated/floor/tiled/freezer,
+/area/crew_quarters/head/deck1)
 "gVR" = (
 /obj/floor_decal/corner/blue{
 	dir = 6
@@ -19488,6 +19495,10 @@
 /obj/floor_decal/corner/research/half,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/firstdeck/center)
+"iUs" = (
+/obj/random_multi/single_item/punitelli,
+/turf/simulated/floor/tiled/white,
+/area/crew_quarters/sleep/cryo/aux)
 "iVb" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/green{
@@ -22556,6 +22567,7 @@
 	dir = 4
 	},
 /obj/random_multi/single_item/poppy,
+/obj/random_multi/single_item/punitelli,
 /turf/simulated/floor/selfestructgrid,
 /area/security/nuke_storage)
 "mOb" = (
@@ -44980,7 +44992,7 @@ adx
 aAm
 aaL
 abR
-riD
+gSl
 riD
 ado
 ltt
@@ -47610,7 +47622,7 @@ aDY
 aDY
 aDY
 aHe
-aDY
+iUs
 aJP
 aDY
 aDY

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -2127,6 +2127,7 @@
 /obj/random_multi/single_item/memo_scgr,
 /obj/random_multi/single_item/memo_command,
 /obj/random_multi/single_item/memo_corporate,
+/obj/random_multi/single_item/punitelli,
 /turf/simulated/floor/carpet/blue2,
 /area/bridge/meeting_room)
 "dQ" = (
@@ -13643,6 +13644,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/random_multi/single_item/punitelli,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
 "Qh" = (

--- a/maps/torch/torch_npcs.dm
+++ b/maps/torch/torch_npcs.dm
@@ -1,4 +1,4 @@
-/obj/random_multi/single_item/punitelly
+/obj/random_multi/single_item/punitelli
 	name = "Multi Point - Warrant Officer Punitelli"
 	id = "Punitelli"
 	item_path = /mob/living/carbon/human/monkey/punitelli


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
tweak: Punitelli now spawns in various random rooms instead of in maintenance and other dangerous places.
/:cl:

## Other Changes
- Renamed `/obj/random_multi/single_item/punitelly` to `/obj/random_multi/single_item/punitelli`