### PR TITLE
Fixes dragging taped papers and storing in sealed storage

### DIFF
--- a/code/game/objects/items/weapons/storage/fancy/_fancy.dm
+++ b/code/game/objects/items/weapons/storage/fancy/_fancy.dm
@@ -81,9 +81,17 @@
 
 /obj/item/storage/fancy/open(mob/user as mob)
 	if(sealed)
-		to_chat(user, "You need to unseal \the [src] first!")
+		to_chat(user, SPAN_WARNING("You need to unseal \the [src] first!"))
 		return
 	..()
+
+/obj/item/storage/fancy/can_be_inserted(obj/item/item, mob/user, stop_messages)
+	if (!istype(item))
+		return FALSE
+	if (sealed)
+		to_chat(user, SPAN_WARNING("You need to unseal \the [src] first!"))
+		return FALSE
+	return ..()
 
 
 /obj/item/storage/fancy/proc/UpdateTypeCounts()

--- a/code/game/objects/items/weapons/storage/fancy/smokable/basic.dm
+++ b/code/game/objects/items/weapons/storage/fancy/smokable/basic.dm
@@ -150,6 +150,7 @@
 	max_storage_space = null
 	storage_slots = 7
 	slot_flags = SLOT_BELT
+	sealed = FALSE
 	key_type = list(/obj/item/clothing/mask/smokable/cigarette/cigar)
 	startswith = list(
 		/obj/item/clothing/mask/smokable/cigarette/cigar = 6

--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -106,7 +106,6 @@
 
 /obj/item/ducttape/proc/attach(obj/item/W)
 	stuck = W
-	anchored = TRUE
 	W.forceMove(src)
 	icon_state = W.icon_state + "_taped"
 	name = W.name + " (taped)"
@@ -141,6 +140,7 @@
 
 	playsound(src, 'sound/effects/tape.ogg',25)
 	layer = ABOVE_WINDOW_LAYER
+	anchored = TRUE
 
 	if(click_parameters)
 		if(click_parameters["icon-x"])

--- a/code/game/objects/items/weapons/wrapping_paper.dm
+++ b/code/game/objects/items/weapons/wrapping_paper.dm
@@ -76,7 +76,7 @@
 /obj/item/stack/package_wrap/use_before(atom/target, mob/living/user)
 	if (isobj(target))
 		var/obj/wrapped_object = target
-		if (istype(wrapped_object, /obj/item/stack/package_wrap) || istype(wrapped_object, /obj/item/storage/backpack) || istype(wrapped_object, /obj/item/storage/belt) || istype(wrapped_object,/obj/item/storage/bag || istype(wrapped_object, /obj/item/storage/briefcase)))
+		if (istype(wrapped_object, /obj/item/stack/package_wrap) || istype(wrapped_object, /obj/item/storage/backpack) || istype(wrapped_object, /obj/item/storage/belt) || istype(wrapped_object,/obj/item/storage/bag) || istype(wrapped_object, /obj/item/storage/briefcase)|| istype(wrapped_object, /obj/structure/table))
 			return FALSE
 		if (istype(wrapped_object, /obj/item/smallDelivery) || istype(wrapped_object, /obj/structure/bigDelivery) || istype(wrapped_object, /obj/item/evidencebag))
 			to_chat(user, SPAN_WARNING("\The [wrapped_object] is already wrapped."))


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: Fix being able to store items in sealed storage containers
tweak: Cigar cases now start the round unsealed; like cigarette cases already behave.
bugfix: Fixes being able to drag taped papers around on a wall.
/🆑 

