### PR TITLE
Fix light sprites not matching light color

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -299,7 +299,7 @@
 	if(istype(lightbulb, /obj/item/light))
 		if (on)
 			AddOverlays(emissive_appearance(icon, _state))
-		AddOverlays(overlay_image(icon, _state, color))
+		AddOverlays(overlay_image(icon, _state, lightbulb.color))
 
 	if(on)
 


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Fixes the sprite color of lights not matching the actual color of the light itself.
/:cl: