### PR TITLE
Fix ironing board runtimes when ironing clothes

### DIFF
--- a/code/game/objects/structures/ironing_board.dm
+++ b/code/game/objects/structures/ironing_board.dm
@@ -186,8 +186,9 @@
 			)
 			if (!do_after(user, 5 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
 				return TRUE
-			if (!iron.iron_enabled)
-				USE_FEEDBACK_FAILURE("\The [src] wasn't turned on!")
+			var/obj/item/ironing_iron/used_iron = tool
+			if (!used_iron.iron_enabled)
+				USE_FEEDBACK_FAILURE("\The [used_iron] wasn't turned on!")
 				return TRUE
 			clothing.ironed_state = WRINKLES_NONE
 			user.visible_message(


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Fixes ironing boards and irons not de-wrinkling clothing.
/:cl:

## Bug Fixes
- Fixes #34423

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->