### PR TITLE
fix offship spawn and shuttle bugs

### DIFF
--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -173,7 +173,10 @@
 	new_turf.transport_properties_from(source)
 
 	for(var/obj/O in source)
-		if(O.simulated)
+		if (QDELETED(O))
+			testing("Failed to translate [O] to new turf as it was qdel'd.")
+			continue
+		if(O.simulated || istype(O, /obj/shuttle_landmark) || istype(O, /obj/submap_landmark))
 			O.forceMove(new_turf)
 		else if(istype(O,/obj/effect))
 			var/obj/E = O


### PR DESCRIPTION
:cl: Mucker
bugfix: The shuttles on the Skrell and Vox ships are no longer broken and can jump again.
bugfix: Fixed players being put in space sometimes when joining the Skrell or Vox submap. 
/:cl: