### PR TITLE
Add stethoscope sounds for arterial bleeding

### DIFF
--- a/code/modules/organs/external/diagnostics.dm
+++ b/code/modules/organs/external/diagnostics.dm
@@ -171,6 +171,8 @@
 	if(!length(sounds))
 		if(owner.pulse())
 			sounds += "faint pulse"
+	if(status & ORGAN_ARTERY_CUT)
+		sounds += "rushing liquid"
 	return sounds
 
 /singleton/diagnostic_sign


### PR DESCRIPTION
:cl:
tweak: Using a stethoscope on a body part with arterial bleeding reports "rushing liquid".
/:cl:


![image](https://github.com/Baystation12/Baystation12/assets/5306508/9b0f72e4-58f8-4eb9-a3d6-d3e45a4ed608)


This is something that for a while I thought existed already, but then it turns out it didn't. The use case is using a stethoscope on an injured body part. Right now, arterial bleeding and infection(?) are the only two things that don't have simple mechanical ways of isolating them without a scanner. Arterial bleeds do have other symptoms, but with no scanner med people rely on either context or a large gaping wound (or incision) to tell them. We can low-tech isolate broken bones using grab-inspect for each limb, we can low-tech examine heart damage and lung damage with the stethoscope, this adds a low-tech workflow for those arterial bleeds as well.

There are a few changes I can think of that may improve this, like different or absent pulse sounds when arterial bleeding is present, but I wanted to get this PR up and see if this is even a good place to begin from the dev side of things since it's also my first PR on Bay. If this feels kosher, I'd maybe look at implementing something where downstream organs have an absent pulse (bleed in right arm -> no pulse in right hand).