### PR TITLE
Fixes Firelock Prompts

### DIFF
--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -144,7 +144,8 @@
 	return FALSE
 
 /obj/machinery/door/firedoor/attack_hand(mob/user)
-	if ((. = ..()))
+	if(user.a_intent != I_HELP)
+		..()
 		return
 	if(operating)
 		return//Already doing something.
@@ -160,10 +161,11 @@
 	var/alarmed = lockdown
 	alarmed = get_alarm()
 
-	var/answer = alert(user, "Would you like to [density ? "open" : "close"] this [name]?[ alarmed && density ? "\nNote that by doing so, you acknowledge any damages from opening this\n[name] as being your own fault, and you will be held accountable under the law." : ""]",\
-	"\The [src]", "Yes, [density ? "open" : "close"]", "No")
-	if(answer == "No")
-		return
+	if(!allowed(user))
+		var/answer = alert(user, "Would you like to [density ? "open" : "close"] this [name]?[ alarmed && density ? "\nNote that by doing so, you acknowledge any damages from opening this\n[name] as being your own fault, and you will be held accountable under the law." : ""]",\
+		"\The [src]", "Yes, [density ? "open" : "close"]", "No")
+		if(answer == "No")
+			return
 	if(user.incapacitated() || !user.Adjacent(src) && !issilicon(user))
 		to_chat(user, SPAN_WARNING("You must remain able-bodied and close to \the [src] in order to use it."))
 		return


### PR DESCRIPTION
🆑
bugfix: Firedoor prompts now display correctly again.
tweak: Firedoors can be opened without the prompt by people with engineering access.
/🆑

Basically just fixes firedoors. Zombies can still correctly interact with firedoors as far as I tested (breaking, prying).

I kept in the "feature" of engineers being able to open firelocks without a prompt displaying due to requests from multiple engineering players. Seems harmless enough to me since it originally worked this way if you held any object in your hand.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->