### PR TITLE
removed . = ..() from some on_update_icon impls

### DIFF
--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -153,7 +153,6 @@
 
 //Equivalent to /obj/ebeam, except it also adds an emissive layer
 /obj/ebeam/emissive/on_update_icon()
-	. = ..()
 	var/mutable_appearance/emissive_overlay = emissive_appearance(icon, icon_state, src)
 	AddOverlays(emissive_overlay)
 

--- a/code/game/machinery/teleporter/beacon.dm
+++ b/code/game/machinery/teleporter/beacon.dm
@@ -135,10 +135,7 @@ var/global/const/TELEBEACON_WIRE_SIGNALLER = 4
 
 
 /obj/machinery/tele_beacon/on_update_icon()
-	. = ..()
-
 	icon_state = initial(icon_state)
-
 	if (panel_open)
 		icon_state += "_open"
 	else if (functioning())

--- a/code/game/objects/effects/decals/Cleanable/misc.dm
+++ b/code/game/objects/effects/decals/Cleanable/misc.dm
@@ -91,7 +91,6 @@
 		SetTransform(rotation = pick(90, 180, 270))
 
 /obj/decal/cleanable/vomit/on_update_icon()
-	. = ..()
 	color = reagents.get_color()
 
 /obj/decal/cleanable/tomato_smudge

--- a/code/game/objects/items/devices/inducer.dm
+++ b/code/game/objects/items/devices/inducer.dm
@@ -189,7 +189,7 @@
 	return ..()
 
 /obj/item/inducer/borg/on_update_icon()
-	. = ..()
+	..()
 	AddOverlays(image("icons/obj/guns/gui.dmi","safety[safety()]"))
 
 /obj/item/inducer/borg/verb/toggle_safety(mob/user)

--- a/code/game/objects/items/flora.dm
+++ b/code/game/objects/items/flora.dm
@@ -33,7 +33,6 @@
 	return ..()
 
 /obj/item/flora/pottedplantsmall/fern/on_update_icon()
-	. = ..()
 	if (trimmed)
 		name = "fancy trimmed ferny potted plant"
 		desc = "This leafy desk fern seems to have been trimmed too much."

--- a/code/game/objects/items/paper_fortune_teller.dm
+++ b/code/game/objects/items/paper_fortune_teller.dm
@@ -33,7 +33,6 @@
 	. = ..()
 
 /obj/item/paper_fortune_teller/on_update_icon()
-	. = ..()
 	var/datum/state_machine/fsm = get_state_machine(src, /datum/state_machine/paper_fortune)
 	if(fsm && istype(fsm.current_state, /singleton/state/paper_fortune))
 		var/singleton/state/paper_fortune/fsm_state = fsm.current_state

--- a/code/game/objects/items/weapons/flamethrower.dm
+++ b/code/game/objects/items/weapons/flamethrower.dm
@@ -245,7 +245,7 @@
 		)
 
 /obj/item/flamethrower/full/on_update_icon()
-	. = ..()
+	..()
 	item_state_slots[slot_l_hand_str] = "humanoid body-slot_l_hand_[lit]"
 	item_state_slots[slot_r_hand_str] = "humanoid body-slot_r_hand_[lit]"
 

--- a/code/game/objects/items/weapons/melee/energy.dm
+++ b/code/game/objects/items/weapons/melee/energy.dm
@@ -27,7 +27,6 @@
 
 
 /obj/item/melee/energy/on_update_icon()
-	. = ..()
 	if(active)
 		icon_state = active_icon
 	else

--- a/code/game/objects/items/weapons/storage/misc.dm
+++ b/code/game/objects/items/weapons/storage/misc.dm
@@ -195,7 +195,6 @@
 	startswith = list(/obj/item/clothing/mask/chewable/candy/lolli/weak_meds = 15)
 
 /obj/item/storage/medical_lolli_jar/on_update_icon()
-	. = ..()
 	if(length(contents))
 		icon_state = "lollijar"
 	else

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -710,7 +710,6 @@
 	update_icon()
 
 /obj/structure/hygiene/faucet/on_update_icon()
-	. = ..()
 	icon_state = icon_state = "[initial(icon_state)][open ? "-on" : ""]"
 
 /obj/item/faucet

--- a/code/modules/clothing/masks/cig_crafting.dm
+++ b/code/modules/clothing/masks/cig_crafting.dm
@@ -15,12 +15,11 @@
 		to_chat(user, "One of the ends is capped off by a filter.")
 
 /obj/item/clothing/mask/smokable/cigarette/rolled/on_update_icon()
-	. = ..()
+	..()
 	if(!lit)
 		icon_state = filter ? "cigoff" : "cigroll"
-/////////// //Ported Straight from TG. I am not sorry. - BloodyMan  //YOU SHOULD BE
-//ROLLING//
-///////////
+
+
 /obj/item/paper/cig
 	name = "rolling paper"
 	desc = "A thin piece of paper used to make smokeables."

--- a/code/modules/holomap/ship_holomap.dm
+++ b/code/modules/holomap/ship_holomap.dm
@@ -150,7 +150,6 @@
 		M.client.images -= I
 
 /obj/machinery/ship_map/on_update_icon()
-	. = ..()
 	ClearOverlays()
 	if(MACHINE_IS_BROKEN(src))
 		icon_state = "station_mapb"

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -110,7 +110,6 @@
 	..()
 
 /obj/item/mech_equipment/shields/on_update_icon()
-	. = ..()
 	if(!aura)
 		return
 	if(aura.active)
@@ -186,7 +185,6 @@
 
 
 /obj/aura/mechshield/on_update_icon()
-	. = ..()
 	if(active)
 		icon_state = "shield"
 	else
@@ -581,7 +579,6 @@
 	return ..()
 
 /obj/item/mech_equipment/mounted_system/flamethrower/on_update_icon()
-	. = ..()
 	if(owner && holding)
 		var/obj/item/flamethrower/full/mech/FM = holding
 		if(istype(FM))

--- a/code/modules/mechs/equipment/engineering.dm
+++ b/code/modules/mechs/equipment/engineering.dm
@@ -145,7 +145,6 @@
 		GLOB.dir_set_event.register(owner, src, .proc/on_turned)
 
 /obj/item/mech_equipment/atmos_shields/on_update_icon()
-	. = ..()
 	icon_state = "mech_atmoshield[active ? "_on" : "_off"]"
 
 /obj/item/mech_equipment/atmos_shields/deactivate()

--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -790,7 +790,6 @@
 	update_icon()
 
 /obj/item/mech_equipment/ionjets/on_update_icon()
-	. = ..()
 	if (active)
 		icon_state = "mech_jet_on"
 		set_light(1, 1, l_color = COLOR_LIGHT_CYAN)

--- a/code/modules/mechs/interface/screen_objects.dm
+++ b/code/modules/mechs/interface/screen_objects.dm
@@ -190,7 +190,6 @@
 	queue_icon_update()
 
 /obj/screen/exosuit/toggle/on_update_icon()
-	. = ..()
 	icon_state = "[initial(icon_state)][toggled ? "_enabled" : ""]"
 	maptext = SPAN_COLOR(toggled ? COLOR_WHITE : COLOR_GRAY,initial(maptext))
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider/webslinger.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider/webslinger.dm
@@ -66,8 +66,6 @@
 	. = ..()
 
 /obj/aura/web/on_update_icon()
-	. = ..()
-
 	icon_state = "web_[clamp(stacks, 1, 4)]"
 	user.update_icon()
 

--- a/code/modules/modular_computers/computers/subtypes/dev_console.dm
+++ b/code/modules/modular_computers/computers/subtypes/dev_console.dm
@@ -44,7 +44,7 @@
 	return TRUE
 
 /obj/machinery/computer/modular/on_update_icon()
-	. = ..()
+	..()
 	var/datum/extension/interactive/ntos/os = get_extension(src, /datum/extension/interactive/ntos)
 	if(os)
 		if(os.on)

--- a/code/modules/overmap/contacts/tracker.dm
+++ b/code/modules/overmap/contacts/tracker.dm
@@ -19,7 +19,6 @@
 	update_icon()
 
 /obj/item/ship_tracker/on_update_icon()
-	. = ..()
 	icon_state = enabled ? "enabled" : "disabled"
 
 /obj/item/ship_tracker/examine(mob/user)

--- a/code/modules/projectiles/guns/magnetic/magnetic.dm
+++ b/code/modules/projectiles/guns/magnetic/magnetic.dm
@@ -65,7 +65,7 @@
 	update_icon()
 
 /obj/item/gun/magnetic/on_update_icon()
-	. = ..()
+	..()
 	var/list/overlays_to_add = list()
 	if(removable_components)
 		if(cell)

--- a/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks/bottle.dm
@@ -492,7 +492,7 @@
 
 
 /obj/item/reagent_containers/food/drinks/bottle/champagne/on_update_icon()
-	. = ..()
+	..()
 	if(is_open_container())
 		if(sabraged)
 			icon_state = "[initial(icon_state)]_sabrage"

--- a/code/modules/xenoarcheaology/tools/transport_drone.dm
+++ b/code/modules/xenoarcheaology/tools/transport_drone.dm
@@ -116,7 +116,6 @@
 		QDEL_NULL(current_flight)
 
 /obj/machinery/drone_pad/on_update_icon()
-	. = ..()
 	ClearOverlays()
 	if (current_flight)
 		AddOverlays(list(

--- a/maps/away/skrellscoutship/skrellscoutship_machines.dm
+++ b/maps/away/skrellscoutship/skrellscoutship_machines.dm
@@ -29,8 +29,6 @@
 	update_icon()
 
 /obj/machinery/power/skrell_reactor/on_update_icon()
-	. = ..()
-
 	if(!field_image)
 		field_image = image(icon = 'icons/obj/machines/power/fusion_core.dmi', icon_state = "emfield_s1")
 		field_image.color = COLOR_CYAN

--- a/maps/torch/structures/memorabilia.dm
+++ b/maps/torch/structures/memorabilia.dm
@@ -24,10 +24,10 @@
 		to_chat(user, "Magnetic chains hold it in place. Somebody isn't taking any risks with this one.")
 
 /obj/structure/decorative/ed209/on_update_icon()
-	. = ..()
 	if(anchored)
 		pixel_z = 8
-	else pixel_z = 0
+	else
+		pixel_z = 0
 
 
 /obj/structure/decorative/ed209/use_tool(obj/item/tool, mob/user, list/click_params)


### PR DESCRIPTION
on_update_icon should not return a value and most implementations are leaves, making super calls typically unwanted and setting a return always so. Cleaning up the easiest of these to find using `/on_update_icon\(\)\n\s+\.\s*=/`
