### PR TITLE
Premade exosuits now actually spawn with boards

### DIFF
--- a/code/modules/mechs/components/head.dm
+++ b/code/modules/mechs/components/head.dm
@@ -8,6 +8,8 @@
 	var/obj/item/robot_parts/robot_component/radio/radio
 	var/obj/item/robot_parts/robot_component/camera/camera
 	var/obj/item/mech_component/control_module/software
+	/// Takes /obj/item/circuitboard/exosystem type paths for what boards get put in for prefabs
+	var/list/prebuilt_software = list()
 	has_hardpoints = list(HARDPOINT_HEAD)
 	var/active_sensors = 0
 	power_use = 15
@@ -30,6 +32,9 @@
 /obj/item/mech_component/sensors/prebuild()
 	radio = new(src)
 	camera = new(src)
+	software = new(src)
+	for(var/board in prebuilt_software)
+		software.install_software(new board)
 
 /obj/item/mech_component/sensors/update_components()
 	radio = locate() in src
@@ -154,11 +159,7 @@
 	desc = "A primitive set of sensors designed to work in tandem with most MKI Eyeball platforms."
 	max_damage = 100
 	power_use = 0
-
-/obj/item/mech_component/sensors/powerloader/prebuild()
-	..()
-	software = new(src)
-	software.installed_software = list(MECH_SOFTWARE_UTILITY, MECH_SOFTWARE_ENGINEERING)
+	prebuilt_software = list(/obj/item/circuitboard/exosystem/utility, /obj/item/circuitboard/exosystem/engineering)
 
 /obj/item/mech_component/sensors/light
 	name = "light sensors"
@@ -170,11 +171,7 @@
 	see_invisible = SEE_INVISIBLE_NOLIGHTING
 	power_use = 50
 	desc = "A series of high resolution optical sensors. They can overlay several images to give the pilot a sense of location even in total darkness. "
-
-/obj/item/mech_component/sensors/light/prebuild()
-	..()
-	software = new(src)
-	software.installed_software = list(MECH_SOFTWARE_UTILITY, MECH_SOFTWARE_MEDICAL)
+	prebuilt_software = list(/obj/item/circuitboard/exosystem/medical, /obj/item/circuitboard/exosystem/utility)
 
 /obj/item/mech_component/sensors/heavy
 	name = "heavy sensors"
@@ -183,11 +180,7 @@
 	icon_state = "heavy_head"
 	max_damage = 120
 	power_use = 0
-
-/obj/item/mech_component/sensors/heavy/prebuild()
-	..()
-	software = new(src)
-	software.installed_software = list(MECH_SOFTWARE_WEAPONS)
+	prebuilt_software = list(/obj/item/circuitboard/exosystem/weapons)
 
 /obj/item/mech_component/sensors/combat
 	name = "combat sensors"
@@ -197,8 +190,4 @@
 	vision_flags = SEE_MOBS
 	see_invisible = SEE_INVISIBLE_NOLIGHTING
 	power_use = 200
-
-/obj/item/mech_component/sensors/combat/prebuild()
-	..()
-	software = new(src)
-	software.installed_software = list(MECH_SOFTWARE_WEAPONS)
+	prebuilt_software = list(/obj/item/circuitboard/exosystem/weapons)

--- a/code/modules/mechs/premade/powerloader.dm
+++ b/code/modules/mechs/premade/powerloader.dm
@@ -81,11 +81,6 @@
 	install_system(new /obj/item/mech_equipment/mounted_system/extinguisher(src), HARDPOINT_RIGHT_HAND)
 	install_system(new /obj/item/mech_equipment/atmos_shields(src), HARDPOINT_BACK)
 
-/obj/item/mech_component/sensors/firefighter/prebuild()
-	..()
-	software = new(src)
-	software.installed_software = list(MECH_SOFTWARE_UTILITY, MECH_SOFTWARE_ENGINEERING)
-
 /mob/living/exosuit/premade/powerloader/old
 	name = "weathered power loader"
 	desc = "An ancient, but well-liked cargo handling exosuit. The paint is starting to flake. Perhaps some maintenance is in order?"

--- a/maps/away/scavver/scavver_gantry.dm
+++ b/maps/away/scavver/scavver_gantry.dm
@@ -67,9 +67,8 @@
 		"Desperado" = list("nav_gantry_desperado")
 	)
 
-/obj/item/mech_component/sensors/light/salvage/prebuild()
-  ..()
-  software.installed_software = list(MECH_SOFTWARE_UTILITY, MECH_SOFTWARE_ENGINEERING)
+/obj/item/mech_component/sensors/light/salvage
+	prebuilt_software = list(/obj/item/circuitboard/exosystem/utility, /obj/item/circuitboard/exosystem/engineering)
 
 /mob/living/exosuit/premade/salvage_gantry
 	name = "\improper Carrion Crawler"


### PR DESCRIPTION
:cl:
bugfix: Roundstart exosuits now actually spawn with boards instead of having their software work via black magic
/:cl:

Also changes up how prebuild works by adding the `prebuilt_software` var instead of having each and every type having to override the prebuild proc to change the software

Also removes sensors/firefighter for being completely unused besides that one prebuild proc (it wasnt even used in the premade file its in, it was just the prebuild proc), and removes the scavenger subtype of light sensors because needing to do a subtype for software is no longer a thing