### PR TITLE
QoL and immersion engineering improvements

### DIFF
--- a/code/game/objects/structures/wall_frame.dm
+++ b/code/game/objects/structures/wall_frame.dm
@@ -194,6 +194,9 @@
 /obj/structure/wall_frame/titanium
 	material = MATERIAL_TITANIUM
 
+/obj/structure/wall_frame/ocp
+	material = MATERIAL_OSMIUM_CARBIDE_PLASTEEL
+
 /obj/structure/wall_frame/hull
 	paint_color = COLOR_SOL
 

--- a/code/game/objects/structures/wallframe_spawner.dm
+++ b/code/game/objects/structures/wallframe_spawner.dm
@@ -143,6 +143,8 @@
 /obj/wallframe_spawn/reinforced_phoron/hull
 	frame_path = /obj/structure/wall_frame/hull
 
+/obj/wallframe_spawn/reinforced_phoron/ocp
+	frame_path = /obj/structure/wall_frame/ocp
 
 /obj/wallframe_spawn/reinforced/polarized
 	name = "polarized reinforced wall frame window spawner"

--- a/code/modules/client/preference_setup/loadout/lists/headwear.dm
+++ b/code/modules/client/preference_setup/loadout/lists/headwear.dm
@@ -80,6 +80,7 @@
 	hardhats["orange hardhat"] = /obj/item/clothing/head/hardhat/orange
 	hardhats["red hardhat"] = /obj/item/clothing/head/hardhat/red
 	hardhats["light damage control helmet"] = /obj/item/clothing/head/hardhat/light
+	hardhats["yellow hardhat"] = /obj/item/clothing/head/hardhat
 	gear_tweaks += new/datum/gear_tweak/path(hardhats)
 
 /datum/gear/head/formalhat

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -106,7 +106,7 @@
 	var/aw_EPR = FALSE
 
 	var/list/threshholds = list( // List of lists defining the amber/red labeling threshholds in readouts. Numbers are minminum red and amber and maximum amber and red, in that order
-		list("name" = SUPERMATTER_DATA_EER,         "min_h" = -1, "min_l" = -1,  "max_l" = 150,  "max_h" = 300),
+		list("name" = SUPERMATTER_DATA_EER,         "min_h" = -1, "min_l" = -1,  "max_l" = 1100,  "max_h" = 1300),
 		list("name" = SUPERMATTER_DATA_TEMPERATURE, "min_h" = -1, "min_l" = -1,  "max_l" = 4000, "max_h" = 5000),
 		list("name" = SUPERMATTER_DATA_PRESSURE,    "min_h" = -1, "min_l" = -1,  "max_l" = 5000, "max_h" = 10000),
 		list("name" = SUPERMATTER_DATA_EPR,         "min_h" = -1, "min_l" = 1.0, "max_l" = 2.5,  "max_h" = 4.0)

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -2976,11 +2976,11 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/item/folder/blue,
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
+/obj/item/folder/yellow,
 /turf/simulated/floor/lino,
 /area/tcommsat/computer)
 "ku" = (
@@ -3049,12 +3049,12 @@
 /obj/structure/table/standard{
 	name = "plastic table frame"
 	},
-/obj/item/clothing/suit/storage/hooded/wintercoat/engineering,
 /obj/machinery/power/apc/super/critical{
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24
 	},
+/obj/item/clothing/suit/storage/hooded/wintercoat/solgov,
 /turf/simulated/floor/lino,
 /area/tcommsat/computer)
 "kH" = (

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -6390,14 +6390,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftport)
-"pa" = (
-/obj/wallframe_spawn/reinforced_phoron,
-/obj/machinery/door/blast/regular{
-	id_tag = "SupermatterPort";
-	name = "Reactor Blast Door"
-	},
-/turf/simulated/floor/reinforced,
-/area/engineering/engine_room)
 "pb" = (
 /obj/floor_decal/industrial/warning{
 	dir = 1;
@@ -9576,7 +9568,7 @@
 /turf/simulated/floor/tiled,
 /area/engineering/engineering_bay)
 "xw" = (
-/obj/wingrille_spawn/reinforced_phoron/full,
+/obj/wallframe_spawn/reinforced_phoron/ocp,
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	icon_state = "pdoor0";
@@ -12018,7 +12010,7 @@
 	icon_state = "pdoor0";
 	id_tag = "prototype_chamber_blast"
 	},
-/obj/wingrille_spawn/reinforced_phoron/full,
+/obj/wallframe_spawn/reinforced_phoron/ocp,
 /turf/simulated/floor/reinforced,
 /area/vacant/prototype/engine)
 "Ek" = (
@@ -15148,11 +15140,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/vacant/prototype/control)
 "Oj" = (
-/obj/machinery/door/airlock/hatch/maintenance/bolted{
-	frequency = 1379;
-	id_tag = "prototype_interior";
-	name = "Fusion Maintenance"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -15164,6 +15151,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/hatch/maintenance{
+	frequency = 1379;
+	id_tag = "prototype_interior";
+	name = "Fusion Maintenance"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/prototype/control)
@@ -15768,11 +15760,6 @@
 /turf/simulated/floor/plating,
 /area/vacant/prototype/engine)
 "Qj" = (
-/obj/machinery/door/airlock/hatch/maintenance/bolted{
-	frequency = 1379;
-	id_tag = "prototype_exterior";
-	name = "Fusion Maintenance"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -15784,6 +15771,11 @@
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/hatch/maintenance{
+	frequency = 1379;
+	id_tag = "prototype_exterior";
+	name = "Fusion Maintenance"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/vacant/prototype/control)
@@ -16703,7 +16695,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/wingrille_spawn/reinforced_phoron/full,
+/obj/wallframe_spawn/reinforced_phoron/ocp,
 /obj/machinery/door/blast/regular/open{
 	dir = 4;
 	icon_state = "pdoor0";
@@ -44933,7 +44925,7 @@ kw
 lj
 lY
 So
-pa
+qc
 Ck
 Uo
 Zo


### PR DESCRIPTION
🆑
rscadd: Yellow hardhat (the default one) can now be picked in loadout.
tweak: Default EER thresholds are raised to 1100 and 1300.
maptweak: R-UST now gets low wall windows instead of full-sized.
maptweak: R-UST airlock is now unbolted by default, on par with the SM one.
/🆑

Also replaced the generic engineering coat with EC coat in t-comms, and the folder too! Yay, we are Expeditionary now! Both engines have been tested, RUST works perfectly normal with low walls, ~and SM is pretty much the same except it doesn't break the chamber until the complete delam explosion, making it somewhat safer.~

![image](https://github.com/Baystation12/Baystation12/assets/5092934/0e44e326-c849-4e47-b645-5f6388b6ba3c)
