### PR TITLE
Fix broken borg overlays

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -881,11 +881,7 @@
 			if(!eye_overlay)
 				eye_overlay = image(icon, eye_icon_state)
 				var/mutable_appearance/A = emissive_appearance(icon, eye_icon_state)
-				A.render_target = "*I am testing stuff ok"
-				eye_overlay.filters += filter(type = "layer", render_source = "*I am testing stuff ok")
 				eye_overlay.AddOverlays(A)
-				//eye_overlay.plane = EFFECTS_ABOVE_LIGHTING_PLANE
-				//eye_overlay.layer = EYE_GLOW_LAYER
 				eye_overlays[eye_icon_state] = eye_overlay
 				z_flags |= ZMM_MANGLE_PLANES
 			AddOverlays(eye_overlay)


### PR DESCRIPTION
Go yell at Crimson for leaving test lines in his PR.

## Changelog
:cl: SierraKomodo
bugfix: Fixes borgs having broken and weirdly cached/synchronized eye overlays that had no color.
/:cl:

## Bug Fixes
- Fixes #34435