### PR TITLE
(re)moves the fleet report

### DIFF
--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -2200,7 +2200,6 @@
 /obj/floor_decal/corner/blue{
 	dir = 10
 	},
-/obj/item/folder/envelope/declassified1,
 /obj/machinery/camera/network/bridge{
 	c_tag = "Bridge";
 	dir = 1
@@ -11491,6 +11490,7 @@
 /obj/item/folder/yellow,
 /obj/item/folder/white,
 /obj/floor_decal/industrial/outline/yellow,
+/obj/item/paper/dclassreport1,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
 "Hg" = (

--- a/packs/event_2022jul30/documents.dm
+++ b/packs/event_2022jul30/documents.dm
@@ -1,12 +1,3 @@
-/obj/item/folder/envelope/declassified1
-	desc = "A thick envelope. The Sol Fleet crest is stamped in the corner, along with 'PUBLIC RELEASE DOCUMENTATION.'"
-
-
-/obj/item/folder/envelope/declassified1/Initialize()
-	. = ..()
-	new /obj/item/paper/dclassreport1 (src)
-
-
 /obj/item/paper/dclassreport1
 	name = "Declassified Report: Status of the Fleets"
 	info = {"\


### PR DESCRIPTION
:cl:
maptweak: The "Status of the Fleets" is moved to the Bridge storage.
/:cl:

It's been a year and a half, everybody read it. There's no way it would lay on the table, sealed, for more than a year.

For people who still wants to read the piece of lore, I moved it to the Bridge storage instead.