### PR TITLE
Fixes #34462

### DIFF
--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -15,23 +15,25 @@
 	max_w_class = ITEM_SIZE_SMALL
 	max_storage_space = DEFAULT_BOX_STORAGE
 
-
-/obj/item/storage/secure/attackby(obj/item/W, mob/user)
+/obj/item/storage/secure/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if (!locked)
 		return ..()
+
 	if (istype(W, /obj/item/melee/energy/blade) && emag_act(INFINITY, user, "You slice through the lock of \the [src]"))
 		var/datum/effect/spark_spread/spark_system = new /datum/effect/spark_spread()
 		spark_system.set_up(5, 0, loc)
 		spark_system.start()
 		playsound(loc, 'sound/weapons/blade1.ogg', 50, 1)
 		playsound(loc, "sparks", 50, 1)
-		return
-	if (isScrewdriver(W))
+		return TRUE
+
+	else if (isScrewdriver(W))
 		if (do_after(user, (W.toolspeed * 2) SECONDS, src, DO_REPAIR_CONSTRUCT))
 			open = ! open
 			user.show_message(SPAN_NOTICE("You [open ? "open" : "close"] the service panel."))
-		return
-	if (isMultitool(W) && (open == 1)&& (!l_hacking))
+		return TRUE
+
+	else if (isMultitool(W) && (open == 1)&& (!l_hacking))
 		user.show_message(SPAN_NOTICE("Now attempting to reset internal memory, please hold."), 1)
 		l_hacking = 1
 		if (do_after(usr, (W.toolspeed * 10) SECONDS, src, DO_REPAIR_CONSTRUCT))
@@ -47,6 +49,11 @@
 				l_hacking = 0
 		else
 			l_hacking = 0
+		return TRUE
+
+	else
+		to_chat(user, SPAN_WARNING("\The [src] is locked and cannot be opened!"))
+		return TRUE
 
 
 /obj/item/storage/secure/MouseDrop(over_object, src_location, over_location)

--- a/code/modules/mechs/equipment/medical.dm
+++ b/code/modules/mechs/equipment/medical.dm
@@ -110,6 +110,7 @@
 	var/obj/item/device/scanner/health/scanner = null
 
 /obj/item/mech_equipment/mender/attack_self(mob/user)
+	. = ..()
 	if(!.)
 		return
 	mode = mode == MEDIGEL_SALVE ? MEDIGEL_SCAN : MEDIGEL_SALVE

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -57,7 +57,7 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 7 "uses of .len" '\.len\b' -P
-exactly 208 "attackby() override" '\/attackby\((.*)\)'  -P
+exactly 207 "attackby() override" '\/attackby\((.*)\)'  -P
 exactly 15 "uses of examine()" '[.|\s]examine\(' -P # If this fails it's likely because you used '/atom/proc/examine(mob)' instead of '/proc/examinate(mob, atom)' - Exception: An examine()-proc may call other examine()-procs
 exactly 7 "direct modifications of overlays list" '\boverlays((\s*[|^=+&-])|(\.(Cut)|(Add)|(Copy)|(Remove)|(Remove)))' -P
 exactly 0 "new/list list instantiations" 'new\s*/list' -P


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: Fixes switching medigel scanner modes on mechs.
bugfix: Fixes being able to place item into locked briefcases
/🆑 

Fixes #34462

Same bug report has a comment mentioning mounted RCDs no longer let you switch modes. My suspicion is this has to do with radial menus not finding a place to show up since the mob's loc is not exactly where the mech is when someone is inside it. I need an actual day not at work to look into that, but if someone's up for it why not.