### PR TITLE
Uncap oxygenation for asystole mobs

### DIFF
--- a/code/game/objects/items/devices/auto_cpr.dm
+++ b/code/game/objects/items/devices/auto_cpr.dm
@@ -54,7 +54,7 @@
 	if(H.get_inventory_slot(src) != slot_wear_suit)
 		return PROCESS_KILL
 
-	if(world.time > last_pump + 15 SECONDS)
+	if(world.time > last_pump + 10 SECONDS)
 		last_pump = world.time
 		playsound(src, 'sound/machines/pump.ogg', 25)
 		if(!skilled_setup && prob(20))
@@ -66,4 +66,4 @@
 		else
 			var/obj/item/organ/internal/heart/heart = H.internal_organs_by_name[BP_HEART]
 			if(heart)
-				heart.external_pump = list(world.time, 0.6)
+				heart.external_pump = list(world.time, 0.5)

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -95,7 +95,7 @@
 
 					var/obj/item/organ/internal/heart/heart = internal_organs_by_name[BP_HEART]
 					if (heart)
-						heart.external_pump = list(world.time, 0.4 + 0.1*pumping_skill + Frand(-0.1,0.1))
+						heart.external_pump = list(world.time, 0.4 + 0.05*pumping_skill + Frand(-0.1,0.1))
 
 					if (stat != DEAD && prob(2 * pumping_skill))
 						resuscitate()

--- a/code/modules/organs/blood.dm
+++ b/code/modules/organs/blood.dm
@@ -315,9 +315,6 @@
 /mob/living/carbon/human/proc/get_blood_oxygenation()
 	var/blood_volume = get_blood_circulation()
 	if(blood_carries_oxygen())
-		if(is_asystole()) // Heart is missing or isn't beating and we're not breathing (hardcrit)
-			return min(blood_volume, BLOOD_VOLUME_SURVIVE)
-
 		if(!need_breathe())
 			return blood_volume
 	else


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl:
tweak: Increased the effectiveness of chest compressions. Manual compressions can actually be more effective than automatic ones now.
/:cl:

Removes the 30% oxygenation cap for asystole mobs.

Reasoning:
- Asystole is already considered by `get_blood_circulation()`, and effectively caps oxygenation at 25% without CPR. It shouldn't need to be capped again.

- The wiki states that manual CPR is more effective than compression from auto-compressors, and their code indicates that this was clearly the intent. However, capping oxygenation at 30% makes this difference completely useless.

- The removed conditional caused `get_blood_oxygenation()` to return before taking respiration/dexalin into account, which is probably undesirable.

If necessary I can adjust the circulation granted by CPR and autocompressors, since masterful compressions grant 80-100% circulation, and automatic compressions grant 60% circulation. (Ignoring other factors like blood loss and respiration) Those values seem like they might be too high.

Shouldn't be merged without #34670 or else manual compressions will grant more than 100% circulation half of the time.