### PR TITLE
pill bottles hold tacks, certain mob types ignore shards

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -81,3 +81,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define OVERMAP_SECTOR_IN_SPACE     FLAG(2)
 /// If the sector is untargetable by missiles.
 #define OVERMAP_SECTOR_UNTARGETABLE FLAG(3)
+
+
+/// For mob/living/ignore_hazard_flags. When set, shards do not damage the mob.
+var/global/const/HAZARD_FLAG_SHARD = FLAG(0)

--- a/code/datums/uplink/stealth_and_camouflage_items.dm
+++ b/code/datums/uplink/stealth_and_camouflage_items.dm
@@ -95,5 +95,5 @@
 /datum/uplink_item/item/stealth_items/caltrops
 	name = "Box of Caltrops"
 	desc = "A set of 4 steel caltrops, cunningly hidden in an innocent lunchbox."
-	item_cost = 5
+	item_cost = 20
 	path = /obj/item/storage/lunchbox/caltrops

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -82,6 +82,8 @@
 	if (human.buckled)
 		return
 	playsound(src, step_sound, 50, TRUE)
+	if (human.ignore_hazard_flags & HAZARD_FLAG_SHARD)
+		return
 	if (!istype(human))
 		to_chat(human, SPAN_WARNING("\A [src] cuts you!"))
 		human.take_overall_damage(force * 0.75, 0)

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -172,7 +172,7 @@
 	max_force = 12
 	thrown_force_multiplier = 0.3
 	step_sound = 'sound/obj/item/material/shard/caltrop.ogg'
-	embed_chance = 65
+	embed_chance = 50
 	pierce_thin_footwear = TRUE
 	applies_material_details = FALSE
 

--- a/code/game/objects/items/weapons/storage/pill_bottle.dm
+++ b/code/game/objects/items/weapons/storage/pill_bottle.dm
@@ -10,7 +10,8 @@
 	contents_allowed = list(
 		/obj/item/reagent_containers/pill,
 		/obj/item/dice,
-		/obj/item/paper
+		/obj/item/paper,
+		/obj/item/material/shard/caltrop/tack
 	)
 	allow_quick_gather = TRUE
 	allow_quick_empty = TRUE

--- a/code/modules/mechs/mech.dm
+++ b/code/modules/mechs/mech.dm
@@ -24,6 +24,8 @@
 
 	can_be_buckled = FALSE
 
+	ignore_hazard_flags = HAZARD_FLAG_SHARD
+
 	var/emp_damage = 0
 
 	var/obj/item/device/radio/exosuit/radio

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -13,6 +13,8 @@
 	bone_material = null
 	bone_amount = 0
 
+	ignore_hazard_flags = HAZARD_FLAG_SHARD
+
 	var/obj/item/card/id/botcard = null
 	var/list/botcard_access = list()
 	var/on = 1

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -68,3 +68,6 @@
 
 	/// An associative list of /singleton/trait and trait level - See individual traits for valid levels
 	var/list/traits
+
+	/// Some combination of HAZARD_FLAG_*. When set, the flagged hazard types will not damage the mob.
+	var/ignore_hazard_flags = EMPTY_BITFIELD

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -10,6 +10,8 @@
 	bone_material = null
 	bone_amount = 0
 
+	ignore_hazard_flags = HAZARD_FLAG_SHARD
+
 	var/syndicate = 0
 	var/const/MAIN_CHANNEL = "Main Frequency"
 	var/lawchannel = MAIN_CHANNEL // Default channel on which to state laws


### PR DESCRIPTION
:cl:
bugfix: Pill bottles can hold tacks.
tweak: Some mob types (mechs, silicons, bots) are not damaged by shards.
tweak: Caltrops are less good.
/:cl:
