### PR TITLE
fix projector paper slide distance bug

### DIFF
--- a/code/game/objects/items/devices/slide_projector.dm
+++ b/code/game/objects/items/devices/slide_projector.dm
@@ -187,7 +187,7 @@
 	if(!istype(slide))
 		qdel(src)
 		return
-	return slide.examine(user, max(distance, 1), FALSE)
+	return slide.examine(user, 0, FALSE)
 
 /obj/projection/photo
 	alpha = 170


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed projector slides requiring you to be next to them to properly examine what they're projecting. 
/:cl: