### PR TITLE
fixes null rig sprite

### DIFF
--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -478,7 +478,7 @@
 
 //All in one suit
 /obj/item/clothing/suit/space/rig/zero
-	icon_state = "null_rig"
+	icon_state = "null_rig_sealed"
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL, SPECIES_UNATHI, SPECIES_IPC)
 	sprite_sheets = list(
 		SPECIES_UNATHI = 'icons/mob/species/unathi/onmob_suit_unathi.dmi'

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -478,7 +478,7 @@
 
 //All in one suit
 /obj/item/clothing/suit/space/rig/zero
-	icon_state = "null_rig_sealed"
+	icon_state = "null_rig"
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL, SPECIES_UNATHI, SPECIES_IPC)
 	sprite_sheets = list(
 		SPECIES_UNATHI = 'icons/mob/species/unathi/onmob_suit_unathi.dmi'

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -478,6 +478,7 @@
 
 //All in one suit
 /obj/item/clothing/suit/space/rig/zero
+	icon_state = "null_rig_sealed"
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL, SPECIES_UNATHI, SPECIES_IPC)
 	sprite_sheets = list(
 		SPECIES_UNATHI = 'icons/mob/species/unathi/onmob_suit_unathi.dmi'


### PR DESCRIPTION
...kind of.

it goes from this:
![image](https://github.com/Baystation12/Baystation12/assets/16391918/724c13e7-2424-43b7-abd7-09f7a1a8935b)

to this:
![image](https://github.com/Baystation12/Baystation12/assets/16391918/99a9e4e3-72ff-4275-ba7c-a162d8a278f1)


which isn't perfect because the sprite is supposed to change when deployed/undeployed, but i can't get it to work that way, so this is a temporary fix until someone more intelligent than me does the rest properly. for some reason literally only the null rig has this problem - the rest of the rig suits work just fine.