### PR TITLE
Fix barsigns having a null sprite option

### DIFF
--- a/code/game/objects/structures/barsign.dm
+++ b/code/game/objects/structures/barsign.dm
@@ -8,6 +8,7 @@
 
 /obj/structure/sign/double/barsign/proc/get_valid_states(initial=1)
 	. = icon_states(icon)
+	. -= ""
 	. -= "on"
 	. -= "narsiebistro"
 	. -= "empty"


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Fixes barsigns having an empty string as a selectable sprite option.
/:cl: