### PR TITLE
Add `sexplorer` generic memo

### DIFF
--- a/maps/torch/items/memos.dm
+++ b/maps/torch/items/memos.dm
@@ -169,6 +169,9 @@
 	name = "offical guides"
 	info = {"Some "internal use only" reports on inter-departmental communications, reminding personnel that unless the document specifies it is from and issued by EXO or Expeditionary Command, it is not offical policy and should not be referenced as a definitive reasoning for any action."}
 
+/obj/item/paper/memo/generic/sexplorer
+	name = "explorer rank abbreviations"
+	info = {"Some "internal use only" reports on proper and improper ways of abbreviating explorer ranks and roles, including emphasis that "sexplorer" is NOT an authorized way, shorthand or otherwise, to refer to senior explorers."}
 
 
 // scgr memos

--- a/maps/torch/items/memos.dm
+++ b/maps/torch/items/memos.dm
@@ -170,8 +170,12 @@
 	info = {"Some "internal use only" reports on inter-departmental communications, reminding personnel that unless the document specifies it is from and issued by EXO or Expeditionary Command, it is not offical policy and should not be referenced as a definitive reasoning for any action."}
 
 /obj/item/paper/memo/generic/sexplorer
-	name = "explorer rank abbreviations"
+	name = "\improper EC rank abbreviations"
 	info = {"Some "internal use only" reports on proper and improper ways of abbreviating explorer ranks and roles, including emphasis that "sexplorer" is NOT an authorized way, shorthand or otherwise, to refer to senior explorers."}
+
+/obj/item/paper/memo/generic/sublt
+	name = "fleet rank abbreviations"
+	info = {"Some "internal use only" reports on proper and improper ways of abbreviating fleet ranks and roles, including emphasis that "sub" is NOT an authorized way, shorthand or otherwise, to refer to sub lieutenant."}
 
 
 // scgr memos


### PR DESCRIPTION
![Discord_fkuCFZ1zPj](https://github.com/Baystation12/Baystation12/assets/11140088/2cf5fd81-2033-4ff8-ab65-6a4db5d92ddc)

## Changelog
:cl: SierraKomodo
rscadd: Added new generic memos about explorer and fleet rank abbreviations.
/:cl: