### PR TITLE
allows pAIs to target limbs

### DIFF
--- a/code/_onclick/hud/pai.dm
+++ b/code/_onclick/hud/pai.dm
@@ -32,8 +32,15 @@
 	adding += using
 	action_intent = using
 
+	// Limb Targeting
+	mymob.zone_sel = new /obj/screen/zone_sel()
+	mymob.zone_sel.icon = 'icons/mob/screen1_robot.dmi'
+	mymob.zone_sel.ClearOverlays()
+	mymob.zone_sel.AddOverlays(image('icons/mob/zone_sel.dmi', "[mymob.zone_sel.selecting]"))
+
 	mymob.client.screen = list()
 	mymob.client.screen += adding
+	mymob.client.screen += mymob.zone_sel
 	inventory_shown = 0
 
 /obj/screen/pai
@@ -42,7 +49,7 @@
 /obj/screen/pai/Click()
 	if(!isobserver(usr) && (!usr.incapacitated() || usr.resting))
 		OnClick()
-	
+
 /obj/screen/pai/proc/OnClick()
 
 /obj/screen/pai/software

--- a/code/modules/mechs/equipment/medical.dm
+++ b/code/modules/mechs/equipment/medical.dm
@@ -125,7 +125,7 @@
 	if (mode == MEDIGEL_SALVE)
 		if (istype(target, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = target
-			var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel.selecting)
+			var/obj/item/organ/external/affecting = H.get_organ(user.zone_sel ? user.zone_sel.selecting : ran_zone())
 
 			if(affecting.is_bandaged() && affecting.is_disinfected() && affecting.is_salved())
 				to_chat(user, SPAN_WARNING("The wounds on \the [H]'s [affecting.name] have already been treated."))


### PR DESCRIPTION
:cl: Mewlin1230
bugfix: pAIs can now target specific limbs, to allow for the use of certain exosuits modules
/:cl:

Did this since I noticed that the medigel module for exosuits actually runtimed since pAIs didnt have zone selection, so considering the fact they can already attack with exosuit weapons alongside that, i thought I may as well just give them zone selection

I also did a bit of a patch job with the medigel zone selection bit so that its "technically" usable if somehow a different mob without zone selection was piloting the exosuit. I just figured "technically" usable is better then runtiming.

fixes #34584 