### PR TITLE
Standardized Health - Breakable Airlocks

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -796,6 +796,7 @@
 #include "code\game\machinery\doors\blast_door.dm"
 #include "code\game\machinery\doors\braces.dm"
 #include "code\game\machinery\doors\brigdoors.dm"
+#include "code\game\machinery\doors\broken_door.dm"
 #include "code\game\machinery\doors\checkForMultipleDoors.dm"
 #include "code\game\machinery\doors\door.dm"
 #include "code\game\machinery\doors\firedoor.dm"

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -16,6 +16,8 @@
 	power_channel = ENVIRON
 	interact_offline = FALSE
 
+	health_flags = HEALTH_FLAG_BREAKABLE
+
 	explosion_resistance = 10
 	/// Boolean. Whether or not the AI control mechanism is disabled.
 	var/ai_control_disabled = FALSE
@@ -644,6 +646,29 @@ About the new airlock wires panel:
 			icon_state = "blank"
 
 	set_airlock_overlays(state)
+
+
+/obj/machinery/door/airlock/on_broken()
+	if (health_dead())
+		return // Anything here is redundant since it's going to qdel anyway
+	set_broken(TRUE, MACHINE_BROKEN_HEALTH)
+	health_min_damage = floor(initial(health_min_damage) * 3.5) // The frame is beefier than the control panel.
+	update_icon()
+
+
+/obj/machinery/door/airlock/on_unbroken()
+	set_broken(FALSE, MACHINE_BROKEN_HEALTH)
+	health_min_damage = initial(health_min_damage)
+	update_icon()
+
+
+/obj/machinery/door/airlock/on_death()
+	visible_message(SPAN_DANGER("\The [src] completely breaks apart!"))
+	var/obj/structure/broken_door/broken_door = new(loc)
+	transfer_fingerprints_to(broken_door)
+	broken_door.icon = icon
+	broken_door.dir = dir
+	qdel_self()
 
 
 /obj/machinery/door/airlock/proc/set_airlock_overlays(state)
@@ -1363,6 +1388,8 @@ About the new airlock wires panel:
 		to_chat(user, "The bolt cover has been cut open.")
 	if (lock_cut_state == BOLTS_CUT)
 		to_chat(user, "The door bolts have been cut.")
+	if (health_broken())
+		to_chat(user, SPAN_WARNING("The control panel is broken open."))
 	if(brace)
 		to_chat(user, "\The [brace] is installed on \the [src], preventing it from opening.")
 		brace.examine_damage_state(user)

--- a/code/game/machinery/doors/broken_door.dm
+++ b/code/game/machinery/doors/broken_door.dm
@@ -1,0 +1,41 @@
+/obj/structure/broken_door
+	name = "broken airlock"
+	desc = "An airlock that's been completely and forcefully broken open. There's barely anything left to salvage."
+	icon = 'icons/obj/doors/station/door.dmi'
+	icon_state = "open"
+	anchored = TRUE
+	obj_flags = OBJ_FLAG_NOFALL
+
+
+/obj/structure/broken_door/get_interactions_info()
+	. = ..()
+	.[CODEX_INTERACTION_WELDER] = "<p>Dismantles \the [initial(name)]. Costs 1 unit of fuel and provides 1 sheet of steel.</p>"
+
+
+/obj/structure/broken_door/use_tool(obj/item/tool, mob/living/user, list/click_params)
+	if (isWelder(tool))
+		var/obj/item/weldingtool/welder = tool
+		if (!welder.can_use(1, user, "to deconstruct \the [src]"))
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts welding \the [src] with \a [tool]."),
+			SPAN_NOTICE("You start welding \the [src] with \the [tool]."),
+			SPAN_ITALIC("You hear welding.")
+		)
+		add_fingerprint(user, FALSE, tool)
+		playsound(src, 'sound/items/Welder.ogg', 50, TRUE)
+		if (!user.do_skilled(SKILL_CONSTRUCTION, 2 SECONDS, src, do_flags = DO_REPAIR_CONSTRUCT) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (!welder.remove_fuel(1, user))
+			return TRUE
+		var/obj/item/stack/material/steel/materials = new (loc, 1)
+		transfer_fingerprints_to(materials)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] dismantles \the [src] with \a [tool]."),
+			SPAN_NOTICE("You dismantle \the [src] with \the [tool]."),
+			SPAN_ITALIC("You hear welding.")
+		)
+		qdel_self()
+		return TRUE
+
+	return ..()

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -287,12 +287,6 @@
 		to_chat(user, SPAN_WARNING("\The [src]'s control panel looks fried."))
 
 
-/obj/machinery/door/set_broken(new_state)
-	. = ..()
-	if(. && new_state)
-		visible_message(SPAN_WARNING("\The [src.name] breaks!"))
-
-
 /obj/machinery/door/on_update_icon()
 	update_dir()
 	if(density)


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
rscadd: Airlocks can now be further damaged after the panel breaks with a sufficiently strong weapon, allowing you to fully break the airlock open by force instead of prying it or (if the door was bolted at the time it broke) going through the process of cutting through the bolts and cover.
rscadd: Fully broken doors can be dismantled with a welding tool, giving back a small amount of resources.
/:cl:

## Dependencies
- #34641

## TODO
- [x] Rebalance damage/health values for airlocks.