### PR TITLE
Fix bundles using fax toner

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -223,9 +223,9 @@
 			break
 
 		if(istype(W, /obj/item/paper))
-			W = copy(W)
+			W = copy(W, need_toner)
 		else if(istype(W, /obj/item/photo))
-			W = photocopy(W)
+			W = photocopy(W, need_toner)
 		W.forceMove(p)
 		p.pages += W
 


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Fax machines no longer run out of toner, which they don't actually have or use, when receiving bundled faxes.
/:cl: