### PR TITLE
remove robot flying module's gun

### DIFF
--- a/code/modules/mob/living/silicon/robot/flying/module_flying.dm
+++ b/code/modules/mob/living/silicon/robot/flying/module_flying.dm
@@ -10,6 +10,5 @@
 	emag_gear = list(
 		/obj/item/melee/baton/robot/electrified_arm,
 		/obj/item/device/flash,
-		/obj/item/gun/energy/gun,
 		/obj/item/borg/combat/shield
 	)


### PR DESCRIPTION
:cl: Mucker
rscdel: Removed the e-gun from the flying borg module's emag/antag tools. 
/:cl:

Missed this in the pr removing guns from all borg modules.