### PR TITLE
Fix robotics fabricator not animating

### DIFF
--- a/code/game/machinery/robotics_fabricator.dm
+++ b/code/game/machinery/robotics_fabricator.dm
@@ -53,11 +53,12 @@
 	if(panel_open)
 		AddOverlays("[icon_state]_panel")
 	if(is_powered())
-		AddOverlays(emissive_appearance(icon, "[icon_state]_lights"))
-		AddOverlays("[icon_state]_lights")
-	else if(busy)
-		AddOverlays(emissive_appearance(icon, "[icon_state]_lights_working"))
-		AddOverlays("[icon_state]_lights_working")
+		if (busy)
+			AddOverlays(emissive_appearance(icon, "[icon_state]_lights_working"))
+			AddOverlays("[icon_state]_lights_working")
+		else
+			AddOverlays(emissive_appearance(icon, "[icon_state]_lights"))
+			AddOverlays("[icon_state]_lights")
 
 /obj/machinery/robotics_fabricator/dismantle()
 	for(var/f in materials)


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Fixes robotics fabricator machines not properly animating while printing.
/:cl:

## Bug Fixes
- Fixes #34432

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->