### PR TITLE
Toggle safety verb no longer brings up a menu if you have more than one

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -628,6 +628,7 @@
 
 /obj/item/gun/proc/toggle_safety(mob/user)
 	if (user?.is_physically_disabled())
+		to_chat(user, SPAN_WARNING("You can't do this right now!"))
 		return
 
 	safety_state = !safety_state
@@ -637,12 +638,22 @@
 		last_safety_check = world.time
 		playsound(src, 'sound/weapons/flipblade.ogg', 15, 1)
 
+
 /obj/item/gun/verb/toggle_safety_verb()
-	set src in usr
-	set category = "Object"
 	set name = "Toggle Gun Safety"
-	if(usr == loc)
-		toggle_safety(usr)
+	set category = "Object"
+	set src in usr
+	if (usr.incapacitated())
+		to_chat(usr, SPAN_WARNING("You're in no condition to do that."))
+		return
+	var/obj/item/gun/gun = usr.get_active_hand()
+	if (!istype(gun))
+		gun = usr.get_inactive_hand()
+		if (!istype(gun))
+			to_chat(usr, SPAN_WARNING("You need a gun in your hands to do that."))
+			return
+	gun.toggle_safety(usr)
+
 
 /obj/item/gun/CtrlClick(mob/user)
 	if(loc == user)


### PR DESCRIPTION
Porting a fix I recently figured out how to make on Sojourn. Currently, if you're holding a gun and also have one on your belt/suit storage and you toggle safety, it brings up a menu where you must select the weapon to toggle. This is extremely inconvenient, especially in combat. This PR makes the verb check your active hand for a gun, toggle safety if there is one. If there isn't a gun in your active hand, it checks your inactive hand and toggles safety if there is a gun there. If your hands do not hold any guns, it just says you can't do it without a gun in your hands.

:cl: SingingSpock
tweak: Using the toggle-gun-safety verb will no longer bring up a dialogue box and will instead toggle safety for a gun in your hands, preferring the active hand.
/:cl: