### PR TITLE
Vox only get neuter pronouns

### DIFF
--- a/code/modules/species/outsider/vox.dm
+++ b/code/modules/species/outsider/vox.dm
@@ -79,6 +79,7 @@
 		)
 
 	genders = list(NEUTER)
+	pronouns = list(PRONOUNS_THEY_THEM, PRONOUNS_IT_ITS)
 	descriptors = list(
 		/datum/mob_descriptor/height = -1,
 		/datum/mob_descriptor/build = 1,


### PR DESCRIPTION
As per maintainer, vox can now only use they/them and it/its.

:cl: Nyvrem
tweak: Vox have had errant thoughts of excessive identity pruned from their mindscapes. Again.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->