### PR TITLE
riot helmets can attach visors, visors don't incorrectly show in storage

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -101,7 +101,7 @@
 	name = "riot helmet"
 	desc = "It's a helmet specifically designed to protect against close range attacks."
 	icon_state = "helmet_riot"
-	valid_accessory_slots = null
+	valid_accessory_slots = list(ACCESSORY_SLOT_HELMET_VISOR)
 	body_parts_covered = HEAD|FACE|EYES //face shield
 	armor = list(
 		melee = ARMOR_MELEE_VERY_HIGH,

--- a/code/modules/clothing/under/accessories/goggle_mods.dm
+++ b/code/modules/clothing/under/accessories/goggle_mods.dm
@@ -22,8 +22,13 @@
 /obj/item/clothing/accessory/glassesmod/proc/process_hud(mob/M)
 	return
 
+/obj/item/clothing/accessory/glassesmod/get_mob_overlay(mob/user_mob, slot)
+	if (slot == "slot_s_store")
+		return null
+	return ..()
+
 /obj/item/clothing/accessory/glassesmod/activate()
-	. = ..()
+	..()
 	parent.CutOverlays(inv_overlay)
 	inv_overlay = null
 	inv_overlay = get_inv_overlay()
@@ -31,7 +36,7 @@
 	parent.update_vision()
 
 /obj/item/clothing/accessory/glassesmod/deactivate()
-	. = ..()
+	..()
 	parent.CutOverlays(inv_overlay)
 	inv_overlay = null
 	inv_overlay = get_inv_overlay()


### PR DESCRIPTION
:cl: Karl Johansson
tweak: Riot helmets can attach visors.
bugfix: Visors don't show on mob when in storage.
/:cl: