### PR TITLE
Fixes Unathi nutrition

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food.dm
@@ -48,10 +48,10 @@
 	M.add_chemical_effect(CE_BLOODRESTORE, 4 * removed)
 
 /datum/reagent/nutriment/proc/adjust_nutrition(mob/living/carbon/M, removed)
-	var/nut_removed = removed
-	var/hyd_removed = removed
 	if (HAS_TRAIT(M, /singleton/trait/boon/cast_iron_stomach))
 		removed *= 0.1 // Unathi get most of their nutrition from meat.
+	var/nut_removed = removed
+	var/hyd_removed = removed
 	if(nutriment_factor)
 		M.adjust_nutrition(nutriment_factor * nut_removed) // For hunger and fatness
 	if(hydration_factor)


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: Unathi no longer get as much nutrition from non-meat items
/🆑 

Caught this oversight while learning trait  code.