### PR TITLE
Revert "Fix white skybox appearance"

### DIFF
--- a/code/_onclick/hud/skybox.dm
+++ b/code/_onclick/hud/skybox.dm
@@ -23,14 +23,9 @@
 			screen |= skybox
 		skybox.screen_loc = "CENTER:[-224 - T.x],CENTER:[-224 - T.y]"
 
-/client/proc/deferred_update_skybox(rebuild)
-	set waitfor = FALSE
-	sleep(1)
-	update_skybox(rebuild)
-
 /mob/Login()
 	..()
-	client.deferred_update_skybox(1)
+	client.update_skybox(1)
 
 /mob/Move()
 	var/old_z = get_z(src)

--- a/code/controllers/subsystems/skybox.dm
+++ b/code/controllers/subsystems/skybox.dm
@@ -42,7 +42,6 @@ SUBSYSTEM_DEF(skybox)
 		dust.blend_mode = BLEND_ADD
 		var/mutable_appearance/space = new /mutable_appearance(/turf/space)
 		space.icon_state = "white"
-		space.plane = SKYBOX_PLANE
 		space.AddOverlays(dust)
 		space_appearance_cache[index] = space.appearance
 	background_color = RANDOM_RGB


### PR DESCRIPTION
This reverts commit 30e85fcb178f04f848462b7161652586f356d44c.

:cl: Mucker
bugfix: Brought back the good skybox. 
/:cl:

Reverting this until a proper fix for the flashbang skybox can be done. The return of the old, dull background just isn't worth it.