### PR TITLE
Standardized Health - Destroyable Airlocks

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -797,6 +797,7 @@
 #include "code\game\machinery\doors\blast_door.dm"
 #include "code\game\machinery\doors\braces.dm"
 #include "code\game\machinery\doors\brigdoors.dm"
+#include "code\game\machinery\doors\broken_door.dm"
 #include "code\game\machinery\doors\checkForMultipleDoors.dm"
 #include "code\game\machinery\doors\door.dm"
 #include "code\game\machinery\doors\firedoor.dm"

--- a/code/__defines/health.dm
+++ b/code/__defines/health.dm
@@ -85,3 +85,8 @@
 #define DAMAGE_FLAG_DISPERSED               FLAG(7)
 /// Toxin damage that should be mitigated by biological (i.e. sterile) armor
 #define DAMAGE_FLAG_BIO                     FLAG(8)
+
+
+/// Health Status flags for `/atom/var/health_status`.
+/// The atom is currently dead.
+#define HEALTH_STATUS_DEAD FLAG(0)

--- a/code/__defines/health.dm
+++ b/code/__defines/health.dm
@@ -90,3 +90,10 @@
 /// Health Status flags for `/atom/var/health_status`.
 /// The atom is currently dead.
 #define HEALTH_STATUS_DEAD FLAG(0)
+/// The atom is currently broken. An atom is `broken` if `HEALTH_FLAG_BREAKABLE` is set and the atom's health falls below 1/2 of `health_max`. Used for certain atoms that needed an additional damage state.
+#define HEALTH_STATUS_BROKEN FLAG(1)
+
+
+/// Health Flags for `/atom/var/health_flags`.
+/// The atom is 'breakable', and considered broken upon reaching 1/2 health.
+#define HEALTH_FLAG_BREAKABLE FLAG(0)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -94,7 +94,6 @@
 
 	if (health_max)
 		health_current = health_max
-		health_dead = FALSE
 
 	return INITIALIZE_HINT_NORMAL
 

--- a/code/game/machinery/doors/broken_door.dm
+++ b/code/game/machinery/doors/broken_door.dm
@@ -1,0 +1,41 @@
+/obj/structure/broken_door
+	name = "broken airlock"
+	desc = "An airlock that's been completely and forcefully broken open. There's barely anything left to salvage."
+	icon = 'icons/obj/doors/station/door.dmi'
+	icon_state = "open"
+	anchored = TRUE
+	obj_flags = OBJ_FLAG_NOFALL
+
+
+/obj/structure/broken_door/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_WELDER] = "<p>Dismantles \the [initial(name)]. Costs 1 unit of fuel and provides 1 sheet of steel.</p>"
+
+
+/obj/structure/broken_door/use_tool(obj/item/tool, mob/living/user, list/click_params)
+	if (isWelder(tool))
+		var/obj/item/weldingtool/welder = tool
+		if (!welder.can_use(1, user, "to deconstruct \the [src]"))
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts welding \the [src] with \a [tool]."),
+			SPAN_NOTICE("You start welding \the [src] with \the [tool]."),
+			SPAN_ITALIC("You hear welding.")
+		)
+		add_fingerprint(user, FALSE, tool)
+		playsound(src, 'sound/items/Welder.ogg', 50, TRUE)
+		if (!user.do_skilled(SKILL_CONSTRUCTION, 2 SECONDS, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (!welder.remove_fuel(1, user))
+			return TRUE
+		var/obj/item/stack/material/steel/materials = new (loc, 1)
+		transfer_fingerprints_to(materials)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] dismantles \the [src] with \a [tool]."),
+			SPAN_NOTICE("You dismantle \the [src] with \the [tool]."),
+			SPAN_ITALIC("You hear welding.")
+		)
+		qdel_self()
+		return TRUE
+
+	return ..()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -287,12 +287,6 @@
 		to_chat(user, SPAN_WARNING("\The [src]'s control panel looks fried."))
 
 
-/obj/machinery/door/set_broken(new_state)
-	. = ..()
-	if(. && new_state)
-		visible_message(SPAN_WARNING("\The [src.name] breaks!"))
-
-
 /obj/machinery/door/on_update_icon()
 	update_dir()
 	if(density)

--- a/code/game/objects/structures/fireaxe_cabinet.dm
+++ b/code/game/objects/structures/fireaxe_cabinet.dm
@@ -25,7 +25,7 @@
 	ClearOverlays()
 	if(fireaxe)
 		AddOverlays(image(icon, "fireaxe_item"))
-	if(health_dead)
+	if(health_dead())
 		AddOverlays(image(icon, "fireaxe_window_broken"))
 	else if(!open)
 		AddOverlays(image(icon, "fireaxe_window"))
@@ -93,7 +93,7 @@
 		var/obj/item/stack/material/stack = tool
 		if (stack.material.name != MATERIAL_GLASS)
 			return ..()
-		if (!health_dead && !health_damaged())
+		if (!health_dead() && !health_damaged())
 			USE_FEEDBACK_FAILURE("\The [src] doesn't need repair.")
 			return TRUE
 		if (!stack.reinf_material)
@@ -114,7 +114,7 @@
 		if (open)
 			USE_FEEDBACK_FAILURE("\The [src] must be closed before you can lock it.")
 			return TRUE
-		if (health_dead)
+		if (health_dead())
 			USE_FEEDBACK_FAILURE("\The [src] is shattered and the lock doesn't function.")
 			return TRUE
 		user.visible_message(
@@ -136,7 +136,7 @@
 
 
 /obj/structure/fireaxecabinet/proc/toggle_open(mob/user)
-	if(health_dead)
+	if(health_dead())
 		open = 1
 		unlocked = 1
 	else

--- a/code/modules/admin/view_variables/vv_set_handlers.dm
+++ b/code/modules/admin/view_variables/vv_set_handlers.dm
@@ -145,7 +145,7 @@
 	predicates = list(/proc/is_strict_bool_predicate)
 
 /singleton/vv_set_handler/health_dead_handler/handle_set_var(atom/target, variable, var_value, client)
-	if (var_value == target.health_dead)
+	if (var_value == target.health_dead())
 		return
 	switch (var_value)
 		if (TRUE)

--- a/code/modules/xenoarcheaology/anomaly_container.dm
+++ b/code/modules/xenoarcheaology/anomaly_container.dm
@@ -41,7 +41,7 @@
 		if(!src.allowed(user))
 			to_chat(user, SPAN_WARNING("\The [src] blinks red, notifying you of your incorrect access."))
 			return
-		if(!src.health_dead)
+		if(!src.health_dead())
 			user.visible_message(
 				SPAN_NOTICE("\The [user] begins undoing the locks and latches on \the [src]..."),
 				SPAN_NOTICE("You begin undoing the locks and latches on \the [src]...")
@@ -71,7 +71,7 @@
 		if(!src.allowed(user))
 			to_chat(user, SPAN_WARNING("\The [src] blinks red, notifying you of your incorrect access."))
 			return
-		if(!src.health_dead)
+		if(!src.health_dead())
 			user.visible_message(
 				SPAN_NOTICE("\The [user] begins undoing the locks and latches on \the [src]..."),
 				SPAN_NOTICE("You begin undoing the locks and latches on \the [src]...")
@@ -95,7 +95,7 @@
 	if (attached_paper)
 		to_chat(usr, SPAN_NOTICE("There's a paper clipped on the side."))
 		attached_paper.examine(user, distance)
-	if (health_dead)
+	if (health_dead())
 		to_chat(usr, SPAN_DANGER("The borosilicate panels are completely shattered."))
 
 /obj/machinery/anomaly_container/proc/contain(obj/machinery/artifact)
@@ -146,7 +146,7 @@
 
 /obj/machinery/anomaly_container/emp_act(severity)
 	SHOULD_CALL_PARENT(FALSE)
-	if(health_dead)
+	if(health_dead())
 		return
 	if(contained)
 		visible_message(SPAN_DANGER("\The [src]'s latches break loose, freeing the contents!"))
@@ -174,7 +174,7 @@
 		return TRUE
 
 	if (istype(P, /obj/item/stack/material))
-		if (!health_dead)
+		if (!health_dead())
 			to_chat(user, SPAN_NOTICE("\The [src] doesn't require repairs."))
 			return TRUE
 		if (contained)
@@ -211,7 +211,7 @@
 		return TRUE
 
 	if (isWrench(P))
-		if (!health_dead)
+		if (!health_dead())
 			return TRUE
 
 		user.visible_message(
@@ -234,7 +234,7 @@
 
 /obj/machinery/anomaly_container/on_update_icon()
 	ClearOverlays()
-	if(health_dead)
+	if(health_dead())
 		icon_state = "anomaly_container_broken"
 	if(attached_paper)
 		AddOverlays("anomaly_container_paper")


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
rscadd: Airlocks can now be broken completely open with enough damage. Note that the frame of an airlock is much sturdier than the control panel, so damaging it further than a broken panel requires a much stronger weapon (~35 force),
/:cl:

## Other Changes
- Added `/atom/var/health_flags` property.
- Replaced `/atom/var/health_dead` with `HEALTH_FLAG_DEAD`.
- Updated `/atom/proc/health_dead()` to also check if `health_max` is defined.
- Added `HEALTH_DEAD(X)` macro.

## Notes
- The broken flag stuff is planned to be used when I get organs running on standardized health as well. In fact, a WIP branch of that is what inspired this in the first place.
- Technically needs a sprite, but the open sprite works well enough until someone less lazy gets to it.
- The damage required to fully break the airlock probably needs tweaking, but I didn't want it to be "Anything can do this".