### PR TITLE
Anomaly analysis QOL Tweaks

### DIFF
--- a/code/modules/xenoarcheaology/tools/ano_device_battery.dm
+++ b/code/modules/xenoarcheaology/tools/ano_device_battery.dm
@@ -208,8 +208,11 @@
 	. = FALSE
 	if (!istype(M))
 		return FALSE
+	if(!inserted_battery)
+		user.visible_message(SPAN_NOTICE("[user] taps [M] with [src], but with no battery inserted, nothing happens."))
+		return FALSE
 
-	if (activated && inserted_battery.battery_effect.effect == EFFECT_TOUCH && !isnull(inserted_battery))
+	if (inserted_battery.battery_effect.effect == EFFECT_TOUCH  && ((inserted_battery.stored_charge - energy_consumed_on_touch) > 0))
 		inserted_battery.battery_effect.DoEffectTouch(M)
 		inserted_battery.use_power(energy_consumed_on_touch)
 		user.visible_message(SPAN_NOTICE("[user] taps [M] with [src], and it shudders on contact."))

--- a/code/modules/xenoarcheaology/tools/artifact_harvester.dm
+++ b/code/modules/xenoarcheaology/tools/artifact_harvester.dm
@@ -2,24 +2,34 @@
 	name = "Exotic Particle Harvester"
 	icon = 'icons/obj/machines/research/virology.dmi'
 	icon_state = "incubator"	//incubator_on
+
 	anchored = TRUE
 	density = TRUE
 	idle_power_usage = 50
 	active_power_usage = 750
 	var/harvesting = 0
+	var/obj/item/disk/tech_disk/inserted_disk
 	var/obj/item/anobattery/inserted_battery
 	var/obj/machinery/artifact/cur_artifact
 	var/obj/machinery/artifact_scanpad/owned_scanner = null
 	var/last_process = 0
-
+	var/list/data = list("screen" = 1)
 /obj/machinery/artifact_harvester/New()
 	..()
-	//connect to a nearby scanner pad
-	owned_scanner = locate(/obj/machinery/artifact_scanpad) in get_step(src, dir)
-	if(!owned_scanner)
-		owned_scanner = locate(/obj/machinery/artifact_scanpad) in orange(1, src)
+	sync_with_pad()
 
 /obj/machinery/artifact_harvester/use_tool(obj/item/I, mob/living/user, list/click_params)
+	if(istype(I,/obj/item/disk/tech_disk))
+		if(!inserted_disk)
+			if(!user.unEquip(I, src))
+				return TRUE
+			to_chat(user, SPAN_NOTICE("You insert [I] into [src]."))
+			src.inserted_disk = I
+			updateDialog()
+			return TRUE
+		else
+			to_chat(user, SPAN_WARNING("There is already a technology disk in [src]."))
+			return TRUE
 	if(istype(I,/obj/item/anobattery))
 		if(!inserted_battery)
 			if(!user.unEquip(I, src))
@@ -32,7 +42,13 @@
 			to_chat(user, SPAN_WARNING("There is already a battery in [src]."))
 			return TRUE
 	return..()
-
+/obj/machinery/artifact_harvester/proc/sync_with_pad()
+	for(var/obj/machinery/artifact_scanpad/scanner in range(5, src))
+		owned_scanner = scanner
+		src.visible_message("<b>[name]</b> states, \"Pad located, commencing sync.\"")
+		return
+	src.visible_message("<b>[name]</b> states, \"Scan unsuccessful, could not locate pad.\"")
+	return
 /obj/machinery/artifact_harvester/attack_hand(mob/user as mob)
 	..()
 	interact(user)
@@ -58,17 +74,26 @@
 				dat += "<A href='?src=\ref[src];ejectbattery=1'>Eject battery</a><BR>"
 				dat += "<A href='?src=\ref[src];drainbattery=1'>Drain battery of all charge</a><BR>"
 				dat += "<A href='?src=\ref[src];harvest=1'>Begin harvesting</a><BR>"
-
-			else
+			if(inserted_disk)
+				dat += "[inserted_disk.name] inserted.<BR>"
+				dat += "<A href='?src=\ref[src];loaddisk=1'>Copy data to disk</a><BR>"
+				dat += "<A href='?src=\ref[src];ejectdisk=1'>Eject technology disk</a><BR>"
+			if(!inserted_disk)
+				dat += "No technology disk inserted.<BR>"
+			if(!inserted_battery)
 				dat += "No battery inserted.<BR>"
+			else
+
 	else
 		dat += "<B>[SPAN_COLOR("red", "Unable to locate analysis pad.")]<BR></b>"
+	dat += "<A href='?src=\ref[src];syncpads=1'>Sync with nearby pad</a><BR>"
 	dat += "<A href='?src=\ref[src];close=1'>Close</a><BR>"
 	dat += "<HR>"
 	var/datum/browser/popup = new(user, "artifact_harvester", "Artifact Power Harvester", 450, 500)
 	popup.set_content(dat)
 	popup.open()
-
+	user.set_machine(src)
+	onclose(user, "artifactharvester")
 /obj/machinery/artifact_harvester/Process()
 	if(inoperable())
 		return
@@ -118,7 +143,7 @@
 	if (href_list["harvest"])
 		if(!inserted_battery)
 			src.visible_message("<b>[src]</b> states, \"Cannot harvest. No battery inserted.\"")
-
+			return TOPIC_REFRESH
 		else if(inserted_battery.stored_charge >= inserted_battery.capacity)
 			src.visible_message("<b>[src]</b> states, \"Cannot harvest. battery is full.\"")
 
@@ -136,7 +161,7 @@
 				var/message = "<b>[src]</b> states, \"Cannot harvest. No noteworthy energy signature isolated.\""
 				src.visible_message(message)
 
-			else if(analysed && analysed.being_used)
+			else if(analysed && analysed.being_used )
 				src.visible_message("<b>[src]</b> states, \"Cannot harvest. Source already being harvested.\"")
 
 			else
@@ -170,7 +195,7 @@
 								source_effect = cur_artifact.my_effect
 
 							var/battery_matches_secondary_id = 0
-							if(inserted_battery.battery_effect && inserted_battery.battery_effect.artifact_id == cur_artifact.secondary_effect.artifact_id)
+							if(inserted_battery.battery_effect && inserted_battery.battery_effect.artifact_id == cur_artifact.secondary_effect?.artifact_id)
 								battery_matches_secondary_id = 1
 							if(battery_matches_secondary_id && cur_artifact.secondary_effect.activated)
 								//we're good to recharge the secondary effect!
@@ -249,9 +274,46 @@
 			var/message = "<b>[src]</b> states, \"Cannot dump energy. No battery inserted.\""
 			src.visible_message(message)
 		. = TOPIC_REFRESH
+	else if (href_list["loaddisk"])
+		if(!inserted_battery)
+			src.visible_message("<b>[src]</b> states, \"Cannot conduct analysis. No battery inserted.\"")
 
+		else if(inserted_battery.battery_effect && inserted_battery.stored_charge > 0)
+			var/effect_type = inserted_battery.battery_effect.effect_type
+			//horrifying copypasta but unfortunately think it might be necessary
+			if(effect_type == EFFECT_BLUESPACE)
+				var/datum/tech/anomaly_tech = new /datum/tech/bluespace
+				anomaly_tech.level = 8
+				src.inserted_disk.stored = anomaly_tech
+			else if(effect_type == EFFECT_ORGANIC)
+				var/datum/tech/anomaly_tech = new /datum/tech/biotech
+				anomaly_tech.level = 8
+				src.inserted_disk.stored = anomaly_tech
+			else if(effect_type == EFFECT_ELECTRO)
+				var/datum/tech/anomaly_tech = new /datum/tech/powerstorage
+				anomaly_tech.level = 8
+				src.inserted_disk.stored = anomaly_tech
+			else if(effect_type == EFFECT_ENERGY)
+				var/datum/tech/anomaly_tech = new /datum/tech/magnets
+				anomaly_tech.level = 8
+				src.inserted_disk.stored = anomaly_tech
+			else if(effect_type == EFFECT_PARTICLE)
+				var/datum/tech/anomaly_tech = new /datum/tech/materials
+				anomaly_tech.level = 8
+				src.inserted_disk.stored = anomaly_tech
+			. = TOPIC_REFRESH
+		else
+			var/message = "<b>[src]</b> states, \"No energy signature detected from battery, analysis inconclusive.\""
+			src.visible_message(message)
+	else if (href_list["ejectdisk"])
+		src.inserted_disk.dropInto(loc)
+		src.inserted_disk = null
+		. = TOPIC_REFRESH
+	else if(href_list["syncpads"])
+		sync_with_pad()
+		. = TOPIC_REFRESH
 	else if(href_list["close"])
-		close_browser(user, "window=artharvester")
+		close_browser(user, "window=artifact_harvester")
 		return TOPIC_HANDLED
 
 	if(. == TOPIC_REFRESH)

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -2489,6 +2489,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/machinery/artifact_analyser,
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/isolation)
 "fE" = (
@@ -10895,9 +10897,7 @@
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/rnd)
 "zm" = (
-/obj/structure/table/standard,
 /obj/machinery/atmospherics/pipe/simple/visible/red,
-/obj/random/tool,
 /obj/machinery/button/blast_door{
 	id_tag = "petrovcell1";
 	name = "Test Chamber Vent";
@@ -10909,6 +10909,8 @@
 	pixel_x = -36;
 	pixel_y = -25
 	},
+/obj/machinery/artifact_harvester,
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/isolation)
 "zn" = (
@@ -11333,7 +11335,6 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "Bn" = (
-/obj/machinery/artifact_analyser,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -12606,7 +12607,6 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/eva)
 "GG" = (
-/obj/machinery/artifact_scanpad,
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/cell1)
 "GI" = (
@@ -13705,6 +13705,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/artifact_scanpad,
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/cell1)
 "KQ" = (


### PR DESCRIPTION
🆑 PapiSmirnov
:rscadd: Anomaly harvesters will now accept technology disks that can have data from anomaly harvesting copied to them for techlevels, providing levels based on the type of anomaly.
:tweak: The anomaly utiliser and harvester no longer need to be right next to the scanner pad to work, and can be resynced with any scanner pad nearby.
:tweak: Moved the anomaly scanner and harvester outside of the chamber so it's actually possible to scan and harvest hazardous anomalies now without flooding a lab with toxic gas/destroying the entire lab.
:bugfix: The anomaly utiliser's on-touch method will actually work as intended now and can be activated without using the AOE effect
:bugfix: The anomaly harvester can now actually recharge anomaly batteries that have been depleted.
/:cl:

Basically this PR's just a bunch of quality-of-life tweaks/fixes/slight upgrades that'll make anomalies actually useful/something you can turn the abilities of into a tool and not just big dumb rocks that'll never see any use as well as fixing some items that were ported but never actually made to work like the power utiliser.

Photo of the new anomaly cell below

![image](https://github.com/Baystation12/Baystation12/assets/134344460/7092d782-cd1b-42bd-9df5-c59347f0f6ea)
