### PR TITLE
Allows filling fire extinguishers with beakers/glass containers.

### DIFF
--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -21,6 +21,8 @@
 	var/last_use = 1.0
 	var/safety = 1
 	var/sprite_name = "fire_extinguisher"
+	var/list/preferred_reagent = list(/datum/reagent/water)
+	var/broken = FALSE
 
 /obj/item/extinguisher/mini
 	name = "mini fire extinguisher"
@@ -52,7 +54,7 @@
 /obj/item/extinguisher/examine(mob/user, distance)
 	. = ..()
 	if(distance <= 0)
-		to_chat(user, text("[icon2html(src, viewers(get_turf(src)))] [] contains [] units of water left!", src, src.reagents.total_volume))
+		to_chat(user, text("[icon2html(src, viewers(get_turf(src)))] [] contains [] units of fluid left!", src, src.reagents.total_volume))
 
 /obj/item/extinguisher/attack_self(mob/user as mob)
 	safety = !safety
@@ -79,39 +81,66 @@
 		O.Move(get_step(user,movementdirection), movementdirection)
 		sleep(3)
 
-/obj/item/extinguisher/resolve_attackby(atom/target, mob/user, flag)
-	if (istype(target, /obj/structure/hygiene/sink) && reagents.get_free_space() > 0) // fill first, wash if full
+/obj/item/extinguisher/use_before(obj/target, mob/living/user, click_parameters)
+	if (!(istype(target, /obj/structure/hygiene/sink) || istype(target, /obj/structure/reagent_dispensers)))
 		return FALSE
-	return ..()
+
+	var/amount = reagents.get_free_space()
+	if (istype(target, /obj/structure/hygiene))
+		if (amount <= 0)
+			return FALSE //Will proceed with washing the extinguisher
+		reagents.add_reagent(/datum/reagent/water, amount)
+
+	else
+		if (amount <= 0)
+			to_chat(user, SPAN_WARNING("\The [src] is already full."))
+			return TRUE
+		if (target.reagents.total_volume <= 0)
+			to_chat(user, SPAN_WARNING("\The [target] is empty."))
+			return TRUE
+		amount = target.reagents.trans_to_obj(src, max_water)
+
+	if (istype(target, /obj/structure/reagent_dispensers/acid))
+		to_chat(user, SPAN_DANGER("The acid violently eats away at \the [src]!"))
+		do_spray(user)
+		qdel(src)
+		return TRUE
+
+	to_chat(user, SPAN_NOTICE("You fill \the [src] with [amount] unit\s from \the [target]."))
+	playsound(loc, 'sound/effects/refill.ogg', 50, 1, -6)
+	return TRUE
+
+/obj/item/extinguisher/use_tool(obj/item/item, mob/living/user, list/click_params)
+	if (istype(item, /obj/item/reagent_containers/glass))
+		var/obj/item/reagent_containers/container = item
+		if (container.reagents.total_volume <= 0)
+			to_chat(user, SPAN_WARNING("\The [item] is empty."))
+			return TRUE
+		if (reagents.get_free_space() <= 0)
+			to_chat(user, SPAN_WARNING("\The [src] is already full"))
+			return TRUE
+		var/trans_amount = container.amount_per_transfer_from_this
+		var/amount = container.reagents.trans_to_obj(src, trans_amount)
+
+		if (reagents.has_reagent(/datum/reagent/acid))
+			to_chat(user, SPAN_DANGER("The acid violently eats away at \the [src]!"))
+			do_spray(user)
+			qdel(src)
+			return TRUE
+
+		to_chat(user, SPAN_NOTICE("You fill \the [src] with [amount] unit\s from \the [container]."))
+		playsound(src, 'sound/effects/pour.ogg', 25, 1)
+		return TRUE
+	else return ..()
 
 /obj/item/extinguisher/afterattack(atom/target, mob/user, flag)
-	var/issink = istype(target, /obj/structure/hygiene/sink)
-
-	if (flag && (issink || istype(target, /obj/structure/reagent_dispensers)))
-		var/obj/dispenser = target
-		var/amount = reagents.get_free_space()
-		if (amount <= 0)
-			to_chat(user, SPAN_NOTICE("\The [src] is full."))
-			return
-		if (!issink) // sinks create reagents, they don't "contain" them
-			if (dispenser.reagents.total_volume <= 0)
-				to_chat(user, SPAN_NOTICE("\The [dispenser] is empty."))
-				return
-			amount = dispenser.reagents.trans_to_obj(src, max_water)
-		else
-			reagents.add_reagent(/datum/reagent/water, amount)
-		to_chat(user, SPAN_NOTICE("You fill \the [src] with [amount] units from \the [dispenser]."))
-		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
-		if (istype(target, /obj/structure/reagent_dispensers/acid))
-			to_chat(user, SPAN_WARNING("The acid violently eats away at \the [src]!"))
-			if (prob(50))
-				reagents.splash(user, 5)
-			qdel(src)
-		return
-
 	if (!safety)
 		if (src.reagents.total_volume < 1)
 			to_chat(usr, SPAN_NOTICE("\The [src] is empty."))
+			return
+
+		if (broken)
+			to_chat(user, SPAN_WARNING("The nozzle of \the [src] is gunked up beyond repair!"))
 			return
 
 		if (world.time < src.last_use + 20)
@@ -132,9 +161,12 @@
 		if(!user.check_space_footing())
 			step(user, direction)
 
+		if (reagents.has_other_reagent(preferred_reagent) && prob(15))
+			broken = TRUE
+			to_chat(user, SPAN_WARNING("The foreign reagents gunked up the spraying mechanism, breaking \the [src]."))
+
 	else
 		return ..()
-	return
 
 /obj/item/extinguisher/proc/do_spray(atom/Target)
 	var/turf/T = get_turf(Target)

--- a/code/modules/mob/living/silicon/robot/modules/_module.dm
+++ b/code/modules/mob/living/silicon/robot/modules/_module.dm
@@ -205,6 +205,12 @@
 			if (length(P.loaded) <= P.max_shells)
 				P.loaded += new P.ammo_type(src)
 
+	var/obj/item/extinguisher/extinguisher = locate() in equipment
+	if (extinguisher?.broken)
+		var/remaining_volume = extinguisher.reagents.total_volume
+		extinguisher.broken = FALSE
+		extinguisher.reagents.remove_any(remaining_volume)
+
 	for (var/obj/gear in equipment)
 		gear.update_icon()
 

--- a/code/modules/reagents/Chemistry-Holder.dm
+++ b/code/modules/reagents/Chemistry-Holder.dm
@@ -246,6 +246,14 @@ GLOBAL_DATUM_INIT(temp_reagents_holder, /obj, new)
 				missing--
 	return !missing
 
+///Returns True if holder has a reagent that is not on the supplied list. Useful to check for forbidden reagents.
+/datum/reagents/proc/has_other_reagent(list/check_reagents)
+	for (var/datum/reagent/current in reagent_list)
+		if (!(current.type in check_reagents))
+			return TRUE
+
+	return FALSE
+
 /datum/reagents/proc/clear_reagents()
 	for(var/datum/reagent/current in reagent_list)
 		del_reagent(current.type)


### PR DESCRIPTION
🆑 emmanuelbassil
tweak: Can now fill fire extinguishers using beakers. Can effectively fill them with any liquid.
tweak: Fire extinguishers have a chance to break when firing any liquid that isn't water. They cannot be repaired.
tweak: Borgs can repair broken fire extinguishers at the recharging station.
/🆑 

Putting in any acid will melt the extinguisher and have it spray you.
Also changed the prob (50) for using an acid dispenser into a guaranteed self-spray. The idea that an exploding fire extinguisher has a 50% chance of gently dropping some liquid on you is weird. At least get a full spray to the mouth.