### PR TITLE
remove mapped tacks, add single tacks to junk spawns and a tack pot to office supply crates, shard embed limits

### DIFF
--- a/code/datums/supplypacks/operations.dm
+++ b/code/datums/supplypacks/operations.dm
@@ -75,19 +75,22 @@
 	access = access_brig
 
 /singleton/hierarchy/supply_pack/operations/bureaucracy
-	contains = list(/obj/item/material/clipboard,
-					 /obj/item/material/clipboard,
-					 /obj/item/pen/retractable/red,
-					 /obj/item/pen/retractable/blue,
-					 /obj/item/pen/green,
-					 /obj/item/device/camera_film,
-					 /obj/item/folder/blue,
-					 /obj/item/folder/red,
-					 /obj/item/folder/yellow,
-					 /obj/item/hand_labeler,
-					 /obj/item/tape_roll,
-					 /obj/structure/filingcabinet/chestdrawer{anchored = FALSE},
-					 /obj/item/paper_bin)
+	contains = list(
+		/obj/item/material/clipboard,
+		/obj/item/material/clipboard,
+		/obj/item/pen/retractable/red,
+		/obj/item/pen/retractable/blue,
+		/obj/item/pen/green,
+		/obj/item/device/camera_film,
+		/obj/item/folder/blue,
+		/obj/item/folder/red,
+		/obj/item/folder/yellow,
+		/obj/item/hand_labeler,
+		/obj/item/tape_roll,
+		/obj/structure/filingcabinet/chestdrawer{anchored = FALSE},
+		/obj/item/paper_bin,
+		/obj/item/storage/pill_bottle/tacks
+	)
 	name = "Office supplies"
 	cost = 15
 	containertype = /obj/structure/closet/crate/large

--- a/code/game/objects/items/weapons/material/shards.dm
+++ b/code/game/objects/items/weapons/material/shards.dm
@@ -119,7 +119,7 @@
 			damage_text = "gouges"
 		else
 			var/damage_flags = DAMAGE_FLAG_SHARP
-			if (prob(embed_chance))
+			if (prob(embed_chance) && length(external.implants) < 2)
 				damage_flags |= DAMAGE_FLAG_EDGE
 				damage_text = "pierces into"
 			var/wound = external.take_external_damage(force * 0.75, 0, damage_flags)
@@ -189,7 +189,7 @@
 	icon_state = "tack0"
 	w_class = ITEM_SIZE_TINY
 	default_material = MATERIAL_ALUMINIUM
-	max_force = 3
+	max_force = 2
 	step_sound = 'sound/obj/item/material/shard/tack.ogg'
 	embed_chance = 100
 	pierce_thin_footwear = FALSE

--- a/code/game/objects/random/random.dm
+++ b/code/game/objects/random/random.dm
@@ -445,19 +445,22 @@
 	icon_state = "greenglow"
 
 /obj/random/trash/spawn_choices()
-	return list(/obj/item/remains/lizard,
-				/obj/decal/cleanable/blood/gibs/robot,
-				/obj/decal/cleanable/blood/oil,
-				/obj/decal/cleanable/blood/oil/streak,
-				/obj/decal/cleanable/spiderling_remains,
-				/obj/item/remains/mouse,
-				/obj/decal/cleanable/vomit,
-				/obj/decal/cleanable/blood/splatter,
-				/obj/decal/cleanable/ash,
-				/obj/decal/cleanable/generic,
-				/obj/decal/cleanable/flour,
-				/obj/decal/cleanable/dirt,
-				/obj/item/remains/robot)
+	return list(
+		/obj/item/remains/lizard,
+		/obj/decal/cleanable/blood/gibs/robot,
+		/obj/decal/cleanable/blood/oil,
+		/obj/decal/cleanable/blood/oil/streak,
+		/obj/decal/cleanable/spiderling_remains,
+		/obj/item/remains/mouse,
+		/obj/decal/cleanable/vomit,
+		/obj/decal/cleanable/blood/splatter,
+		/obj/decal/cleanable/ash,
+		/obj/decal/cleanable/generic,
+		/obj/decal/cleanable/flour,
+		/obj/decal/cleanable/dirt,
+		/obj/item/remains/robot,
+		/obj/item/material/shard/caltrop/tack
+	)
 
 
 /obj/random/closet //A couple of random closets to spice up maint

--- a/maps/antag_spawn/ert/ert_base.dmm
+++ b/maps/antag_spawn/ert/ert_base.dmm
@@ -1456,7 +1456,6 @@
 /obj/structure/noticeboard{
 	pixel_x = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /turf/unsimulated/floor{
 	dir = 1;
 	icon_state = "vault"

--- a/maps/away/derelict/derelict-station.dmm
+++ b/maps/away/derelict/derelict-station.dmm
@@ -883,7 +883,6 @@
 /obj/structure/noticeboard{
 	pixel_x = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /turf/simulated/floor,
 /area/constructionsite/bridge)
 "cS" = (

--- a/maps/away/mining/mining-signal.dmm
+++ b/maps/away/mining/mining-signal.dmm
@@ -403,7 +403,6 @@
 /obj/structure/noticeboard/anomaly{
 	pixel_y = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/floor_decal/corner/purple{
 	dir = 5
 	},

--- a/maps/away/miningstation/miningstation.dmm
+++ b/maps/away/miningstation/miningstation.dmm
@@ -2554,7 +2554,6 @@
 /area/miningstation/bridge)
 "gj" = (
 /obj/structure/noticeboard,
-/obj/item/storage/pill_bottle/tacks,
 /obj/paint/black,
 /turf/simulated/wall/r_titanium,
 /area/miningstation/bridge)

--- a/maps/away/smugglers/smugglers.dmm
+++ b/maps/away/smugglers/smugglers.dmm
@@ -861,7 +861,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 30
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/decal/cleanable/dirt,
 /obj/structure/table/standard,
 /obj/machinery/microwave{

--- a/maps/bluespace_interlude/bluespace_interlude.dmm
+++ b/maps/bluespace_interlude/bluespace_interlude.dmm
@@ -18,7 +18,6 @@
 /obj/structure/noticeboard/anomaly{
 	pixel_x = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/decal/cleanable/cobweb2,
 /obj/item/paper/bluespace_interlude/note1,
 /turf/simulated/floor/tiled/white,

--- a/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dmm
@@ -6424,7 +6424,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /turf/simulated/floor/tiled/white,
 /area/map_template/oldlab2/office)
 "Hq" = (

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -11169,7 +11169,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -16413,7 +16412,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/machinery/light{
 	dir = 8
 	},

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -2809,7 +2809,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/machinery/button/blast_door{
 	id_tag = "sup_office";
 	name = "Desk Shutter Control";
@@ -13427,7 +13426,6 @@
 /obj/structure/noticeboard{
 	pixel_x = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/random_multi/single_item/memo_supply,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/deckchief)

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -4970,7 +4970,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/thirddeck/center)
 "lf" = (
@@ -7375,7 +7374,6 @@
 	dir = 4;
 	pixel_x = -31
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/machinery/microwave{
 	pixel_x = -1;
 	pixel_y = 6

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -11051,7 +11051,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /turf/simulated/floor/tiled/techfloor,
 /area/vacant/cargo)
 "BS" = (
@@ -15225,7 +15224,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_bay)
 "Ou" = (

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -4309,7 +4309,6 @@
 /obj/structure/noticeboard{
 	pixel_x = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /turf/simulated/floor/carpet,
 /area/medical/counselor/therapy)
 "ahK" = (
@@ -17410,7 +17409,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /turf/simulated/floor/tiled/white,
 /area/medical/foyer)
 "fVw" = (
@@ -19012,7 +19010,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/floor_decal/corner/paleblue/mono,
 /obj/machinery/recharger,
 /obj/structure/table/glass,
@@ -19892,7 +19889,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /turf/simulated/floor/tiled/monotile,
 /area/security/detectives_office)
 "jrH" = (
@@ -22143,7 +22139,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /turf/simulated/floor/tiled/white,
 /area/rnd/research)
 "mpq" = (
@@ -22876,7 +22871,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /turf/simulated/floor/tiled/steel_ridged,
 /area/security/locker)
 "nkh" = (
@@ -29188,7 +29182,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/command/conference)
 "vii" = (

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -1318,7 +1318,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 30
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/item/storage/toolbox/emergency,
 /obj/item/device/flashlight,
 /turf/simulated/floor/tiled/dark/monotile,
@@ -2138,7 +2137,6 @@
 /obj/structure/noticeboard{
 	pixel_x = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /turf/simulated/floor/tiled/dark,
 /area/bridge/meeting_room)
 "dR" = (
@@ -3979,7 +3977,6 @@
 /obj/structure/noticeboard{
 	pixel_x = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/machinery/button/alternate/door/bolts{
 	desc = "A remote control-switch for the office door.";
 	id_tag = "liaisondoor2";
@@ -5659,7 +5656,6 @@
 /obj/structure/noticeboard{
 	pixel_y = -30
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
@@ -7709,7 +7705,6 @@
 /obj/structure/noticeboard{
 	pixel_x = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "tC" = (
@@ -8082,7 +8077,6 @@
 /obj/structure/noticeboard{
 	pixel_x = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /turf/simulated/floor/carpet/blue2,
 /area/crew_quarters/heads/office/sgr)
 "uB" = (
@@ -8417,7 +8411,6 @@
 /obj/structure/noticeboard{
 	pixel_x = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/item/reagent_containers/food/drinks/glass2/rocks,
 /obj/item/reagent_containers/food/drinks/glass2/rocks,
 /obj/item/reagent_containers/food/drinks/glass2/rocks,
@@ -8880,7 +8873,6 @@
 /obj/structure/noticeboard{
 	pixel_x = -32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/machinery/keycard_auth/torch{
 	pixel_y = -24
 	},
@@ -10584,7 +10576,6 @@
 /obj/structure/noticeboard{
 	pixel_x = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/machinery/newscaster{
 	pixel_y = -32
 	},
@@ -11167,7 +11158,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 30
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/machinery/newscaster{
 	pixel_x = 32
@@ -11465,7 +11455,6 @@
 /obj/structure/noticeboard{
 	pixel_x = 32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/machinery/computer/modular/preset/aislot/sysadmin,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/bridge/storage)
@@ -12137,7 +12126,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 30
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/item/sticky_pad/random,
 /obj/machinery/button/alternate/door{
 	desc = "A remote control-switch for the office door.";
@@ -12386,7 +12374,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 30
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/item/aiModule/freeform,
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/cobed)
@@ -14361,7 +14348,6 @@
 /obj/structure/noticeboard{
 	pixel_x = -32
 	},
-/obj/item/storage/pill_bottle/tacks,
 /obj/floor_decal/corner/blue/three_quarters{
 	dir = 8
 	},
@@ -15704,7 +15690,6 @@
 /obj/structure/noticeboard{
 	pixel_y = 30
 	},
-/obj/item/storage/pill_bottle/tacks,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "Zx" = (


### PR DESCRIPTION
:cl:
tweak: Removed mapped tack pots.
tweak: Added single tacks to junk spawns.
tweak: Added single tack pots to office supply crates.
tweak: Shards can only embed on body parts with less than two existing embeds.
/:cl:
