### PR TITLE
Remove authorization when changing the target of a warrant

### DIFF
--- a/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
+++ b/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
@@ -169,6 +169,9 @@ LEGACY_RECORD_STRUCTURE(all_warrants, warrant)
 			var/job = copytext(entry_components[2], 1, length(entry_components[2]))
 			activewarrant.fields["namewarrant"] = name
 			activewarrant.fields["jobwarrant"] = job
+			activewarrant.fields["auth"] = "Unauthorized"
+			activewarrant.fields["idauth"] = "Unauthorized"
+			activewarrant.fields["access"] = list()
 
 	if(href_list["editwarrantnamecustom"])
 		. = TRUE
@@ -179,6 +182,9 @@ LEGACY_RECORD_STRUCTURE(all_warrants, warrant)
 				return
 			activewarrant.fields["namewarrant"] = new_name
 			activewarrant.fields["jobwarrant"] = new_job
+			activewarrant.fields["auth"] = "Unauthorized"
+			activewarrant.fields["idauth"] = "Unauthorized"
+			activewarrant.fields["access"] = list()
 
 	if(href_list["editwarrantcharges"])
 		. = TRUE
@@ -212,7 +218,7 @@ LEGACY_RECORD_STRUCTURE(all_warrants, warrant)
 			to_chat(user, "Lookup error: Unable to locate specified job in access database.")
 			return
 		for(var/datum/computer_file/report/crew_record/CR in GLOB.all_crew_records)
-			if(CR.get_name() == activewarrant.fields["namewarrant"] && CR.get_job() == J.title)
+			if(CR.get_name() == activewarrant.fields["namewarrant"] && CR.get_job() == activewarrant.fields["jobwarrant"])
 				warrant_subject = CR
 
 		if(!warrant_subject)


### PR DESCRIPTION
:cl: sick trigger
tweak: Warrant authorization is removed if given a new target
bugfix: Warrant access authorization works with alt-titles
/:cl:

fixes #34669

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->