### PR TITLE
adds an air alarm to chemistry

### DIFF
--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -631,6 +631,9 @@
 /obj/item/stack/material/phoron{
 	amount = 6
 	},
+/obj/machinery/alarm{
+	pixel_y = 24
+	},
 /turf/simulated/floor/tiled/white,
 /area/medical/chemistry)
 "abt" = (


### PR DESCRIPTION
🆑 Gy1ta23
maptweak: chemistry has an air alarm
/🆑

How did this happen? How, exactly, did a Chemistry lab miss not having an air alarm for at least a year? Did nobody lose a single drop of phoron to the decking? I spent ten minutes of my life repeatedly right clicking every tile in-game and in the editor, I did experiments, I did all I could to confirm there is indeed no functional air alarm system associated with the chemistry lab - it is completely barren. I am baffled. Back in my day, we wouldn't stand for this nonsense. We had real men. Real women. Real enbies and otherwise. None of them would've taken this baboonery standing up, sitting down, or on their knees, in that order.

Imagine me shaking my head, really hard. Like, as hard as a dog shakes to get water off. That's how shaking my head right now I am at this. I can't even get banned for flooding the lab with Phoron because nobody can tell I did it without an analyzer. It drains my soul so - knowing these injustices. Maybe I will die before I find them all corrected.




![image](https://github.com/Baystation12/Baystation12/assets/44277885/8aace8ee-ef1c-4394-8de7-195619e8df1b)
