### PR TITLE
Add antagonist vote fix

### DIFF
--- a/code/datums/vote/add_antag.dm
+++ b/code/datums/vote/add_antag.dm
@@ -48,7 +48,7 @@
 /datum/vote/add_antagonist/proc/spawn_antags()
 	var/list/antag_choices = list()
 	for(var/antag_type in result)
-		antag_choices += GLOB.all_antag_types_[antag_type]
+		antag_choices += GLOB.all_antag_types_[GLOB.antag_names_to_ids_[antag_type]]
 	if(SSticker.attempt_late_antag_spawn(antag_choices)) // This takes a while.
 		antag_add_finished = 1
 		if(automatic)

--- a/code/game/antagonist/antagonist_create.dm
+++ b/code/game/antagonist/antagonist_create.dm
@@ -26,6 +26,10 @@
 	else
 		M = new /mob/living/carbon/human(get_turf(source))
 	M.ckey = source.ckey
+
+	if(!M.ckey && source.mind)
+		M.ckey = source.mind.key
+
 	add_antagonist(M.mind, 1, 0, 1) // Equip them and move them to spawn.
 	return M
 

--- a/code/game/antagonist/antagonist_helpers.dm
+++ b/code/game/antagonist/antagonist_helpers.dm
@@ -8,7 +8,7 @@
 		if(jobban_isbanned(player.current, id))
 			return "Player is banned from this antagonist role."
 
-	if(is_type_in_list(player.assigned_job, blacklisted_jobs))
+	if(is_type_in_list(player.assigned_job, blacklisted_jobs) && !isghostmind(player))
 		return "Player's assigned job ([player.assigned_job]) is blacklisted from this antagonist role."
 
 	if(!ignore_role)
@@ -17,9 +17,9 @@
 			// Limits antag status to clients above player age, if the age system is being used.
 			if(C && config.use_age_restriction_for_jobs && isnum(C.player_age) && isnum(min_player_age) && (C.player_age < min_player_age))
 				return "Player's server age ([C.player_age]) is below the minimum player age ([min_player_age])."
-		if(is_type_in_list(player.assigned_job, restricted_jobs))
+		if(is_type_in_list(player.assigned_job, restricted_jobs) && !isghostmind(player))
 			return "Player's assigned job ([player.assigned_job]) is restricted from this antagonist role."
-		if(player.current && (player.current.status_flags & NO_ANTAG))
+		if(player.current && (player.current.status_flags & NO_ANTAG) && !isghostmind(player))
 			return "Player's mob has the NO_ANTAG flag set."
 	return FALSE
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Currently, no matter the vote result, Add antagonist vote can never really add any antags. This is an attempt to restore the intended functionality.

Additionaly, changes were made to antag spawn and antag check: Ckey is transferred, even if the player ghosted from their body and ghosts are no longer getting checked for the job or for the NO_ANTAG flag of their previous body. (Otherwise, it could spawn an empty body, if ckey isn't transferred correctly to the off-ship roles. Or totally prevent someone from spawning as an off-ship role, because of their last body with a specific job role, or if their body had NO_ANTAG flag (ex:mouses), even if they are already ghosts)

**Changelog**
:cl: Builder13
bugfix: Add Antagonist vote can now add antags.
/:cl: