### PR TITLE
changes the taste of DnB from sassafras (wrong) to fruit and aniseed (correct)

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drinks.dm
@@ -1053,7 +1053,7 @@
 /datum/reagent/drink/dandelionburdock
 	name = "Dandelion and Burdock"
 	description = "Does not contain any Taraxacum officinale, or Arctium lappa."
-	taste_description = "sassafras"
+	taste_description = "fruit and aniseed"
 	reagent_state = LIQUID
 	color = "#ff8cff"
 	nutrition = 1


### PR DESCRIPTION
Unlike root beer and sarsaparilla, DnB doesn't taste like or contain sassafras. This is corrected here.

:cl: Noreaus
tweak: changes the taste of DnB from sassafras (wrong) to fruit and aniseed (correct)
/:cl: