### PR TITLE
Vending machines have standardized health

### DIFF
--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -89,6 +89,17 @@
 	RefreshParts()
 	power_change()
 
+/obj/machinery/post_health_change(health_mod, prior_health, damage_type)
+	if (health_mod < 0 && !health_dead())
+		var/initial_damage_percentage = Percent(get_max_health() - prior_health, get_max_health(), 0)
+		var/damage_percentage = get_damage_percentage()
+		if (damage_percentage >= 75 && initial_damage_percentage < 75)
+			visible_message("\The [src] looks like it's about to break!" )
+		else if (damage_percentage >= 50 && initial_damage_percentage < 50)
+			visible_message("\The [src] looks seriously damaged!" )
+		else if (damage_percentage >= 25 && initial_damage_percentage < 25)
+			visible_message("\The [src] shows signs of damage!" )
+
 /obj/machinery/Destroy()
 	if(istype(wires))
 		QDEL_NULL(wires)

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -289,16 +289,6 @@
 /obj/machinery/door/post_health_change(health_mod, prior_health, damage_type)
 	. = ..()
 	queue_icon_update()
-	if (health_mod < 0 && !health_dead())
-		var/initial_damage_percentage = round((prior_health / get_max_health()) * 100)
-		var/damage_percentage = get_damage_percentage()
-		if (damage_percentage >= 75 && initial_damage_percentage < 75)
-			visible_message("\The [src] looks like it's about to break!" )
-		else if (damage_percentage >= 50 && initial_damage_percentage < 50)
-			visible_message("\The [src] looks seriously damaged!" )
-		else if (damage_percentage >= 25 && initial_damage_percentage < 25)
-			visible_message("\The [src] shows signs of damage!" )
-
 
 /obj/machinery/door/on_revive()
 	. = ..()

--- a/code/game/machinery/vending/coffee.dm
+++ b/code/game/machinery/vending/coffee.dm
@@ -71,7 +71,5 @@
 
 /obj/machinery/vending/coffee/on_update_icon()
 	..()
-	if (MACHINE_IS_BROKEN(src) && prob(20))
-		icon_state = "[initial(icon_state)]-hellfire"
-	else if (is_powered())
+	if (is_powered())
 		AddOverlays(image(icon, "[initial(icon_state)]-screen"))

--- a/code/modules/xenoarcheaology/artifacts/artifact.dm
+++ b/code/modules/xenoarcheaology/artifacts/artifact.dm
@@ -208,15 +208,6 @@
 	..()
 	queue_icon_update()
 	if (health_mod < 0)
-		var/initial_damage_percentage = round((prior_health / get_max_health()) * 100)
-		var/damage_percentage = get_damage_percentage()
-		if (damage_percentage >= 75 && initial_damage_percentage < 75)
-			visible_message("\The [src] looks like it's about to break!")
-		else if (damage_percentage >= 50 && initial_damage_percentage < 50)
-			visible_message("\The [src] looks seriously damaged!" )
-		else if (damage_percentage >= 25 && initial_damage_percentage < 25)
-			visible_message("\The [src] shows signs of damage!" )
-
 		for (var/datum/artifact_effect/A in list(my_effect, secondary_effect))
 			A.holder_damaged(get_current_health(), abs(health_mod))
 

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -48,7 +48,7 @@ exactly 24 "text2path uses" 'text2path'
 exactly 4 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 4 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 342 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 341 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 0 "anchored = 0/1" 'anchored\s*=\s*\d' -P
 exactly 2 "density = 0/1" 'density\s*=\s*\d' -P


### PR DESCRIPTION
🆑 emmanuelbassil
tweak: Vending machines are now destructible. They have a chance to start speaking, randomly have wires cut, or completely malfunction as they are more and more damaged.
tweak: Vending machines with the speaker enabled speak a slogan every two minutes instead of 10. Speaker disabled by default.
/🆑 

Changed slogan_delay to 2 minutes since 10 minutes is excessive given all machines start muted by default. 
Fixed malfunction proc as it dumped the first item on its list every time. Also had chance to dump antag products.
