### PR TITLE
little renderer refactor

### DIFF
--- a/code/__defines/_renderer.dm
+++ b/code/__defines/_renderer.dm
@@ -7,6 +7,21 @@
 * visual effects.
 */
 
+
+/// Main renderers are expected to always be on mobs with clients.
+#define RENDERER_MAIN FLAG(0)
+
+/**
+ * Shared renderers have a single instance and are added/removed instead of created/deleted.
+ * Many renderers can be shared - only ones that depend on the state of the mob seeing them,
+ * such as effects with preferences, require an owner.
+ */
+#define RENDERER_SHARED FLAG(1)
+
+/// Renderers with non-default setup behavior in hook/startup/proc/setup_renderers.
+#define RENDERER_SHARED_CUSTOM FLAG(2)
+
+
 /// The base /renderer definition and defaults.
 /atom/movable/renderer
 	abstract_type = /atom/movable/renderer
@@ -14,6 +29,9 @@
 	screen_loc = "CENTER"
 	plane = LOWEST_PLANE
 	blend_mode = BLEND_OVERLAY
+
+	/// A bitfield of RENDERER_* defines.
+	var/renderer_flags = EMPTY_BITFIELD
 
 	/// The compositing renderer this renderer belongs to.
 	var/group = RENDER_GROUP_FINAL
@@ -24,21 +42,22 @@
 	/// Optional blend mode override for the renderer's composition relay.
 	var/relay_blend_mode
 
-	/// If text, uses the text or, if TRUE, uses "*AUTO-[name]"
+	/// If text, uses the text or, if TRUE, uses "*AUTO-[name]".
 	var/render_target_name = TRUE
 
-	var/mob/owner = null
+	/// When not shared, the mob associated with this renderer.
+	var/mob/owner
 
 
 /atom/movable/renderer/Destroy()
-	owner = null
+	if (renderer_flags & RENDERER_SHARED)
+		return QDEL_HINT_LETMELIVE
 	QDEL_NULL(relay)
+	owner = null
 	return ..()
 
 
 INITIALIZE_IMMEDIATE(/atom/movable/renderer)
-
-
 /atom/movable/renderer/Initialize(mapload, mob/owner)
 	. = ..()
 	if (. == INITIALIZE_HINT_QDEL)
@@ -65,10 +84,11 @@ INITIALIZE_IMMEDIATE(/atom/movable/renderer)
 	else
 		relay.blend_mode = relay_blend_mode
 
+
 /**
 * Graphic preferences
-*
-* Some renderers may be able to use a graphic preference to determine how to display effects. For example reduce particle counts or filter variables.
+* Some renderers may be able to use a graphic preference to determine how to display effects.
+* For example reduce particle counts or filter variables.
 */
 /atom/movable/renderer/proc/GraphicsUpdate()
 	return
@@ -82,50 +102,98 @@ INITIALIZE_IMMEDIATE(/atom/movable/renderer)
 * to share them globally.
 */
 
-/// The list of renderers associated with this mob.
+/// The map of (instance = plane) renderers in use by this mob.
 /mob/var/list/atom/movable/renderer/renderers
+
+/// A list of non-main types of renderers in use by this mob.
+/mob/var/list/atom/movable/renderer/extra_renderers
 
 
 /// Creates the mob's renderers on /Login()
-/mob/proc/CreateRenderers()
-	if (!renderers)
-		renderers = list()
-	for (var/atom/movable/renderer/renderer as anything in subtypesof(/atom/movable/renderer))
-		if(ispath(renderer, /atom/movable/renderer/shared))
-			continue
+/mob/proc/AddDefaultRenderers()
+	if (renderers)
+		ClearRenderers()
+	renderers = list()
+	extra_renderers = list()
+	for (var/atom/movable/renderer/renderer as anything in GLOB.rdr_main_owned)
 		renderer = new renderer (null, src)
-		renderers[renderer] = renderer.plane // (renderer = plane) format for visual debugging
+		renderers[renderer] = renderer.plane
+		if (renderer.relay)
+			my_client.screen += renderer.relay
+		my_client.screen += renderer
+	for (var/atom/movable/renderer/renderer as anything in GLOB.rdr_main_shared)
+		renderers[renderer] = renderer.plane
 		if (renderer.relay)
 			my_client.screen += renderer.relay
 		my_client.screen += renderer
 
-	for (var/atom/movable/renderer/zrenderer as anything in GLOB.zmimic_renderers)
-		if (zrenderer.relay)
-			my_client.screen += zrenderer.relay
-		my_client.screen += zrenderer
 
 /// Removes the mob's renderers on /Logout()
-/mob/proc/RemoveRenderers()
-	if(my_client)
-		for(var/atom/movable/renderer/renderer as anything in renderers)
-			my_client.screen -= renderer
+/mob/proc/ClearRenderers()
+	if (my_client)
+		for (var/atom/movable/renderer/renderer as anything in renderers)
 			if (renderer.relay)
 				my_client.screen -= renderer.relay
-			qdel(renderer)
-		for (var/atom/movable/renderer/renderer as anything in GLOB.zmimic_renderers)
 			my_client.screen -= renderer
-	if (renderers)
-		renderers.Cut()
+			if (~renderer.renderer_flags & RENDERER_SHARED)
+				qdel(renderer)
+	extra_renderers = null
+	renderers = null
+
+
+/// Adds a non-main renderer to the mob by type if the mob doesn't already have it.
+/mob/proc/AddRenderer(atom/movable/renderer/of_type)
+	if (!my_client)
+		return
+	var/flags = initial(of_type.renderer_flags)
+	if (flags & RENDERER_MAIN)
+		return
+	if (of_type in extra_renderers)
+		return
+	var/atom/movable/renderer/renderer
+	if (flags & RENDERER_SHARED)
+		renderer = GLOB.rdr_all_shared[of_type]
+	else
+		renderer = new of_type (null, src)
+	if (renderer.relay)
+		my_client.screen += renderer.relay
+	my_client.screen += renderer
+	renderers[renderer] = renderer.plane
+	extra_renderers += of_type
+
+
+/// Removes a non-main renderer to the mob by type.
+/mob/proc/RemoveRenderer(atom/movable/renderer/of_type)
+	if (!my_client)
+		return
+	var/flags = initial(of_type.renderer_flags)
+	if (flags & RENDERER_MAIN)
+		return
+	if (!(of_type in extra_renderers))
+		return
+	for (var/atom/movable/renderer/renderer as anything in renderers)
+		if (renderer.type != of_type)
+			continue
+		extra_renderers -= of_type
+		renderers -= renderer
+		if (renderer.relay)
+			my_client.screen -= renderer.relay
+		my_client.screen -= renderer
+		if (~renderer.renderer_flags & RENDERER_SHARED)
+			qdel(renderer)
+		return
+
 
 /* *
 * Plane Renderers
 * We treat some renderers as planes with layers. When some atom has the same plane
 * as a Plane Renderer, it is drawn by that renderer. The layer of the atom determines
 * its draw order within the scope of the renderer. The draw order of same-layered things
-* is probably by atom contents order, but can be assumed not to matter - if it's out of
-* order, it should have a more appropriate layer value.
+* is probably by atom contents order, but can be assumed not to matter - if it's visibly
+* incorrect, it should have a more appropriate layer value.
 * Higher plane values are composited over lower. Here, they are ordered from under to over.
 */
+
 
  /// Handles byond internal letterboxing. Avoid touching.
 /atom/movable/renderer/letterbox
@@ -134,52 +202,50 @@ INITIALIZE_IMMEDIATE(/atom/movable/renderer)
 	plane = BLACKNESS_PLANE
 	blend_mode = BLEND_MULTIPLY
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
+	renderer_flags = RENDERER_MAIN | RENDERER_SHARED
+
 
 /atom/movable/renderer/space
 	name = "Space"
 	group = RENDER_GROUP_SCENE
 	plane = SPACE_PLANE
+	renderer_flags = RENDERER_MAIN | RENDERER_SHARED
+
 
 /atom/movable/renderer/skybox
 	name = "Skybox"
 	group = RENDER_GROUP_SCENE
 	plane = SKYBOX_PLANE
 	relay_blend_mode = BLEND_MULTIPLY
+	renderer_flags = RENDERER_MAIN | RENDERER_SHARED
 
-//Z Mimic planemasters -> Could apply scaling for parallax though that requires copying appearances from adjacent turfs
-GLOBAL_LIST_EMPTY(zmimic_renderers)
 
-/hook/startup/proc/create_global_renderers() //Some (most) renderers probably do not need to be instantiated per mob. So may as well make them global and just add to screen
-	//Zmimic planemasters
-	for(var/i = 0 to OPENTURF_MAX_DEPTH)
-		GLOB.zmimic_renderers += new /atom/movable/renderer/shared/zmimic(null, null, OPENTURF_MAX_PLANE - i)
-
-	return TRUE
-
-/atom/movable/renderer/shared/zmimic
+/atom/movable/renderer/zmimic
 	name = "Zrenderer"
 	group = RENDER_GROUP_SCENE
+	renderer_flags = RENDERER_MAIN | RENDERER_SHARED | RENDERER_SHARED_CUSTOM
 
-/atom/movable/renderer/shared/zmimic/Initialize(mapload, _owner, _plane)
+
+/atom/movable/renderer/zmimic/Initialize(mapload, _owner, _plane)
 	plane = _plane
 	name = "Zrenderer [plane]"
-	. = ..()
-
-/atom/movable/renderer/shared/zmimic/Destroy()
-	GLOB.zmimic_renderers -= src
 	return ..()
+
 
 // Draws the game world; live mobs, items, turfs, etc.
 /atom/movable/renderer/game
 	name = "Game"
 	group = RENDER_GROUP_SCENE
 	plane = DEFAULT_PLANE
+	renderer_flags = RENDERER_MAIN | RENDERER_SHARED
+
 
 /// Draws observers; ghosts, camera eyes, etc.
 /atom/movable/renderer/observers
 	name = "Observers"
 	group = RENDER_GROUP_SCENE
 	plane = OBSERVER_PLANE
+	renderer_flags = RENDERER_MAIN | RENDERER_SHARED
 
 
 /// Draws darkness effects.
@@ -189,6 +255,7 @@ GLOBAL_LIST_EMPTY(zmimic_renderers)
 	plane = LIGHTING_PLANE
 	relay_blend_mode = BLEND_MULTIPLY
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
+	renderer_flags = RENDERER_MAIN | RENDERER_SHARED
 
 
 /atom/movable/renderer/lighting/Initialize()
@@ -199,11 +266,13 @@ GLOBAL_LIST_EMPTY(zmimic_renderers)
 		flags = MASK_INVERSE
 	)
 
+
 /// Draws visuals that should not be affected by darkness.
 /atom/movable/renderer/above_lighting
 	name = "Above Lighting"
 	group = RENDER_GROUP_SCENE
 	plane = EFFECTS_ABOVE_LIGHTING_PLANE
+	renderer_flags = RENDERER_MAIN | RENDERER_SHARED
 
 
 /// Draws full screen visual effects, like pain and bluespace.
@@ -212,6 +281,7 @@ GLOBAL_LIST_EMPTY(zmimic_renderers)
 	group = RENDER_GROUP_SCENE
 	plane = FULLSCREEN_PLANE
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
+	renderer_flags = RENDERER_MAIN | RENDERER_SHARED
 
 
 /// Draws user interface elements.
@@ -219,6 +289,7 @@ GLOBAL_LIST_EMPTY(zmimic_renderers)
 	name = "Interface"
 	group = RENDER_GROUP_SCREEN
 	plane = HUD_PLANE
+	renderer_flags = RENDERER_MAIN | RENDERER_SHARED
 
 
 /* *
@@ -231,17 +302,21 @@ GLOBAL_LIST_EMPTY(zmimic_renderers)
 * granular manipulation of how the final scene is composed.
 */
 
+
 /// Render group for stuff INSIDE the typical game context - people, items, lighting, etc.
 /atom/movable/renderer/scene_group
 	name = "Scene Group"
 	group = RENDER_GROUP_FINAL
 	plane = RENDER_GROUP_SCENE
+	renderer_flags = RENDERER_MAIN | RENDERER_SHARED
+
 
 /// Render group for stuff OUTSIDE the typical game context - UI, full screen effects, etc.
 /atom/movable/renderer/screen_group
 	name = "Screen Group"
 	group = RENDER_GROUP_FINAL
 	plane = RENDER_GROUP_SCREEN
+	renderer_flags = RENDERER_MAIN | RENDERER_SHARED
 
 
 /// Render group for final compositing before user display.
@@ -249,6 +324,7 @@ GLOBAL_LIST_EMPTY(zmimic_renderers)
 	name = "Final Group"
 	group = RENDER_GROUP_NONE
 	plane = RENDER_GROUP_FINAL
+	renderer_flags = RENDERER_MAIN | RENDERER_SHARED
 
 
 /* *
@@ -268,6 +344,8 @@ GLOBAL_LIST_EMPTY(zmimic_renderers)
 	plane = WARP_EFFECT_PLANE
 	render_target_name = "*warp"
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
+	renderer_flags = RENDERER_MAIN | RENDERER_SHARED
+
 
 //Similar to warp but not as strong
 /atom/movable/renderer/heat
@@ -276,39 +354,35 @@ GLOBAL_LIST_EMPTY(zmimic_renderers)
 	plane = HEAT_EFFECT_PLANE
 	render_target_name = HEAT_COMPOSITE_TARGET
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
+	renderer_flags = RENDERER_MAIN
 
-	var/obj/gas_heat_object = null
-	var/obj/gas_cold_object = null // Not strictly a heat effect but similar setup so may as well
+	var/obj/gas_heat_object
+	var/obj/gas_cold_object
+
 
 /atom/movable/renderer/heat/proc/Setup()
 	var/mob/M = owner
-
-	if(istype(M))
+	if (ismob(M))
 		var/quality = M.get_preference_value(/datum/client_preference/graphics_quality)
-
-		if(gas_heat_object)
+		if (gas_heat_object)
 			vis_contents -= gas_heat_object
-
-		if(gas_cold_object)
+		if (gas_cold_object)
 			vis_contents -= gas_cold_object
-
 		if (quality == GLOB.PREF_LOW)
 			QDEL_NULL(gas_heat_object)
-			gas_heat_object = new /obj/heat(null)
-
+			gas_heat_object = new /obj/heat
 			QDEL_NULL(gas_cold_object)
-			gas_cold_object = new /obj/effect/cold_mist_gas(null)
+			gas_cold_object = new /obj/effect/cold_mist_gas
 		else
 			QDEL_NULL(gas_heat_object)
 			QDEL_NULL(gas_cold_object)
-			gas_cold_object = new /obj/particle_emitter/mist/gas(null)
+			gas_cold_object = new /obj/particle_emitter/mist/gas
 			if (quality == GLOB.PREF_MED)
-				gas_heat_object = new /obj/particle_emitter/heat(null)
+				gas_heat_object = new /obj/particle_emitter/heat
 			else if (quality == GLOB.PREF_HIGH)
-				gas_heat_object = new /obj/particle_emitter/heat/high(null)
-
+				gas_heat_object = new /obj/particle_emitter/heat/high
 		vis_contents += gas_heat_object
-		if(config.enable_cold_mist)
+		if (config.enable_cold_mist)
 			vis_contents += gas_cold_object
 
 
@@ -316,17 +390,28 @@ GLOBAL_LIST_EMPTY(zmimic_renderers)
 	. = ..()
 	Setup()
 
+
 /atom/movable/renderer/heat/GraphicsUpdate()
 	. = ..()
 	Setup()
 
+
 /atom/movable/renderer/scene_group/Initialize()
 	. = ..()
-	filters += filter(type = "displace", render_source = "*warp", size = 5)
-	filters += filter(type = "displace", render_source = HEAT_COMPOSITE_TARGET, size = 2.5)
+	filters += filter(
+		type = "displace",
+		render_source = "*warp",
+		size = 5
+	)
+	filters += filter(
+		type = "displace",
+		render_source = HEAT_COMPOSITE_TARGET,
+		size = 2.5
+	)
+
 
 /*!
- * This system works by exploiting BYONDs color matrix filter to use layers to handle emissive blockers.
+ * Emmissives work by exploiting BYONDs color matrix filter to use layers to handle emissive blockers.
  *
  * Emissive overlays are pasted with an atom color that converts them to be entirely some specific color.
  * Emissive blockers are pasted with an atom color that converts them to be entirely some different color.
@@ -338,12 +423,16 @@ GLOBAL_LIST_EMPTY(zmimic_renderers)
  * This works best if emissive overlays applied only to objects that emit light,
  * since luminosity=0 turfs may not be rendered.
  */
+
+
 /atom/movable/renderer/emissive
 	name = "Emissive"
 	group = RENDER_GROUP_NONE
 	plane = EMISSIVE_PLANE
 	mouse_opacity = MOUSE_OPACITY_UNCLICKABLE
 	render_target_name = EMISSIVE_TARGET
+	renderer_flags = RENDERER_MAIN | RENDERER_SHARED
+
 
 /atom/movable/renderer/emissive/Initialize()
 	. = ..()
@@ -351,3 +440,37 @@ GLOBAL_LIST_EMPTY(zmimic_renderers)
 		type = "color",
 		color = GLOB.em_mask_matrix
 	)
+
+
+/// A map of (type = instance|list(instance)) of all normal renderers that mobs can share an instance of.
+GLOBAL_LIST_EMPTY(rdr_all_shared)
+
+
+/// A map of (instance = plane) renderers that should be attached to all cliented mobs by default.
+GLOBAL_LIST_EMPTY(rdr_main_shared)
+
+
+/// A list of renderer types to instantiate on all cliented mobs by default.
+GLOBAL_LIST_EMPTY(rdr_main_owned)
+
+
+/hook/startup/proc/setup_renderers()
+	for (var/atom/movable/renderer/renderer as anything in subtypesof(/atom/movable/renderer))
+		var/flags = initial(renderer.renderer_flags)
+		if (~flags & RENDERER_SHARED)
+			if (flags & RENDERER_MAIN)
+				GLOB.rdr_main_owned += renderer
+			continue
+		if (flags & RENDERER_SHARED_CUSTOM)
+			continue
+		renderer = new renderer
+		GLOB.rdr_all_shared[renderer.type] = renderer
+		if (flags & RENDERER_MAIN)
+			GLOB.rdr_main_shared[renderer] = renderer.plane
+	var/list/zmimic_renderers = list()
+	for (var/i = 0 to OPENTURF_MAX_DEPTH)
+		var/atom/movable/renderer/zmimic/renderer = new (null, null, OPENTURF_MAX_PLANE - i)
+		GLOB.rdr_main_shared[renderer] = renderer.plane
+		zmimic_renderers += renderer
+	GLOB.rdr_all_shared[/atom/movable/renderer/zmimic] = zmimic_renderers
+	return TRUE

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -95,7 +95,7 @@
 	darksight = new()
 	client.screen += darksight
 
-	CreateRenderers()
+	AddDefaultRenderers()
 
 	refresh_client_images()
 	reload_fullscreen() // Reload any fullscreen overlays this mob has.

--- a/code/modules/mob/logout.dm
+++ b/code/modules/mob/logout.dm
@@ -5,7 +5,7 @@
 	handle_admin_logout()
 	if(my_client)
 		my_client.screen -= darksight
-	RemoveRenderers()
+	ClearRenderers()
 
 	QDEL_NULL(darksight)
 	hide_client_images()

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -20,7 +20,7 @@
 
 	new_player_panel()
 
-	CreateRenderers()
+	AddDefaultRenderers()
 
 	if(!SScharacter_setup.initialized)
 		SScharacter_setup.newplayers_requiring_init += src


### PR DESCRIPTION
Makes most renderers shared. Also adds AddRenderer(some/type) and RemoveRenderer(some/type) to /mob, allowing non-main renderers to be safely added and removed from a mob with a client.
