### PR TITLE
Standardized Health - Health Flags

### DIFF
--- a/code/__defines/health.dm
+++ b/code/__defines/health.dm
@@ -85,3 +85,8 @@
 #define DAMAGE_FLAG_DISPERSED               FLAG(7)
 /// Toxin damage that should be mitigated by biological (i.e. sterile) armor
 #define DAMAGE_FLAG_BIO                     FLAG(8)
+
+
+/// Health Status flags for `/atom/var/health_status`.
+/// The atom is currently dead.
+#define HEALTH_STATUS_DEAD FLAG(0)

--- a/code/__defines/health.dm
+++ b/code/__defines/health.dm
@@ -97,3 +97,5 @@
 /// Health Flags for `/atom/var/health_flags`.
 /// The atom is 'breakable', and considered broken upon reaching 1/2 health.
 #define HEALTH_FLAG_BREAKABLE FLAG(0)
+/// The atom should be treated as a structure for damage calculations.
+#define HEALTH_FLAG_STRUCTURE FLAG(1)

--- a/code/__defines/health.dm
+++ b/code/__defines/health.dm
@@ -90,3 +90,10 @@
 /// Health Status flags for `/atom/var/health_status`.
 /// The atom is currently dead.
 #define HEALTH_STATUS_DEAD FLAG(0)
+/// The atom is currently broken. An atom is `broken` if `HEALTH_FLAG_BREAKABLE` is set and the atom's health falls below 1/2 of `health_max`. Used for certain atoms that needed an additional damage state.
+#define HEALTH_STATUS_BROKEN FLAG(1)
+
+
+/// Health Flags for `/atom/var/health_flags`.
+/// The atom is 'breakable', and considered broken upon reaching 1/2 health.
+#define HEALTH_FLAG_BREAKABLE FLAG(0)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -94,7 +94,6 @@
 
 	if (health_max)
 		health_current = health_max
-		health_dead = FALSE
 
 	return INITIALIZE_HINT_NORMAL
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -293,7 +293,7 @@
 	. = 0
 	if (get_max_health())
 		var/damage = P.damage
-		if (istype(src, /obj/structure) || istype(src, /turf/simulated/wall) || istype(src, /obj/machinery)) // TODO Better conditions for non-structures that want to use structure damage
+		if (GET_FLAGS(health_flags, HEALTH_FLAG_STRUCTURE))
 			damage = P.get_structure_damage()
 		if (!can_damage_health(damage, P.damage_type, P.damage_flags))
 			return

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -15,6 +15,7 @@
 	throw_range = 5
 
 	health_resistances = DAMAGE_RESIST_ELECTRICAL
+	health_flags = HEALTH_FLAG_STRUCTURE
 
 	/// Boolean. Whether or not the machine has been emagged.
 	var/emagged = FALSE

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -3,6 +3,8 @@
 	w_class = ITEM_SIZE_NO_CONTAINER
 	layer = STRUCTURE_LAYER
 
+	health_flags = HEALTH_FLAG_STRUCTURE
+
 	var/fragile
 	var/parts
 	var/list/connections = list("0", "0", "0", "0")

--- a/code/game/objects/structures/fireaxe_cabinet.dm
+++ b/code/game/objects/structures/fireaxe_cabinet.dm
@@ -25,7 +25,7 @@
 	ClearOverlays()
 	if(fireaxe)
 		AddOverlays(image(icon, "fireaxe_item"))
-	if(health_dead)
+	if(health_dead())
 		AddOverlays(image(icon, "fireaxe_window_broken"))
 	else if(!open)
 		AddOverlays(image(icon, "fireaxe_window"))
@@ -93,7 +93,7 @@
 		var/obj/item/stack/material/stack = tool
 		if (stack.material.name != MATERIAL_GLASS)
 			return ..()
-		if (!health_dead && !health_damaged())
+		if (!health_dead() && !health_damaged())
 			USE_FEEDBACK_FAILURE("\The [src] doesn't need repair.")
 			return TRUE
 		if (!stack.reinf_material)
@@ -114,7 +114,7 @@
 		if (open)
 			USE_FEEDBACK_FAILURE("\The [src] must be closed before you can lock it.")
 			return TRUE
-		if (health_dead)
+		if (health_dead())
 			USE_FEEDBACK_FAILURE("\The [src] is shattered and the lock doesn't function.")
 			return TRUE
 		user.visible_message(
@@ -136,7 +136,7 @@
 
 
 /obj/structure/fireaxecabinet/proc/toggle_open(mob/user)
-	if(health_dead)
+	if(health_dead())
 		open = 1
 		unlocked = 1
 	else

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -9,6 +9,7 @@
 	thermal_conductivity = WALL_HEAT_TRANSFER_COEFFICIENT
 	heat_capacity = 312500 //a little over 5 cm thick , 312500 for 1 m by 2.5 m by 0.25 m plasteel wall
 	atom_flags = ATOM_FLAG_CAN_BE_PAINTED
+	health_flags = HEALTH_FLAG_STRUCTURE
 
 	var/damage_overlay = 0
 	var/static/damage_overlays[16]

--- a/code/modules/admin/view_variables/vv_set_handlers.dm
+++ b/code/modules/admin/view_variables/vv_set_handlers.dm
@@ -145,7 +145,7 @@
 	predicates = list(/proc/is_strict_bool_predicate)
 
 /singleton/vv_set_handler/health_dead_handler/handle_set_var(atom/target, variable, var_value, client)
-	if (var_value == target.health_dead)
+	if (var_value == target.health_dead())
 		return
 	switch (var_value)
 		if (TRUE)

--- a/code/modules/xenoarcheaology/anomaly_container.dm
+++ b/code/modules/xenoarcheaology/anomaly_container.dm
@@ -41,7 +41,7 @@
 		if(!src.allowed(user))
 			to_chat(user, SPAN_WARNING("\The [src] blinks red, notifying you of your incorrect access."))
 			return
-		if(!src.health_dead)
+		if(!src.health_dead())
 			user.visible_message(
 				SPAN_NOTICE("\The [user] begins undoing the locks and latches on \the [src]..."),
 				SPAN_NOTICE("You begin undoing the locks and latches on \the [src]...")
@@ -71,7 +71,7 @@
 		if(!src.allowed(user))
 			to_chat(user, SPAN_WARNING("\The [src] blinks red, notifying you of your incorrect access."))
 			return
-		if(!src.health_dead)
+		if(!src.health_dead())
 			user.visible_message(
 				SPAN_NOTICE("\The [user] begins undoing the locks and latches on \the [src]..."),
 				SPAN_NOTICE("You begin undoing the locks and latches on \the [src]...")
@@ -95,7 +95,7 @@
 	if (attached_paper)
 		to_chat(usr, SPAN_NOTICE("There's a paper clipped on the side."))
 		attached_paper.examine(user, distance)
-	if (health_dead)
+	if (health_dead())
 		to_chat(usr, SPAN_DANGER("The borosilicate panels are completely shattered."))
 
 /obj/machinery/anomaly_container/proc/contain(obj/machinery/artifact)
@@ -146,7 +146,7 @@
 
 /obj/machinery/anomaly_container/emp_act(severity)
 	SHOULD_CALL_PARENT(FALSE)
-	if(health_dead)
+	if(health_dead())
 		return
 	if(contained)
 		visible_message(SPAN_DANGER("\The [src]'s latches break loose, freeing the contents!"))
@@ -174,7 +174,7 @@
 		return TRUE
 
 	if (istype(P, /obj/item/stack/material))
-		if (!health_dead)
+		if (!health_dead())
 			to_chat(user, SPAN_NOTICE("\The [src] doesn't require repairs."))
 			return TRUE
 		if (contained)
@@ -211,7 +211,7 @@
 		return TRUE
 
 	if (isWrench(P))
-		if (!health_dead)
+		if (!health_dead())
 			return TRUE
 
 		user.visible_message(
@@ -234,7 +234,7 @@
 
 /obj/machinery/anomaly_container/on_update_icon()
 	ClearOverlays()
-	if(health_dead)
+	if(health_dead())
 		icon_state = "anomaly_container_broken"
 	if(attached_paper)
 		AddOverlays("anomaly_container_paper")


### PR DESCRIPTION
## Changelog
NUFC

## Other Changes
- Replaced `health_dead` (boolean) with `health_status` (bitflag) for health status conditions (dead and 'broken' state in this PR).
- Added `HEALTH_STATUS_DEAD` flag and `health_dead()` proc for dead atoms.
- Added `health_flags` bitflag for health-related configuration flags.
- Added `HEALTH_FLAG_BREAKABLE` and `HEALTH_STATUS_BROKEN` flags for `health_dead` and `health_flags`, `health_broken()`, `on_broken()` and `on_unbroken()` procs, and modified health logic to accomodate atoms being able to have a 'broken' state.
  - **NOTE**: Not currently implemented but planned in two upcoming WIP PRs involving destroyable airlocks and organ health handling.
- Added `HEALTH_FLAG_STRUCTURE` flag for atoms to be treated as structures in damage calculations. Primarily used for `bullet_act()` to know when to use `P.get_structure_damage()` instead of `P.damage`.