### PR TITLE
use cdnjs with SRI tags for remote jquery

### DIFF
--- a/code/modules/tooltip/tooltip.html
+++ b/code/modules/tooltip/tooltip.html
@@ -93,7 +93,10 @@
 	<div id="wrap" class="wrap">
 		<div id="content" class="content"></div>
 	</div>
-	<script type="text/javascript" src="https://code.jquery.com/jquery-1.12.4.min.js"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.4/jquery.min.js"
+		integrity="sha512-jGsMH83oKe9asCpkOVkBnUrDDTp8wl+adkB2D+//JtlxO4SrLoJdhbOysIFQJloQFD+C4Fl1rMsQZF76JjV0eQ=="
+		crossorigin="anonymous"
+		referrerpolicy="no-referrer"></script>
 	<script type="text/javascript">
 		var tooltip = {
 			'tileSize': 32,


### PR DESCRIPTION
Satisfies [code scanning security #9](https://github.com/Baystation12/Baystation12/security/code-scanning/9) by using sri tags. Shouldn't affect system targets before the implementation of those. If overmap popups stop working for people in edge case configurations, this is why.
