### PR TITLE
Some medical-related fixes

### DIFF
--- a/code/game/objects/structures/roller_bed.dm
+++ b/code/game/objects/structures/roller_bed.dm
@@ -274,6 +274,7 @@
 	if (istype(human))
 		human.custom_pain(power = 20)
 	buckled_mob.apply_damage(rand(1, 3), DAMAGE_BRUTE, pick(BP_R_ARM, BP_L_ARM), damage_flags = DAMAGE_FLAG_SHARP, armor_pen = 100)
+	drip_active = FALSE
 	update_icon()
 
 

--- a/code/modules/augment/active/glare_dampeners.dm
+++ b/code/modules/augment/active/glare_dampeners.dm
@@ -4,6 +4,6 @@
 	icon_state = "glare_dampeners"
 	desc = "Thick, tinted lenses installed in your head can deploy over your eyes, providing protection from bright lights."
 	action_button_name = "Deploy dampeners"
-	augment_flags = AUGMENT_BIOLOGICAL
+	augment_flags = AUGMENT_BIOLOGICAL | AUGMENT_SCANNABLE
 	origin_tech = list(TECH_DATA = 2, TECH_BIO = 2)
 	item = /obj/item/clothing/glasses/glare_dampeners

--- a/code/modules/augment/active/leukocyte_breeder.dm
+++ b/code/modules/augment/active/leukocyte_breeder.dm
@@ -4,7 +4,7 @@
 	icon_state = "leukosuite"
 	desc = "These stimulators augment the immune system and promote the growth of hunter-killer cells in the presence of a foreign invader, effectively boosting the body's immunity to parasites and disease."
 	action_button_name = "Toggle leukocyte breeder"
-	augment_flags = AUGMENT_BIOLOGICAL
+	augment_flags = AUGMENT_BIOLOGICAL | AUGMENT_SCANNABLE
 	origin_tech = list(TECH_DATA = 2, TECH_BIO = 4)
 	var/active = FALSE
 

--- a/code/modules/augment/active/polytool.dm
+++ b/code/modules/augment/active/polytool.dm
@@ -5,7 +5,7 @@
 	augment_slots = AUGMENT_HAND
 	var/list/items = list()
 	var/list/paths = list() //We may lose them
-	augment_flags = AUGMENT_MECHANICAL
+	augment_flags = AUGMENT_MECHANICAL | AUGMENT_SCANNABLE
 
 
 /obj/item/organ/internal/augment/active/polytool/Initialize()

--- a/code/modules/organs/internal/_internal.dm
+++ b/code/modules/organs/internal/_internal.dm
@@ -12,7 +12,7 @@
 	if(max_damage)
 		min_bruised_damage = floor(max_damage / 4)
 	..()
-	if(istype(holder))
+	if(istype(holder) && !istype(src, /obj/item/organ/internal/augment))
 		holder.internal_organs |= src
 
 		var/mob/living/carbon/human/H = holder

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -107,7 +107,7 @@
 		if (I && !(I.status & ORGAN_CUT_AWAY) && I.parent_organ == target_zone)
 			var/image/radial_button = image(icon = I.icon, icon_state = I.icon_state)
 			radial_button.name = "Detach \the [I.name]"
-			attached_organs[I.organ_tag] = radial_button
+			attached_organs[I] = radial_button
 	if (!length(attached_organs))
 		to_chat(user, SPAN_WARNING("You can't find any organs to separate."))
 		return FALSE
@@ -119,17 +119,17 @@
 	return FALSE
 
 /singleton/surgery_step/internal/detatch_organ/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message("[user] starts to separate [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool].", \
-	"You start to separate [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool]." )
-	target.custom_pain("Someone's ripping out your [LAZYACCESS(target.surgeries_in_progress, target_zone)]!",100)
+	var/obj/item/organ/detaching = LAZYACCESS(target.surgeries_in_progress, target_zone)
+	user.visible_message("[user] starts to separate [target]'s [detaching.name] with \the [tool].", \
+	"You start to separate [target]'s [detaching.name] with \the [tool]." )
+	target.custom_pain("Someone's ripping out your [detaching.name]!",100)
 	playsound(target.loc, 'sound/items/scalpel.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/internal/detatch_organ/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message(SPAN_NOTICE("[user] has separated [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool].") , \
-	SPAN_NOTICE("You have separated [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool]."))
-
-	var/obj/item/organ/I = target.internal_organs_by_name[LAZYACCESS(target.surgeries_in_progress, target_zone)]
+	var/obj/item/organ/I = LAZYACCESS(target.surgeries_in_progress, target_zone)
+	user.visible_message(SPAN_NOTICE("[user] has separated [target]'s [I.name] with \the [tool].") , \
+	SPAN_NOTICE("You have separated [target]'s [I.name] with \the [tool]."))
 	if(I && istype(I))
 		I.cut_away(user)
 
@@ -188,19 +188,20 @@
 		return ..()
 
 /singleton/surgery_step/internal/remove_organ/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	var/obj/item/organ/removing = LAZYACCESS(target.surgeries_in_progress, target_zone)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("\The [user] starts removing [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool].", \
-	"You start removing \the [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool].")
+	user.visible_message("\The [user] starts removing [target]'s [removing.name] with \the [tool].", \
+	"You start removing \the [target]'s [removing.name] with \the [tool].")
 	target.custom_pain("The pain in your [affected.name] is living hell!",100,affecting = affected)
 	playsound(target.loc, 'sound/items/hemostat.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/internal/remove_organ/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message(SPAN_NOTICE("\The [user] has removed \the [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool]."), \
-	SPAN_NOTICE("You have removed \the [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool]."))
+	var/obj/item/organ/O = LAZYACCESS(target.surgeries_in_progress, target_zone)
+	user.visible_message(SPAN_NOTICE("\The [user] has removed \the [target]'s [O.name] with \the [tool]."), \
+	SPAN_NOTICE("You have removed \the [target]'s [O.name] with \the [tool]."))
 
 	// Extract the organ!
-	var/obj/item/organ/O = LAZYACCESS(target.surgeries_in_progress, target_zone)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(istype(O) && istype(affected))
 		affected.implants -= O
@@ -282,16 +283,16 @@
 
 /singleton/surgery_step/internal/replace_organ/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] starts [robotic_surgery ? "reinstalling" : "transplanting"] \the [tool] into [target]'s [affected.name].", \
-	"You start [robotic_surgery ? "reinstalling" : "transplanting"] \the [tool] into [target]'s [affected.name].")
+	user.visible_message("[user] starts [robotic_surgery ? "installing" : "transplanting"] \the [tool] into [target]'s [affected.name].", \
+	"You start [robotic_surgery ? "installing" : "transplanting"] \the [tool] into [target]'s [affected.name].")
 	target.custom_pain("Someone's rooting around in your [affected.name]!",100,affecting = affected)
 	playsound(target.loc, 'sound/items/scalpel.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/internal/replace_organ/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("\The [user] has [robotic_surgery ? "reinstalled" : "transplanted"] \the [tool] into [target]'s [affected.name]."), \
-	SPAN_NOTICE("You have [robotic_surgery ? "reinstalled" : "transplanted"] \the [tool] into [target]'s [affected.name]."))
+	user.visible_message(SPAN_NOTICE("\The [user] has [robotic_surgery ? "installed" : "transplanted"] \the [tool] into [target]'s [affected.name]."), \
+	SPAN_NOTICE("You have [robotic_surgery ? "installed" : "transplanted"] \the [tool] into [target]'s [affected.name]."))
 	var/obj/item/organ/O = tool
 	if(istype(O) && user.unEquip(O, target))
 		affected.implants |= O //move the organ into the patient. The organ is properly reattached in the next step
@@ -378,17 +379,18 @@
 	return organ_to_replace
 
 /singleton/surgery_step/internal/attach_organ/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message("[user] begins reattaching [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool].", \
-	"You start reattaching [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool].")
-	target.custom_pain("Someone's digging needles into your [LAZYACCESS(target.surgeries_in_progress, target_zone)]!",100)
+	var/obj/item/organ/attaching = LAZYACCESS(target.surgeries_in_progress, target_zone)
+	user.visible_message("[user] begins attaching [target]'s [attaching.name] with \the [tool].", \
+	"You start attaching [target]'s [attaching.name] with \the [tool].")
+	target.custom_pain("Someone's digging needles into your [attaching.name]!",100)
 	playsound(target.loc, 'sound/items/fixovein.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/internal/attach_organ/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/I = LAZYACCESS(target.surgeries_in_progress, target_zone)
 
-	user.visible_message(SPAN_NOTICE("[user] has reattached [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool].") , \
-	SPAN_NOTICE("You have reattached [target]'s [LAZYACCESS(target.surgeries_in_progress, target_zone)] with \the [tool]."))
+	user.visible_message(SPAN_NOTICE("[user] has attached [target]'s [I.name] with \the [tool].") , \
+	SPAN_NOTICE("You have attached [target]'s [I.name] with \the [tool]."))
 
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	if(istype(I) && I.parent_organ == target_zone && affected && (I in affected.implants))

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -463,7 +463,7 @@
 
 /singleton/surgery_step/robotics/detatch_organ_robotic/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/affected = target.get_organ(target_zone)
-	var/obj/removing = target.internal_organs_by_name[LAZYACCESS(target.surgeries_in_progress, target_zone)]
+	var/obj/removing = LAZYACCESS(target.surgeries_in_progress, target_zone)
 	user.visible_message(SPAN_NOTICE("[user] has decoupled \the [removing] from \the [target]'s [affected.name] with \the [tool].") , \
 	SPAN_NOTICE("You have decoupled \the [removing] from \the [target]'s [affected.name] with \the [tool]."))
 
@@ -479,7 +479,7 @@
 //	robotic organ transplant finalization surgery step
 //////////////////////////////////////////////////////////////////
 /singleton/surgery_step/robotics/attach_organ_robotic
-	name = "Reattach prosthetic organ"
+	name = "Attach prosthetic organ"
 	allowed_tools = list(
 		/obj/item/screwdriver = 50,
 		/obj/item/swapper/power_drill = 70,
@@ -504,7 +504,7 @@
 		if (organ.organ_tag in target.internal_organs_by_name)
 			continue
 		var/image/radial_button = image(icon = organ.icon, icon_state = organ.icon_state)
-		radial_button.name = "Reattach \the [organ.name]"
+		radial_button.name = "Attach \the [organ.name]"
 		LAZYSET(candidates, organ, radial_button)
 	if (length(candidates) == 1 && user.get_preference_value(/datum/client_preference/surgery_skip_radial))
 		return candidates[1]
@@ -521,9 +521,9 @@
 
 /singleton/surgery_step/robotics/attach_organ_robotic/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/affected = target.get_organ(target_zone)
-	var/obj/attaching = target.internal_organs_by_name[LAZYACCESS(target.surgeries_in_progress, target_zone)]
-	user.visible_message("[user] begins reattaching \the [attaching] from \the [target]'s [affected.name] with \the [tool].", \
-	"You start reattaching \the [attaching] from \the [target]'s [affected.name] with \the [tool].")
+	var/obj/attaching = LAZYACCESS(target.surgeries_in_progress, target_zone)
+	user.visible_message("[user] begins attaching \the [attaching] to \the [target]'s [affected.name] with \the [tool].", \
+	"You start attaching \the [attaching] to \the [target]'s [affected.name] with \the [tool].")
 	playsound(target.loc, 'sound/items/Screwdriver.ogg', 15, 1)
 	..()
 
@@ -534,8 +534,8 @@
 	attaching.status &= ~ORGAN_CUT_AWAY
 	attaching.replaced(target, affected)
 	user.visible_message(
-		SPAN_NOTICE("\The [user] has reattached \a [target]'s [attaching] with \a [tool]."),
-		SPAN_NOTICE("You have reattached \the [target]'s [attaching] with \the [tool].")
+		SPAN_NOTICE("\The [user] has attached \the [target]'s [attaching.name] with \the [tool]."),
+		SPAN_NOTICE("You have attached \the [target]'s [attaching.name] with \the [tool].")
 	)
 
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl:
bugfix: Ripping out a roller bed's cannula actually detaches it now.
bugfix: Loadout augmentations no longer create phantom copies in the chest.
tweak: Body scans now detect implanted toolkits, leukocyte breeders, and glare dampeners.
tweak: Various fixes to transplantation/removal surgery text.
/:cl:

I changed "reattach" to "attach" in some surgery steps because they also cover things like implanting new augmentations, which don't make sense to "reattach".