### PR TITLE
Gyrotron damage fix & emitter damage refactor

### DIFF
--- a/code/modules/power/fusion/gyrotron/gyrotron.dm
+++ b/code/modules/power/fusion/gyrotron/gyrotron.dm
@@ -42,10 +42,8 @@
 /obj/machinery/power/emitter/gyrotron/get_burst_delay()
 	return rate * 10
 
-/obj/machinery/power/emitter/gyrotron/get_emitter_beam()
-	var/obj/item/projectile/beam/emitter/E = ..()
-	E.damage = mega_energy * 50
-	return E
+/obj/machinery/power/emitter/gyrotron/get_emitter_damage()
+	return mega_energy * 50
 
 /obj/machinery/power/emitter/gyrotron/on_update_icon()
 	ClearOverlays()

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -23,6 +23,8 @@
 	var/shot_number = 0
 	var/state = EMITTER_LOOSE
 	var/locked = FALSE
+	/// Type path (Type of `/obj/item/projectile`). The projectile type this emitter fires.
+	var/projectile_type = /obj/item/projectile/beam/emitter
 	core_skill = SKILL_ENGINES
 
 	uncreated_component_parts = list(
@@ -178,9 +180,10 @@
 			s.set_up(5, 1, src)
 			s.start()
 
-		var/obj/item/projectile/A = get_emitter_beam()
-		playsound(loc, A.fire_sound, 25, TRUE)
-		A.launch( get_step(loc, dir) )
+		var/obj/item/projectile/proj = new projectile_type(get_turf(src))
+		proj.damage = get_emitter_damage()
+		playsound(loc, proj.fire_sound, 25, TRUE)
+		proj.launch( get_step(loc, dir) )
 
 /obj/machinery/power/emitter/post_anchor_change()
 	if (anchored)
@@ -282,13 +285,16 @@
 /obj/machinery/power/emitter/proc/get_burst_delay()
 	return 0.2 SECONDS // This value doesn't really affect normal emitters, but *does* affect subtypes like the gyrotron that can have very long delays
 
-/obj/machinery/power/emitter/proc/get_emitter_beam()
-	var/obj/item/projectile/beam/emitter/proj = new /obj/item/projectile/beam/emitter(get_turf(src))
+
+/**
+ * Calculates the damage the emitter should fire with its projectile.
+ */
+/obj/machinery/power/emitter/proc/get_emitter_damage()
 	//need to calculate the power per shot as the emitter doesn't fire continuously.
 	var/burst_time = (min_burst_delay + max_burst_delay) / 2 + 2 * (burst_shots - 1)
 	var/power_per_shot = (active_power_usage * efficiency) * (burst_time / 10) / burst_shots
-	proj.damage = round(power_per_shot / EMITTER_DAMAGE_POWER_TRANSFER)
-	return proj
+	return round(power_per_shot / EMITTER_DAMAGE_POWER_TRANSFER)
+
 
 /singleton/public_access/public_method/toggle_emitter
 	name = "toggle emitter"

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -173,18 +173,13 @@
 			fire_delay = get_rand_burst_delay()
 			shot_number = 0
 
-		//need to calculate the power per shot as the emitter doesn't fire continuously.
-		var/burst_time = (min_burst_delay + max_burst_delay) / 2 + 2 * (burst_shots - 1)
-		var/power_per_shot = (active_power_usage * efficiency) * (burst_time / 10) / burst_shots
-
 		if (prob(35))
 			var/datum/effect/spark_spread/s = new /datum/effect/spark_spread
 			s.set_up(5, 1, src)
 			s.start()
 
-		var/obj/item/projectile/beam/emitter/A = get_emitter_beam()
+		var/obj/item/projectile/A = get_emitter_beam()
 		playsound(loc, A.fire_sound, 25, TRUE)
-		A.damage = round (power_per_shot / EMITTER_DAMAGE_POWER_TRANSFER)
 		A.launch( get_step(loc, dir) )
 
 /obj/machinery/power/emitter/post_anchor_change()
@@ -288,7 +283,12 @@
 	return 0.2 SECONDS // This value doesn't really affect normal emitters, but *does* affect subtypes like the gyrotron that can have very long delays
 
 /obj/machinery/power/emitter/proc/get_emitter_beam()
-	return new /obj/item/projectile/beam/emitter(get_turf(src))
+	var/obj/item/projectile/beam/emitter/proj = new /obj/item/projectile/beam/emitter(get_turf(src))
+	//need to calculate the power per shot as the emitter doesn't fire continuously.
+	var/burst_time = (min_burst_delay + max_burst_delay) / 2 + 2 * (burst_shots - 1)
+	var/power_per_shot = (active_power_usage * efficiency) * (burst_time / 10) / burst_shots
+	proj.damage = round(power_per_shot / EMITTER_DAMAGE_POWER_TRANSFER)
+	return proj
 
 /singleton/public_access/public_method/toggle_emitter
 	name = "toggle emitter"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -161,7 +161,7 @@
 	name = "emitter beam"
 	icon_state = "emitter"
 	fire_sound = 'sound/weapons/emitter.ogg'
-	damage = 0 // The actual damage is computed in /code/modules/power/singularity/emitter.dm
+	damage = 0 // The actual damage is computed in `/obj/machinery/power/emitter/proc/get_emitter_beam()`
 
 	muzzle_type = /obj/projectile/laser/emitter/muzzle
 	tracer_type = /obj/projectile/laser/emitter/tracer

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -161,7 +161,7 @@
 	name = "emitter beam"
 	icon_state = "emitter"
 	fire_sound = 'sound/weapons/emitter.ogg'
-	damage = 0 // The actual damage is computed in `/obj/machinery/power/emitter/proc/get_emitter_beam()`
+	damage = 0 // The actual damage is computed in `/obj/machinery/power/emitter/proc/get_emitter_damage()`
 
 	muzzle_type = /obj/projectile/laser/emitter/muzzle
 	tracer_type = /obj/projectile/laser/emitter/tracer


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Gyrotron beams now cause damage.
/:cl:

## Bug Fixes
- Fixes #34543

## Other Changes
- Refactored the generation of emitter projectiles and emitter projectile damage.