### PR TITLE
Adds microscope functionality

### DIFF
--- a/code/modules/detectivework/microscope/microscope.dm
+++ b/code/modules/detectivework/microscope/microscope.dm
@@ -17,8 +17,30 @@
 
 /obj/machinery/microscope/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(sample)
-		to_chat(user, SPAN_WARNING("There is already a slide in the microscope."))
-		return ..()
+		if (istype(W, /obj/item/evidencebag))
+			var/obj/item/evidencebag/bag = W
+			if(bag.stored_item)
+				to_chat(user, SPAN_WARNING("\The [bag] already has \a [bag.stored_item] in it."))
+				return TRUE
+			if(sample.w_class > ITEM_SIZE_NORMAL)
+				to_chat(user, SPAN_WARNING("\The [src]'s [sample.name] is too big for \the [bag]."))
+				return TRUE
+			user.visible_message(
+				SPAN_NOTICE("\The [user] transfers \a [sample] from \the [src] to \a [bag]."),
+				SPAN_NOTICE("You transfer \a [sample] from \the [src] to \a [bag].")
+			)
+			if(!user.skill_check(SKILL_FORENSICS, SKILL_BASIC))
+				sample.add_fingerprint(user)
+			sample.forceMove(bag)
+			bag.stored_item = sample
+			bag.w_class = sample.w_class
+			bag.update_icon()
+			sample = null
+			update_icon()
+			return TRUE
+		else
+			to_chat(user, SPAN_WARNING("There is already a slide in the microscope."))
+			return ..()
 
 	if (istype(W, /obj/item/evidencebag))
 		var/obj/item/evidencebag/B = W
@@ -27,6 +49,7 @@
 			B.stored_item.forceMove(src)
 			sample = B.stored_item
 			B.empty()
+			update_icon()
 		else
 			to_chat(user, SPAN_WARNING("\The [B] is empty!"))
 		return TRUE


### PR DESCRIPTION
:cl:
tweak: The forensic microscope can now be clicked with an evidence bag, which will remove the sample from the machine and put it in the bag, no contamination if you have at least basic forensics.
/:cl: