### PR TITLE
null equality to isnull

### DIFF
--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -148,7 +148,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 
 /proc/LinkBlocked(turf/A, turf/B)
-	if(A == null || B == null) return 1
+	if(isnull(A) || isnull(B)) return 1
 	var/adir = get_dir(A,B)
 	var/rdir = get_dir(B,A)
 	if((adir & (NORTH|SOUTH)) && (adir & (EAST|WEST)))	//	diagonal

--- a/code/controllers/subsystems/ambient_lighting.dm
+++ b/code/controllers/subsystems/ambient_lighting.dm
@@ -167,7 +167,7 @@ SUBSYSTEM_DEF(ambient_lighting) //A simple SS that handles updating ambient ligh
  */
 /datum/controller/subsystem/ambient_lighting/proc/create_ambient_group(color, multiplier)
 
-	if(ambient_groups[SPACE_AMBIENT_GROUP] == null) //Something (probably a planet) wants to add an ambient group, add space first
+	if(isnull(ambient_groups[SPACE_AMBIENT_GROUP])) //Something (probably a planet) wants to add an ambient group, add space first
 		add_space_ambient_group()
 
 	// Find the first free index in the bitmap.
@@ -196,7 +196,7 @@ SUBSYSTEM_DEF(ambient_lighting) //A simple SS that handles updating ambient ligh
 
 /datum/controller/subsystem/ambient_lighting/Initialize(start_timeofday)
 	//Create space ambient group if nothing created it until now.
-	if(ambient_groups[SPACE_AMBIENT_GROUP] == null)
+	if(isnull(ambient_groups[SPACE_AMBIENT_GROUP]))
 		add_space_ambient_group()
 
 	fire(FALSE, TRUE)

--- a/code/controllers/subsystems/zcopy.dm
+++ b/code/controllers/subsystems/zcopy.dm
@@ -261,7 +261,7 @@ SUBSYSTEM_DEF(zcopy)
 			TO.plane = t_target
 			TO.mouse_opacity = initial(TO.mouse_opacity)
 
-		T.queue_ao(T.ao_neighbors_mimic == null)	// If ao_neighbors hasn't been set yet, we need to do a rebuild
+		T.queue_ao(isnull(T.ao_neighbors_mimic))	// If ao_neighbors hasn't been set yet, we need to do a rebuild
 
 		// Explicitly copy turf delegates so they show up properly on below levels.
 		//   I think it's possible to get this to work without discrete delegate copy objects, but I'd rather this just work.
@@ -538,7 +538,7 @@ SUBSYSTEM_DEF(zcopy)
 
 	return MA
 
-#define FMT_DEPTH(X) (X == null ? "(null)" : X)
+#define FMT_DEPTH(X) (isnull(X) ? "(null)" : X)
 
 // This is a dummy object used so overlays can be shown in the analyzer.
 /atom/movable/openspace/debug

--- a/code/controllers/subsystems/zcopy.dm
+++ b/code/controllers/subsystems/zcopy.dm
@@ -495,7 +495,7 @@ SUBSYSTEM_DEF(zcopy)
 
 		if (mutated)
 			for (var/i in 1 to length(fixed_overlays))
-				if (fixed_overlays[i] == null)
+				if (isnull(fixed_overlays[i]))
 					fixed_overlays[i] = appearance:overlays[i]
 
 	// Scan & fix underlays
@@ -512,7 +512,7 @@ SUBSYSTEM_DEF(zcopy)
 
 		if (mutated)
 			for (var/i in 1 to  length(fixed_overlays))
-				if (fixed_underlays[i] == null)
+				if (isnull(fixed_underlays[i]))
 					fixed_underlays[i] = appearance:underlays[i]
 
 	// If we did nothing (no violations), don't bother creating a new appearance

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -200,7 +200,7 @@
 //so that they do not occupy regular job slots. All other antag roles should be spawned after jobs are
 //assigned, so that job restrictions can be respected.
 /datum/antagonist/proc/attempt_spawn(spawn_target = null)
-	if(spawn_target == null)
+	if(isnull(spawn_target))
 		spawn_target = initial_spawn_target
 
 	// Update our boundaries.

--- a/code/game/gamemodes/changeling/modularchangling.dm
+++ b/code/game/gamemodes/changeling/modularchangling.dm
@@ -460,7 +460,7 @@ var/global/list/datum/power/changeling/powerinstances = list()
 			break
 
 
-	if(Thepower == null)
+	if(isnull(Thepower))
 		to_chat(M.current, "This is awkward.  Changeling power purchase failed, please report this bug to a coder!")
 		return
 

--- a/code/game/machinery/computer/arcade_orion.dm
+++ b/code/game/machinery/computer/arcade_orion.dm
@@ -87,7 +87,7 @@
 
 /obj/machinery/computer/arcade/orion_trail/interact(mob/user)
 	var/dat = ""
-	if(event == null)
+	if(isnull(event))
 		newgame()
 	user.set_machine(src)
 	switch(view)
@@ -201,7 +201,7 @@
 
 			if(!href_list["food"])
 				var/temp = supplies["5"] - travel/1000 * (href_list["slow"] ? 2 : 1)
-				if(temp < 0 && (distance-travel != 0) && next_event == null) //uh oh. Better start a fuel event.
+				if(temp < 0 && (distance-travel != 0) && isnull(next_event)) //uh oh. Better start a fuel event.
 					next_event = ORION_TRAIL_STUCK
 					travel -= (temp*-1)*1000/(href_list["slow"] ? 2 : 1)
 					temp = 0
@@ -219,7 +219,7 @@
 				event_desc = "You and your crew starved to death, never to reach Orion."
 				supplies["4"] = 0
 
-			if(distance == 0 && next_event == null) //POOORT!
+			if(distance == 0 && isnull(next_event)) //POOORT!
 				port++
 				event = ORION_TRAIL_SPACEPORT
 				distance = stop_distance[port]
@@ -294,7 +294,7 @@
 	if(!specific)
 		specific = rand(1,length(settlers))
 
-	event_info += "The crewmember, [settlers[specific]] [desc == null ? "has died!":"[desc]"]<BR>"
+	event_info += "The crewmember, [settlers[specific]] [isnull(desc) ? "has died!":"[desc]"]<BR>"
 	settlers -= settlers[specific]
 	if(num_traitors > 0 && prob(100/max(1,length(settlers)-1)))
 		num_traitors--

--- a/code/game/machinery/computer/message.dm
+++ b/code/game/machinery/computer/message.dm
@@ -286,7 +286,7 @@
 
 	//Request Console Logs - KEY REQUIRED
 	if(href_list["viewr"])
-		if(src.linkedServer == null || (src.linkedServer.inoperable()))
+		if(isnull(src.linkedServer) || (src.linkedServer.inoperable()))
 			message = noserver
 		else
 			if(auth)

--- a/code/game/machinery/doors/airlock_control.dm
+++ b/code/game/machinery/doors/airlock_control.dm
@@ -185,7 +185,7 @@
 		var/datum/gas_mixture/air_sample = return_air()
 		var/pressure = round(air_sample.return_pressure(),0.1)
 
-		if(abs(pressure - previousPressure) > 0.001 || previousPressure == null)
+		if(abs(pressure - previousPressure) > 0.001 || isnull(previousPressure))
 			var/datum/signal/signal = new
 			signal.transmission_method = 1 //radio signal
 			signal.data["tag"] = id_tag

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -343,7 +343,7 @@
 		var/old_alerts = dir_alerts
 		for(var/index = 1; index <= 4; index++)
 			var/list/tileinfo = tile_info[index]
-			if(tileinfo == null)
+			if(isnull(tileinfo))
 				continue // Bad data.
 			var/celsius = convert_k2c(tileinfo[1])
 

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -113,7 +113,7 @@
 				o += "EAST: "
 			if(4)
 				o += "WEST: "
-		if(tile_info[index] == null)
+		if(isnull(tile_info[index]))
 			o += SPAN_WARNING("DATA UNAVAILABLE")
 			to_chat(user, o)
 			continue

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -272,7 +272,7 @@ var/global/bomb_set
 					code = null
 				else
 					lastentered = text("[]", href_list["type"])
-					if(text2num(lastentered) == null)
+					if(isnull(text2num_or_default(lastentered)))
 						log_and_message_admins("tried to exploit a nuclear bomb by entering non-numerical codes")
 					else
 						code += lastentered

--- a/code/game/machinery/teleporter/beacon.dm
+++ b/code/game/machinery/teleporter/beacon.dm
@@ -65,7 +65,7 @@ var/global/const/TELEBEACON_WIRE_SIGNALLER = 4
 		var/new_name = input(user, "What label would you like to set this beacon to? Leave empty to enable automatic naming based on area.", "Set Beacon Label", beacon_name) as text|null
 		if (QDELETED(src))
 			return TRUE
-		if (new_name == null)
+		if (isnull(new_name))
 			autoset_name = TRUE
 			generate_name()
 			user.visible_message(

--- a/code/game/movietitles.dm
+++ b/code/game/movietitles.dm
@@ -24,7 +24,7 @@ GLOBAL_LIST(end_titles)
 
 		if(mob.get_preference_value(/datum/client_preference/play_lobby_music) == GLOB.PREF_YES)
 			sound_to(mob, sound(null, channel = GLOB.lobby_sound_channel))
-			if(GLOB.end_credits_song == null)
+			if(isnull(GLOB.end_credits_song))
 				var/title_song = pick('sound/music/THUNDERDOME.ogg', 'sound/music/europa/Chronox_-_03_-_In_Orbit.ogg', 'sound/music/europa/asfarasitgets.ogg')
 				sound_to(mob, sound(title_song, wait = 0, volume = 40, channel = GLOB.lobby_sound_channel))
 			else if(get_preference_value(/datum/client_preference/play_admin_midis) == GLOB.PREF_YES)
@@ -118,7 +118,7 @@ GLOBAL_LIST(end_titles)
 			continue
 		if(H.is_species(SPECIES_MONKEY) && findtext(H.real_name,"[lowertext(H.species.name)]")) //no monki
 			continue
-		if(H.last_ckey == null) //don't mention these losers (prespawned corpses mostly)
+		if(isnull(H.last_ckey)) //don't mention these losers (prespawned corpses mostly)
 			continue
 		if(!length(cast) && !chunksize)
 			chunk += "CAST:"
@@ -159,7 +159,7 @@ GLOBAL_LIST(end_titles)
 	var/list/corpses = list()
 	var/list/monkies = list()
 	for(var/mob/living/carbon/human/H in GLOB.dead_mobs)
-		if(H.last_ckey == null) //no prespawned corpses
+		if(isnull(H.last_ckey)) //no prespawned corpses
 			continue
 		if(H.is_species(SPECIES_MONKEY) && findtext(H.real_name,"[lowertext(H.species.name)]"))
 			monkies[H.species.name] += 1

--- a/code/game/objects/effects/fire/fire.dm
+++ b/code/game/objects/effects/fire/fire.dm
@@ -66,7 +66,7 @@
 	if(open_turf.turf_fire)
 		return INITIALIZE_HINT_QDEL
 
-	if(fire_color && ((color != fire_color) && color == null)) //Take colour from proc unless base colour was already custom
+	if(fire_color && ((color != fire_color) && isnull(color))) //Take colour from proc unless base colour was already custom
 		color = fire_color
 	if(color != null)
 		set_color(color)

--- a/code/game/objects/effects/spawners/bombspawner.dm
+++ b/code/game/objects/effects/spawners/bombspawner.dm
@@ -115,13 +115,13 @@
 	var/obj/spawner/newbomb/proto = /obj/spawner/newbomb/radio/custom
 
 	var/p = input("Enter phoron amount (mol):","Phoron", initial(proto.phoron_amt)) as num|null
-	if(p == null) return
+	if(isnull(p)) return
 
 	var/o = input("Enter oxygen amount (mol):","Oxygen", initial(proto.oxygen_amt)) as num|null
-	if(o == null) return
+	if(isnull(o)) return
 
 	var/c = input("Enter carbon dioxide amount (mol):","Carbon Dioxide", initial(proto.carbon_amt)) as num|null
-	if(c == null) return
+	if(isnull(c)) return
 
 	new /obj/spawner/newbomb/radio/custom(get_turf(mob), p, o, c)
 

--- a/code/game/objects/items/weapons/grenades/grenade.dm
+++ b/code/game/objects/items/weapons/grenades/grenade.dm
@@ -31,7 +31,7 @@
 		if(det_time > 1)
 			to_chat(user, "The timer is set to [det_time/10] seconds.")
 			return
-		if(det_time == null)
+		if(isnull(det_time))
 			return
 		to_chat(user, "\The [src] is set for instant detonation.")
 

--- a/code/game/objects/items/weapons/implants/implants/compressed.dm
+++ b/code/game/objects/items/weapons/implants/implants/compressed.dm
@@ -8,7 +8,7 @@
 	var/obj/item/scanned
 
 /obj/item/implant/compressed/trigger(emote, mob/source)
-	if (src.scanned == null)
+	if (isnull(src.scanned))
 		return 0
 
 	if (emote == src.activation_emote)
@@ -53,7 +53,7 @@
 	var/obj/item/implant/compressed/c = imp
 	if (!c || !istype(M, /mob/living/carbon))
 		return FALSE
-	if (c.scanned == null)
+	if (isnull(c.scanned))
 		to_chat(user, "Please compress an object with the implanter first.")
 		return TRUE
 	else return ..()

--- a/code/game/objects/items/weapons/policetape.dm
+++ b/code/game/objects/items/weapons/policetape.dm
@@ -300,7 +300,7 @@ var/global/list/tape_roll_applications = list()
 		var/turf/F = A
 		var/direction = user.loc == F ? user.dir : turn(user.dir, 180)
 		var/hazard_overlay = GLOB.hazard_overlays["[direction]"]
-		if(tape_roll_applications[F] == null)
+		if(isnull(tape_roll_applications[F]))
 			tape_roll_applications[F] = 0
 
 		if(tape_roll_applications[F] & direction)

--- a/code/game/objects/items/weapons/storage/storage_ui/default.dm
+++ b/code/game/objects/items/weapons/storage/storage_ui/default.dm
@@ -132,7 +132,7 @@
 //Creates the storage UI
 /datum/storage_ui/default/prepare_ui()
 	//if storage slots is null then use the storage space UI, otherwise use the slots UI
-	if(storage.storage_slots == null)
+	if(isnull(storage.storage_slots))
 		space_orient_objs()
 	else
 		slot_orient_objs()

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -93,7 +93,7 @@
 /obj/structure/transit_tube/New(loc)
 	..(loc)
 
-	if(tube_dirs == null)
+	if(isnull(tube_dirs))
 		init_dirs()
 
 
@@ -314,7 +314,7 @@
 					current_tube = tube
 					break
 
-			if(current_tube == null)
+			if(isnull(current_tube))
 				set_dir(next_dir)
 				Move(get_step(loc, dir)) // Allow collisions when leaving the tubes.
 				break

--- a/code/game/objects/structures/transit_tubes.dm
+++ b/code/game/objects/structures/transit_tubes.dm
@@ -446,7 +446,7 @@
 	for(var/direction in tube_dir_list)
 		var/location = get_step(loc, direction)
 		for(var/obj/structure/transit_tube/tube in location)
-			if(tube.directions() == null && tube.icon_state == "auto")
+			if(isnull(tube.directions()) && tube.icon_state == "auto")
 				connected_auto += direction
 				break
 

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1318,7 +1318,7 @@ GLOBAL_VAR_INIT(skip_allow_lists, FALSE)
 		else
 			to_chat(usr, "<b>SOMETHING SILICON [key_name(S, usr)]'s laws:</b>")
 
-		if (S.laws == null)
+		if (isnull(S.laws))
 			to_chat(usr, "[key_name(S, usr)]'s laws are null?? Contact a coder.")
 		else
 			S.laws.show_laws(usr)

--- a/code/modules/admin/verbs/SDQL_2/SDQL_2_parser.dm
+++ b/code/modules/admin/verbs/SDQL_2/SDQL_2_parser.dm
@@ -396,7 +396,7 @@
 		do
 			tok = token(i)
 			if (tok == "," || tok == ":")
-				if (temp_expression_list == null)
+				if (isnull(temp_expression_list))
 					parse_error("Found ',' or ':' without expression in an array.")
 					return i + 1
 

--- a/code/modules/admin/verbs/massmodvar.dm
+++ b/code/modules/admin/verbs/massmodvar.dm
@@ -169,7 +169,7 @@
 
 		if("text")
 			var/new_value = input("Enter new text:","Text",O.vars[variable]) as text|null//todo: sanitize ???
-			if(new_value == null) return
+			if(isnull(new_value)) return
 			O.vars[variable] = new_value
 
 			if(method)
@@ -206,7 +206,7 @@
 		if("num")
 			var/new_value = input("Enter new number:","Num",\
 					O.vars[variable]) as num|null
-			if(new_value == null) return
+			if(isnull(new_value)) return
 			O.vars[variable] = new_value
 
 			if(method)
@@ -244,7 +244,7 @@
 		if("type")
 			var/new_value
 			new_value = select_subpath(within_scope = /datum)
-			if(new_value == null) return
+			if(isnull(new_value)) return
 			O.vars[variable] = new_value
 			if(method)
 				if(istype(O, /mob))
@@ -279,7 +279,7 @@
 
 		if("file")
 			var/new_value = input("Pick file:","File",O.vars[variable]) as null|file
-			if(new_value == null) return
+			if(isnull(new_value)) return
 			O.vars[variable] = new_value
 
 			if(method)
@@ -315,7 +315,7 @@
 
 		if("icon")
 			var/new_value = input("Pick icon:","Icon",O.vars[variable]) as null|icon
-			if(new_value == null) return
+			if(isnull(new_value)) return
 			O.vars[variable] = new_value
 			if(method)
 				if(istype(O, /mob))

--- a/code/modules/admin/verbs/modifyvariables.dm
+++ b/code/modules/admin/verbs/modifyvariables.dm
@@ -501,13 +501,13 @@
 
 		if("text")
 			var/var_new = input("Enter new text:","Text",O.get_variable_value(variable)) as null|text
-			if(var_new==null) return
+			if(isnull(var_new)) return
 			var_value = var_new
 
 		if("num")
 			if(variable=="stat")
 				var/var_new = input("Enter new number:","Num",O.get_variable_value(variable)) as null|num
-				if(var_new == null) return
+				if(isnull(var_new)) return
 				if((O.get_variable_value(variable) == 2) && (var_new < 2))//Bringing the dead back to life
 					var/mob/M = O
 					M.switch_from_dead_to_living_mob_list()
@@ -517,7 +517,7 @@
 				var_value = var_new
 			else
 				var/var_new =  input("Enter new number:","Num",O.get_variable_value(variable)) as null|num
-				if(var_new==null) return
+				if(isnull(var_new)) return
 				var_value = var_new
 
 		if("type")
@@ -528,22 +528,22 @@
 
 		if("reference")
 			var/var_new = input("Select reference:","Reference",O.get_variable_value(variable)) as null|mob|obj|turf|area in world
-			if(var_new==null) return
+			if(isnull(var_new)) return
 			var_value = var_new
 
 		if("mob reference")
 			var/var_new = input("Select reference:","Reference",O.get_variable_value(variable)) as null|mob in world
-			if(var_new==null) return
+			if(isnull(var_new)) return
 			var_value = var_new
 
 		if("file")
 			var/var_new = input("Pick file:","File",O.get_variable_value(variable)) as null|file
-			if(var_new==null) return
+			if(isnull(var_new)) return
 			var_value = var_new
 
 		if("icon")
 			var/var_new = input("Pick icon:","Icon",O.get_variable_value(variable)) as null|icon
-			if(var_new==null) return
+			if(isnull(var_new)) return
 			var_value = var_new
 
 		if("color")

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -701,9 +701,9 @@ Ccomp's first proc.
 	if(!check_rights(R_DEBUG|R_FUN))	return
 
 	var/heavy = input("Range of heavy pulse.", text("Input"))  as num|null
-	if(heavy == null) return
+	if(isnull(heavy)) return
 	var/light = input("Range of light pulse.", text("Input"))  as num|null
-	if(light == null) return
+	if(isnull(light)) return
 
 	if (heavy || light)
 

--- a/code/modules/atmospherics/components/omni_devices/filter.dm
+++ b/code/modules/atmospherics/components/omni_devices/filter.dm
@@ -237,7 +237,7 @@ GLOBAL_LIST_INIT(filter_mode_to_gas_id, list( \
 	switch_mode(dir, mode)
 
 /obj/machinery/atmospherics/omni/filter/proc/switch_mode(port, mode)
-	if(mode == null || !port)
+	if(isnull(mode) || !port)
 		return
 	var/datum/omni_port/target_port = null
 	var/list/other_ports = new()

--- a/code/modules/atmospherics/components/pipesparker.dm
+++ b/code/modules/atmospherics/components/pipesparker.dm
@@ -83,7 +83,7 @@
 		update_icon()
 		return TRUE
 
-	if (istype(W, /obj/item/device/assembly/signaler) && signaler == null)
+	if (istype(W, /obj/item/device/assembly/signaler) && isnull(signaler))
 		if (disabled)
 			to_chat(user, SPAN_WARNING("\The [src] is disabled!"))
 			return TRUE

--- a/code/modules/client/preferences_persist.dm
+++ b/code/modules/client/preferences_persist.dm
@@ -9,7 +9,7 @@
 	if(!fexists(path))
 		return null
 	var/text = file2text(path)
-	if(text == null)
+	if(isnull(text))
 		CRASH("failed to read [path]")
 	var/list/data = json_decode(text)
 	if(!istype(data))
@@ -19,7 +19,7 @@
 /datum/preferences/proc/save_pref_record(record_key, list/data)
 	var/path = get_path(client_ckey, record_key)
 	var/text = json_encode(data)
-	if(text == null)
+	if(isnull(text))
 		CRASH("failed to encode JSON for [path]")
 
 	// Why this dance? If text2file fails, we want to leave the record as it was.

--- a/code/modules/clothing/under/accessories/buddy_tag.dm
+++ b/code/modules/clothing/under/accessories/buddy_tag.dm
@@ -37,7 +37,7 @@
 		return TOPIC_REFRESH
 	if (href_list["setcode"])
 		var/newcode = input("Set new buddy ID number.", "Buddy Tag ID", "") as null | num
-		if (newcode == null || !CanInteract(user, state))
+		if (isnull(newcode) || !CanInteract(user, state))
 			return
 		id = newcode
 		return TOPIC_REFRESH

--- a/code/modules/economy/EFTPOS.dm
+++ b/code/modules/economy/EFTPOS.dm
@@ -249,7 +249,7 @@
 /obj/item/device/eftpos/proc/scan_card(obj/item/card/I, obj/item/ID_container)
 	if (istype(I, /obj/item/card/id))
 		var/obj/item/card/id/C = I
-		if(I==ID_container || ID_container == null)
+		if(I==ID_container || isnull(ID_container))
 			usr.visible_message(SPAN_INFO("\The [usr] swipes a card through \the [src]."))
 		else
 			usr.visible_message(SPAN_INFO("\The [usr] swipes \the [ID_container] through \the [src]."))

--- a/code/modules/error_handler/error_handler.dm
+++ b/code/modules/error_handler/error_handler.dm
@@ -30,7 +30,7 @@ GLOBAL_VAR_INIT(actual_error_file_line, new/regex("^%% (.*?),(.*?) %% "))
 	var/last_seen = error_last_seen[erroruid]
 	var/cooldown = error_cooldown[erroruid] || 0
 
-	if(last_seen == null)
+	if(isnull(last_seen))
 		error_last_seen[erroruid] = world.time
 		last_seen = world.time
 

--- a/code/modules/holodeck/HolodeckControl.dm
+++ b/code/modules/holodeck/HolodeckControl.dm
@@ -218,7 +218,7 @@
 /obj/machinery/computer/HolodeckControl/proc/derez(obj/obj , silent = 1)
 	holographic_objs.Remove(obj)
 
-	if(obj == null)
+	if(isnull(obj))
 		return
 
 	if(!silent)

--- a/code/modules/integrated_electronics/subtypes/converters.dm
+++ b/code/modules/integrated_electronics/subtypes/converters.dm
@@ -315,7 +315,7 @@
 /obj/item/integrated_circuit/converter/exploders/do_work()
 	var/strin = get_pin_data(IC_INPUT, 1)
 	var/delimiter = get_pin_data(IC_INPUT, 2)
-	if(delimiter == null)
+	if(isnull(delimiter))
 		set_pin_data(IC_OUTPUT, 1, splittext(strin,null))
 	else
 		set_pin_data(IC_OUTPUT, 1, splittext(strin, delimiter))

--- a/code/modules/lighting/lighting_turf.dm
+++ b/code/modules/lighting/lighting_turf.dm
@@ -108,7 +108,7 @@
 		C.update_ambient_lumcount(lr, lg, lb, !update)
 
 /turf/proc/clear_ambient_light()
-	if (ambient_light == null)
+	if (isnull(ambient_light))
 		return
 
 	ambient_light = null

--- a/code/modules/materials/_materials.dm
+++ b/code/modules/materials/_materials.dm
@@ -249,7 +249,7 @@
 /material/proc/place_dismantled_product(turf/target,is_devastated)
 	if (is_devastated)
 		var/return_count = rand(1, 2)
-		if (place_shard(target, return_count) == null)
+		if (isnull(place_shard(target, return_count)))
 			place_sheet(target, return_count)
 	else
 		place_sheet(target, 2)

--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -397,7 +397,7 @@
 			return TRUE
 		var/free_hardpoints = list()
 		for (var/hardpoint in hardpoints)
-			if (hardpoints[hardpoint] == null && (!length(mech_equipment.restricted_hardpoints) || (hardpoint in mech_equipment.restricted_hardpoints)))
+			if (isnull(hardpoints[hardpoint]) && (!length(mech_equipment.restricted_hardpoints) || (hardpoint in mech_equipment.restricted_hardpoints)))
 				free_hardpoints += hardpoint
 		if (!length(free_hardpoints))
 			USE_FEEDBACK_FAILURE("\The [src] has no free hardpoints for \the [tool].")
@@ -423,7 +423,7 @@
 		var/input = input(user, "Which component would you like to remove?", "\The [src] - Remove Hardpoint") as null|anything in parts
 		if (!input || !user.use_sanity_check(src, tool))
 			return TRUE
-		if (hardpoints[input] == null)
+		if (isnull(hardpoints[input]))
 			USE_FEEDBACK_FAILURE("\The [src] not longer has a component in the [input] slot.")
 			return TRUE
 		remove_system(input, user)

--- a/code/modules/mining/abandonedcrates.dm
+++ b/code/modules/mining/abandonedcrates.dm
@@ -146,7 +146,7 @@
 	if(!Adjacent(user))
 		return
 
-	if(input == null || length(input) != codelen)
+	if(isnull(input) || length(input) != codelen)
 		to_chat(user, SPAN_NOTICE("You leave the crate alone."))
 	else if(check_input(input) && locked)
 		to_chat(user, SPAN_NOTICE("The crate unlocks!"))

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -212,12 +212,12 @@
 
 /// Whether or not the mob's hands or other holding slots are empty. Returns boolean.
 /mob/proc/HandsEmpty()
-	return l_hand == null && r_hand == null
+	return isnull(l_hand) && isnull(r_hand)
 
 
 /// Whether or not the mob has any free hands/holding slots.
 /mob/proc/HasFreeHand()
-	return l_hand == null || r_hand == null
+	return isnull(l_hand) || isnull(r_hand)
 
 
 // Removes an item from inventory and places it in the target atom.

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -413,7 +413,7 @@
 // Movement through doors allowed if ID has access
 /proc/LinkBlockedWithAccess(turf/A, turf/B, obj/item/card/id/ID)
 
-	if(A == null || B == null) return 1
+	if(isnull(A) || isnull(B)) return 1
 	var/adir = get_dir(A,B)
 	var/rdir = get_dir(B,A)
 	if((adir & (NORTH|SOUTH)) && (adir & (EAST|WEST)))	//	diagonal

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -4,7 +4,7 @@
 
 	if(incapacitated())
 		return
-	if(!istype(target) || target.incapacitated() || target.client == null)
+	if(!istype(target) || target.incapacitated() || isnull(target.client))
 		return
 
 	var/obj/item/I = usr.get_active_hand()

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -445,7 +445,7 @@
 	if(robolimb_count)
 		bodytemperature += round(robolimb_count/2)
 
-	if (species.body_temperature == null || isSynthetic())
+	if (isnull(species.body_temperature) || isSynthetic())
 		return //this species doesn't have metabolic thermoregulation
 
 	var/body_temperature_difference = species.body_temperature - bodytemperature
@@ -827,7 +827,7 @@
 			else
 				//TODO: precalculate all of this stuff when the species datum is created
 				var/base_temperature = species.body_temperature
-				if(base_temperature == null) //some species don't have a set metabolic temperature
+				if(isnull(base_temperature)) //some species don't have a set metabolic temperature
 					base_temperature = (getSpeciesOrSynthTemp(HEAT_LEVEL_1) + getSpeciesOrSynthTemp(COLD_LEVEL_1))/2
 
 				var/temp_step

--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -292,7 +292,7 @@ var/global/list/damage_icon_parts = list()
 		var/icon/DI
 		var/use_colour = (BP_IS_ROBOTIC(O) ? SYNTH_BLOOD_COLOUR : O.species.get_blood_colour(src))
 		var/cache_index = "[O.damage_state]/[O.icon_name]/[use_colour]/[species.get_bodytype(src)]"
-		if(damage_icon_parts[cache_index] == null)
+		if(isnull(damage_icon_parts[cache_index]))
 			DI = new /icon(species.get_damage_overlays(src), O.damage_state)			// the damage icon for whole human
 			DI.Blend(new /icon(species.get_damage_mask(src), O.icon_name), ICON_MULTIPLY)	// mask with this organ's pixels
 			DI.Blend(use_colour, ICON_MULTIPLY)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -364,7 +364,7 @@
 	var/button_number = 0
 	for(var/datum/action/A in actions)
 		button_number++
-		if(A.button == null)
+		if(isnull(A.button))
 			var/obj/screen/movable/action_button/N = new(hud_used, A)
 			A.button = N
 

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -28,11 +28,11 @@
 
 
 /mob/living/silicon/robot/HandsEmpty()
-	return module_state_1 == null && module_state_2 == null && module_state_3 == null
+	return isnull(module_state_1) && isnull(module_state_2) && isnull(module_state_3)
 
 
 /mob/living/silicon/robot/HasFreeHand()
-	return module_state_1 == null || module_state_2 == null || module_state_3 == null
+	return isnull(module_state_1) || isnull(module_state_2) || isnull(module_state_3)
 
 
 /mob/living/silicon/robot/GetAllHeld(item_path)

--- a/code/modules/modular_computers/file_system/programs/engineering/alarm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/alarm_monitor.dm
@@ -123,7 +123,7 @@
 
 			categories[length(categories)]["alarms"] += list(list(
 					"name" = sanitize(A.alarm_name()),
-					"origin_lost" = A.origin == null,
+					"origin_lost" = isnull(A.origin),
 					"has_cameras" = length(cameras),
 					"cameras" = cameras,
 					"lost_sources" = length(lost_sources) ? sanitize(english_list(lost_sources, nothing_text = "", and_text = ", ")) : ""))

--- a/code/modules/modular_computers/laptop_vendor.dm
+++ b/code/modules/modular_computers/laptop_vendor.dm
@@ -302,7 +302,7 @@
 
 // Simplified payment processing, returns 1 on success.
 /obj/machinery/lapvend/proc/process_payment(obj/item/card/id/I, obj/item/ID_container)
-	if(I==ID_container || ID_container == null)
+	if(I==ID_container || isnull(ID_container))
 		visible_message(SPAN_INFO("\The [usr] swipes \the [I] through \the [src]."))
 	else
 		visible_message(SPAN_INFO("\The [usr] swipes \the [ID_container] through \the [src]."))

--- a/code/modules/overmap/exoplanets/planet_themes/mountains.dm
+++ b/code/modules/overmap/exoplanets/planet_themes/mountains.dm
@@ -27,9 +27,9 @@
 /datum/random_map/automata/cave_system/mountains/New(seed, tx, ty, tz, tlx, tly, do_not_apply, do_not_announce, never_be_priority = 0, used_area, _rock_color)
 	if (_rock_color)
 		rock_color = _rock_color
-	if (target_turf_type == null)
+	if (isnull(target_turf_type))
 		target_turf_type = world.turf
-	if (floor_type == null)
+	if (isnull(floor_type))
 		floor_type = world.turf
 	..()
 

--- a/code/modules/overmap/exoplanets/planet_types/volcanic.dm
+++ b/code/modules/overmap/exoplanets/planet_types/volcanic.dm
@@ -130,7 +130,7 @@
 		return PROCESS_KILL
 	for(var/weakref/W in victims)
 		var/atom/movable/AM = W.resolve()
-		if (AM == null || get_turf(AM) != src || AM.is_burnable() == FALSE)
+		if (isnull(AM) || get_turf(AM) != src || AM.is_burnable() == FALSE)
 			victims -= W
 			continue
 		var/datum/gas_mixture/environment = return_air()

--- a/code/modules/overmap/exoplanets/random_map.dm
+++ b/code/modules/overmap/exoplanets/random_map.dm
@@ -24,7 +24,7 @@
 	var/list/grass_cache
 
 /datum/random_map/noise/exoplanet/New(seed, tx, ty, tz, tlx, tly, do_not_apply, do_not_announce, never_be_priority = 0, used_area, list/_plant_colors)
-	if (target_turf_type == null)
+	if (isnull(target_turf_type))
 		target_turf_type = world.turf
 	water_level = rand(water_level_min,water_level_max)
 	//automagically adjust probs for bigger maps to help with lag

--- a/code/modules/power/cell_rack.dm
+++ b/code/modules/power/cell_rack.dm
@@ -134,7 +134,7 @@
 /obj/machinery/power/smes/batteryrack/proc/get_most_charged_cell()
 	var/obj/item/cell/CL = null
 	for(var/obj/item/cell/C in internal_cells)
-		if(CL == null)
+		if(isnull(CL))
 			CL = C
 		else if(CL.percent() < C.percent())
 			CL = C
@@ -142,7 +142,7 @@
 /obj/machinery/power/smes/batteryrack/proc/get_least_charged_cell()
 	var/obj/item/cell/CL = null
 	for(var/obj/item/cell/C in internal_cells)
-		if(CL == null)
+		if(isnull(CL))
 			CL = C
 		else if(CL.percent() > C.percent())
 			CL = C

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -381,7 +381,7 @@
 	var/stack_percent = round(sheet_left * 100, 1)
 	dat += text("Current stack: [stack_percent]% <br>")
 	dat += text("Power output: <A href='?src=\ref[src];action=lower_power'>-</A> [power_gen * power_output] Watts<A href='?src=\ref[src];action=higher_power'>+</A><br>")
-	dat += text("Power current: [(powernet == null ? "Unconnected" : "[avail()]")]<br>")
+	dat += text("Power current: [(isnull(powernet) ? "Unconnected" : "[avail()]")]<br>")
 
 	var/tempstr = "Temperature: [temperature]&deg;C<br>"
 	dat += (overheating)? SPAN_DANGER("[tempstr]") : tempstr

--- a/code/modules/radiation/radiation.dm
+++ b/code/modules/radiation/radiation.dm
@@ -21,7 +21,7 @@
 	. = ..()
 
 /datum/radiation_source/proc/update_rad_power(new_power = null)
-	if(new_power == null || new_power == rad_power)
+	if(isnull(new_power) || new_power == rad_power)
 		return // No change
 	else if(new_power <= config.radiation_lower_limit)
 		qdel(src) // Decayed to nothing

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -153,11 +153,11 @@
 		var/image/I = new/image('icons/obj/parcels.dmi',"delivery_label")
 		if (icon_state == "[package_type]closet")
 			I.pixel_x = 2
-			if(label_y == null)
+			if(isnull(label_y))
 				label_y = rand(-6, 11)
 			I.pixel_y = label_y
 		else if (icon_state == "[package_type]crate")
-			if(label_x == null)
+			if(isnull(label_x))
 				label_x = rand(-8, 6)
 			I.pixel_x = label_x
 			I.pixel_y = -3
@@ -165,12 +165,12 @@
 	if(src.sortTag)
 		var/image/I = new/image('icons/obj/parcels.dmi',"delivery_tag")
 		if (icon_state == "[package_type]closet")
-			if(tag_x == null)
+			if(isnull(tag_x))
 				tag_x = rand(-2, 3)
 			I.pixel_x = tag_x
 			I.pixel_y = 9
 		else if (icon_state == "[package_type]crate")
-			if(tag_x == null)
+			if(isnull(tag_x))
 				tag_x = rand(-8, 6)
 			I.pixel_x = tag_x
 			I.pixel_y = -3
@@ -218,14 +218,14 @@
 	if (nameset || examtext)
 		var/image/I = new/image('icons/obj/parcels.dmi',"delivery_label")
 		I.pixel_x = 2
-		if (label_y == null)
+		if (isnull(label_y))
 			label_y = rand (2,5)
 		I.pixel_y = label_y
 		AddOverlays(I)
 
 	if (sortTag)
 		var/image/I = new/image('icons/obj/parcels.dmi',"delivery_tag")
-		if (tag_x == null)
+		if (isnull(tag_x))
 			tag_x = 0
 		I.pixel_x = tag_x
 		I.pixel_y = 0
@@ -439,7 +439,7 @@
 			if(ITEM_SIZE_NORMAL)
 				I.pixel_y = 0
 			if(ITEM_SIZE_LARGE)
-				if(tag_x == null)
+				if(isnull(tag_x))
 					tag_x = rand(0,5)
 				I.pixel_x = tag_x
 				I.pixel_y = 3

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -106,15 +106,15 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		if(D.linked_console != null || D.panel_open)
 			continue
 		if(istype(D, /obj/machinery/r_n_d/destructive_analyzer) && can_analyze == TRUE) // Only science R&D consoles can do research
-			if(linked_destroy == null)
+			if(isnull(linked_destroy))
 				linked_destroy = D
 				D.linked_console = src
 		else if(istype(D, /obj/machinery/r_n_d/protolathe))
-			if(linked_lathe == null)
+			if(isnull(linked_lathe))
 				linked_lathe = D
 				D.linked_console = src
 		else if(istype(D, /obj/machinery/r_n_d/circuit_imprinter))
-			if(linked_imprinter == null)
+			if(isnull(linked_imprinter))
 				linked_imprinter = D
 				D.linked_console = src
 	return
@@ -556,17 +556,17 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	files.RefreshResearch()
 	switch(screen) //A quick check to make sure you get the right screen when a device is disconnected.
 		if(2 to 2.9)
-			if(linked_destroy == null)
+			if(isnull(linked_destroy))
 				screen = 2.0
-			else if(linked_destroy.loaded_item == null)
+			else if(isnull(linked_destroy.loaded_item))
 				screen = 2.1
 			else
 				screen = 2.2
 		if(3 to 3.9)
-			if(linked_lathe == null)
+			if(isnull(linked_lathe))
 				screen = 3.0
 		if(4 to 4.9)
-			if(linked_imprinter == null)
+			if(isnull(linked_imprinter))
 				screen = 4.0
 
 	switch(screen)
@@ -626,7 +626,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				return
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
 			dat += "Disk Contents: (Technology Data Disk)<BR><BR>"
-			if(t_disk.stored == null)
+			if(isnull(t_disk.stored))
 				dat += "The disk has no data stored on it.<HR>"
 				dat += "Operations: "
 				dat += "<A href='?src=\ref[src];menu=1.3'>Load Tech to Disk</A> || "
@@ -657,7 +657,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				screen = 1
 				return
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
-			if(d_disk.blueprint == null)
+			if(isnull(d_disk.blueprint))
 				dat += "The disk has no data stored on it.<HR>"
 				dat += "Operations: "
 				dat += "<A href='?src=\ref[src];menu=1.5'>Load Design to Disk</A> || "

--- a/code/modules/spells/contracts.dm
+++ b/code/modules/spells/contracts.dm
@@ -8,7 +8,7 @@
 	var/list/contract_spells = list(/spell/contract/reward,/spell/contract/punish,/spell/contract/return_master)
 
 /obj/item/contract/attack_self(mob/user as mob)
-	if(contract_master == null)
+	if(isnull(contract_master))
 		to_chat(user, SPAN_NOTICE("You bind the contract to your soul, making you the recipient of whatever poor fool's soul that decides to contract with you."))
 		contract_master = user
 		return

--- a/code/unit_tests/unit_test.dm
+++ b/code/unit_tests/unit_test.dm
@@ -133,7 +133,7 @@ var/global/ascii_reset = "[ascii_esc]\[0m"
 	if(world.time > end_time)
 		test.fail("Unit Tests Ran out of time")   // This should never happen, and if it does either fix your unit tests to be faster or if you can make them async checks.
 		return
-	if (test.start_test() == null)	// Runtimed.
+	if (isnull(test.start_test()))	// Runtimed.
 		test.fail("Test Runtimed")
 	return 1
 

--- a/maps/mapsystem/maps.dm
+++ b/maps/mapsystem/maps.dm
@@ -439,7 +439,7 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	return text2num(pickweight(candidates))
 
 /datum/map/proc/get_empty_zlevel()
-	if(empty_levels == null)
+	if(isnull(empty_levels))
 		INCREMENT_WORLD_Z_SIZE
 		empty_levels = list(world.maxz)
 	return pick(empty_levels)

--- a/packs/deepmaint/generator/jp_dungeon_gen.dm
+++ b/packs/deepmaint/generator/jp_dungeon_gen.dm
@@ -569,7 +569,7 @@
 
 	var/timer = world.timeofday
 
-	if(seed==null)
+	if(isnull(seed))
 		out_seed = rand(-65535, 65535)
 		rand_seed(out_seed)
 	else

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -25,7 +25,7 @@ exactly() { # exactly N name search [mode] [filter]
 	fi
 }
 
-# With the potential exception of << if you increase any of these numbers you're probably doing it wrong
+# If you increase any of these numbers you're probably doing it wrong
 exactly 0 "escapes" '\\\\(red|blue|green|black|b|i[^mc])'
 exactly 4 "Del()s" '\WDel\('
 exactly 2 "/atom text paths" '"/atom'
@@ -61,7 +61,8 @@ exactly 210 "attackby() override" '\/attackby\((.*)\)'  -P
 exactly 15 "uses of examine()" '[.|\s]examine\(' -P # If this fails it's likely because you used '/atom/proc/examine(mob)' instead of '/proc/examinate(mob, atom)' - Exception: An examine()-proc may call other examine()-procs
 exactly 7 "direct modifications of overlays list" '\boverlays((\s*[|^=+&-])|(\.(Cut)|(Add)|(Copy)|(Remove)|(Remove)))' -P
 exactly 0 "new/list list instantiations" 'new\s*/list' -P
-# With the potential exception of << if you increase any of these numbers you're probably doing it wrong
+exactly 0 "== null tests" '(==\s*null\b)|(\bnull\s*==)' -P #Use isnull() instead
+# If you increase any of these numbers you're probably doing it wrong
 
 num=`find ./html/changelogs -not -name "*.yml" | wc -l`
 echo "$num non-yml files (expecting exactly 2)"


### PR DESCRIPTION
isnull is (in a very tiny way) faster; converts all `== null` tests to `isnull()` and adds a check to invalidate new uses

driveby fixed an issue in nukes where an existing href guard was weak due to:
![explorer_xCTZfKJfez](https://github.com/Baystation12/Baystation12/assets/918997/08eb0850-37b6-4413-ba12-8d2c4e4940da)

nufc
