### PR TITLE
Increases SKILL_DEVICES cap for the CE

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -202,15 +202,14 @@
 		/datum/mil_rank/fleet/o3
 	)
 	skill_points = 36
-	min_skill = list( // 35 points
+	min_skill = list( // 31 points
 		SKILL_BUREAUCRACY  = SKILL_BASIC, // 1 point
 		SKILL_COMPUTER = SKILL_TRAINED, // 2 points
 		SKILL_EVA = SKILL_TRAINED, // 2 points
 		SKILL_CONSTRUCTION = SKILL_TRAINED, // 2 points
 		SKILL_ELECTRICAL = SKILL_TRAINED, // 4 points
 		SKILL_ATMOS = SKILL_TRAINED, // 4 points
-		SKILL_ENGINES = SKILL_EXPERIENCED, // 16 points
-		SKILL_DEVICES = SKILL_TRAINED // 4 points
+		SKILL_ENGINES = SKILL_EXPERIENCED // 16 points
 	)
 
 	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,

--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -202,20 +202,22 @@
 		/datum/mil_rank/fleet/o3
 	)
 	skill_points = 36
-	min_skill = list( // 31 points
+	min_skill = list( // 35 points
 		SKILL_BUREAUCRACY  = SKILL_BASIC, // 1 point
 		SKILL_COMPUTER = SKILL_TRAINED, // 2 points
 		SKILL_EVA = SKILL_TRAINED, // 2 points
 		SKILL_CONSTRUCTION = SKILL_TRAINED, // 2 points
 		SKILL_ELECTRICAL = SKILL_TRAINED, // 4 points
 		SKILL_ATMOS = SKILL_TRAINED, // 4 points
-		SKILL_ENGINES = SKILL_EXPERIENCED // 16 points
+		SKILL_ENGINES = SKILL_EXPERIENCED, // 16 points
+		SKILL_DEVICES = SKILL_TRAINED // 4 points
 	)
 
 	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,
 	                    SKILL_ELECTRICAL   = SKILL_MAX,
 	                    SKILL_ATMOS        = SKILL_MAX,
-	                    SKILL_ENGINES      = SKILL_MAX)
+	                    SKILL_ENGINES      = SKILL_MAX,
+						SKILL_DEVICES = SKILL_EXPERIENCED)
 
 	access = list(
 		access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,

--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -34,7 +34,8 @@
 	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,
 						SKILL_ELECTRICAL   = SKILL_MAX,
 						SKILL_ATMOS        = SKILL_MAX,
-						SKILL_ENGINES      = SKILL_MAX)
+						SKILL_ENGINES      = SKILL_MAX,
+						SKILL_DEVICES = SKILL_EXPERIENCED)
 
 	access = list(
 		access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,

--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -34,8 +34,7 @@
 	max_skill = list(   SKILL_CONSTRUCTION = SKILL_MAX,
 						SKILL_ELECTRICAL   = SKILL_MAX,
 						SKILL_ATMOS        = SKILL_MAX,
-						SKILL_ENGINES      = SKILL_MAX,
-						SKILL_DEVICES = SKILL_EXPERIENCED)
+						SKILL_ENGINES      = SKILL_MAX)
 
 	access = list(
 		access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

:cl: Titanized
tweak: Increases the maximum complex devices skill level to 'experienced' for the CE.
/:cl:
Currently, only roboticists and scientific staff can perform the robotic surgery steps safely, but unfortunately, the frequent absence of a roboticist leads to a lack of qualified staff for FBP and IPC repairs and provokes unrelated departments to aid in repairs themselves or engage in self-repairs.

To solve the issue above the CE and SE are now both able to pick up to SKILL_EXPERIENCED for SKILL_DEVICES, with the CE also being forced to have at least SKILL_TRAINED for SKILL_DEVICES. SEs were not granted robotics access as the skill modification for the SE is mostly fluff-based but still allows a character with enough skill to act in an emergency.

The roboticist continues to be the only one within the engineering department to be able to select SKILL_MAX for SKILL_DEVICES due to the nature of their job and how specific it is.

