### PR TITLE
ai aifast update

### DIFF
--- a/code/controllers/subsystems/ai.dm
+++ b/code/controllers/subsystems/ai.dm
@@ -3,8 +3,20 @@ SUBSYSTEM_DEF(ai)
 	init_order = SS_INIT_AI
 	priority = SS_PRIORITY_AI
 	wait = 2 SECONDS
+#ifdef UNIT_TEST
+	flags = SS_NO_INIT | SS_NO_FIRE
+#else
+	flags = SS_NO_INIT
+#endif
+
+	/// The set of all ai_holders currently being updated
 	var/static/list/datum/ai_holder/ai_holders = list()
+
+	/// The current queue of ai_holder instances to update
 	var/static/list/datum/ai_holder/queue = list()
+
+	/// If the queue was not finished, the index to read from on the next run
+	var/static/saved_index
 
 
 /datum/controller/subsystem/ai/UpdateStat(time)
@@ -16,17 +28,17 @@ SUBSYSTEM_DEF(ai)
 	"})
 
 
-/datum/controller/subsystem/ai/fire(resume, no_mc_tick)
-	if (!resume)
+/datum/controller/subsystem/ai/fire(resumed, no_mc_tick)
+	if (!resumed)
 		queue = ai_holders.Copy()
-		if (!length(queue))
-			return
-	var/cut_until = 1
-	for (var/datum/ai_holder/ai as anything in queue)
-		++cut_until
-		if (QDELETED(ai) || ai.busy)
-			continue
-		if (!ai.holder)
+		saved_index = 1
+	var/queue_length = length(queue)
+	if (!queue_length)
+		return
+	var/datum/ai_holder/ai
+	for (var/i = saved_index to queue_length)
+		ai = queue[i]
+		if (QDELETED(ai) || ai.busy || !ai.holder)
 			continue
 		if (!config.run_empty_levels && !SSpresence.population(get_z(ai.holder)))
 			continue
@@ -34,13 +46,6 @@ SUBSYSTEM_DEF(ai)
 		if (no_mc_tick)
 			CHECK_TICK
 		else if (MC_TICK_CHECK)
-			queue.Cut(1, cut_until)
+			saved_index = i + 1
 			return
 	queue.Cut()
-
-
-#ifdef UNIT_TEST
-/datum/controller/subsystem/ai/flags = SS_NO_INIT | SS_NO_FIRE
-#else
-/datum/controller/subsystem/ai/flags = SS_NO_INIT
-#endif

--- a/code/modules/ai/ai_holder.dm
+++ b/code/modules/ai/ai_holder.dm
@@ -188,6 +188,7 @@ if (!(datum.process_flags & AI_FASTPROCESSING)) { \
 
 /// 'Tactical' processes such as moving a step, meleeing an enemy, firing a projectile, and other fairly cheap actions that need to happen quickly.
 /datum/ai_holder/proc/handle_tactics()
+	set background = TRUE
 	if (holder.key && !autopilot)
 		return
 	if (!is_disabled())
@@ -196,6 +197,7 @@ if (!(datum.process_flags & AI_FASTPROCESSING)) { \
 
 /// 'Strategical' processes that are more expensive on the CPU and so don't get run as often as the above proc, such as A* pathfinding or robust targeting.
 /datum/ai_holder/proc/handle_strategicals()
+	set background = TRUE
 	if (holder.key && !autopilot)
 		return
 	if (!is_disabled())


### PR DESCRIPTION
attempts to minimize unecessary work in ssai/fast by only mutating queues at the start and end of a run, regardless of actual ticks taken to complete

also backgrounds handle_tactics and handle_strategicals - feels-like more responsive mobs, and shouldn't be too dangerous unless we add new bad handler implementations in future
