### PR TITLE
Fix empty announcements when exceeding character limit

### DIFF
--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -141,11 +141,11 @@
 				if(announcment_cooldown)
 					to_chat(usr, "Please allow at least one minute to pass between announcements")
 					return
-				var/input = input(usr, "Please write a message to announce to the [station_name()].", "Priority Announcement") as null|message
+				var/input = sanitize(input(usr, "Please write a message to announce to the [station_name()].", "Priority Announcement") as null|message, extra = FALSE)
 				if(!input || !can_still_topic())
 					return
 				var/affected_zlevels = GetConnectedZlevels(get_host_z())
-				crew_announcement.Announce(input, zlevels = affected_zlevels)
+				crew_announcement.Announce(input, msg_sanitized = TRUE, zlevels = affected_zlevels)
 				announcment_cooldown = 1
 				spawn(600)//One minute cooldown
 					announcment_cooldown = 0


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Blank announcements are no longer sent if your message exceeds the character limits.
/:cl: