### PR TITLE
tweaked playsound, changes & fixes for storage items

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -277,30 +277,37 @@
 		R.activate_module(src)
 		R.hud_used.update_robot_modules_display()
 
-/obj/item/use_tool(obj/item/W, mob/living/user, list/click_params)
-	if(SSfabrication.try_craft_with(src, W, user))
+
+/obj/item/use_tool(obj/item/item, mob/living/user, list/click_params)
+	if (SSfabrication.try_craft_with(src, item, user))
 		return TRUE
-
-	if(istype(W, /obj/item/storage))
-		var/obj/item/storage/S = W
-		if (S.collection_mode && isturf(loc)) //Mode is set to collect all items
-			S.gather_all(loc, user)
-			return TRUE
-
+	if (istype(item, /obj/item/storage) && isturf(loc))
+		var/obj/item/storage/storage = item
+		if (!storage.allow_quick_gather)
+			return ..()
+		if (!storage.quick_gather_single)
+			storage.gather_all(loc, user)
+		else if (storage.can_be_inserted(src, user))
+			storage.handle_item_insertion(src)
+		return TRUE
 	return ..()
+
 
 ///Eventually should be deleted in favor of use_tool; keeping duplicate until downstream attackbys are replaced.
-/obj/item/attackby(obj/item/W, mob/living/user, list/click_params)
-	if(SSfabrication.try_craft_with(src, W, user))
+/obj/item/attackby(obj/item/item, mob/living/user, list/click_params)
+	if (SSfabrication.try_craft_with(src, item, user))
 		return TRUE
-
-	if(istype(W, /obj/item/storage))
-		var/obj/item/storage/S = W
-		if (S.collection_mode && isturf(loc)) //Mode is set to collect all items
-			S.gather_all(loc, user)
-			return TRUE
-
+	if (istype(item, /obj/item/storage) && isturf(loc))
+		var/obj/item/storage/storage = item
+		if (!storage.allow_quick_gather)
+			return ..()
+		if (!storage.quick_gather_single)
+			storage.gather_all(loc, user)
+		else if (storage.can_be_inserted(src, user))
+			storage.handle_item_insertion(src)
+		return TRUE
 	return ..()
+
 
 /obj/item/can_embed()
 	if (!canremove)

--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -459,7 +459,7 @@
 	storage_slots = 5
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = 15
-	cant_hold = list(/obj/item/storage/backpack/satchel/flat) //muh recursive backpacks
+	contents_banned = list(/obj/item/storage/backpack/satchel/flat)
 	startswith = list(
 		/obj/item/stack/tile/floor,
 		/obj/item/crowbar

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -4,7 +4,6 @@
 /obj/item/storage/bag
 	allow_quick_gather = TRUE
 	allow_quick_empty = TRUE
-	collection_mode = TRUE
 	slot_flags = SLOT_BELT
 
 /obj/item/storage/bag/handle_item_insertion(obj/item/W as obj, prevent_warning = 0)
@@ -49,7 +48,6 @@
 	w_class = ITEM_SIZE_SMALL
 	max_w_class = ITEM_SIZE_HUGE //can fit a backpack inside a trash bag, seems right
 	max_storage_space = DEFAULT_BACKPACK_STORAGE
-	can_hold = list() // any
 
 /obj/item/storage/bag/trash/update_w_class()
 	..()
@@ -89,7 +87,6 @@
 	w_class = ITEM_SIZE_TINY
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = DEFAULT_BOX_STORAGE
-	can_hold = list() // any
 
 // -----------------------------
 //           Cash Bag
@@ -103,4 +100,7 @@
 	max_storage_space = 100
 	max_w_class = ITEM_SIZE_HUGE
 	w_class = ITEM_SIZE_SMALL
-	can_hold = list(/obj/item/material/coin,/obj/item/spacecash)
+	contents_allowed = list(
+		/obj/item/material/coin,
+		/obj/item/spacecash
+	)

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -56,7 +56,7 @@
 	var/list/can_holster //List of objects which this item can store in the designated holster slot(if unset, it will default to any holsterable items)
 	var/sound_in = 'sound/effects/holster/holsterin.ogg'
 	var/sound_out = 'sound/effects/holster/holsterout.ogg'
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/melee/baton,
 		/obj/item/melee/telebaton
 		)
@@ -107,7 +107,7 @@
 	icon_state = "utilitybelt"
 	item_state = "utility"
 	overlay_flags = BELT_OVERLAY_ITEMS
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/crowbar,
 		/obj/item/screwdriver,
 		/obj/item/weldingtool,
@@ -175,7 +175,7 @@
 	desc = "Can hold various medical equipment."
 	icon_state = "medicalbelt"
 	item_state = "medical"
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/device/scanner/health,
 		/obj/item/reagent_containers/dropper,
 		/obj/item/reagent_containers/glass/beaker,
@@ -220,7 +220,7 @@
 	item_state = "security"
 	storage_slots = 8
 	overlay_flags = BELT_OVERLAY_ITEMS|BELT_OVERLAY_HOLSTER
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/crowbar,
 		/obj/item/grenade,
 		/obj/item/reagent_containers/spray/pepper,
@@ -263,7 +263,7 @@
 	icon_state = "basicsecuritybelt"
 	item_state = "basicsecurity"
 	overlay_flags = BELT_OVERLAY_ITEMS
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/crowbar,
 		/obj/item/grenade,
 		/obj/item/reagent_containers/spray/pepper,
@@ -298,7 +298,7 @@
 	icon_state = "gearbelt"
 	item_state = "gear"
 	overlay_flags = BELT_OVERLAY_ITEMS
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/device/flash,
 		/obj/item/melee/telebaton,
 		/obj/item/device/taperecorder,
@@ -351,7 +351,7 @@
 	desc = "A belt used to hold most janitorial supplies."
 	icon_state = "janibelt"
 	item_state = "janibelt"
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/grenade/chem_grenade,
 		/obj/item/device/lightreplacer,
 		/obj/item/device/flashlight,
@@ -367,7 +367,7 @@
 		/obj/item/material/knife/folding,
 		/obj/item/modular_computer/tablet,
 		/obj/item/modular_computer/pda
-		)
+	)
 
 /obj/item/storage/belt/holster/general
 	name = "holster belt"
@@ -376,7 +376,7 @@
 	item_state = "command"
 	storage_slots = 7
 	overlay_flags = BELT_OVERLAY_ITEMS|BELT_OVERLAY_HOLSTER
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/device/flash,
 		/obj/item/melee/telebaton,
 		/obj/item/device/taperecorder,
@@ -412,7 +412,7 @@
 		/obj/item/clothing/head/beret,
 		/obj/item/material/knife/folding,
 		/obj/item/device/tape
-		)
+	)
 
 /obj/item/storage/belt/holster/forensic
 	name = "forensic holster belt"
@@ -421,7 +421,7 @@
 	item_state = "forensic"
 	storage_slots = 8
 	overlay_flags = BELT_OVERLAY_HOLSTER
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/reagent_containers/spray/luminol,
 		/obj/item/device/uv_light,
 		/obj/item/reagent_containers/syringe,
@@ -449,7 +449,7 @@
 		/obj/item/clothing/glasses,
 		/obj/item/reagent_containers/spray/pepper,
 		/obj/item/device/flash
-		)
+	)
 
 /obj/item/storage/belt/forensic
 	name = "forensic belt"
@@ -457,7 +457,7 @@
 	icon_state = "basicforensicbelt"
 	item_state = "basicforensic"
 	storage_slots = 8
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/reagent_containers/spray/luminol,
 		/obj/item/device/uv_light,
 		/obj/item/reagent_containers/syringe,
@@ -485,7 +485,7 @@
 		/obj/item/clothing/glasses,
 		/obj/item/reagent_containers/spray/pepper,
 		/obj/item/device/flash
-		)
+	)
 
 /obj/item/storage/belt/holster/machete
 	name = "machete belt"
@@ -494,7 +494,7 @@
 	item_state = "machetebelt"
 	storage_slots = 8
 	overlay_flags = BELT_OVERLAY_HOLSTER
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/device/binoculars,
 		/obj/item/device/camera,
 		/obj/item/stack/flag,
@@ -522,7 +522,7 @@
 		/obj/item/device/drone_designator,
 		/obj/item/modular_computer/tablet,
 		/obj/item/modular_computer/pda
-		)
+	)
 	can_holster = list(/obj/item/material/hatchet/machete)
 	sound_in = 'sound/effects/holster/sheathin.ogg'
 	sound_out = 'sound/effects/holster/sheathout.ogg'
@@ -532,9 +532,7 @@
 	desc = "Designed for ease of access to the shards during a fight, as to not let a single enemy spirit slip away."
 	icon_state = "soulstonebelt"
 	item_state = "soulstonebelt"
-	can_hold = list(
-		/obj/item/device/soulstone
-		)
+	contents_allowed = list(/obj/item/device/soulstone)
 
 /obj/item/storage/belt/soulstone/full/New()
 	..()
@@ -554,9 +552,7 @@
 	item_state = "champion"
 	storage_slots = null
 	max_storage_space = ITEM_SIZE_SMALL
-	can_hold = list(
-		/obj/item/clothing/mask/luchador
-		)
+	contents_allowed = list(/obj/item/clothing/mask/luchador)
 
 /obj/item/storage/belt/holster/security/tactical
 	name = "combat belt"
@@ -583,12 +579,12 @@
 	item_state = "gear"
 	storage_slots = 5
 	overlay_flags = BELT_OVERLAY_ITEMS
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/grenade/chem_grenade/water,
 		/obj/item/crowbar/emergency_forcing_tool,
 		/obj/item/extinguisher/mini,
 		/obj/item/inflatable/door
-		)
+	)
 
 
 /obj/item/storage/belt/fire_belt/full

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -377,7 +377,7 @@
 	desc = "Drymate brand monkey cubes. Just add water!"
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = "monkeycubebox"
-	can_hold = list(/obj/item/reagent_containers/food/snacks/monkeycube)
+	contents_allowed = list(/obj/item/reagent_containers/food/snacks/monkeycube)
 	startswith = list(/obj/item/reagent_containers/food/snacks/monkeycube/wrapped = 5)
 
 
@@ -448,7 +448,7 @@
 	desc = "Eight wrappers of fun! Ages 8 and up. Not suitable for children."
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "spbox"
-	can_hold = list(/obj/item/toy/snappop)
+	contents_allowed = list(/obj/item/toy/snappop)
 	startswith = list(/obj/item/toy/snappop = 8)
 
 
@@ -466,7 +466,6 @@
 	desc = "This box is shaped on the inside so that only light tubes and bulbs fit."
 	item_state = "syringe_kit"
 	allow_quick_gather = TRUE
-	collection_mode = TRUE
 
 
 /obj/item/storage/box/lights/Initialize()
@@ -531,7 +530,7 @@
 	icon_state = "checkers"
 	max_storage_space = 24
 	foldable = null
-	can_hold = list(/obj/item/reagent_containers/food/snacks/checker)
+	contents_allowed = list(/obj/item/reagent_containers/food/snacks/checker)
 	startswith = list(/obj/item/reagent_containers/food/snacks/checker = 12,
 					/obj/item/reagent_containers/food/snacks/checker/red = 12)
 

--- a/code/game/objects/items/weapons/storage/fancy/crackers.dm
+++ b/code/game/objects/items/weapons/storage/fancy/crackers.dm
@@ -7,7 +7,7 @@
 	max_w_class = ITEM_SIZE_TINY
 	w_class = ITEM_SIZE_SMALL
 	key_type = list(/obj/item/reagent_containers/food/snacks/cracker)
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/reagent_containers/food/snacks/cracker
 	)
 	startswith = list(

--- a/code/game/objects/items/weapons/storage/fancy/egg_box.dm
+++ b/code/game/objects/items/weapons/storage/fancy/egg_box.dm
@@ -7,7 +7,7 @@
 	max_w_class = ITEM_SIZE_SMALL
 	w_class = ITEM_SIZE_NORMAL
 	key_type = list(/obj/item/reagent_containers/food/snacks/egg)
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/reagent_containers/food/snacks/egg,
 		/obj/item/reagent_containers/food/snacks/boiledegg
 	)

--- a/code/game/objects/items/weapons/storage/fancy/matchbox.dm
+++ b/code/game/objects/items/weapons/storage/fancy/matchbox.dm
@@ -7,7 +7,7 @@
 	max_storage_space = 10
 	w_class = ITEM_SIZE_SMALL
 	slot_flags = SLOT_BELT
-	can_hold = list(/obj/item/flame/match)
+	contents_allowed = list(/obj/item/flame/match)
 	key_type = list(/obj/item/flame/match)
 	startswith = list(/obj/item/flame/match = 10)
 	var/sprite_key_type_count = 3
@@ -21,7 +21,7 @@
 	max_storage_space = 3
 	w_class = ITEM_SIZE_TINY
 	slot_flags = SLOT_EARS
-	can_hold = list(/obj/item/flame/match)
+	contents_allowed = list(/obj/item/flame/match)
 	key_type = list(/obj/item/flame/match)
 	startswith = list(/obj/item/flame/match = 3)
 

--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -158,7 +158,7 @@
 		/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/dexalin,
 		/obj/item/stack/medical/bruise_pack
 	)
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/clothing/gloves/latex,
 		/obj/item/reagent_containers/hypospray/autoinjector,
 		/obj/item/stack/medical/bruise_pack
@@ -174,7 +174,7 @@
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = null
 	w_class = ITEM_SIZE_LARGE
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/bonesetter,
 		/obj/item/cautery,
 		/obj/item/circular_saw,
@@ -212,11 +212,10 @@
 	w_class = ITEM_SIZE_LARGE
 	max_storage_space = DEFAULT_LARGEBOX_STORAGE
 	allow_quick_gather = TRUE
-	collection_mode = TRUE
 	temperature = -16 CELSIUS
 	matter = list(MATERIAL_PLASTIC = 350)
 	origin_tech = list(TECH_MATERIAL = 3, TECH_POWER = 2)
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/organ,
 		/obj/item/reagent_containers
 	)

--- a/code/game/objects/items/weapons/storage/laundry_basket.dm
+++ b/code/game/objects/items/weapons/storage/laundry_basket.dm
@@ -16,7 +16,6 @@
 	storage_slots = 14
 	allow_quick_empty = TRUE
 	allow_quick_gather = TRUE
-	collection_mode = TRUE
 	var/linked
 
 
@@ -78,8 +77,8 @@
 	icon = 'icons/obj/weapons/other.dmi'
 	icon_state = "offhand"
 	name = "second hand"
-	collection_mode = FALSE
 	allow_quick_gather = FALSE
+	quick_gather_single = TRUE
 
 /obj/item/storage/laundry_basket/offhand/dropped(mob/user as mob)
 	..()

--- a/code/game/objects/items/weapons/storage/misc.dm
+++ b/code/game/objects/items/weapons/storage/misc.dm
@@ -30,7 +30,7 @@
 	icon = 'icons/obj/food/food.dmi'
 	icon_state = "donutbox"
 	name = "donut box"
-	can_hold = list(/obj/item/reagent_containers/food/snacks/donut)
+	contents_allowed = list(/obj/item/reagent_containers/food/snacks/donut)
 	foldable = /obj/item/stack/material/cardboard
 
 	startswith = list(/obj/item/reagent_containers/food/snacks/donut/normal = 6)
@@ -61,7 +61,7 @@
 	throwforce = 2
 	slot_flags = SLOT_BELT
 	startswith = list(/obj/item/paper/cig = 10)
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/paper/cig,
 		/obj/item/clothing/mask/smokable/cigarette,
 		/obj/item/storage/cigpaper/filters

--- a/code/game/objects/items/weapons/storage/pill_bottle.dm
+++ b/code/game/objects/items/weapons/storage/pill_bottle.dm
@@ -7,10 +7,13 @@
 	w_class = ITEM_SIZE_SMALL
 	max_w_class = ITEM_SIZE_TINY
 	max_storage_space = 21
-	can_hold = list(/obj/item/reagent_containers/pill,/obj/item/dice,/obj/item/paper)
+	contents_allowed = list(
+		/obj/item/reagent_containers/pill,
+		/obj/item/dice,
+		/obj/item/paper
+	)
 	allow_quick_gather = TRUE
 	allow_quick_empty = TRUE
-	collection_mode = TRUE
 	use_sound = 'sound/effects/storage/pillbottle.ogg'
 	matter = list(MATERIAL_PLASTIC = 250)
 	var/wrapper_color

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -166,7 +166,7 @@
 	max_storage_space = 56
 	anchored = TRUE
 	density = FALSE
-	cant_hold = list(/obj/item/storage/secure/briefcase)
+	contents_banned = list(/obj/item/storage/secure/briefcase)
 	startswith = list(
 		/obj/item/paper = 1,
 		/obj/item/pen = 1

--- a/code/game/objects/items/weapons/storage/specialized.dm
+++ b/code/game/objects/items/weapons/storage/specialized.dm
@@ -7,12 +7,11 @@
 	max_storage_space = 200
 	max_w_class = ITEM_SIZE_NORMAL
 	w_class = ITEM_SIZE_LARGE
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/ore
 	)
 	allow_quick_gather = TRUE
 	allow_quick_empty = TRUE
-	collection_mode = TRUE
 
 
 /obj/item/storage/evidence
@@ -23,7 +22,7 @@
 	max_storage_space = 100
 	max_w_class = ITEM_SIZE_SMALL
 	w_class = ITEM_SIZE_NORMAL
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/sample,
 		/obj/item/evidencebag,
 		/obj/item/forensics,
@@ -33,7 +32,6 @@
 	)
 	allow_quick_gather = TRUE
 	allow_quick_empty = TRUE
-	collection_mode = TRUE
 
 
 /obj/item/storage/plants
@@ -45,14 +43,13 @@
 	max_storage_space = 100
 	max_w_class = ITEM_SIZE_NORMAL
 	w_class = ITEM_SIZE_NORMAL
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/reagent_containers/food/snacks/grown,
 		/obj/item/seeds,
 		/obj/item/shellfish
 	)
 	allow_quick_gather = TRUE
 	allow_quick_empty = TRUE
-	collection_mode = TRUE
 
 
 /obj/item/storage/sheetsnatcher
@@ -63,7 +60,6 @@
 	storage_ui = /datum/storage_ui/default/sheetsnatcher
 	w_class = ITEM_SIZE_NORMAL
 	storage_slots = 7
-	collection_mode = TRUE
 	allow_quick_gather = TRUE
 	virtual = TRUE
 	var/max_sheets = 300

--- a/code/game/objects/items/weapons/storage/wallets.dm
+++ b/code/game/objects/items/weapons/storage/wallets.dm
@@ -8,7 +8,7 @@
 	max_w_class = ITEM_SIZE_SMALL
 	max_storage_space = ITEM_SIZE_SMALL * 3
 	slot_flags = SLOT_ID
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/spacecash,
 		/obj/item/card,
 		/obj/item/clothing/mask/smokable,

--- a/code/game/objects/structures/inflatable.dm
+++ b/code/game/objects/structures/inflatable.dm
@@ -336,5 +336,5 @@
 	item_state = "case"
 	w_class = ITEM_SIZE_LARGE
 	max_storage_space = DEFAULT_LARGEBOX_STORAGE
-	can_hold = list(/obj/item/inflatable)
+	contents_allowed = list(/obj/item/inflatable)
 	startswith = list(/obj/item/inflatable/door = 2, /obj/item/inflatable/wall = 3)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -56,7 +56,8 @@ GLOBAL_LIST_INIT(glasscrack_sound,list('sound/effects/glass_crack1.ogg','sound/e
 GLOBAL_LIST_INIT(tray_hit_sound,list('sound/items/trayhit1.ogg', 'sound/items/trayhit2.ogg'))
 
 /proc/playsound(atom/source, soundin, vol as num, vary, extrarange as num, falloff, is_global, frequency, is_ambiance = 0)
-
+	if (isnull(soundin))
+		return
 	soundin = get_sfx(soundin) // same sound for everyone
 
 	if(isarea(source))
@@ -77,6 +78,8 @@ GLOBAL_LIST_INIT(tray_hit_sound,list('sound/items/trayhit1.ogg', 'sound/items/tr
 var/global/const/FALLOFF_SOUNDS = 0.5
 
 /mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, is_global, extrarange)
+	if (isnull(soundin))
+		return
 	if(!src.client || ear_deaf > 0)	return
 	var/sound/S = soundin
 	if(!istype(S))

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -134,12 +134,15 @@
 	if(Adjacent(user))
 		attack_hand(user)
 
-/turf/attackby(obj/item/W as obj, mob/user as mob)
-	if(istype(W, /obj/item/storage))
-		var/obj/item/storage/S = W
-		if(S.collection_mode)
-			S.gather_all(src, user)
+
+/turf/use_tool(obj/item/item, mob/living/user, list/click_params)
+	if (istype(item, /obj/item/storage))
+		var/obj/item/storage/storage = item
+		if (storage.allow_quick_gather && !storage.quick_gather_single)
+			storage.gather_all(src, user)
+			return TRUE
 	return ..()
+
 
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)
 

--- a/code/modules/clothing/under/accessories/storage.dm
+++ b/code/modules/clothing/under/accessories/storage.dm
@@ -149,7 +149,7 @@
 /obj/item/clothing/accessory/storage/knifeharness/Initialize()
 	. = ..()
 	if (container)
-		container.can_hold = list(
+		container.contents_allowed = list(
 			/obj/item/material/hatchet,
 			/obj/item/material/knife
 		)
@@ -168,7 +168,7 @@
 /obj/item/clothing/accessory/storage/bandolier/Initialize()
 	. = ..()
 	if (container)
-		container.can_hold = list(
+		container.contents_allowed = list(
 			/obj/item/ammo_casing,
 			/obj/item/grenade,
 			/obj/item/material/knife,

--- a/code/modules/detectivework/tools/crimekit.dm
+++ b/code/modules/detectivework/tools/crimekit.dm
@@ -13,8 +13,8 @@
 		/obj/item/forensics/sample_kit,
 		/obj/item/forensics/sample_kit/powder,
 		/obj/item/storage/csi_markers
-		)
-	can_hold = list(
+	)
+	contents_allowed = list(
 		/obj/item/storage/box/swabs,
 		/obj/item/storage/box/fingerprints,
 		/obj/item/storage/box/evidence,
@@ -40,4 +40,4 @@
 		/obj/item/device/scanner,
 		/obj/item/modular_computer/tablet,
 		/obj/item/evidencebag
-		)
+	)

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -483,20 +483,20 @@ var/global/list/mining_floors = list()
 
 	else if(istype(W,/obj/item/storage/ore))
 		var/obj/item/storage/ore/S = W
-		if(S.collection_mode)
+		if(!S.quick_gather_single)
 			for(var/obj/item/ore/O in contents)
 				O.attackby(W,user)
 				return
 	else if(istype(W,/obj/item/storage/bag/fossils))
 		var/obj/item/storage/bag/fossils/S = W
-		if(S.collection_mode)
+		if(!S.quick_gather_single)
 			for(var/obj/item/fossil/F in contents)
 				F.attackby(W,user)
 				return
 
 	else
 		..(W,user)
-	return
+
 
 /turf/simulated/floor/asteroid/proc/gets_dug()
 

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -110,7 +110,7 @@ var/global/photo_count = 0
 	item_state = "briefcase"
 	w_class = ITEM_SIZE_NORMAL //same as book
 	storage_slots = DEFAULT_BOX_STORAGE //yes, that's storage_slots. Photos are w_class 1 so this has as many slots equal to the number of photos you could put in a box
-	can_hold = list(/obj/item/photo)
+	contents_allowed = list(/obj/item/photo)
 
 /obj/item/storage/photo_album/MouseDrop(obj/over_object as obj)
 

--- a/code/modules/reagents/reagent_containers/drinkingglass/glass_boxes.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/glass_boxes.dm
@@ -1,7 +1,7 @@
 /obj/item/storage/box/mixedglasses
 	name = "glassware box"
 	desc = "A box of assorted glassware."
-	can_hold = list(/obj/item/reagent_containers/food/drinks/glass2)
+	contents_allowed = list(/obj/item/reagent_containers/food/drinks/glass2)
 
 	startswith = list(
 		/obj/item/reagent_containers/food/drinks/glass2/square,
@@ -21,7 +21,7 @@
 /obj/item/storage/box/glasses
 	name = "box of glasses"
 	var/glass_type = /obj/item/reagent_containers/food/drinks/glass2
-	can_hold = list(/obj/item/reagent_containers/food/drinks/glass2)
+	contents_allowed = list(/obj/item/reagent_containers/food/drinks/glass2)
 
 /obj/item/storage/box/glasses/Initialize()
 	. = ..()
@@ -65,7 +65,7 @@
 /obj/item/storage/box/glass_extras
 	name = "box of cocktail garnishings"
 	var/extra_type = /obj/item/glass_extra
-	can_hold = list(/obj/item/glass_extra)
+	contents_allowed = list(/obj/item/glass_extra)
 	storage_slots = 14
 
 /obj/item/storage/box/glass_extras/Initialize()

--- a/code/modules/reagents/reagent_containers/food/snacks/bugmeat.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/bugmeat.dm
@@ -8,7 +8,7 @@
 	max_w_class = ITEM_SIZE_SMALL
 	w_class = ITEM_SIZE_NORMAL
 	key_type = list(/obj/item/reagent_containers/food/snacks/rawcutlet/bugmeat)
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/reagent_containers/food/snacks/rawcutlet/bugmeat,
 		/obj/item/reagent_containers/food/snacks/cutlet/bugmeat
 	)

--- a/code/modules/research/part_replacer.dm
+++ b/code/modules/research/part_replacer.dm
@@ -5,11 +5,10 @@
 	icon_state = "RPED"
 	item_state = "RPED"
 	w_class = ITEM_SIZE_HUGE
-	can_hold = list(/obj/item/stock_parts)
+	contents_allowed = list(/obj/item/stock_parts)
 	storage_slots = 50
 	allow_quick_gather = TRUE
 	allow_quick_empty = TRUE
-	collection_mode = TRUE
 	max_w_class = ITEM_SIZE_NORMAL
 	max_storage_space = 100
 	origin_tech = list(TECH_ENGINEERING = 4, TECH_MATERIAL = 3)

--- a/code/modules/xenoarcheaology/tools/equipment.dm
+++ b/code/modules/xenoarcheaology/tools/equipment.dm
@@ -60,7 +60,7 @@
 	desc = "Can hold various excavation gear."
 	icon_state = "gearbelt"
 	item_state = ACCESSORY_SLOT_UTILITY
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/storage/box/samplebags,
 		/obj/item/device/core_sampler,
 		/obj/item/pinpointer/radio,

--- a/code/modules/xenoarcheaology/tools/tools.dm
+++ b/code/modules/xenoarcheaology/tools/tools.dm
@@ -17,7 +17,7 @@
 	storage_slots = 50
 	max_storage_space = 200
 	max_w_class = ITEM_SIZE_NORMAL
-	can_hold = list(/obj/item/fossil)
+	contents_allowed = list(/obj/item/fossil)
 
 /obj/item/storage/box/samplebags
 	name = "sample bag box"

--- a/code/modules/xenoarcheaology/tools/tools_pickaxe.dm
+++ b/code/modules/xenoarcheaology/tools/tools_pickaxe.dm
@@ -176,12 +176,11 @@
 	storage_slots = 7
 	slot_flags = SLOT_BELT
 	w_class = ITEM_SIZE_NORMAL
-	can_hold = list(/obj/item/pickaxe/xeno)
+	contents_allowed = list(/obj/item/pickaxe/xeno)
 	max_storage_space = 18
 	max_w_class = ITEM_SIZE_NORMAL
 	allow_quick_gather = TRUE
 	allow_quick_empty = TRUE
-	collection_mode = TRUE
 	startswith = list(
 		/obj/item/pickaxe/xeno/brush,
 		/obj/item/pickaxe/xeno/one_pick,

--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -223,7 +223,7 @@ var/global/const/access_skrellscoutship = "ACCESS_SKRELLSCOUT"
 	item_state = "security"
 	storage_slots = 8
 	overlay_flags = BELT_OVERLAY_ITEMS|BELT_OVERLAY_HOLSTER
-	can_hold = list(
+	contents_allowed = list(
 		/obj/item/crowbar,
 		/obj/item/grenade,
 		/obj/item/reagent_containers/spray/pepper,

--- a/maps/torch/items/wallets.dm
+++ b/maps/torch/items/wallets.dm
@@ -1,6 +1,6 @@
 /obj/item/storage/wallet/Initialize()
 	. = ..()
-	can_hold |= list(
+	contents_allowed |= list(
 		/obj/item/clothing/accessory/solgov,
 		/obj/item/clothing/accessory/ribbon
 	)

--- a/packs/factions/iccgn/tweaks.dm
+++ b/packs/factions/iccgn/tweaks.dm
@@ -1,6 +1,6 @@
 /obj/item/storage/wallet/Initialize()
 	. = ..()
-	can_hold |= list(
+	contents_allowed |= list(
 		/obj/item/clothing/accessory/iccgn_badge,
 		/obj/item/clothing/accessory/iccgn_patch,
 		/obj/item/clothing/accessory/iccgn_rank

--- a/packs/factions/scga/tweaks.dm
+++ b/packs/factions/scga/tweaks.dm
@@ -1,6 +1,6 @@
 /obj/item/storage/wallet/Initialize()
 	. = ..()
-	can_hold |= list(
+	contents_allowed |= list(
 		/obj/item/clothing/accessory/scga_badge,
 		/obj/item/clothing/accessory/scga_rank
 	)

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -57,7 +57,7 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 7 "uses of .len" '\.len\b' -P
-exactly 210 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 208 "attackby() override" '\/attackby\((.*)\)'  -P
 exactly 15 "uses of examine()" '[.|\s]examine\(' -P # If this fails it's likely because you used '/atom/proc/examine(mob)' instead of '/proc/examinate(mob, atom)' - Exception: An examine()-proc may call other examine()-procs
 exactly 7 "direct modifications of overlays list" '\boverlays((\s*[|^=+&-])|(\.(Cut)|(Add)|(Copy)|(Remove)|(Remove)))' -P
 exactly 0 "new/list list instantiations" 'new\s*/list' -P


### PR DESCRIPTION
no changes people will notice, besides perhaps the quick gather corrections.

----

playsound and playsound_local return early on null sound sources

can_hold -> contents_allowed
cant_hold -> contents_banned
contents_allowed & contents_banned allow null instead of empty lists

collection_mode -> quick_gather_single
storage items correctly respect whether they can quick gather & which quick gather mode they are in
fixed quick gathering not working on turfs
toggle_gathering_mode verb respects distance

got rid of open_sound_played

corrected comments for /obj/item/storage member vars