### PR TITLE
Fix inconsistent can-move-into checks in machinery interactions

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -239,6 +239,8 @@
 	if (occupant)
 		to_chat(user, SPAN_WARNING("\The [src] is already occupied."))
 		return FALSE
+	if (!user_can_move_target_inside(target, user))
+		return
 	if (target == user)
 		visible_message("\The [user] starts climbing into \the [src].")
 	else

--- a/code/game/machinery/suit_cycler.dm
+++ b/code/game/machinery/suit_cycler.dm
@@ -129,6 +129,8 @@
 	return ..()
 
 /obj/machinery/suit_cycler/proc/move_target_inside(mob/target, mob/user)
+	if (!user_can_move_target_inside(target, user))
+		return
 	visible_message(SPAN_NOTICE("\The [user] starts putting \the [target] into \the [src]."), range = 3)
 	add_fingerprint(user)
 	if (do_after(user, 2 SECONDS, src, DO_PUBLIC_UNIQUE))

--- a/code/game/machinery/suit_storage.dm
+++ b/code/game/machinery/suit_storage.dm
@@ -136,6 +136,8 @@
 	return TRUE
 
 /obj/machinery/suit_storage_unit/proc/move_target_inside(mob/target, mob/user)
+	if (!user_can_move_target_inside(target, user))
+		return
 	visible_message(SPAN_WARNING("\The [user] starts putting \the [target] into \the [src]."))
 	add_fingerprint(user)
 	if(do_after(user, 2 SECONDS, src, DO_PUBLIC_UNIQUE))

--- a/code/modules/recycling/disposal.dm
+++ b/code/modules/recycling/disposal.dm
@@ -66,8 +66,10 @@ GLOBAL_LIST_EMPTY(diversion_junctions)
 	if (ismob(G.affecting))
 		var/mob/GM = G.affecting
 		var/mob/user = G.assailant
-		user.visible_message(SPAN_DANGER("\The [user] starts putting \the [GM.name] into the disposal."))
-		if (do_after(user, 2 SECONDS, src, DO_PUBLIC_UNIQUE))
+		if (!user_can_move_target_inside(G.affecting, user))
+			return
+		user.visible_message(SPAN_DANGER("\The [user] starts putting \the [GM] into the disposal."))
+		if (do_after(user, 2 SECONDS, src, DO_PUBLIC_UNIQUE) && user_can_move_target_inside(GM, user))
 			if (GM.client)
 				GM.client.perspective = EYE_PERSPECTIVE
 				GM.client.eye = src


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Machinery that can be entered now checks if all conditions are met before starting the "Put person in thing" timer.
bugfix: It is no longer possible to put people into disposal bins if they manage to escape or are thrown away from the bin during the timer.
/:cl: