### PR TITLE
Change rand() to Frand() in some places

### DIFF
--- a/code/game/machinery/bluespace_drive.dm
+++ b/code/game/machinery/bluespace_drive.dm
@@ -226,7 +226,7 @@
 					zlevels[1])
 				if (!T)
 					return
-				GLOB.using_map.do_interlude_teleport(mob, T, rand(1, 2.5) MINUTES)
+				GLOB.using_map.do_interlude_teleport(mob, T, Frand(1, 2.5) MINUTES)
 				return
 			if (mob != being)
 				var/source_position = being.loc

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -482,7 +482,7 @@
 	var/obj/overmap/visitable/sector/exoplanet/new_planet = new exoplanet_type(null, world.maxx, world.maxy)
 	new_planet.features_budget = budget
 	new_planet.themes = list(new theme)
-	new_planet.sun_brightness_modifier = rand(0.1, 0.6)
+	new_planet.sun_brightness_modifier = Frand(0.1, 0.6)
 
 	log_and_message_admins("is spawning [new_planet] at [new_planet.start_x],[new_planet.start_y], containing Z [english_list(new_planet.map_z)]")
 	new_planet.build_level()

--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -576,7 +576,7 @@
 				set_trait(TRAIT_ENDURANCE,get_trait(TRAIT_ENDURANCE)-rand(10,20),null,0)
 				source_turf.visible_message(SPAN_DANGER("\The [display_name] withers rapidly!"))
 			if(1)
-				set_trait(TRAIT_NUTRIENT_CONSUMPTION,get_trait(TRAIT_NUTRIENT_CONSUMPTION)+rand(-(degree*0.1),(degree*0.1)),5,0)
+				set_trait(TRAIT_NUTRIENT_CONSUMPTION,get_trait(TRAIT_NUTRIENT_CONSUMPTION)+Frand(-(degree*0.1),(degree*0.1)),5,0)
 				set_trait(TRAIT_WATER_CONSUMPTION,   get_trait(TRAIT_WATER_CONSUMPTION)   +rand(-degree,degree),50,0)
 				set_trait(TRAIT_JUICY,              !get_trait(TRAIT_JUICY))
 				set_trait(TRAIT_STINGS,             !get_trait(TRAIT_STINGS))

--- a/code/modules/hydroponics/seed_gene_mut.dm
+++ b/code/modules/hydroponics/seed_gene_mut.dm
@@ -86,7 +86,7 @@
 	if(prob(60))
 		S.set_trait(TRAIT_PARASITE, !S.get_trait(TRAIT_PARASITE))
 	if(prob(65))
-		S.set_trait(TRAIT_NUTRIENT_CONSUMPTION, S.get_trait(TRAIT_NUTRIENT_CONSUMPTION)+rand(-0.1,0.1),5,0)
+		S.set_trait(TRAIT_NUTRIENT_CONSUMPTION, S.get_trait(TRAIT_NUTRIENT_CONSUMPTION)+Frand(-0.1,0.1),5,0)
 	if(prob(65))
 		S.set_trait(TRAIT_WATER_CONSUMPTION, S.get_trait(TRAIT_WATER_CONSUMPTION)+rand(-1,1),50,0)
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -95,7 +95,7 @@
 
 					var/obj/item/organ/internal/heart/heart = internal_organs_by_name[BP_HEART]
 					if (heart)
-						heart.external_pump = list(world.time, 0.4 + 0.1*pumping_skill + rand(-0.1,0.1))
+						heart.external_pump = list(world.time, 0.4 + 0.1*pumping_skill + Frand(-0.1,0.1))
 
 					if (stat != DEAD && prob(2 * pumping_skill))
 						resuscitate()

--- a/code/modules/mob/living/simple_animal/borer/borer_captive.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_captive.dm
@@ -48,7 +48,7 @@
 		spawn(rand(200,250)+B.host.getBrainLoss())
 			if(!B || !B.controlling) return
 
-			B.host.adjustBrainLoss(rand(0.1,0.5))
+			B.host.adjustBrainLoss(Frand(0.1,0.5))
 			to_chat(H, SPAN_DANGER("With an immense exertion of will, you regain control of your body!"))
 			to_chat(B.host, SPAN_DANGER("You feel control of the host brain ripped from your grasp, and retract your probosci before the wild neural impulses can damage you."))
 			B.detatch()

--- a/code/modules/overmap/exoplanets/planet_themes/radiation_bombing.dm
+++ b/code/modules/overmap/exoplanets/planet_themes/radiation_bombing.dm
@@ -11,7 +11,7 @@
 	return "Hotspots of radiation detected."
 
 /datum/exoplanet_theme/radiation_bombing/after_map_generation(obj/overmap/visitable/sector/exoplanet/E)
-	var/radiation_power = rand(10, 37.5)
+	var/radiation_power = Frand(10, 37.5)
 	var/num_craters = round(min(0.04, rand()) * 0.02 * E.maxx * E.maxy)
 	for (var/i = 1 to num_craters)
 		var/turf/simulated/T = pick_area_turf(E.planetary_area, list(/proc/not_turf_contains_dense_objects))

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -217,7 +217,7 @@
 			if(percent_unstable > 1)
 				percent_unstable = 1
 			if(percent_unstable > 0)
-				percent_unstable = max(0, percent_unstable-rand(0.01,0.03))
+				percent_unstable = max(0, percent_unstable-Frand(0.01,0.03))
 				UpdateVisuals()
 
 	if(percent_unstable >= 1)

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -484,7 +484,7 @@
 			s.set_up(3, 1, src)
 			s.start()
 			if (prob(75))
-				electrocute_mob(user, get_area(src), src, rand(0.7,1.0))
+				electrocute_mob(user, get_area(src), src, Frand(0.7,1.0))
 		return TRUE
 
 	return ..()

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -617,7 +617,7 @@
 
 /obj/machinery/power/supermatter/randomsample/Initialize()
 	. = ..()
-	nitrogen_retardation_factor = rand(0.01, 1)	//Higher == N2 slows reaction more
+	nitrogen_retardation_factor = Frand(0.01, 1)	//Higher == N2 slows reaction more
 	thermal_release_modifier = rand(100, 1000000)		//Higher == more heat released during reaction
 	phoron_release_modifier = rand(0, 100000)		//Higher == less phoron released by reaction
 	oxygen_release_modifier = rand(0, 100000)		//Higher == less oxygen released at high temperature/power


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl:
tweak: made some instances of randomness return real numbers instead of integers
/:cl:

Changes some instances of rand() to Frand() where the result shouldn't necessarily be an integer.