### PR TITLE
Make desk lamps start turned off

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -247,8 +247,6 @@
 	flashlight_range = 5
 	light_wedge = LIGHT_OMNI
 
-	on = 1
-
 // green-shaded desk lamp
 /obj/item/device/flashlight/lamp/green
 	desc = "A classic green-shaded desk lamp."


### PR DESCRIPTION
Finally taught the pesky office dwellers to turn the damn lamps off on their way out. Yes, I was annoyed by this, and no, I am not ashamed.

🆑
tweak: Desk lamps start turned off by default.
/🆑