### PR TITLE
empty round check is a timeout instead of periodic

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -81,8 +81,8 @@
 	/// length of voting period (deciseconds, default 1 minute)
 	var/static/vote_period = 600
 
-	/// Time in minutes between checks for ending empty rounds
-	var/static/empty_round_check_interval = 0
+	/// Time in minutes after which a round with no living players ends
+	var/static/empty_round_timeout = 0
 
 	/// Time in minutes before the first autotransfer vote
 	var/static/vote_autotransfer_initial = 120
@@ -587,11 +587,11 @@
 				if (isnull(transfer_vote_block_antag_time) || transfer_vote_block_antag_time < 0)
 					log_misc("Invalid transfer_vote_block_antag_time: [value]")
 					transfer_vote_block_antag_time = 0
-			if ("empty_round_check_interval")
-				empty_round_check_interval = text2num_or_default(value)
-				if (isnull(empty_round_check_interval) || empty_round_check_interval < 0)
-					log_misc("Invalid empty_round_check_interval: [value]")
-					empty_round_check_interval = 0
+			if ("empty_round_timeout")
+				empty_round_timeout = text2num_or_default(value)
+				if (isnull(empty_round_timeout) || empty_round_timeout < 0)
+					log_misc("Invalid empty_round_timeout: [value]")
+					empty_round_timeout = 0
 			if ("vote_autogamemode_timeleft")
 				vote_autogamemode_timeleft = text2num(value)
 			if ("pre_game_time")

--- a/code/controllers/subsystems/roundend.dm
+++ b/code/controllers/subsystems/roundend.dm
@@ -7,8 +7,11 @@ SUBSYSTEM_DEF(roundend)
 	/// The time in minutes when the round will be ended.
 	var/static/max_length
 
-	/// The next time in minutes to check whether a round is empty.
-	var/static/empty_check
+	/**
+	* The time after no players are alive in the round at which the game ends.
+	* Reset by new living players existing. If falsy, this behavior is disabled.
+	*/
+	var/static/empty_timeout
 
 	/// The next time in minutes to start a round end vote.
 	var/static/vote_check
@@ -25,36 +28,42 @@ SUBSYSTEM_DEF(roundend)
 		var/show_max
 		if (max_length)
 			show_max = max(round(max_length - round_time, 0.1), 0)
-		var/show_empty
-		if (empty_check)
-			show_empty = max(round(empty_check - round_time, 0.1), 0)
 		var/show_vote
 		if (vote_check)
 			show_vote = max(round(vote_check - round_time, 0.1), 0)
-		..({"\n\
+		var/show_empty
+		if (empty_timeout)
+			show_empty = "Players Alive"
+			if (empty_timeout != POSITIVE_INFINITY)
+				show_empty = "[max(round(empty_timeout - round_time, 0.1), 0)]m"
+		return ..({"\n\
 			Max Time: [isnull(show_max) ? "Off" : "[show_max]m"]\n\
-			Empty End: [isnull(show_empty) ? "Off" : "[show_empty]m"]\n\
-			Next Vote: [isnull(show_vote) ? "Off" : "[show_vote]m"]\
+			Next Vote: [isnull(show_vote) ? "Off" : "[show_vote]m"]\n\
+			Empty End: [isnull(show_empty) ? "Off" : "[show_empty]"]\
 		"})
 	else
-		..("Game Finished")
+		return ..("Game Finished")
 
 
 /datum/controller/subsystem/roundend/Initialize(start_uptime)
 	max_length = config.maximum_round_length
-	empty_check = config.empty_round_check_interval
 	vote_check = config.vote_autotransfer_initial
+	if (config.empty_round_timeout)
+		empty_timeout = POSITIVE_INFINITY
 
 
 /datum/controller/subsystem/roundend/fire(resumed, no_mc_tick)
-	var/time = round_duration_in_ticks / 600
+	var/time = round_duration_in_ticks / (1 MINUTE)
 	if (max_length && time > max_length)
 		if (evacuation_controller.is_idle())
 			init_autotransfer()
 		return
-	if (empty_check && time > empty_check)
-		empty_check += config.empty_round_check_interval
-		if (!length(GLOB.living_players))
+	if (empty_timeout)
+		if (length(GLOB.living_players))
+			empty_timeout = POSITIVE_INFINITY
+		else if (empty_timeout == POSITIVE_INFINITY)
+			empty_timeout = time + config.empty_round_timeout
+		else if (time > empty_timeout)
 			SSticker.forced_end = TRUE
 			return
 	if (vote_check)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -139,8 +139,8 @@ VOTE_PERIOD 600
 # will autotransfer without a vote at the next continue vote. Leave disabled for no limit.
 #MAXIMUM_ROUND_LENGTH 120
 
-## If set, the time in minutes between checks for ending empty rounds. Default off.
-#EMPTY_ROUND_CHECK_INTERVAL 15
+## The time in minutes after no living players remain at which the round will end. Defaults off.
+#EMPTY_ROUND_TIMEOUT 5
 
 ## autovote initial delay in minutes before first automatic transfer vote call (default 120)
 # using seven semicolon (;) separated values allows for different weekday-based values


### PR DESCRIPTION
Swapped empty round checks from periodic to frequent with a timeout. NUFC, this is just more convenient for test builds /etc. Already accounted for in live config.
