### PR TITLE
prevent audible emote spam

### DIFF
--- a/code/modules/emotes/definitions/_mob.dm
+++ b/code/modules/emotes/definitions/_mob.dm
@@ -1,5 +1,7 @@
 /mob/var/list/default_emotes = list()
 /mob/var/list/usable_emotes = list()
+/mob/var/next_audible_emote_time = 0
+/mob/var/audible_emote_cooldown = 0.5 SECONDS
 
 /mob/proc/update_emotes(skip_sort)
 	usable_emotes.Cut()

--- a/code/modules/emotes/definitions/audible.dm
+++ b/code/modules/emotes/definitions/audible.dm
@@ -5,11 +5,18 @@
 	var/list/emote_sound
 
 /singleton/emote/audible/do_extra(atom/user)
-	if(emote_sound)
-		var/playable = emote_sound
-		if (islist(emote_sound))
-			playable = pick(emote_sound)
-		playsound(user.loc, playable, 50, 0)
+	if(!emote_sound)
+		return
+	if (ismob(user))
+		var/mob/M = user
+		if (world.time < M.next_audible_emote_time)
+			M.next_audible_emote_time = world.time + M.audible_emote_cooldown
+			return
+		M.next_audible_emote_time = world.time + M.audible_emote_cooldown
+	var/playable = emote_sound
+	if (islist(emote_sound))
+		playable = pick(emote_sound)
+	playsound(user.loc, playable, 50, 0)
 
 /singleton/emote/audible/deathgasp_alien
 	key = "deathgasp"


### PR DESCRIPTION
:cl: Mucker
tweak: Audible emotes with sounds can no longer be spammed.
/:cl:

the text still appears but the sound is prevented from being spammed, it'd take a little bit of refactoring to prevent both from being spammed.