### PR TITLE
Makes raw ores do damage when thrown

### DIFF
--- a/code/modules/materials/materials_ore.dm
+++ b/code/modules/materials/materials_ore.dm
@@ -1,9 +1,11 @@
 /obj/item/ore
+	force = 5.0
+	throwforce = 5.0
 	name = "ore"
 	icon_state = "lump"
 	icon = 'icons/obj/materials/ore.dmi'
 	randpixel = 8
-	w_class = 2
+	w_class = ITEM_SIZE_SMALL
 	var/material/material
 	var/datum/geosample/geologic_data
 

--- a/code/modules/materials/materials_ore.dm
+++ b/code/modules/materials/materials_ore.dm
@@ -38,6 +38,8 @@
 				desc = M.ore_desc
 			if(icon_state == "dust")
 				slot_flags = SLOT_HOLSTER
+				throwforce = 0
+				force = 0 
 			break
 	. = ..()
 

--- a/code/modules/materials/materials_ore.dm
+++ b/code/modules/materials/materials_ore.dm
@@ -1,6 +1,6 @@
 /obj/item/ore
-	force = 5.0
-	throwforce = 5.0
+	force = 5
+	throwforce = 5
 	name = "ore"
 	icon_state = "lump"
 	icon = 'icons/obj/materials/ore.dmi'


### PR DESCRIPTION
Gives 5 force and 5 throwforce to raw ores.
Also makes their weight class use the defined ITEM_SIZE_SMALL instead of just 2.
Thanks Ryan for help making sand not have force/throwforce. (throwing sand already causes blindness anyway)

:cl: Nyvrem
rscadd: Getting hit with ores/rocks now hurts a little.
/:cl:

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->