### PR TITLE
Standardized Health - Organs

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -2587,6 +2587,7 @@
 #include "code\modules\organs\_organ_setup.dm"
 #include "code\modules\organs\blood.dm"
 #include "code\modules\organs\organ.dm"
+#include "code\modules\organs\organ_health.dm"
 #include "code\modules\organs\pain.dm"
 #include "code\modules\organs\robolimbs.dm"
 #include "code\modules\organs\external\_external.dm"

--- a/code/__defines/health.dm
+++ b/code/__defines/health.dm
@@ -85,3 +85,8 @@
 #define DAMAGE_FLAG_DISPERSED               FLAG(7)
 /// Toxin damage that should be mitigated by biological (i.e. sterile) armor
 #define DAMAGE_FLAG_BIO                     FLAG(8)
+
+
+/// Health Status flags for `/atom/var/health_status`.
+/// The atom is currently dead.
+#define HEALTH_STATUS_DEAD FLAG(0)

--- a/code/__defines/health.dm
+++ b/code/__defines/health.dm
@@ -97,3 +97,5 @@
 /// Health Flags for `/atom/var/health_flags`.
 /// The atom is 'breakable', and considered broken upon reaching 1/2 health.
 #define HEALTH_FLAG_BREAKABLE FLAG(0)
+/// The atom should be treated as a structure for damage calculations.
+#define HEALTH_FLAG_STRUCTURE FLAG(1)

--- a/code/__defines/health.dm
+++ b/code/__defines/health.dm
@@ -90,3 +90,10 @@
 /// Health Status flags for `/atom/var/health_status`.
 /// The atom is currently dead.
 #define HEALTH_STATUS_DEAD FLAG(0)
+/// The atom is currently broken. An atom is `broken` if `HEALTH_FLAG_BREAKABLE` is set and the atom's health falls below 1/2 of `health_max`. Used for certain atoms that needed an additional damage state.
+#define HEALTH_STATUS_BROKEN FLAG(1)
+
+
+/// Health Flags for `/atom/var/health_flags`.
+/// The atom is 'breakable', and considered broken upon reaching 1/2 health.
+#define HEALTH_FLAG_BREAKABLE FLAG(0)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -94,7 +94,6 @@
 
 	if (health_max)
 		health_current = health_max
-		health_dead = FALSE
 
 	return INITIALIZE_HINT_NORMAL
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -293,7 +293,7 @@
 	. = 0
 	if (get_max_health())
 		var/damage = P.damage
-		if (istype(src, /obj/structure) || istype(src, /turf/simulated/wall) || istype(src, /obj/machinery)) // TODO Better conditions for non-structures that want to use structure damage
+		if (GET_FLAGS(health_flags, HEALTH_FLAG_STRUCTURE))
 			damage = P.get_structure_damage()
 		if (!can_damage_health(damage, P.damage_type, P.damage_flags))
 			return

--- a/code/game/machinery/_machines_base/machinery.dm
+++ b/code/game/machinery/_machines_base/machinery.dm
@@ -15,6 +15,7 @@
 	throw_range = 5
 
 	health_resistances = DAMAGE_RESIST_ELECTRICAL
+	health_flags = HEALTH_FLAG_STRUCTURE
 
 	/// Boolean. Whether or not the machine has been emagged.
 	var/emagged = FALSE

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -3,6 +3,8 @@
 	w_class = ITEM_SIZE_NO_CONTAINER
 	layer = STRUCTURE_LAYER
 
+	health_flags = HEALTH_FLAG_STRUCTURE
+
 	var/fragile
 	var/parts
 	var/list/connections = list("0", "0", "0", "0")

--- a/code/game/objects/structures/fireaxe_cabinet.dm
+++ b/code/game/objects/structures/fireaxe_cabinet.dm
@@ -25,7 +25,7 @@
 	ClearOverlays()
 	if(fireaxe)
 		AddOverlays(image(icon, "fireaxe_item"))
-	if(health_dead)
+	if(health_dead())
 		AddOverlays(image(icon, "fireaxe_window_broken"))
 	else if(!open)
 		AddOverlays(image(icon, "fireaxe_window"))
@@ -93,7 +93,7 @@
 		var/obj/item/stack/material/stack = tool
 		if (stack.material.name != MATERIAL_GLASS)
 			return ..()
-		if (!health_dead && !health_damaged())
+		if (!health_dead() && !health_damaged())
 			USE_FEEDBACK_FAILURE("\The [src] doesn't need repair.")
 			return TRUE
 		if (!stack.reinf_material)
@@ -114,7 +114,7 @@
 		if (open)
 			USE_FEEDBACK_FAILURE("\The [src] must be closed before you can lock it.")
 			return TRUE
-		if (health_dead)
+		if (health_dead())
 			USE_FEEDBACK_FAILURE("\The [src] is shattered and the lock doesn't function.")
 			return TRUE
 		user.visible_message(
@@ -136,7 +136,7 @@
 
 
 /obj/structure/fireaxecabinet/proc/toggle_open(mob/user)
-	if(health_dead)
+	if(health_dead())
 		open = 1
 		unlocked = 1
 	else

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -9,6 +9,7 @@
 	thermal_conductivity = WALL_HEAT_TRANSFER_COEFFICIENT
 	heat_capacity = 312500 //a little over 5 cm thick , 312500 for 1 m by 2.5 m by 0.25 m plasteel wall
 	atom_flags = ATOM_FLAG_CAN_BE_PAINTED
+	health_flags = HEALTH_FLAG_STRUCTURE
 
 	var/damage_overlay = 0
 	var/static/damage_overlays[16]

--- a/code/modules/admin/view_variables/vv_set_handlers.dm
+++ b/code/modules/admin/view_variables/vv_set_handlers.dm
@@ -145,7 +145,7 @@
 	predicates = list(/proc/is_strict_bool_predicate)
 
 /singleton/vv_set_handler/health_dead_handler/handle_set_var(atom/target, variable, var_value, client)
-	if (var_value == target.health_dead)
+	if (var_value == target.health_dead())
 		return
 	switch (var_value)
 		if (TRUE)

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -4,7 +4,6 @@
 
 /obj/item/organ/external
 	name = "external"
-	min_broken_damage = 30
 	dir = SOUTH
 	organ_tag = "limb"
 	appearance_flags = DEFAULT_APPEARANCE_FLAGS | PIXEL_SCALE

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -312,10 +312,6 @@
 				return
 		owner.verbs -= /mob/living/carbon/human/proc/undislocate
 
-/obj/item/organ/external/update_health()
-	damage = min(max_damage, (brute_dam + burn_dam))
-	return
-
 
 /obj/item/organ/external/replaced(mob/living/carbon/human/target)
 	..()

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -4,7 +4,6 @@
 	name = "head"
 	slot_flags = SLOT_BELT
 	max_damage = 75
-	min_broken_damage = 35
 	w_class = ITEM_SIZE_NORMAL
 	cavity_max_w_class = ITEM_SIZE_SMALL
 	body_part = HEAD

--- a/code/modules/organs/external/species/adherent.dm
+++ b/code/modules/organs/external/species/adherent.dm
@@ -8,7 +8,6 @@
 	parent_organ =            BP_CHEST
 	dislocated =              -1
 	max_damage =              50
-	min_broken_damage =       25
 	arterial_bleed_severity = 0
 	encased = "ceramic hull"
 	force_icon = 'icons/mob/human_races/species/adherent/body.dmi'
@@ -21,7 +20,6 @@
 	arterial_bleed_severity = 0
 	dislocated =              -1
 	max_damage =              50
-	min_broken_damage =       25
 	encased = "ceramic hull"
 	force_icon = 'icons/mob/human_races/species/adherent/body.dmi'
 	status = ORGAN_ROBOTIC
@@ -35,7 +33,6 @@
 	arterial_bleed_severity = 0
 	dislocated =              -1
 	max_damage =              50
-	min_broken_damage =       25
 	cavity_max_w_class =      ITEM_SIZE_NORMAL // Apparently their brains change w_class to this.
 	encased = "ceramic hull"
 	force_icon = 'icons/mob/human_races/species/adherent/body.dmi'
@@ -49,7 +46,6 @@
 	arterial_bleed_severity = 0
 	dislocated =              -1
 	max_damage =              20
-	min_broken_damage =       10
 	force_icon = 'icons/mob/human_races/species/adherent/body.dmi'
 	status = ORGAN_ROBOTIC
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_GRASP | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_CAN_BREAK
@@ -61,7 +57,6 @@
 	arterial_bleed_severity = 0
 	dislocated =              -1
 	max_damage =              20
-	min_broken_damage =       10
 	force_icon = 'icons/mob/human_races/species/adherent/body.dmi'
 	status = ORGAN_ROBOTIC
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_GRASP | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_CAN_BREAK
@@ -73,7 +68,6 @@
 	arterial_bleed_severity = 0
 	dislocated =              -1
 	max_damage =              20
-	min_broken_damage =       10
 	force_icon = 'icons/mob/human_races/species/adherent/body.dmi'
 	status = ORGAN_ROBOTIC
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_GRASP | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_CAN_BREAK
@@ -85,7 +79,6 @@
 	arterial_bleed_severity = 0
 	dislocated =              -1
 	max_damage =              20
-	min_broken_damage =       10
 	force_icon = 'icons/mob/human_races/species/adherent/body.dmi'
 	status = ORGAN_ROBOTIC
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_GRASP | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_CAN_BREAK
@@ -100,7 +93,6 @@
 	arterial_bleed_severity = 0
 	dislocated =              -1
 	max_damage =              20
-	min_broken_damage =       10
 	force_icon = 'icons/mob/human_races/species/adherent/body.dmi'
 	status = ORGAN_ROBOTIC
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE | ORGAN_FLAG_CAN_GRASP | ORGAN_FLAG_CAN_STAND | ORGAN_FLAG_CAN_BREAK

--- a/code/modules/organs/external/species/diona.dm
+++ b/code/modules/organs/external/species/diona.dm
@@ -10,7 +10,6 @@
 	organ_tag = BP_CHEST
 	icon_name = "torso"
 	max_damage = 200
-	min_broken_damage = 50
 	w_class = ITEM_SIZE_HUGE
 	cavity_max_w_class = ITEM_SIZE_NORMAL
 	body_part = UPPER_TORSO
@@ -23,7 +22,6 @@
 	organ_tag = BP_GROIN
 	icon_name = "groin"
 	max_damage = 100
-	min_broken_damage = 50
 	w_class = ITEM_SIZE_LARGE
 	cavity_max_w_class = ITEM_SIZE_SMALL
 	body_part = LOWER_TORSO
@@ -34,7 +32,6 @@
 	organ_tag = BP_L_ARM
 	icon_name = "l_arm"
 	max_damage = 35
-	min_broken_damage = 20
 	w_class = ITEM_SIZE_NORMAL
 	body_part = ARM_LEFT
 	parent_organ = BP_CHEST
@@ -51,7 +48,6 @@
 	organ_tag = BP_L_LEG
 	icon_name = "l_leg"
 	max_damage = 35
-	min_broken_damage = 20
 	w_class = ITEM_SIZE_NORMAL
 	body_part = LEG_LEFT
 	icon_position = LEFT
@@ -70,7 +66,6 @@
 	organ_tag = BP_L_FOOT
 	icon_name = "l_foot"
 	max_damage = 20
-	min_broken_damage = 10
 	w_class = ITEM_SIZE_SMALL
 	body_part = FOOT_LEFT
 	icon_position = LEFT
@@ -92,7 +87,6 @@
 	organ_tag = BP_L_HAND
 	icon_name = "l_hand"
 	max_damage = 30
-	min_broken_damage = 15
 	w_class = ITEM_SIZE_SMALL
 	body_part = HAND_LEFT
 	parent_organ = BP_L_ARM
@@ -120,7 +114,6 @@
 /obj/item/organ/external/head/diona
 	can_intake_reagents = 0
 	max_damage = 50
-	min_broken_damage = 25
 	glowing_eyes = TRUE
 	limb_flags = ORGAN_FLAG_CAN_AMPUTATE
 	cavity_max_w_class = ITEM_SIZE_SMALL

--- a/code/modules/organs/external/standard.dm
+++ b/code/modules/organs/external/standard.dm
@@ -9,7 +9,6 @@
 	organ_tag = BP_CHEST
 	icon_name = "torso"
 	max_damage = 100
-	min_broken_damage = 35
 	w_class = ITEM_SIZE_HUGE //Used for dismembering thresholds, in addition to storage. Humans are w_class 6, so it makes sense that chest is w_class 5.
 	cavity_max_w_class = ITEM_SIZE_NORMAL
 	body_part = UPPER_TORSO
@@ -45,7 +44,6 @@
 	organ_tag = BP_GROIN
 	icon_name = "groin"
 	max_damage = 100
-	min_broken_damage = 35
 	w_class = ITEM_SIZE_LARGE
 	cavity_max_w_class = ITEM_SIZE_SMALL
 	body_part = LOWER_TORSO
@@ -62,7 +60,6 @@
 	name = "left arm"
 	icon_name = "l_arm"
 	max_damage = 50
-	min_broken_damage = 30
 	w_class = ITEM_SIZE_NORMAL
 	body_part = ARM_LEFT
 	parent_organ = BP_CHEST
@@ -86,7 +83,6 @@
 	name = "left leg"
 	icon_name = "l_leg"
 	max_damage = 50
-	min_broken_damage = 30
 	w_class = ITEM_SIZE_NORMAL
 	body_part = LEG_LEFT
 	icon_position = LEFT
@@ -112,7 +108,6 @@
 	name = "left foot"
 	icon_name = "l_foot"
 	max_damage = 30
-	min_broken_damage = 15
 	w_class = ITEM_SIZE_SMALL
 	body_part = FOOT_LEFT
 	icon_position = LEFT
@@ -138,7 +133,6 @@
 	name = "left hand"
 	icon_name = "l_hand"
 	max_damage = 30
-	min_broken_damage = 15
 	w_class = ITEM_SIZE_SMALL
 	body_part = HAND_LEFT
 	parent_organ = BP_L_ARM

--- a/code/modules/organs/internal/kidneys.dm
+++ b/code/modules/organs/internal/kidneys.dm
@@ -5,7 +5,6 @@
 	organ_tag = BP_KIDNEYS
 	parent_organ = BP_GROIN
 	min_bruised_damage = 25
-	min_broken_damage = 45
 	max_damage = 70
 	relative_size = 10
 
@@ -43,5 +42,3 @@
 				owner.adjustToxLoss(0.5)
 			if(status & ORGAN_DEAD)
 				owner.adjustToxLoss(1)
-
-

--- a/code/modules/organs/internal/liver.dm
+++ b/code/modules/organs/internal/liver.dm
@@ -6,7 +6,6 @@
 	organ_tag = BP_LIVER
 	parent_organ = BP_GROIN
 	min_bruised_damage = 25
-	min_broken_damage = 45
 	max_damage = 70
 	relative_size = 60
 

--- a/code/modules/organs/internal/lungs.dm
+++ b/code/modules/organs/internal/lungs.dm
@@ -6,7 +6,6 @@
 	parent_organ = BP_CHEST
 	w_class = ITEM_SIZE_NORMAL
 	min_bruised_damage = 25
-	min_broken_damage = 45
 	max_damage = 70
 	relative_size = 60
 

--- a/code/modules/organs/internal/species/ipc.dm
+++ b/code/modules/organs/internal/species/ipc.dm
@@ -16,7 +16,6 @@
 	attack_verb = list("attacked", "slapped", "whacked")
 	max_damage = 90
 	min_bruised_damage = 30
-	min_broken_damage = 60
 	relative_size = 60
 
 	var/mob/living/silicon/sil_brainmob/brainmob = null

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -43,9 +43,6 @@ var/global/list/organ_cache = list()
 /obj/item/organ/attack_self(mob/user)
 	return (owner && loc == owner && owner == user)
 
-/obj/item/organ/proc/update_health()
-	return
-
 /obj/item/organ/proc/is_broken()
 	return (damage >= min_broken_damage || (status & ORGAN_CUT_AWAY) || (status & ORGAN_BROKEN))
 

--- a/code/modules/organs/organ_health.dm
+++ b/code/modules/organs/organ_health.dm
@@ -1,0 +1,77 @@
+// Legacy damage properties
+/// Current damage to the organ
+/obj/item/organ/var/damage = 0
+/// Damage before becoming broken
+/obj/item/organ/var/min_broken_damage = 30
+/// Damage cap
+/obj/item/organ/var/max_damage = 30
+/// Time of organ death
+/obj/item/organ/var/death_time
+
+
+/obj/item/organ/Initialize()
+	. = ..()
+
+	if(max_damage)
+		min_broken_damage = floor(max_damage / 2)
+	else
+		max_damage = min_broken_damage * 2
+
+	queue_icon_update()
+
+
+/**
+ * Whether or not the organ is considered broken. By default, this checks `health_broken_threshhold`, and the
+ * `ORGAN_CUT_AWAY` and `ORGAN_BROKEN` status flags.
+ *
+ * Returns boolean.
+ */
+/obj/item/organ/proc/is_broken()
+	return (damage >= min_broken_damage || (status & ORGAN_CUT_AWAY) || (status & ORGAN_BROKEN))
+	// return (get_current_health() <= health_broken_threshhold || GET_FLAGS(status, ORGAN_CUT_AWAY | ORGAN_BROKEN)) TODO: Swap over
+
+
+/**
+ * Kills the organ.
+ */
+/obj/item/organ/proc/die()
+	damage = max_damage
+	status |= ORGAN_DEAD
+	STOP_PROCESSING(SSobj, src)
+	death_time = world.time
+	if(owner && vital)
+		owner.death()
+
+
+/**
+ * Displays a message to `user` if the organ is decayed.
+ */
+/obj/item/organ/proc/show_decay_status(mob/user)
+	if(BP_IS_ROBOTIC(src))
+		if(status & ORGAN_DEAD)
+			to_chat(user, SPAN_NOTICE("\The [src] looks completely spent."))
+	else
+		if(status & ORGAN_DEAD)
+			to_chat(user, SPAN_NOTICE("The decay has set into \the [src]."))
+
+
+/**
+ *
+ */
+/obj/item/organ/proc/take_general_damage(amount, silent = FALSE)
+	CRASH("Not Implemented")
+
+
+/**
+ * Heals `amount` points of damage.
+ */
+/obj/item/organ/proc/heal_damage(amount)
+	if (can_recover())
+		damage = clamp(damage - round(amount, 0.1), 0, max_damage)
+
+
+/**
+ * Whether or not the organ can be revived through normal means.
+ */
+/obj/item/organ/proc/can_recover()
+	return (max_damage > 0) && !(status & ORGAN_DEAD) || death_time >= world.time - ORGAN_RECOVERY_THRESHOLD

--- a/code/modules/organs/organ_health.dm
+++ b/code/modules/organs/organ_health.dm
@@ -1,3 +1,8 @@
+/obj/item/organ/health_max = 30
+/obj/item/organ/health_resistances = DAMAGE_RESIST_BIOLOGICAL
+/obj/item/organ/damage_hitsound = 'sound/weapons/bladeslice.ogg'
+
+
 // Legacy damage properties
 /// Current damage to the organ
 /obj/item/organ/var/damage = 0

--- a/code/modules/xenoarcheaology/anomaly_container.dm
+++ b/code/modules/xenoarcheaology/anomaly_container.dm
@@ -41,7 +41,7 @@
 		if(!src.allowed(user))
 			to_chat(user, SPAN_WARNING("\The [src] blinks red, notifying you of your incorrect access."))
 			return
-		if(!src.health_dead)
+		if(!src.health_dead())
 			user.visible_message(
 				SPAN_NOTICE("\The [user] begins undoing the locks and latches on \the [src]..."),
 				SPAN_NOTICE("You begin undoing the locks and latches on \the [src]...")
@@ -71,7 +71,7 @@
 		if(!src.allowed(user))
 			to_chat(user, SPAN_WARNING("\The [src] blinks red, notifying you of your incorrect access."))
 			return
-		if(!src.health_dead)
+		if(!src.health_dead())
 			user.visible_message(
 				SPAN_NOTICE("\The [user] begins undoing the locks and latches on \the [src]..."),
 				SPAN_NOTICE("You begin undoing the locks and latches on \the [src]...")
@@ -95,7 +95,7 @@
 	if (attached_paper)
 		to_chat(usr, SPAN_NOTICE("There's a paper clipped on the side."))
 		attached_paper.examine(user, distance)
-	if (health_dead)
+	if (health_dead())
 		to_chat(usr, SPAN_DANGER("The borosilicate panels are completely shattered."))
 
 /obj/machinery/anomaly_container/proc/contain(obj/machinery/artifact)
@@ -146,7 +146,7 @@
 
 /obj/machinery/anomaly_container/emp_act(severity)
 	SHOULD_CALL_PARENT(FALSE)
-	if(health_dead)
+	if(health_dead())
 		return
 	if(contained)
 		visible_message(SPAN_DANGER("\The [src]'s latches break loose, freeing the contents!"))
@@ -174,7 +174,7 @@
 		return TRUE
 
 	if (istype(P, /obj/item/stack/material))
-		if (!health_dead)
+		if (!health_dead())
 			to_chat(user, SPAN_NOTICE("\The [src] doesn't require repairs."))
 			return TRUE
 		if (contained)
@@ -211,7 +211,7 @@
 		return TRUE
 
 	if (isWrench(P))
-		if (!health_dead)
+		if (!health_dead())
 			return TRUE
 
 		user.visible_message(
@@ -234,7 +234,7 @@
 
 /obj/machinery/anomaly_container/on_update_icon()
 	ClearOverlays()
-	if(health_dead)
+	if(health_dead())
 		icon_state = "anomaly_container_broken"
 	if(attached_paper)
 		AddOverlays("anomaly_container_paper")


### PR DESCRIPTION
WIP. Original post will be updated as I work on this.

## Changelog
:cl: SierraKomodo
refactor: Internal and external organs (body parts) now process using standardized health calls.
/:cl:

## Other Changes
- Removed unused `update_health()` proc from `/obj/item/organ`
- Moved health related vars and procs for `/obj/item/organ` to `code\modules\organs\organ_health.dm`.
- Removed `min_broken_damage` property overrides - These are immediately overwritten by initialize anyway to be 1/2 of `max_health`.

## Dependencies
- #34641