### PR TITLE
Fixes the ICGNV Hound's oxygen canister.

### DIFF
--- a/maps/event/iccgn_ship/icgnv_hound.dmm
+++ b/maps/event/iccgn_ship/icgnv_hound.dmm
@@ -906,10 +906,7 @@
 	dir = 4
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/obj/machinery/portable_atmospherics/canister/oxygen{
-	maximum_pressure = 15000.00;
-	start_pressure = 12000.00
-	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/tiled/techfloor,
 /area/map_template/icgnv_hound)
 "OU" = (


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
🆑 Rockton
maptweak: Fixes the ICGNV Hound's O2 Canister.
/:cl: 
Adds oxygen into the Hounds 02 tank. Now the Indies can breathe (Unfortunately)