### PR TITLE
robots can no longer roll for traitor

### DIFF
--- a/maps/torch/torch_antagonism.dm
+++ b/maps/torch/torch_antagonism.dm
@@ -21,6 +21,7 @@
 
 /datum/antagonist/traitor
 	blacklisted_jobs = list(/datum/job/merchant, /datum/job/captain, /datum/job/hop, /datum/job/ai, /datum/job/submap, /datum/job/hos, /datum/job/medical_trainee, /datum/job/engineer_trainee, /datum/job/junior_doctor)
+	restricted_jobs = list(/datum/job/lawyer, /datum/job/cyborg)
 
 /datum/antagonist/ert
 	var/sic //Second-In-Command


### PR DESCRIPTION
:cl: Mucker
rscdel: Robots can no longer roll traitor. 
/:cl:

Change comes after a long time of observing, pondering, thinking, and judging how people respond to antag robots. Antag borg abilities and playstyles have consistently seemed to be at odds with what can be described as 'fun' and 'engaging' to the rest of the players, thus we are here.

Note: robots can still be subverted via emag by other traitors, that behavior has not changed. They can also still be given the role directly via the traitor panel.
Also note: the 'lawyer' job was already restricted, just had to carry it over from the default list.