### PR TITLE
/datum/map_template -> /singleton/map_template

### DIFF
--- a/code/_helpers/cmp.dm
+++ b/code/_helpers/cmp.dm
@@ -49,7 +49,7 @@
 /proc/cmp_text_dsc(a,b)
 	return sorttext(a, b)
 
-/proc/cmp_ruincost_priority(datum/map_template/ruin/A, datum/map_template/ruin/B)
+/proc/cmp_ruincost_priority(singleton/map_template/ruin/A, singleton/map_template/ruin/B)
 	return initial(A.spawn_cost) - initial(B.spawn_cost)
 
 /proc/cmp_power_component_priority(obj/item/stock_parts/power/A, obj/item/stock_parts/power/B)

--- a/code/controllers/subsystems/mapping.dm
+++ b/code/controllers/subsystems/mapping.dm
@@ -3,11 +3,12 @@ SUBSYSTEM_DEF(mapping)
 	init_order = SS_INIT_MAPPING
 	flags = SS_NO_FIRE
 
-	var/list/map_templates = list()
-	var/list/space_ruins_templates = list()
-	var/list/exoplanet_ruins_templates = list()
-	var/list/away_sites_templates = list()
-	var/list/submaps = list()
+	var/static/list/map_templates
+	var/static/list/space_ruins_templates
+	var/static/list/exoplanet_ruins_templates
+	var/static/list/away_sites_templates
+	var/static/list/submap_archetypes
+	var/static/list/submaps = list()
 
 
 /datum/controller/subsystem/mapping/UpdateStat(time)
@@ -15,81 +16,8 @@ SUBSYSTEM_DEF(mapping)
 
 
 /datum/controller/subsystem/mapping/Initialize(start_uptime)
-	preloadTemplates()
-
-
-/datum/controller/subsystem/mapping/Recover()
-	flags |= SS_NO_INIT
-	map_templates = SSmapping.map_templates
-	space_ruins_templates = SSmapping.space_ruins_templates
-	exoplanet_ruins_templates = SSmapping.exoplanet_ruins_templates
-	away_sites_templates = SSmapping.away_sites_templates
-
-/datum/controller/subsystem/mapping/proc/preloadTemplates(path = "maps/templates/") //see master controller setup
-	var/list/filelist = flist(path)
-	for(var/map in filelist)
-		var/datum/map_template/T = new(paths = "[path][map]", rename = "[map]")
-		map_templates[T.name] = T
-	preloadBlacklistableTemplates()
-
-/datum/controller/subsystem/mapping/proc/preloadBlacklistableTemplates()
-	// Still supporting bans by filename
-	var/list/banned_exoplanet_dmms = generateMapList("config/exoplanet_ruin_blacklist.txt")
-	var/list/banned_space_dmms = generateMapList("config/space_ruin_blacklist.txt")
-	var/list/banned_away_site_dmms = generateMapList("config/away_site_blacklist.txt")
-
-	if (!banned_exoplanet_dmms || !banned_space_dmms || !banned_away_site_dmms)
-		report_progress("One or more map blacklist files are not present in the config directory!")
-
-	var/list/banned_maps = list() + banned_exoplanet_dmms + banned_space_dmms + banned_away_site_dmms
-
-	for(var/item in sortTim(subtypesof(/datum/map_template), GLOBAL_PROC_REF(cmp_ruincost_priority)))
-		var/datum/map_template/map_template_type = item
-		// screen out the abstract subtypes
-		if(!initial(map_template_type.id))
-			continue
-		var/datum/map_template/MT = new map_template_type()
-
-		if (banned_maps)
-			var/is_banned = FALSE
-			for (var/mappath in MT.mappaths)
-				if(banned_maps.Find(mappath))
-					is_banned = TRUE
-					break
-			if (is_banned)
-				continue
-
-		map_templates[MT.name] = MT
-
-		// This is nasty..
-		if(istype(MT, /datum/map_template/ruin/exoplanet))
-			exoplanet_ruins_templates[MT.name] = MT
-		else if(istype(MT, /datum/map_template/ruin/space))
-			space_ruins_templates[MT.name] = MT
-		else if(istype(MT, /datum/map_template/ruin/away_site))
-			away_sites_templates[MT.name] = MT
-
-/proc/generateMapList(filename)
-	RETURN_TYPE(/list)
-	var/list/potentialMaps = list()
-	var/list/Lines = world.file2list(filename)
-	if(!length(Lines))
-		return
-	for (var/t in Lines)
-		if (!t)
-			continue
-		t = trimtext(t)
-		if (length(t) == 0)
-			continue
-		else if (copytext(t, 1, 2) == "#")
-			continue
-		var/pos = findtext(t, " ")
-		var/name = null
-		if (pos)
-			name = lowertext(copytext(t, 1, pos))
-		else
-			name = lowertext(t)
-		if (!name)
-			continue
-		potentialMaps.Add(t)
-	return potentialMaps
+	map_templates = Singletons.GetSubtypeMap(/singleton/map_template)
+	space_ruins_templates = Singletons.GetSubtypeMap(/singleton/map_template/ruin/space)
+	exoplanet_ruins_templates = Singletons.GetSubtypeMap(/singleton/map_template/ruin/exoplanet)
+	away_sites_templates = Singletons.GetSubtypeMap(/singleton/map_template/ruin/away_site)
+	submap_archetypes = Singletons.GetSubtypeMap(/singleton/submap_archetype)

--- a/code/datums/ruins.dm
+++ b/code/datums/ruins.dm
@@ -1,4 +1,5 @@
-/datum/map_template/ruin
+/singleton/map_template/ruin
+	abstract_type = /singleton/map_template/ruin
 	//name = "A Chest of Doubloons"
 	name = null
 	var/description = "In the middle of a clearing in the rockface, there's a chest filled with gold coins with Spanish engravings. \
@@ -18,7 +19,7 @@
 	var/list/allow_ruins // Listed ruins are added to the set of available spawns.
 	var/list/ban_ruins   // Listed ruins are removed from the set of available spawns. Beats allowed.
 
-/datum/map_template/ruin/New()
+/singleton/map_template/ruin/New()
 	if (suffixes)
 		mappaths = list()
 		for (var/suffix in suffixes)

--- a/code/game/antagonist/antagonist.dm
+++ b/code/game/antagonist/antagonist.dm
@@ -78,7 +78,7 @@
 		rules aside from those without explicit exceptions apply to antagonists.</b>"
 
 	// Map template that antag needs to load before spawning. Nulled after it's loaded.
-	var/datum/map_template/base_to_load
+	var/singleton/map_template/base_to_load
 
 /datum/antagonist/New()
 	GLOB.all_antag_types_[id] = src

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -4,7 +4,7 @@
 		return
 
 	if(base_to_load)
-		var/datum/map_template/base = new base_to_load()
+		var/singleton/map_template/base = new base_to_load()
 		report_progress("Loading map template '[base]' for [role_text]...")
 		base_to_load = null
 		base.load_new_z()

--- a/code/game/antagonist/outsider/ert.dm
+++ b/code/game/antagonist/outsider/ert.dm
@@ -24,7 +24,7 @@ GLOBAL_TYPED_NEW(ert, /datum/antagonist/ert)
 	faction = "emergency"
 	no_prior_faction = TRUE
 
-	base_to_load = /datum/map_template/ruin/antag_spawn/ert
+	base_to_load = /singleton/map_template/ruin/antag_spawn/ert
 	/// If set to `TRUE` will prevent shuttle announcements and identifiable overmap icons.
 	var/is_secret = FALSE
 	var/arrived = FALSE

--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -20,7 +20,7 @@ GLOBAL_TYPED_NEW(mercs, /datum/antagonist/mercenary)
 	faction = "mercenary"
 	no_prior_faction = TRUE
 
-	base_to_load = /datum/map_template/ruin/antag_spawn/mercenary
+	base_to_load = /singleton/map_template/ruin/antag_spawn/mercenary
 
 /datum/antagonist/mercenary/create_global_objectives()
 	if(!..())

--- a/code/game/antagonist/outsider/ninja.dm
+++ b/code/game/antagonist/outsider/ninja.dm
@@ -17,7 +17,7 @@ GLOBAL_TYPED_NEW(ninjas, /datum/antagonist/ninja)
 	id_type = /obj/item/card/id/syndicate
 	faction = "ninja"
 	no_prior_faction = TRUE
-	base_to_load = /datum/map_template/ruin/antag_spawn/ninja
+	base_to_load = /singleton/map_template/ruin/antag_spawn/ninja
 
 
 /datum/antagonist/ninja/create_objectives(datum/mind/ninja)

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -21,7 +21,7 @@ GLOBAL_TYPED_NEW(raiders, /datum/antagonist/raider)
 	faction = "pirate"
 	no_prior_faction = TRUE
 
-	base_to_load = /datum/map_template/ruin/antag_spawn/heist
+	base_to_load = /singleton/map_template/ruin/antag_spawn/heist
 
 	var/list/raider_uniforms = list(
 		/obj/item/clothing/under/soviet,

--- a/code/game/antagonist/outsider/vox.dm
+++ b/code/game/antagonist/outsider/vox.dm
@@ -17,7 +17,7 @@ GLOBAL_LIST_EMPTY(vox_artifact_spawners)
 
 	id_type = /obj/item/card/id/syndicate
 
-	base_to_load = /datum/map_template/ruin/antag_spawn/vox_raider
+	base_to_load = /singleton/map_template/ruin/antag_spawn/vox_raider
 	var/pending_item_spawn = TRUE
 	faction = "vox raider"
 	no_prior_faction = TRUE

--- a/code/game/antagonist/outsider/wizard.dm
+++ b/code/game/antagonist/outsider/wizard.dm
@@ -17,7 +17,7 @@ GLOBAL_TYPED_NEW(wizards, /datum/antagonist/wizard)
 
 	faction = "wizard"
 	no_prior_faction = TRUE
-	base_to_load = /datum/map_template/ruin/antag_spawn/wizard
+	base_to_load = /singleton/map_template/ruin/antag_spawn/wizard
 
 /datum/antagonist/wizard/create_objectives(datum/mind/wizard)
 

--- a/code/game/objects/effects/landmarks.dm
+++ b/code/game/objects/effects/landmarks.dm
@@ -244,7 +244,7 @@
 	delete_me = 1
 
 /obj/landmark/ruin
-	var/datum/map_template/ruin/ruin_template
+	var/singleton/map_template/ruin/ruin_template
 
 /obj/landmark/ruin/New(loc, my_ruin_template)
 	name = "ruin_[sequential_id(/obj/landmark/ruin)]"

--- a/code/modules/admin/verbs/map_template_loadverb.dm
+++ b/code/modules/admin/verbs/map_template_loadverb.dm
@@ -9,7 +9,7 @@
 	if(!map)
 		return
 
-	var/datum/map_template/template = SSmapping.map_templates[map]
+	var/singleton/map_template/template = SSmapping.map_templates[map]
 
 	var/turf/T = get_turf(usr)
 	if(!T)
@@ -46,7 +46,7 @@
 	if(!map)
 		return
 
-	var/datum/map_template/template = SSmapping.map_templates[map]
+	var/singleton/map_template/template = SSmapping.map_templates[map]
 	var/log_name = "([template.name]) on a new zlevel"
 
 	if (template.loaded && !(template.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES))
@@ -79,7 +79,7 @@
 		to_chat(usr, "Bad map file: [map]")
 		return
 
-	var/datum/map_template/M = new(list(map), "[map]")
+	var/singleton/map_template/M = new(list(map), "[map]")
 
 	log_and_message_admins("is attempting to upload a map template '[map]''.")
 	to_chat(usr, "Attempting to upload map template '[map]''.")

--- a/code/modules/maps/map_template.dm
+++ b/code/modules/maps/map_template.dm
@@ -1,4 +1,5 @@
-/datum/map_template
+/singleton/map_template
+	abstract_type = /singleton/map_template
 	var/name = "Default Template Name"
 	var/id = null // All maps that should be loadable during runtime needs an id
 	var/width = 0
@@ -15,7 +16,7 @@
 	/// Null, or a string reason for this type to be skipped in unit testing.
 	var/skip_main_unit_tests
 
-/datum/map_template/New(list/paths = null, rename = null)
+/singleton/map_template/New(list/paths = null, rename = null)
 	if(paths && !islist(paths))
 		crash_with("Non-list paths passed into map template constructor.")
 	if(paths)
@@ -27,7 +28,7 @@
 	if(!name && id)
 		name = id
 
-/datum/map_template/proc/preload_size()
+/singleton/map_template/proc/preload_size()
 	var/list/bounds = list(1.#INF, 1.#INF, 1.#INF, -1.#INF, -1.#INF, -1.#INF)
 	var/z_offset = 1 // needed to calculate z-bounds correctly
 	for (var/mappath in mappaths)
@@ -42,7 +43,7 @@
 	tallness = bounds[MAP_MAXZ] - bounds[MAP_MINZ] + 1
 	return TRUE
 
-/datum/map_template/proc/init_atoms(list/atoms)
+/singleton/map_template/proc/init_atoms(list/atoms)
 	if (SSatoms.atom_init_stage == INITIALIZATION_INSSATOMS)
 		return // let proper initialisation handle it later
 
@@ -90,17 +91,17 @@
 			var/turf/simulated/sim = T
 			sim.update_air_properties()
 
-/datum/map_template/proc/pre_init_shuttles()
+/singleton/map_template/proc/pre_init_shuttles()
 	. = SSshuttle.block_queue
 	SSshuttle.block_queue = TRUE
 
-/datum/map_template/proc/init_shuttles(pre_init_state)
+/singleton/map_template/proc/init_shuttles(pre_init_state)
 	for (var/shuttle_type in shuttles_to_initialise)
 		LAZYADD(SSshuttle.shuttles_to_initialize, shuttle_type) // queue up for init.
 	SSshuttle.block_queue = pre_init_state
 	SSshuttle.clear_init_queue() // We will flush the queue unless there were other blockers, in which case they will do it.
 
-/datum/map_template/proc/load_new_z(no_changeturf = TRUE)
+/singleton/map_template/proc/load_new_z(no_changeturf = TRUE)
 
 	var/x = round((world.maxx - width)/2)
 	var/y = round((world.maxy - height)/2)
@@ -141,7 +142,7 @@
 
 	return locate(world.maxx/2, world.maxy/2, world.maxz)
 
-/datum/map_template/proc/load(turf/T, centered=FALSE)
+/singleton/map_template/proc/load(turf/T, centered=FALSE)
 	if(centered)
 		T = locate(T.x - round(width/2) , T.y - round(height/2) , T.z)
 	if(!T)
@@ -176,17 +177,17 @@
 
 	return TRUE
 
-/datum/map_template/proc/after_load(z)
+/singleton/map_template/proc/after_load(z)
 	for(var/obj/landmark/map_load_mark/mark in subtemplates_to_spawn)
 		subtemplates_to_spawn -= mark
 		if(LAZYLEN(mark.templates))
 			var/template = pick(mark.templates)
-			var/datum/map_template/M = new template()
+			var/singleton/map_template/M = new template()
 			M.load(get_turf(mark), TRUE)
 			qdel(mark)
 	LAZYCLEARLIST(subtemplates_to_spawn)
 
-/datum/map_template/proc/extend_bounds_if_needed(list/existing_bounds, list/new_bounds)
+/singleton/map_template/proc/extend_bounds_if_needed(list/existing_bounds, list/new_bounds)
 	var/list/bounds_to_combine = existing_bounds.Copy()
 	for (var/min_bound in list(MAP_MINX, MAP_MINY, MAP_MINZ))
 		bounds_to_combine[min_bound] = min(existing_bounds[min_bound], new_bounds[min_bound])
@@ -195,7 +196,7 @@
 	return bounds_to_combine
 
 
-/datum/map_template/proc/get_affected_turfs(turf/T, centered = FALSE)
+/singleton/map_template/proc/get_affected_turfs(turf/T, centered = FALSE)
 	var/turf/placement = T
 	if(centered)
 		var/turf/corner = locate(placement.x - round(width/2), placement.y - round(height/2), placement.z)
@@ -206,5 +207,5 @@
 //for your ever biggening badminnery kevinz000
 //? - Cyberboss
 /proc/load_new_z_level(file, name)
-	var/datum/map_template/template = new(file, name)
+	var/singleton/map_template/template = new(file, name)
 	template.load_new_z()

--- a/code/modules/maps/map_template_unit_testing.dm
+++ b/code/modules/maps/map_template_unit_testing.dm
@@ -1,4 +1,4 @@
-/datum/map_template
+/singleton/map_template
 	var/const/NO_APC = 1
 	var/const/NO_VENT = 2
 	var/const/NO_SCRUBBER = 4
@@ -9,7 +9,7 @@
 	var/list/area_coherency_test_exempt_areas = list()
 	var/list/area_coherency_test_subarea_count = list()
 
-/datum/map_template/New(list/paths = null, rename = null)
+/singleton/map_template/New(list/paths = null, rename = null)
 	..()
 	GLOB.using_map.area_usage_test_exempted_areas |= area_usage_test_exempted_areas
 	GLOB.using_map.area_usage_test_exempted_root_areas |= area_usage_test_exempted_root_areas

--- a/code/modules/maps/ruins.dm
+++ b/code/modules/maps/ruins.dm
@@ -19,11 +19,11 @@ GLOBAL_LIST_EMPTY(banned_ruin_ids)
 	for (var/client/C)
 		++player_budget
 
-	for (var/datum/map_template/ruin/map in SSmapping.map_templates)
+	for (var/singleton/map_template/ruin/map in SSmapping.map_templates)
 		if (map.loaded && map.player_cost)
 			player_budget -= map.player_cost
 	player_budget = max(0, player_budget)
-	for(var/datum/map_template/ruin/ruin in potentialRuins)
+	for(var/singleton/map_template/ruin/ruin in potentialRuins)
 		if (ruin.id in GLOB.banned_ruin_ids)
 			continue
 		available[ruin] = ruin.spawn_weight
@@ -32,7 +32,7 @@ GLOBAL_LIST_EMPTY(banned_ruin_ids)
 		UNLINT(WARNING("No ruins available - Not generating ruins"))
 
 	while (ruin_budget > 0 && length(available))
-		var/datum/map_template/ruin/ruin = pickweight(available)
+		var/singleton/map_template/ruin/ruin = pickweight(available)
 		if (ruin.spawn_cost > ruin_budget || ruin.player_cost > player_budget)
 			available -= ruin
 			continue
@@ -78,7 +78,7 @@ GLOBAL_LIST_EMPTY(banned_ruin_ids)
 
 	return selected
 
-/proc/load_ruin(turf/central_turf, datum/map_template/template)
+/proc/load_ruin(turf/central_turf, singleton/map_template/template)
 	if(!template)
 		return FALSE
 	for(var/i in template.get_affected_turfs(central_turf, 1))
@@ -86,7 +86,7 @@ GLOBAL_LIST_EMPTY(banned_ruin_ids)
 		for(var/mob/living/simple_animal/monster in T)
 			qdel(monster)
 	template.load(central_turf,centered = TRUE)
-	var/datum/map_template/ruin = template
+	var/singleton/map_template/ruin = template
 	if(istype(ruin))
 		new /obj/landmark/ruin(central_turf, ruin)
 	return TRUE

--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -104,8 +104,8 @@ GLOBAL_VAR(planet_repopulation_disabled)
 		if (T.ruin_tags_blacklist)
 			ruin_tags_blacklist |= T.ruin_tags_blacklist
 
-	for (var/T in subtypesof(/datum/map_template/ruin/exoplanet))
-		var/datum/map_template/ruin/exoplanet/ruin = T
+	for (var/T in subtypesof(/singleton/map_template/ruin/exoplanet))
+		var/singleton/map_template/ruin/exoplanet/ruin = T
 		if (initial(ruin.template_flags) & TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED)
 			continue
 		if (ruin_tags_whitelist && !(ruin_tags_whitelist & initial(ruin.ruin_tags)))
@@ -363,7 +363,7 @@ GLOBAL_VAR(planet_repopulation_disabled)
 	if (LAZYLEN(spawned_features) && user.skill_check(SKILL_SCIENCE, SKILL_TRAINED))
 		var/ruin_num = 0
 		var/inaccuracy = rand(-2,2)
-		for (var/datum/map_template/ruin/exoplanet/R in spawned_features)
+		for (var/singleton/map_template/ruin/exoplanet/R in spawned_features)
 			if (!(R.ruin_tags & RUIN_NATURAL))
 				ruin_num++
 		if (ruin_num)

--- a/code/modules/overmap/sectors.dm
+++ b/code/modules/overmap/sectors.dm
@@ -51,12 +51,15 @@ GLOBAL_LIST_EMPTY(known_overmap_sectors)
 		var/map_high = GLOB.using_map.overmap_size - OVERMAP_EDGE
 		var/turf/home
 		if (place_near_main)
-			var/obj/overmap/visitable/main = map_sectors["1"]
-			if (islist(place_near_main))
-				place_near_main = Roundm(Frand(place_near_main[1], place_near_main[2]), 0.1)
-			home = CircularRandomTurfAround(main, abs(place_near_main), map_low, map_low, map_high, map_high)
-			log_debug("place_near_main moving [src] near [main] ([main.x],[main.y]) with radius [place_near_main], got ([home.x],[home.y])")
-		else
+			var/obj/overmap/main = SSshuttle.ship_by_type(GLOB.using_map.overmap_entity)
+			if (main)
+				if (islist(place_near_main))
+					place_near_main = Roundm(Frand(place_near_main[1], place_near_main[2]), 0.1)
+				home = CircularRandomTurfAround(main, abs(place_near_main), map_low, map_low, map_high, map_high)
+				log_debug("place_near_main moving [src] near [main] ([main.x],[main.y]) with radius [place_near_main], got ([home.x],[home.y])")
+			if (!home)
+				log_debug("place_near_main failed for [src] (no main site found) -placing randomly")
+		if (!home)
 			start_x = start_x || rand(map_low, map_high)
 			start_y = start_y || rand(map_low, map_high)
 			home = locate(start_x, start_y, GLOB.using_map.overmap_z)

--- a/code/unit_tests/~unit_test_subsystems.dm
+++ b/code/unit_tests/~unit_test_subsystems.dm
@@ -38,7 +38,7 @@ SUBSYSTEM_DEF(unit_tests)
 
 /datum/controller/subsystem/unit_tests/proc/load_map_templates()
 	for(var/map_template_name in (SSmapping.map_templates))
-		var/datum/map_template/map_template = SSmapping.map_templates[map_template_name]
+		var/singleton/map_template/map_template = SSmapping.map_templates[map_template_name]
 		if (map_template.skip_main_unit_tests)
 			report_progress("Skipping template '[map_template]' ([map_template.type]): [map_template.skip_main_unit_tests]")
 			continue

--- a/config/example/away_site_blacklist.txt
+++ b/config/example/away_site_blacklist.txt
@@ -1,5 +1,0 @@
-#Listing maps here will blacklist them from generating as away sites.
-#Maps must be the full path to them
-#SPECIFYING AN INVALID MAP WILL RESULT IN RUNTIMES ON GAME START
-
-#maps/random_ruins/away_sites/example.dmm

--- a/config/example/exoplanet_ruin_blacklist.txt
+++ b/config/example/exoplanet_ruin_blacklist.txt
@@ -1,5 +1,0 @@
-#Listing maps here will blacklist them from generating on exoplanets.
-#Maps must be the full path to them
-#SPECIFYING AN INVALID MAP WILL RESULT IN RUNTIMES ON GAME START
-
-#maps/random_ruins/exoplanet_ruins/example.dmm

--- a/config/example/space_ruin_blacklist.txt
+++ b/config/example/space_ruin_blacklist.txt
@@ -1,5 +1,0 @@
-#Listing maps here will blacklist them from generating in space.
-#Maps must be the full path to them
-#SPECIFYING AN INVALID MAP WILL RESULT IN RUNTIMES ON GAME START
-
-#maps/random_ruins/space_ruins/example.dmm

--- a/maps/antag_spawn/antag_spawn_bases.dm
+++ b/maps/antag_spawn/antag_spawn_bases.dm
@@ -1,2 +1,3 @@
-/datum/map_template/ruin/antag_spawn
+/singleton/map_template/ruin/antag_spawn
+	abstract_type = /singleton/map_template/ruin/antag_spawn
 	prefix = "maps/antag_spawn/"

--- a/maps/antag_spawn/ert/ert_ship.dm
+++ b/maps/antag_spawn/ert/ert_ship.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/antag_spawn/ert
+/singleton/map_template/ruin/antag_spawn/ert
 	name = "SFV Trident"
 	suffixes = list("ert/ert_ship.dmm")
 	shuttles_to_initialise = list(/datum/shuttle/autodock/multi/antag/ert)
@@ -6,7 +6,7 @@
 		/area/map_template/ert/ship = NO_APC
 	)
 
-/datum/map_template/ruin/antag_spawn/ert/after_load(zlevel)
+/singleton/map_template/ruin/antag_spawn/ert/after_load(zlevel)
 	..(zlevel)
 	if(zlevel)
 		GLOB.using_map.admin_levels |= GetConnectedZlevels(zlevel)

--- a/maps/antag_spawn/heist/heist.dm
+++ b/maps/antag_spawn/heist/heist.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/antag_spawn/heist
+/singleton/map_template/ruin/antag_spawn/heist
 	name = "Heist Base"
 	suffixes = list("heist/heist_base.dmm")
 	shuttles_to_initialise = list(/datum/shuttle/autodock/multi/antag/skipjack)

--- a/maps/antag_spawn/mercenary/mercenary.dm
+++ b/maps/antag_spawn/mercenary/mercenary.dm
@@ -1,4 +1,6 @@
-/datum/map_template/ruin/antag_spawn/mercenary
+#include "../../../packs/factions/iccgn/_pack.dm"
+
+/singleton/map_template/ruin/antag_spawn/mercenary
 	name = "Mercenary Base"
 	suffixes = list("mercenary/mercenary_base.dmm")
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/merc_shuttle)

--- a/maps/antag_spawn/ninja/ninja.dm
+++ b/maps/antag_spawn/ninja/ninja.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/antag_spawn/ninja
+/singleton/map_template/ruin/antag_spawn/ninja
 	name = "Operative Base"
 	suffixes = list("ninja/ninja_base.dmm")
 	shuttles_to_initialise = list(/datum/shuttle/autodock/multi/antag/ninja)

--- a/maps/antag_spawn/vox/voxraider.dm
+++ b/maps/antag_spawn/vox/voxraider.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/antag_spawn/vox_raider
+/singleton/map_template/ruin/antag_spawn/vox_raider
 	name = "Vox Raider"
 	suffixes = list("vox/vox_raider.dmm")
 	shuttles_to_initialise = list(/datum/shuttle/autodock/overmap/vox_raider)

--- a/maps/antag_spawn/wizard/wizard.dm
+++ b/maps/antag_spawn/wizard/wizard.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/antag_spawn/wizard
+/singleton/map_template/ruin/antag_spawn/wizard
 	name = "Wizard Base"
 	suffixes = list("wizard/wizard_base.dmm")
 

--- a/maps/away/README.md
+++ b/maps/away/README.md
@@ -10,11 +10,11 @@ It's a kind of map template which:
 
 ### Er, what's a map template?
 
-It's a datum you can define in the code (`/datum/map_template`) which points at one or more .dmm map files, and allows the game (or admins) to spawn those map files when and where they please, whether that's into an existing zlevel (like decorating exoplanets with ruins), or on a totally fresh one (like an away site!).
+It's a datum you can define in the code (`/singleton/map_template`) which points at one or more .dmm map files, and allows the game (or admins) to spawn those map files when and where they please, whether that's into an existing zlevel (like decorating exoplanets with ruins), or on a totally fresh one (like an away site!).
 
 ## How do I make away sites?
 
-tl;dr you make your .dmm files, then you write a new map template datum (`/datum/map_template/ruin/away_site/insert_your_away_site_name_here`), then you include whatever file you defined that datum in into `torch.dm` and `away_sites_testing.dm`, and you're all set.
+tl;dr you make your .dmm files, then you write a new map template datum (`/singleton/map_template/ruin/away_site/insert_your_away_site_name_here`), then you include whatever file you defined that datum in into `torch.dm` and `away_sites_testing.dm`, and you're all set.
 
 BUT HEED MY RUMINATIONS
 

--- a/maps/away/abandoned_hotel/abandoned_hotel.dm
+++ b/maps/away/abandoned_hotel/abandoned_hotel.dm
@@ -10,7 +10,7 @@
 		"nav_cinnamon_hotel_3",
 	)
 
-/datum/map_template/ruin/away_site/abandoned_hotel
+/singleton/map_template/ruin/away_site/abandoned_hotel
 	name = "Cinnamon Resort"
 	id = "awaysite_abandoned_hotel"
 	description = "An abandoned hotel."

--- a/maps/away/away_sites.dm
+++ b/maps/away/away_sites.dm
@@ -1,11 +1,10 @@
-// Hey! Listen! Update \config\away_site_blacklist.txt with your new ruins!
-
-/datum/map_template/ruin/away_site
+/singleton/map_template/ruin/away_site
+	abstract_type = /singleton/map_template/ruin/away_site
 	var/list/generate_mining_by_z
 	prefix = "maps/away/"
 	skip_main_unit_tests = "Is an away site."
 
-/datum/map_template/ruin/away_site/after_load(z)
+/singleton/map_template/ruin/away_site/after_load(z)
 	if(islist(generate_mining_by_z))
 		for(var/i in generate_mining_by_z)
 			var/current_z = z + i - 1

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -34,7 +34,7 @@
 	name = "[name], \a [initial(name)]"
 	..()
 
-/datum/map_template/ruin/away_site/bearcat_wreck
+/singleton/map_template/ruin/away_site/bearcat_wreck
 	name = "Bearcat Wreck"
 	id = "awaysite_bearcat_wreck"
 	description = "A wrecked light freighter."

--- a/maps/away/blueriver/blueriver.dm
+++ b/maps/away/blueriver/blueriver.dm
@@ -16,7 +16,7 @@
 	name = "[generate_planet_name()], \a [name]"
 	..()
 
-/datum/map_template/ruin/away_site/blueriver
+/singleton/map_template/ruin/away_site/blueriver
 	name = "Bluespace River"
 	id = "awaysite_blue"
 	spawn_cost = 2

--- a/maps/away/casino/casino.dm
+++ b/maps/away/casino/casino.dm
@@ -24,7 +24,7 @@
 	name = "IPV [pick("Fortuna","Gold Rush","Ebisu","Lucky Paw","Four Leaves")], \a [name]"
 	..()
 
-/datum/map_template/ruin/away_site/casino
+/singleton/map_template/ruin/away_site/casino
 	name = "Casino"
 	id = "awaysite_casino"
 	description = "A casino ship!"

--- a/maps/away/derelict/derelict.dm
+++ b/maps/away/derelict/derelict.dm
@@ -16,7 +16,7 @@
 		"nav_derelict_7"
 	)
 
-/datum/map_template/ruin/away_site/derelict
+/singleton/map_template/ruin/away_site/derelict
 	name = "Derelict Station"
 	id = "awaysite_derelict"
 	description = "An abandoned construction project."

--- a/maps/away/errant_pisces/errant_pisces.dm
+++ b/maps/away/errant_pisces/errant_pisces.dm
@@ -8,7 +8,7 @@
 	burn_delay = 15 SECONDS
 	fore_dir = SOUTH
 
-/datum/map_template/ruin/away_site/errant_pisces
+/singleton/map_template/ruin/away_site/errant_pisces
 	name = "Errant Pisces"
 	id = "awaysite_errant_pisces"
 	description = "Xynergy carp trawler"

--- a/maps/away/lar_maria/lar_maria.dm
+++ b/maps/away/lar_maria/lar_maria.dm
@@ -6,7 +6,7 @@
 	icon_state = "object"
 
 
-/datum/map_template/ruin/away_site/lar_maria
+/singleton/map_template/ruin/away_site/lar_maria
 	name = "Lar Maria"
 	id = "awaysite_lar_maria"
 	description = "An orbital virus research station."

--- a/maps/away/lost_supply_base/lost_supply_base.dm
+++ b/maps/away/lost_supply_base/lost_supply_base.dm
@@ -14,7 +14,7 @@
 		"nav_lost_supply_base_antag"
 	)
 
-/datum/map_template/ruin/away_site/lost_supply_base
+/singleton/map_template/ruin/away_site/lost_supply_base
 	name = "Lost Supply Base"
 	id = "awaysite_lost_supply_base"
 	description = "An abandoned supply base."

--- a/maps/away/magshield/magshield.dm
+++ b/maps/away/magshield/magshield.dm
@@ -14,7 +14,7 @@
 		"nav_magshield_antag"
 	)
 
-/datum/map_template/ruin/away_site/magshield
+/singleton/map_template/ruin/away_site/magshield
 	name = "Magshield"
 	id = "awaysite_magshield"
 	description = "It's an orbital shield station."

--- a/maps/away/meatstation/meatstation.dm
+++ b/maps/away/meatstation/meatstation.dm
@@ -13,7 +13,7 @@
 		"nav_meatstation_antag"
 	)
 
-/datum/map_template/ruin/away_site/meatstation
+/singleton/map_template/ruin/away_site/meatstation
 	name = "Meatstation"
 	id = "awaysite_meatstation"
 	description = "It's a research station full of baddies and some unique loot."

--- a/maps/away/mining/mining.dm
+++ b/maps/away/mining/mining.dm
@@ -28,7 +28,7 @@
 	res.SetTransform(scale = 0.5)
 	return res
 
-/datum/map_template/ruin/away_site/mining_asteroid
+/singleton/map_template/ruin/away_site/mining_asteroid
 	name = "Mining - Asteroid"
 	id = "awaysite_mining_asteroid"
 	description = "A medium-sized asteroid full of minerals."
@@ -100,7 +100,7 @@
 	res.SetTransform(scale = 0.3)
 	return res
 
-/datum/map_template/ruin/away_site/mining_signal
+/singleton/map_template/ruin/away_site/mining_signal
 	name = "Mining - Dwarf Planet"
 	id = "awaysite_mining_signal"
 	description = "A mineral-rich, formerly-volcanic site on a dwarf planet."
@@ -169,7 +169,7 @@
 	res.pixel_y = rand(256,512)
 	return res
 
-/datum/map_template/ruin/away_site/orb
+/singleton/map_template/ruin/away_site/orb
 	name = "Mining - Orb"
 	id = "awaysite_mining_orb"
 	description = "A sort of circular asteroid with a bird."

--- a/maps/away/mining/mining_corporate.dm
+++ b/maps/away/mining/mining_corporate.dm
@@ -28,7 +28,7 @@
 	res.SetTransform(scale = 0.5)
 	return res
 
-/datum/map_template/ruin/away_site/mining_corporate
+/singleton/map_template/ruin/away_site/mining_corporate
 	name = "Mining - Corporate"
 	id = "awaysite_mining_corporate"
 	description = "A medium-sized asteroid full of minerals. Old mining facility detected at one of sides, owner - NanoTrasen."

--- a/maps/away/mininghome/mininghome.dm
+++ b/maps/away/mininghome/mininghome.dm
@@ -10,7 +10,7 @@
 		"nav_mininghome_4"
 	)
 
-/datum/map_template/ruin/away_site/mininghome
+/singleton/map_template/ruin/away_site/mininghome
 	name = "mininghome"
 	id = "awaysite_mininghome"
 	description = "A chill asteroid mining station."

--- a/maps/away/miningstation/miningstation.dm
+++ b/maps/away/miningstation/miningstation.dm
@@ -11,7 +11,7 @@
 		"nav_miningstation_exterior",
 	)
 
-/datum/map_template/ruin/away_site/miningstation
+/singleton/map_template/ruin/away_site/miningstation
 	name = "Mining Station"
 	id = "awaysite_miningstation"
 	description = "An orbital Mining Station bearing authentication codes from Grayson Mining Industries, sensors show inconsistant lifesigns aboard the station."

--- a/maps/away/mobius_rift/mobius_rift.dm
+++ b/maps/away/mobius_rift/mobius_rift.dm
@@ -6,7 +6,7 @@
 	icon_state = "object"
 
 
-/datum/map_template/ruin/away_site/mobius_rift
+/singleton/map_template/ruin/away_site/mobius_rift
 	name = "Mobius rift"
 	id = "awaysite_mobius_rift"
 	description = "Non-euclidian mess."

--- a/maps/away/scavver/scavver_gantry.dm
+++ b/maps/away/scavver/scavver_gantry.dm
@@ -2,7 +2,7 @@
 #include "scavver_gantry_jobs.dm"
 #include "scavver_gantry_radio.dm"
 
-/datum/map_template/ruin/away_site/scavver_gantry
+/singleton/map_template/ruin/away_site/scavver_gantry
 	name =  "\improper Salvage Gantry"
 	id = "awaysite_gantry"
 	description = "Salvage Gantry turned Ship"

--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -5,7 +5,7 @@
 #include "skrellscoutship_radio.dm"
 #include "skrellscoutship_machines.dm"
 
-/datum/map_template/ruin/away_site/skrellscoutship
+/singleton/map_template/ruin/away_site/skrellscoutship
 	name = "Skrellian Scout Ship"
 	id = "awaysite_skrell_scout"
 	description = "A Skrellian SDTF scouting vessel."

--- a/maps/away/slavers/slavers_base.dm
+++ b/maps/away/slavers/slavers_base.dm
@@ -17,7 +17,7 @@
 		"nav_slavers_base_antag"
 	)
 
-/datum/map_template/ruin/away_site/slavers
+/singleton/map_template/ruin/away_site/slavers
 	name = "Slavers' Base"
 	id = "awaysite_slavers"
 	description = "Asteroid with slavers base inside."

--- a/maps/away/smugglers/smugglers.dm
+++ b/maps/away/smugglers/smugglers.dm
@@ -12,7 +12,7 @@
 		"nav_smugglers_antag"
 	)
 
-/datum/map_template/ruin/away_site/smugglers
+/singleton/map_template/ruin/away_site/smugglers
 	name = "Smugglers' Base"
 	id = "awaysite_smugglers"
 	description = "Yarr."

--- a/maps/away/spy_station/spy_station.dm
+++ b/maps/away/spy_station/spy_station.dm
@@ -68,7 +68,7 @@
 	)
 
 
-/datum/map_template/ruin/away_site/spy_station
+/singleton/map_template/ruin/away_site/spy_station
 	name = "Spy Station"
 	id = "awaysite_spy_station"
 	description = "SCGDF station that investigates sensor contacts in deep space."

--- a/maps/away/voxship/voxship.dm
+++ b/maps/away/voxship/voxship.dm
@@ -6,7 +6,7 @@
 #include "voxship_machines.dm"
 #include "voxship_antagonism.dm"
 
-/datum/map_template/ruin/away_site/scavship
+/singleton/map_template/ruin/away_site/scavship
 	name = "Vox Scavenger Ship"
 	id = "awaysite_voxship2"
 	description = "Vox Scavenger Ship."

--- a/maps/away/yacht/yacht.dm
+++ b/maps/away/yacht/yacht.dm
@@ -17,7 +17,7 @@
 	name = "IPV [pick("Razorshark", "Aurora", "Lighting", "Pequod", "Anansi")], \a [name]"
 	..()
 
-/datum/map_template/ruin/away_site/yacht
+/singleton/map_template/ruin/away_site/yacht
 	name = "Yacht"
 	id = "awaysite_yach"
 	description = "Tiny movable ship with spiders."

--- a/maps/away_sites_testing/away_sites_testing_define.dm
+++ b/maps/away_sites_testing/away_sites_testing_define.dm
@@ -49,9 +49,9 @@
 /datum/map/away_sites_testing/build_away_sites()
 	var/list/unsorted_sites = list_values(SSmapping.away_sites_templates)
 	var/list/sorted_sites = sortTim(unsorted_sites, GLOBAL_PROC_REF(cmp_sort_templates_tallest_to_shortest))
-	for (var/datum/map_template/ruin/away_site/A in sorted_sites)
+	for (var/singleton/map_template/ruin/away_site/A in sorted_sites)
 		A.load_new_z()
 		testing("Spawning [A] in [english_list(GetConnectedZlevels(world.maxz))]")
 
-/proc/cmp_sort_templates_tallest_to_shortest(datum/map_template/a, datum/map_template/b)
+/proc/cmp_sort_templates_tallest_to_shortest(singleton/map_template/a, singleton/map_template/b)
 	return b.tallness - a.tallness

--- a/maps/event/empty/empty.dm
+++ b/maps/event/empty/empty.dm
@@ -14,7 +14,7 @@
 	)
 
 
-/datum/map_template/ruin/empty
+/singleton/map_template/ruin/empty
 	name = "Empty"
 	id = "empty_sector"
 	description = "An empty sector devoid of anthything interesting."

--- a/maps/event/iccgn_ship/icgnv_hound.dm
+++ b/maps/event/iccgn_ship/icgnv_hound.dm
@@ -1,6 +1,6 @@
 #include "icgnv_hound_shuttle.dm"
 
-/datum/map_template/ruin/icgnv_hound
+/singleton/map_template/ruin/icgnv_hound
 	name = "ICGNV Hound"
 	id = "icgnv_hound"
 	description = "A standard ALFA-pattern, armed ICCGN transport shuttle. The transponder reads on open channels as ICCG and is broadcasting the designation 'ICGNV Hound' in Zurich Accord Common."

--- a/maps/event/sfv_arbiter/sfv_arbiter.dm
+++ b/maps/event/sfv_arbiter/sfv_arbiter.dm
@@ -1,6 +1,6 @@
 #include "sfv_arbiter_shuttle.dm"
 
-/datum/map_template/ruin/sfv_arbiter
+/singleton/map_template/ruin/sfv_arbiter
 	name = "SFV Arbiter"
 	id = "arbiter"
 	description = "A fairly standard armed transport shuttle belonging to the Sol Fleet. It's transponder reads 'SFV Arbiter'."

--- a/maps/map_tools_showcase/portal_showcase.dm
+++ b/maps/map_tools_showcase/portal_showcase.dm
@@ -4,7 +4,7 @@
 /area/portal_showcase/B
 	name = "Portal showcase zone B"
 
-/datum/map_template/portal_showcase
+/singleton/map_template/portal_showcase
 	name = "portal showcase"
 	id = "showcase portals"
 	mappaths = list("maps/map_tools_showcase/portal_showcase.dmm")

--- a/maps/mapsystem/maps.dm
+++ b/maps/mapsystem/maps.dm
@@ -249,6 +249,10 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 
 	var/maint_all_access = FALSE
 
+	/// The type of this map's overmap entity, if any
+	var/obj/overmap/overmap_entity
+
+
 /datum/map/New()
 	if(!map_levels)
 		map_levels = station_levels.Copy()
@@ -336,7 +340,7 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 
 
 /* It is perfectly possible to create loops with TEMPLATE_FLAG_ALLOW_DUPLICATES and force/allow. Don't. */
-/proc/resolve_site_selection(datum/map_template/ruin/away_site/site, list/selected, list/available, list/unavailable, list/by_type)
+/proc/resolve_site_selection(singleton/map_template/ruin/away_site/site, list/selected, list/available, list/unavailable, list/by_type)
 	RETURN_TYPE(/list)
 	var/spawn_cost = 0
 	var/player_cost = 0
@@ -355,14 +359,14 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 		player_cost += costs[2]
 
 	for (var/banned_type in site.ban_ruins)
-		var/datum/map_template/ruin/away_site/banned = by_type[banned_type]
+		var/singleton/map_template/ruin/away_site/banned = by_type[banned_type]
 		if (banned in unavailable)
 			continue
 		unavailable += banned
 		available -= banned
 
 	for (var/allowed_type in site.allow_ruins)
-		var/datum/map_template/ruin/away_site/allowed = by_type[allowed_type]
+		var/singleton/map_template/ruin/away_site/allowed = by_type[allowed_type]
 		if (allowed in available)
 			continue
 		if (allowed in unavailable)
@@ -389,7 +393,7 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	var/list/by_type = list()
 
 	for (var/site_name in SSmapping.away_sites_templates)
-		var/datum/map_template/ruin/away_site/site = SSmapping.away_sites_templates[site_name]
+		var/singleton/map_template/ruin/away_site/site = SSmapping.away_sites_templates[site_name]
 		if (site.template_flags & TEMPLATE_FLAG_SPAWN_GUARANTEED)
 			guaranteed += site
 			if ((site.template_flags & TEMPLATE_FLAG_ALLOW_DUPLICATES) && !(site.template_flags & TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED))
@@ -403,13 +407,13 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 	for (var/client/C)
 		++players
 
-	for (var/datum/map_template/ruin/away_site/site in guaranteed)
+	for (var/singleton/map_template/ruin/away_site/site in guaranteed)
 		var/list/costs = resolve_site_selection(site, selected, available, unavailable, by_type)
 		points -= costs[1]
 		players -= costs[2]
 
 	while (points > 0 && length(available))
-		var/datum/map_template/ruin/away_site/site = pickweight(available)
+		var/singleton/map_template/ruin/away_site/site = pickweight(available)
 		if (site.spawn_cost && site.spawn_cost > points || site.player_cost && site.player_cost > players)
 			unavailable += site
 			available -= site
@@ -420,7 +424,7 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 
 	report_progress("Finished selecting away sites ([english_list(selected)]) for [away_site_budget - points] cost of [away_site_budget] budget.")
 
-	for (var/datum/map_template/template in selected)
+	for (var/singleton/map_template/template in selected)
 		if (template.load_new_z())
 			report_progress("Loaded away site [template]!")
 		else

--- a/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_pod/crashed_pod.dm
@@ -1,6 +1,6 @@
 GLOBAL_LIST_EMPTY(crashed_pod_areas)
 
-/datum/map_template/ruin/exoplanet/crashed_pod
+/singleton/map_template/ruin/exoplanet/crashed_pod
 	name = "crashed survival pod"
 	id = "crashed_pod"
 	description = "A crashed survival pod from a destroyed ship."

--- a/maps/random_ruins/exoplanet_ruins/crashed_probe/crashed_probe.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_probe/crashed_probe.dm
@@ -1,6 +1,6 @@
 #include "../../../../packs/factions/scgec/_pack.dm"
 
-/datum/map_template/ruin/exoplanet/crashed_probe
+/singleton/map_template/ruin/exoplanet/crashed_probe
 	name = "Expeditionary Probe"
 	id = "crashed_probe"
 	description = "An abandoned ancient STL automated survey drone."

--- a/maps/random_ruins/exoplanet_ruins/crashed_shuttle/crashed_shuttle.dm
+++ b/maps/random_ruins/exoplanet_ruins/crashed_shuttle/crashed_shuttle.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/crashed_shuttle
+/singleton/map_template/ruin/exoplanet/crashed_shuttle
 	name = "Crushed shuttle"
 	id = "crashed_shuttle"
 	description = "Crushed corporate shuttle."

--- a/maps/random_ruins/exoplanet_ruins/deserted_lab/deserted_lab.dm
+++ b/maps/random_ruins/exoplanet_ruins/deserted_lab/deserted_lab.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/deserted_lab
+/singleton/map_template/ruin/exoplanet/deserted_lab
 	name = "deserted lab"
 	id = "deserted_lab"
 	description = "A mid-sized abandoned lab with some enemies, traps, and loot."

--- a/maps/random_ruins/exoplanet_ruins/drill_site/drill_site.dm
+++ b/maps/random_ruins/exoplanet_ruins/drill_site/drill_site.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/drill_site
+/singleton/map_template/ruin/exoplanet/drill_site
 	name = "drill site"
 	id = "drill_site"
 	description = "A small, abandoned mining drill operation."

--- a/maps/random_ruins/exoplanet_ruins/droppod/droppod.dm
+++ b/maps/random_ruins/exoplanet_ruins/droppod/droppod.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/droppod
+/singleton/map_template/ruin/exoplanet/droppod
 	name = "droppod"
 	id = "droppod"
 	description = "A damaged capsule with some strange contents."
@@ -21,19 +21,19 @@
 
 /obj/landmark/map_load_mark/droppod
 	name = "random droppod contents"
-	templates = list(/datum/map_template/droppod_contents, /datum/map_template/droppod_contents/type2, /datum/map_template/droppod_contents/type3)
+	templates = list(/singleton/map_template/droppod_contents, /singleton/map_template/droppod_contents/type2, /singleton/map_template/droppod_contents/type3)
 
-/datum/map_template/droppod_contents
+/singleton/map_template/droppod_contents
 	name = "random droppod contents #1 (shipping)"
 	id = "droppod_1"
 	mappaths = list("maps/random_ruins/exoplanet_ruins/droppod/contents_1.dmm")
 
-/datum/map_template/droppod_contents/type2
+/singleton/map_template/droppod_contents/type2
 	name = "random droppod contents #2 (exosuit)"
 	id = "droppod_2"
 	mappaths = list("maps/random_ruins/exoplanet_ruins/droppod/contents_2.dmm")
 
-/datum/map_template/droppod_contents/type3
+/singleton/map_template/droppod_contents/type3
 	name = "random droppod contents #2 (robots)"
 	id = "droppod_3"
 	mappaths = list("maps/random_ruins/exoplanet_ruins/droppod/contents_3.dmm")

--- a/maps/random_ruins/exoplanet_ruins/ec_old_crash/ec_old_crash.dm
+++ b/maps/random_ruins/exoplanet_ruins/ec_old_crash/ec_old_crash.dm
@@ -1,6 +1,6 @@
 #include "../../../../packs/factions/scgec/_pack.dm"
 
-/datum/map_template/ruin/exoplanet/ec_old_crash
+/singleton/map_template/ruin/exoplanet/ec_old_crash
 	name = "Expeditionary Ship"
 	id = "ec_old_wreck"
 	description = "An abandoned ancient STL exploration ship."

--- a/maps/random_ruins/exoplanet_ruins/ejected_datapod/ejected_datapod.dm
+++ b/maps/random_ruins/exoplanet_ruins/ejected_datapod/ejected_datapod.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/ejected_datapod
+/singleton/map_template/ruin/exoplanet/ejected_datapod
 	name = "ejected data capsule"
 	id = "ejected_datapod"
 	description = "A damaged capsule with some strange contents."
@@ -11,19 +11,19 @@
 	)
 
 
-/datum/map_template/ejected_datapod_contents
+/singleton/map_template/ejected_datapod_contents
 	name = "random datapod contents #1 (chem vials)"
 	id = "datapod_1"
 	mappaths = list("maps/random_ruins/exoplanet_ruins/ejected_datapod/contents_1.dmm")
 
 
-/datum/map_template/ejected_datapod_contents/type2
+/singleton/map_template/ejected_datapod_contents/type2
 	name = "random datapod contents #2 (servers)"
 	id = "datapod_2"
 	mappaths = list("maps/random_ruins/exoplanet_ruins/ejected_datapod/contents_2.dmm")
 
 
-/datum/map_template/ejected_datapod_contents/type3
+/singleton/map_template/ejected_datapod_contents/type3
 	name = "random datapod contents #2 (spiders)"
 	id = "datapod_3"
 	mappaths = list("maps/random_ruins/exoplanet_ruins/ejected_datapod/contents_3.dmm")
@@ -32,9 +32,9 @@
 /obj/landmark/map_load_mark/ejected_datapod
 	name = "random datapod contents"
 	templates = list(
-		/datum/map_template/ejected_datapod_contents,
-		/datum/map_template/ejected_datapod_contents/type2,
-		/datum/map_template/ejected_datapod_contents/type3
+		/singleton/map_template/ejected_datapod_contents,
+		/singleton/map_template/ejected_datapod_contents/type2,
+		/singleton/map_template/ejected_datapod_contents/type3
 	)
 
 

--- a/maps/random_ruins/exoplanet_ruins/excavation_site/excavation_site.dm
+++ b/maps/random_ruins/exoplanet_ruins/excavation_site/excavation_site.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/excavation_site
+/singleton/map_template/ruin/exoplanet/excavation_site
 	name = "excavation site"
 	id = "excavation_site"
 	description = "Abandoned archaeological site."

--- a/maps/random_ruins/exoplanet_ruins/exoplanet_ruins.dm
+++ b/maps/random_ruins/exoplanet_ruins/exoplanet_ruins.dm
@@ -1,5 +1,4 @@
-// Hey! Listen! Update \config\exoplanet_ruin_blacklist.txt with your new ruins!
-
-/datum/map_template/ruin/exoplanet
+/singleton/map_template/ruin/exoplanet
+	abstract_type = /singleton/map_template/ruin/exoplanet
 	prefix = "maps/random_ruins/exoplanet_ruins/"
 	var/list/ruin_tags

--- a/maps/random_ruins/exoplanet_ruins/fountain/fountain_ruin.dm
+++ b/maps/random_ruins/exoplanet_ruins/fountain/fountain_ruin.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/fountain
+/singleton/map_template/ruin/exoplanet/fountain
 	name = "Fountain of Youth"
 	id = "planetsite_fountain"
 	description = "The fountain of youth itself."

--- a/maps/random_ruins/exoplanet_ruins/hut/hut.dm
+++ b/maps/random_ruins/exoplanet_ruins/hut/hut.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/hut
+/singleton/map_template/ruin/exoplanet/hut
 	name = "hut"
 	id = "hut"
 	description = "A small and simple little research hut."

--- a/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dm
+++ b/maps/random_ruins/exoplanet_ruins/hydrobase/hydrobase.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/hydrobase
+/singleton/map_template/ruin/exoplanet/hydrobase
 	name = "hydroponics base"
 	id = "exoplanet_hydrobase"
 	description = "hydroponics base with random plants and a lot of enemies"

--- a/maps/random_ruins/exoplanet_ruins/icarus/icarus.dm
+++ b/maps/random_ruins/exoplanet_ruins/icarus/icarus.dm
@@ -1,6 +1,6 @@
 #include "../../../torch/items/weapons.dm"
 
-/datum/map_template/ruin/exoplanet/icarus
+/singleton/map_template/ruin/exoplanet/icarus
 	name = "SEV Icarus"
 	id = "icarus"
 	description = "The crash of the infamous SEV Icarus."

--- a/maps/random_ruins/exoplanet_ruins/lodge/lodge.dm
+++ b/maps/random_ruins/exoplanet_ruins/lodge/lodge.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/lodge
+/singleton/map_template/ruin/exoplanet/lodge
 	name = "lodge"
 	id = "lodge"
 	description = "A wood cabin."

--- a/maps/random_ruins/exoplanet_ruins/marooned/marooned.dm
+++ b/maps/random_ruins/exoplanet_ruins/marooned/marooned.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/marooned
+/singleton/map_template/ruin/exoplanet/marooned
 	name = "Marooned"
 	id = "awaysite_marooned"
 	description = "crashed dropship with marooned Magnitka officer"

--- a/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
+++ b/maps/random_ruins/exoplanet_ruins/monoliths/monoliths.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/monolith
+/singleton/map_template/ruin/exoplanet/monolith
 	name = "Monolith Ring"
 	id = "planetsite_monoliths"
 	description = "Bunch of monoliths surrounding an artifact."

--- a/maps/random_ruins/exoplanet_ruins/oasis/oasis.dm
+++ b/maps/random_ruins/exoplanet_ruins/oasis/oasis.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/oasis
+/singleton/map_template/ruin/exoplanet/oasis
 	name = "oasis 1"
 	id = "oasis1"
 	description = "A tiny patch of life in a vast desert."
@@ -7,12 +7,12 @@
 	template_flags = TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_ALLOW_DUPLICATES
 	ruin_tags = RUIN_NATURAL|RUIN_WATER
 
-/datum/map_template/ruin/exoplanet/oasis/oasis2
+/singleton/map_template/ruin/exoplanet/oasis/oasis2
 	name = "oasis 2"
 	id = "oasis2"
 	suffixes = list("oasis/oasis2.dmm")
 
-/datum/map_template/ruin/exoplanet/oasis/oasis3
+/singleton/map_template/ruin/exoplanet/oasis/oasis3
 	name = "oasis 3"
 	id = "oasis3"
 	suffixes = list("oasis/oasis3.dmm")

--- a/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab/oldlab.dm
@@ -1,5 +1,5 @@
 
-/datum/map_template/ruin/exoplanet/oldlab
+/singleton/map_template/ruin/exoplanet/oldlab
 	name = "Old Lab"
 	id = "exoplanet_oldlab"
 	description = "an abandoned lab"
@@ -7,7 +7,7 @@
 	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN
-	ban_ruins = list(/datum/map_template/ruin/exoplanet/oldlab2)
+	ban_ruins = list(/singleton/map_template/ruin/exoplanet/oldlab2)
 
 	// Areas //
 

--- a/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dm
+++ b/maps/random_ruins/exoplanet_ruins/oldlab2/oldlab2.dm
@@ -1,5 +1,5 @@
 
-/datum/map_template/ruin/exoplanet/oldlab2
+/singleton/map_template/ruin/exoplanet/oldlab2
 	name = "Old Lab 2"
 	id = "exoplanet_oldlab2"
 	description = "another abandoned lab"
@@ -7,7 +7,7 @@
 	spawn_cost = 1
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS
 	ruin_tags = RUIN_HUMAN
-	ban_ruins = list(/datum/map_template/ruin/exoplanet/oldlab)
+	ban_ruins = list(/singleton/map_template/ruin/exoplanet/oldlab)
 
 	// Areas //
 

--- a/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dm
+++ b/maps/random_ruins/exoplanet_ruins/oldpod/oldpod.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/oldpod
+/singleton/map_template/ruin/exoplanet/oldpod
 	name = "old pod"
 	id = "oldpod"
 	description = "A now unused, crashed escape pod."

--- a/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony/playablecolony.dm
@@ -1,6 +1,6 @@
 #include "playablecolony_radio.dm"
 
-/datum/map_template/ruin/exoplanet/playablecolony
+/singleton/map_template/ruin/exoplanet/playablecolony
 	name = "established colony"
 	id = "playablecolony"
 	description = "a fully functional colony on the frontier of settled space"
@@ -9,7 +9,7 @@
 	player_cost = 4
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	ruin_tags = RUIN_HUMAN|RUIN_HABITAT
-	ban_ruins = list(/datum/map_template/ruin/exoplanet/playablecolony2)
+	ban_ruins = list(/singleton/map_template/ruin/exoplanet/playablecolony2)
 	apc_test_exempt_areas = list(
 		/area/map_template/colony/mineralprocessing = NO_SCRUBBER|NO_VENT
 	)

--- a/maps/random_ruins/exoplanet_ruins/playablecolony2/playablecolony2.dm
+++ b/maps/random_ruins/exoplanet_ruins/playablecolony2/playablecolony2.dm
@@ -1,6 +1,6 @@
 #include "playablecolony2_radio.dm"
 
-/datum/map_template/ruin/exoplanet/playablecolony2
+/singleton/map_template/ruin/exoplanet/playablecolony2
 	name = "Landed Colony Ship"
 	id = "playablecolony2"
 	description = "a recently landed colony ship"
@@ -9,7 +9,7 @@
 	player_cost = 4
 	template_flags = TEMPLATE_FLAG_CLEAR_CONTENTS | TEMPLATE_FLAG_NO_RUINS | TEMPLATE_FLAG_NO_RADS
 	ruin_tags = RUIN_HUMAN|RUIN_HABITAT
-	ban_ruins = list(/datum/map_template/ruin/exoplanet/playablecolony)
+	ban_ruins = list(/singleton/map_template/ruin/exoplanet/playablecolony)
 	apc_test_exempt_areas = list(
 		/area/map_template/colony2/external = NO_SCRUBBER|NO_VENT
 	)

--- a/maps/random_ruins/exoplanet_ruins/radshrine/radshrine.dm
+++ b/maps/random_ruins/exoplanet_ruins/radshrine/radshrine.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/radshrine
+/singleton/map_template/ruin/exoplanet/radshrine
 	name = "radshrine"
 	id = "radshrine"
 	description = "A small radioactive shrine dedicated to an anomaly."

--- a/maps/random_ruins/exoplanet_ruins/skrell_biodome/skrell_biodome.dm
+++ b/maps/random_ruins/exoplanet_ruins/skrell_biodome/skrell_biodome.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/skrell_biodome
+/singleton/map_template/ruin/exoplanet/skrell_biodome
 	name = "Skrellian Biodome"
 	id = "skrell_biodome"
 	description = "Strange round structure."

--- a/maps/random_ruins/exoplanet_ruins/spider_nest/spider_nest.dm
+++ b/maps/random_ruins/exoplanet_ruins/spider_nest/spider_nest.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/spider_nest
+/singleton/map_template/ruin/exoplanet/spider_nest
 	name = "spider nest"
 	id = "spider_nest"
 	description = "A small buidling with a spider infestation."

--- a/maps/random_ruins/exoplanet_ruins/tar_anomaly/tar_anomaly.dm
+++ b/maps/random_ruins/exoplanet_ruins/tar_anomaly/tar_anomaly.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/tar_anomaly
+/singleton/map_template/ruin/exoplanet/tar_anomaly
 	name = "tar anomaly"
 	id = "tar_anomaly"
 	description = "An anomaly in the center of a ring of tar."

--- a/maps/random_ruins/exoplanet_ruins/transshipment/transshipment.dm
+++ b/maps/random_ruins/exoplanet_ruins/transshipment/transshipment.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/transshipment
+/singleton/map_template/ruin/exoplanet/transshipment
 	name = "Raided Transshipment point"
 	id = "transshipment"
 	description = "An abandoned warehouse and damaged CCG-produced shuttle."

--- a/maps/random_ruins/exoplanet_ruins/trash_heap/trash_heap.dm
+++ b/maps/random_ruins/exoplanet_ruins/trash_heap/trash_heap.dm
@@ -1,4 +1,4 @@
-/datum/map_template/ruin/exoplanet/trash_heap
+/singleton/map_template/ruin/exoplanet/trash_heap
 	name = "trash heap"
 	id = "trash_heap"
 	description = "A pile of trash and a few goodies."

--- a/maps/random_ruins/space_ruins/space_ruins.dm
+++ b/maps/random_ruins/space_ruins/space_ruins.dm
@@ -1,10 +1,9 @@
-// Hey! Listen! Update \config\space_ruin_blacklist.txt with your new ruins!
-
-/datum/map_template/ruin/space
+/singleton/map_template/ruin/space
+	abstract_type = /singleton/map_template/ruin/space
 	prefix = "maps/random_ruins/space_ruins/"
 	spawn_cost = 1
 
-/datum/map_template/ruin/space/multi_zas_test
+/singleton/map_template/ruin/space/multi_zas_test
 	name = "Multi-ZAS Test"
 	id = "multi_zas_test"
 	description = "if this has vacuum in it, that's not good!"

--- a/maps/torch/torch_define.dm
+++ b/maps/torch/torch_define.dm
@@ -5,6 +5,8 @@
 	flags = MAP_HAS_BRANCH | MAP_HAS_RANK
 	config_path = "config/torch_config.txt"
 
+	overmap_entity = /obj/overmap/visitable/ship/torch
+
 	admin_levels  = list(7)
 	escape_levels = list(8)
 	empty_levels  = list(9)
@@ -59,3 +61,22 @@
 	welcome_sound = null
 
 	use_bluespace_interlude = TRUE
+
+
+/singleton/map_template/ruin/torch
+	name = "SEV Torch"
+	id = "main_torch"
+	description = "An abandoned construction project."
+	prefix = "maps/torch/"
+	suffixes = list(
+		"torch1_deck5.dmm",
+		"torch2_deck4.dmm",
+		"torch3_deck3.dmm",
+		"torch4_deck2.dmm",
+		"torch5_deck1.dmm",
+		"torch6_bridge.dmm"
+	)
+	width = 200
+	height = 200
+	tallness = 6
+	template_flags = TEMPLATE_FLAG_RUIN_STARTS_DISALLOWED

--- a/maps/torch/torch_setup.dm
+++ b/maps/torch/torch_setup.dm
@@ -11,7 +11,7 @@
 	return jointext(., "<br>")
 
 /datum/map/torch/send_welcome()
-	var/obj/overmap/visitable/ship/torch = SSshuttle.ship_by_type(/obj/overmap/visitable/ship/torch)
+	var/obj/overmap/visitable/ship/torch = SSshuttle.ship_by_type(overmap_entity)
 
 	var/welcome_text = "<center><img src = sollogo.png /><br />[FONT_LARGE("<b>SEV Torch</b> Sensor Readings:")]<br>"
 	welcome_text += "Report generated on [stationdate2text()] at [stationtime2text()]</center><br /><br />"

--- a/maps/using.dm
+++ b/maps/using.dm
@@ -1,4 +1,7 @@
+#if !defined(using_map_DATUM)
 //Easily change which map to build by uncommenting ONE below.
 
 //#include "example\map.dm"
 #include "torch\map.dm"
+
+#endif

--- a/packs/deepmaint/deepmaint.dm
+++ b/packs/deepmaint/deepmaint.dm
@@ -2,11 +2,12 @@
 	name = "Deep Dark Marvelous"
 	height = 1
 
-/datum/map_template/ruin/deepmaint
+/singleton/map_template/ruin/deepmaint
 	name = "Deepmaint"
 	id = "deepmaint"
 	description = "Somewhere inbetween. How did we get here? How do we leave?"
-	suffixes = list("packs/deepmaint/deepmaint-1.dmm")
+	prefix = "packs/deepmaint/"
+	suffixes = list("deepmaint-1.dmm")
 
 /area/map_template/deepmaint
 	name = "\improper Deep Maintenance"

--- a/packs/deepmaint/deepmaint_rooms/core/_core_rooms.dm
+++ b/packs/deepmaint/deepmaint_rooms/core/_core_rooms.dm
@@ -1,25 +1,25 @@
-/datum/map_template/deepmaint_template/big/archive
+/singleton/map_template/deepmaint_template/big/archive
 	name = "archive"
 	desc = "isafigjoa sghjsbzuy Page: 152"
 	id = "deepmaint_coreroom_archive"
 	mappaths = list('packs/deepmaint/deepmaint_rooms/core/archive.dmm')
 
 
-/datum/map_template/deepmaint_template/big/maint_asteroid
+/singleton/map_template/deepmaint_template/big/maint_asteroid
 	name = "maintenance asteroid"
 	desc = "How did this thing even get here?"
 	id = "deepmaint_coreroom_maint_asteroid"
 	mappaths = list('packs/deepmaint/deepmaint_rooms/core/maint_asteroid.dmm')
 
 
-/datum/map_template/deepmaint_template/big/ai_core
+/singleton/map_template/deepmaint_template/big/ai_core
 	name = "AI core"
 	desc = " I'm sorry, Dave."
 	id = "deepmaint_coreroom_ai_core"
 	mappaths = list('packs/deepmaint/deepmaint_rooms/core/ai_core.dmm')
 
 
-/datum/map_template/deepmaint_template/big/dinner
+/singleton/map_template/deepmaint_template/big/dinner
 	name = "dinner"
 	desc = "A last meal."
 	id = "deepmaint_coreroom_dinner"

--- a/packs/deepmaint/deepmaint_rooms/normal/_normal_rooms.dm
+++ b/packs/deepmaint/deepmaint_rooms/normal/_normal_rooms.dm
@@ -1,82 +1,82 @@
-/datum/map_template/deepmaint_template/room/unionists
+/singleton/map_template/deepmaint_template/room/unionists
 	name = "Unionists"
 	desc = "We have seized the means of production!"
 	id = "deepmaint_room_unionists"
 	mappaths = list('packs/deepmaint/deepmaint_rooms/normal/angry_unionists.dmm')
 
-/datum/map_template/deepmaint_template/room/asteroid_bar
+/singleton/map_template/deepmaint_template/room/asteroid_bar
 	name = "Asteroid Bar"
 	desc = "Take a load off."
 	id = "deepmaint_room_asteroid_bar"
 	mappaths = list('packs/deepmaint/deepmaint_rooms/normal/asteroid_bar.dmm')
 
-/datum/map_template/deepmaint_template/room/casino
+/singleton/map_template/deepmaint_template/room/casino
 	name = "Casino"
 	desc = "You can only lose 100% of your money."
 	id = "deepmaint_room_casino"
 	mappaths = list('packs/deepmaint/deepmaint_rooms/normal/casino.dmm')
 
-/datum/map_template/deepmaint_template/room/diner
+/singleton/map_template/deepmaint_template/room/diner
 	name = "Diner"
 	desc = "A lovely dinner, with a twist."
 	id = "deepmaint_room_diner"
 	mappaths = list('packs/deepmaint/deepmaint_rooms/normal/diner.dmm')
 
-/datum/map_template/deepmaint_template/room/engine_room
+/singleton/map_template/deepmaint_template/room/engine_room
 	name = "Engine Room"
 	desc = "Is this what powers this place?"
 	id = "deepmaint_room_engine_room"
 	mappaths = list('packs/deepmaint/deepmaint_rooms/normal/engine_room.dmm')
 
-/datum/map_template/deepmaint_template/room/geese_observation
+/singleton/map_template/deepmaint_template/room/geese_observation
 	name = "Geese Observation"
 	desc = "Look, but for the love of GOD DON'T TOUCH THEM."
 	id = "deepmaint_room_geese_observation"
 	mappaths = list('packs/deepmaint/deepmaint_rooms/normal/geese_observation.dmm')
 
-/datum/map_template/deepmaint_template/room/lab
+/singleton/map_template/deepmaint_template/room/lab
 	name = "Lab"
 	desc = "Science! And monsters!"
 	id = "deepmaint_room_lab"
 	mappaths = list('packs/deepmaint/deepmaint_rooms/normal/lab.dmm')
 
-/datum/map_template/deepmaint_template/room/catwalks
+/singleton/map_template/deepmaint_template/room/catwalks
 	name = "Catwalks"
 	desc = "A pleasent view of the unpleasant fauna."
 	id = "deepmaint_room_catwalks"
 	mappaths = list('packs/deepmaint/deepmaint_rooms/normal/catwalks.dmm')
 
-/datum/map_template/deepmaint_template/room/office
+/singleton/map_template/deepmaint_template/room/office
 	name = "Office"
 	desc = "Ah, hello there! What can I do for you?"
 	id = "deepmaint_room_office"
 	mappaths = list('packs/deepmaint/deepmaint_rooms/normal/office.dmm')
 
-/datum/map_template/deepmaint_template/room/pirate_asteroid
+/singleton/map_template/deepmaint_template/room/pirate_asteroid
 	name = "Pirate Asteroid"
 	desc = "Yar."
 	id = "deepmaint_room_pirate_asteroid"
 	mappaths = list('packs/deepmaint/deepmaint_rooms/normal/pirate_asteroid.dmm')
 
-/datum/map_template/deepmaint_template/room/robot_asteroid
+/singleton/map_template/deepmaint_template/room/robot_asteroid
 	name = "Robot Asteroid"
 	desc = "Beep boop."
 	id = "deepmaint_room_robot_asteroid"
 	mappaths = list('packs/deepmaint/deepmaint_rooms/normal/robot_asteroid.dmm')
 
-/datum/map_template/deepmaint_template/room/ship_wreck
+/singleton/map_template/deepmaint_template/room/ship_wreck
 	name = "Ship Wreck"
 	desc = "Did it crash before or after it got here?"
 	id = "deepmaint_room_ship_wreck"
 	mappaths = list('packs/deepmaint/deepmaint_rooms/normal/ship_wreck.dmm')
 
-/datum/map_template/deepmaint_template/room/supply
+/singleton/map_template/deepmaint_template/room/supply
 	name = "Supply"
 	desc = "Does anyone ever clean this place?"
 	id = "deepmaint_room_supply"
 	mappaths = list('packs/deepmaint/deepmaint_rooms/normal/supply.dmm')
 
-/datum/map_template/deepmaint_template/room/medical
+/singleton/map_template/deepmaint_template/room/medical
 	name = "Medical"
 	desc = "Oops, zat was not medicine!"
 	id = "deepmaint_room_medical"

--- a/packs/deepmaint/deepmaint_rooms/template.dm
+++ b/packs/deepmaint/deepmaint_rooms/template.dm
@@ -1,4 +1,4 @@
-/datum/map_template/deepmaint_template/room
+/singleton/map_template/deepmaint_template/room
 	name = "Deepmaint Template"
 	desc = "Deep. Dark. Marvelous."
 	width = 11
@@ -7,7 +7,7 @@
 	room_tag = null
 
 
-/datum/map_template/deepmaint_template/big
+/singleton/map_template/deepmaint_template/big
 	name = "Deepmaint Template"
 	desc = "Deeper. Darker. Marvelous-er."
 	width = 21

--- a/packs/deepmaint/generator/deepmain_room.dm
+++ b/packs/deepmaint/generator/deepmain_room.dm
@@ -1,7 +1,7 @@
-/datum/map_template/deepmaint_template
+/singleton/map_template/deepmaint_template
 	skip_main_unit_tests = "Is a deepmaint template."
 
-/datum/map_template/deepmaint_template/room
+/singleton/map_template/deepmaint_template/room
 	name = "Deepmaint Template"
 	var/desc = "Deep. Dark. Marvelous."
 	width = 11
@@ -9,7 +9,7 @@
 	var/room_tag = null
 
 
-/datum/map_template/deepmaint_template/big
+/singleton/map_template/deepmaint_template/big
 	name = "Deepmaint Template"
 	var/desc = "Deeper. Darker. Marvelous-er."
 	width = 21

--- a/packs/deepmaint/generator/deepmaint.dm
+++ b/packs/deepmaint/generator/deepmaint.dm
@@ -11,14 +11,14 @@ GLOBAL_LIST_EMPTY(big_deepmaint_room_templates)
 /proc/populateDeepMaintMapLists()
 	if(length(GLOB.big_deepmaint_room_templates) || length(GLOB.small_deepmaint_room_templates))
 		return
-	for(var/item in subtypesof(/datum/map_template/deepmaint_template/room))
-		var/datum/map_template/deepmaint_template/temp = item
-		var/datum/map_template/deepmaint_template/S = new temp()
+	for(var/item in subtypesof(/singleton/map_template/deepmaint_template/room))
+		var/singleton/map_template/deepmaint_template/temp = item
+		var/singleton/map_template/deepmaint_template/S = new temp()
 		GLOB.small_deepmaint_room_templates += S
 
-	for(var/item in subtypesof(/datum/map_template/deepmaint_template/big))
-		var/datum/map_template/deepmaint_template/temp = item
-		var/datum/map_template/deepmaint_template/S = new temp()
+	for(var/item in subtypesof(/singleton/map_template/deepmaint_template/big))
+		var/singleton/map_template/deepmaint_template/temp = item
+		var/singleton/map_template/deepmaint_template/S = new temp()
 		GLOB.big_deepmaint_room_templates += S
 
 /obj/procedural/jp_dungeonroom/preexist/square/submap/deepmaint

--- a/packs/deepmaint/generator/jp_dungeon_gen.dm
+++ b/packs/deepmaint/generator/jp_dungeon_gen.dm
@@ -202,7 +202,7 @@
 
 */
 /obj/procedural/jp_DungeonGenerator/proc/initializeSubmaps()
-	var/datum/map_template/init_template = new /datum/map_template/deepmaint_template/room
+	var/singleton/map_template/init_template = new /singleton/map_template/deepmaint_template/room
 	var/list/bounds = list(1.#INF, 1.#INF, 1.#INF, -1.#INF, -1.#INF, -1.#INF)
 	bounds[MAP_MINX] = 1
 	bounds[MAP_MINY] = world.maxy
@@ -1062,7 +1062,7 @@ want to create new jp_dungeonrooms. Consult the helpfile for more information
 	var/obj/procedural/jp_DungeonGenerator/gen
 
 	///The submap for this room
-	var/datum/map_template/my_map = null
+	var/singleton/map_template/my_map = null
 	///The list of turfs in this room. That should include internal walls.
 	var/list/turfs = list()
 	///The list of walls bordering this room. Anything in this list could be knocked down in order to make a path into the room

--- a/packs/factions/iccgn/outfits.dm
+++ b/packs/factions/iccgn/outfits.dm
@@ -1,7 +1,6 @@
 /singleton/hierarchy/outfit/iccgn
 	hierarchy_type = /singleton/hierarchy/outfit/iccgn
 	flags = OUTFIT_RESET_EQUIPMENT | OUTFIT_ADJUSTMENT_ALL_SKIPS
-	l_ear = /obj/item/device/radio/headset/iccgn
 	back = /obj/item/storage/backpack/satchel/pocketbook/gray
 	l_hand = /obj/item/storage/backpack/dufflebag/iccgn_accessories
 


### PR DESCRIPTION
getting this pushed separately to runtime main map load

map templates are singletons

/datum/map gets an overmap entity path so that they can be found when loaded in an interesting order

corrected using.dm injecting selected map datum into other test steps - evidently this was hiding some sins
