### PR TITLE
Play local sound volume

### DIFF
--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -41,10 +41,13 @@ var/global/list/sounds_cache = list()
 	set category = "Fun"
 	set name = "Play Local Sound"
 	if(!check_rights(R_SOUNDS))	return
+	var/vol = input("Select a volume for the sound", "Play Local Sound", 50) as num|null
+	if (!vol)
+		return
 
 	log_admin("[key_name(src)] played a local sound [S]")
 	message_admins("[key_name_admin(src)] played a local sound [S]", 1)
-	playsound(get_turf(src.mob), S, 50, 0, 0)
+	playsound(get_turf(src.mob), S, vol, 0, 0)
 
 
 /client/proc/play_server_sound()


### PR DESCRIPTION
## Hello comrades! 
With this QoL change, administrators can now change the volume of playing tracks via "play local audio".

## Screenshots 
![image](https://github.com/Baystation12/Baystation12/assets/105150564/de10d169-774b-42f9-957d-ac9ba42efa7b)
![image](https://github.com/Baystation12/Baystation12/assets/105150564/c86269f3-0cb9-484b-8598-ae8c06fe72fd)
![image](https://github.com/Baystation12/Baystation12/assets/105150564/a5412c7d-7895-42af-b590-28ece93c2ea4)


### Changelog
🆑 cuddleandtea
rscadd: admins can change volume for local tracks
/🆑 