### PR TITLE
Fix glucose/unathi interaction

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food.dm
@@ -61,8 +61,11 @@
 	name = "Glucose"
 	color = "#ffffff"
 	scannable = 1
-
 	injectable = 1
+
+/datum/reagent/nutriment/glucose/adjust_nutrition(mob/living/carbon/M, removed)
+	M.adjust_nutrition(nutriment_factor * removed)
+	M.adjust_hydration(hydration_factor * removed)
 
 /datum/reagent/nutriment/protein // Bad for Skrell!
 	name = "Animal Protein"


### PR DESCRIPTION
:cl: Nl208
bugfix: Unathi now process glucose properly again - no more starving to death on the operating table!
/:cl:

This one's fairly straightforward - fixes some unintended behavior introduced in a previous PR by adding an overriding proc to have glucose act like nutrient but injected + without the unathi malus. Tested by playing unathi on a local server, injecting 15u glucose, and carving myself up with a switchblade - gained back nutrition with it in my system even with rapid regen.