### PR TITLE
Attack Refactor - `resolve_attackby()` overrides to `use_*()`

### DIFF
--- a/code/game/objects/items/devices/hacktool.dm
+++ b/code/game/objects/items/devices/hacktool.dm
@@ -38,14 +38,18 @@
 	return ..()
 
 
-/obj/item/device/multitool/hacktool/resolve_attackby(atom/A, mob/user)
+/obj/item/device/multitool/hacktool/use_before(atom/target, mob/living/user, click_parameters)
 	sanity_check()
 
-	if(!in_hack_mode || !attempt_hack(user, A)) //will still show the unable to hack message, oh well
+	if (!in_hack_mode)
 		return ..()
 
-	A.ui_interact(user, state = hack_state)
-	return 1
+	if (!attempt_hack(user, target))
+		return TRUE
+
+	target.ui_interact(user, state = hack_state)
+	return TRUE
+
 
 /obj/item/device/multitool/hacktool/proc/attempt_hack(mob/user, atom/target)
 	if(is_hacking)

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -56,15 +56,16 @@
 		GLOB.destroyed_event.unregister(buffer_object, src)
 		buffer_object = null
 
-/obj/item/device/multitool/resolve_attackby(atom/A, mob/user, params)
-	if(!isobj(A))
+
+/obj/item/device/multitool/use_before(atom/target, mob/living/user, click_parameters)
+	if (!isobj(target))
 		return ..()
 
-	var/obj/O = A
-	var/datum/extension/interactive/multitool/MT = get_extension(O, /datum/extension/interactive/multitool)
-	if(!MT)
+	var/obj/target_obj = target
+	var/datum/extension/interactive/multitool/multiool_interaction = get_extension(target_obj, /datum/extension/interactive/multitool)
+	if (!multiool_interaction)
 		return ..()
 
 	user.AddTopicPrint(src)
-	MT.interact(src, user)
-	return 1
+	multiool_interaction.interact(src, user)
+	return TRUE

--- a/code/game/objects/items/weapons/candle/candle.dm
+++ b/code/game/objects/items/weapons/candle/candle.dm
@@ -35,21 +35,24 @@
 		if(lit)
 			AddOverlays(overlay_image(icon, "[icon_state]_lit", flags=RESET_COLOR))
 
-/obj/item/flame/candle/use_tool(obj/item/W, mob/living/user, list/click_params)
-	if (isFlameOrHeatSource(W))
-		light(user)
+/obj/item/flame/candle/use_tool(obj/item/tool, mob/living/user, list/click_params)
+	// Light the candle
+	if (isFlameOrHeatSource(tool))
+		if (lit)
+			USE_FEEDBACK_FAILURE("\The [src] is already lit.")
+			return TRUE
+		light()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] lights \a [src] with \a [tool]."),
+			SPAN_NOTICE("You light \the [src] with \the [tool].")
+		)
+		return TRUE
+
 	return ..()
 
-/obj/item/flame/candle/resolve_attackby(atom/A, mob/user)
-	. = ..()
-	if (istype(A, /obj/item/flame/candle) && IsHeatSource())
-		var/obj/item/flame/candle/other_candle = A
-		other_candle.light()
-
-/obj/item/flame/candle/proc/light(mob/user)
-	if(!lit)
-		lit = 1
-		visible_message(SPAN_NOTICE("\The [user] lights the [name]."))
+/obj/item/flame/candle/proc/light()
+	if (!lit)
+		lit = TRUE
 		set_light(candle_range, candle_power)
 		START_PROCESSING(SSobj, src)
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -162,23 +162,28 @@
 
 var/global/const/NO_EMAG_ACT = -50
 
-/obj/item/card/emag/resolve_attackby(atom/A, mob/user)
-	var/used_uses = A.emag_act(uses, user, src)
-	if(used_uses == NO_EMAG_ACT)
-		return ..(A, user)
+
+/obj/item/card/emag/use_before(atom/target, mob/living/user, click_parameters)
+	var/used_uses = target.emag_act(uses, user, src)
+	if (used_uses == NO_EMAG_ACT)
+		return ..()
 
 	uses -= used_uses
-	A.add_fingerprint(user)
-	if(used_uses)
-		log_and_message_admins("emagged \an [A].")
+	target.add_fingerprint(user, tool = src)
+	if (used_uses)
+		log_and_message_admins("emagged \a [target].")
 
-	if(uses<1)
-		user.visible_message(SPAN_WARNING("\The [src] fizzles and sparks - it seems it's been used once too often, and is now spent."))
+	if (uses < 1)
+		user.visible_message(
+			SPAN_WARNING("\The [user]'s [name] fizzles and sparks."),
+			SPAN_WARNING("\The [name] fizzles and sparks - it seems it's been used once too often, and is now spent.")
+		)
 		var/obj/item/card/emag_broken/junk = new(user.loc)
-		junk.add_fingerprint(user)
+		transfer_fingerprints_to(junk)
 		qdel(src)
+		user.put_in_active_hand(junk)
+	return TRUE
 
-	return 1
 
 /obj/item/card/emag/Initialize()
 	. = ..()

--- a/code/game/objects/items/weapons/material/swiss.dm
+++ b/code/game/objects/items/weapons/material/swiss.dm
@@ -102,19 +102,28 @@
 /obj/item/material/knife/folding/swiss/IsHatchet()
 	return active_tool == SWISSKNF_WBLADE
 
-/obj/item/material/knife/folding/swiss/resolve_attackby(obj/target, mob/user)
-	if((istype(target, /obj/structure/window) || istype(target, /obj/structure/grille)) && active_tool == SWISSKNF_GBLADE)
-		force = force * 8
-		. = ..()
-		update_force()
-		return
-	if(istype(target, /obj/item))
-		if(target.w_class <= ITEM_SIZE_HUGE)
+
+/obj/item/material/knife/folding/swiss/use_before(atom/target, mob/living/user, click_parameters)
+	// Damage increase for windows and grilles
+	if (active_tool == SWISSKNF_GBLADE && (istype(target, /obj/structure/window) || istype(target, /obj/structure/grille)))
+		force *= 8
+
+	// Allow usage on huge or smaller items
+	if (isitem(target))
+		var/obj/item/target_item = target
+		if (target_item.w_class <= ITEM_SIZE_HUGE)
 			can_use_tools = TRUE
-			. = ..()
-			can_use_tools = FALSE
-			return
+
 	return ..()
+
+
+/obj/item/material/knife/folding/swiss/use_after(atom/target, mob/living/user, click_parameters)
+	// Reset per-use vars
+	update_force()
+	can_use_tools = FALSE
+
+	return ..()
+
 
 /obj/item/material/knife/folding/swiss/officer
 	name = "officer's combi-knife"

--- a/code/game/objects/items/weapons/tools/crowbar.dm
+++ b/code/game/objects/items/weapons/tools/crowbar.dm
@@ -58,12 +58,22 @@
 	matter = list(MATERIAL_STEEL = 150)
 	attack_verb = list("attacked", "bashed", "battered", "bludgeoned", "whacked", "attacked", "slashed", "torn", "ripped", "cut")
 
-/obj/item/crowbar/emergency_forcing_tool/resolve_attackby(atom/A)//extra dmg against glass, it's an emergency forcing tool, it's gotta be good at something
-	if(istype(A, /obj/structure/window))
+
+/obj/item/crowbar/emergency_forcing_tool/use_before(atom/target, mob/living/user, click_parameters)
+	// Double damage against windows
+	if (istype(target, /obj/structure/window))
 		force = initial(force) * 2
-	else
+
+	return ..()
+
+
+/obj/item/crowbar/emergency_forcing_tool/use_after(atom/target, mob/living/user, click_parameters)
+	// Reset force after window interactions
+	if (istype(target, /obj/structure/window))
 		force = initial(force)
-	. = ..()
+
+	return ..()
+
 
 /obj/item/crowbar/emergency_forcing_tool/IsCrowbar()
 	if(ismob(loc))

--- a/code/game/objects/structures/roller_bed.dm
+++ b/code/game/objects/structures/roller_bed.dm
@@ -168,7 +168,7 @@
 		..()
 
 
-/obj/structure/roller_bed/MouseDrop(atom/over_atom)
+/obj/structure/roller_bed/MouseDrop(atom/over_atom, atom/source_loc, atom/over_loc, source_control, over_control, list/mouse_params)
 	if (!usr)
 		return
 	if (!over_atom)

--- a/code/game/objects/structures/roller_bed.dm
+++ b/code/game/objects/structures/roller_bed.dm
@@ -395,34 +395,34 @@
 	interact_type = /obj/structure/roller_bed
 
 
-/obj/item/robot_rack/roller_bed/resolve_attackby(atom/target, mob/living/user, click_params)
-	if (!target.Adjacent(user))
-		return TRUE
-	if (user.incapacitated())
-		to_chat(user, SPAN_WARNING("You're in no condition to do that."))
-		return TRUE
+/obj/item/robot_rack/roller_bed/use_before(atom/target, mob/living/user, click_parameters)
 	if (!length(held))
 		if (istype(target, object_type))
 			user.visible_message(
-				SPAN_ITALIC("\The [user] scoops \a [target] into their [name]."),
-				SPAN_ITALIC("You scoop \the [target] into your [name]."),
+				SPAN_NOTICE("\The [user] scoops \a [target] into their [name]."),
+				SPAN_NOTICE("You scoop \the [target] into your [name]."),
 				SPAN_ITALIC("You hear metal clattering on metal.")
 			)
-			contents += target
+			var/obj/item/target_item = target
+			target_item.forceMove(src)
 			held += target
-		else if (istype(target, interact_type))
+			return TRUE
+
+		if (istype(target, interact_type))
 			target.MouseDrop(src, over_loc = get_turf(target))
-		return TRUE
+			return TRUE
+
+		return ..()
+
 	if (istype(target, object_type))
-		to_chat(user, SPAN_WARNING("You already have \a [target] in your [name]."))
+		USE_FEEDBACK_FAILURE("\The [src] already has \a [held[1]].")
 		return TRUE
-	if (!isturf(target))
-		return
-	if (target.density)
-		return
+	if (!isturf(target) || target.density)
+		return ..()
+
 	var/blocking = target.turf_is_crowded()
 	if (blocking && !ismob(blocking))
-		to_chat(user, SPAN_WARNING("\The [blocking] is in the way."))
+		USE_FEEDBACK_FAILURE("\The [blocking] is in the way of deploying \the [src]'s [held[1]].")
 		return TRUE
 	var/obj/item/roller_bed/roller = pop(held)
 	roller.dropInto(target)

--- a/code/modules/mechs/equipment/combat.dm
+++ b/code/modules/mechs/equipment/combat.dm
@@ -238,16 +238,6 @@
 		if (target.mob_size < user.mob_size) //Damaging attacks overwhelm smaller mobs
 			target.throw_at(get_edge_target_turf(target,get_dir(user, target)),1, 1)
 
-/obj/item/material/hatchet/machete/mech/resolve_attackby(atom/A, mob/user, click_params)
-	//Case 1: Default, you are hitting something that isn't a mob. Just do whatever, this isn't dangerous or op.
-	if (!istype(A, /mob/living))
-		return ..()
-
-	if (user.a_intent == I_HURT)
-		user.visible_message(SPAN_DANGER("\The [user] swings \the [src] at \the [A]!"))
-		playsound(user, 'sound/mecha/mechmove03.ogg', 35, 1)
-		return ..()
-
 /obj/item/material/hatchet/machete/mech/attack_self(mob/living/user)
 	. = ..()
 	if (user.a_intent != I_HURT)

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -439,19 +439,27 @@
 	to_chat(user, SPAN_NOTICE("You deploy \a [R]."))
 	R.add_fingerprint(user)
 
-/obj/item/robot_rack/resolve_attackby(obj/O, mob/user, click_params)
-	if(istype(O, object_type))
-		if(length(held) < capacity)
-			to_chat(user, SPAN_NOTICE("You collect \the [O]."))
-			O.forceMove(src)
-			held += O
-			return
-		to_chat(user, SPAN_WARNING("\The [src] is full and can't store any more items."))
-		return
-	if(istype(O, interact_type))
-		O.attack_hand(user)
-		return
-	. = ..()
+
+/obj/item/robot_rack/use_before(atom/target, mob/living/user, click_parameters)
+	// Pick up thing
+	if (istype(target, object_type))
+		if (length(held) >= capacity)
+			USE_FEEDBACK_FAILURE("\The [src] is full and can't store any more items.")
+			return TRUE
+		var/obj/target_obj = target
+		target_obj.forceMove(src)
+		held += target
+		to_chat(user, SPAN_NOTICE("You collect \the [target] with \the [src]."))
+		return TRUE
+
+	// Use the thing
+	if (istype(target, interact_type))
+		var/obj/target_obj = target
+		if (target_obj.attack_hand(user))
+			return TRUE
+
+	return ..()
+
 
 /obj/item/robot_rack/verb/empty_rack()
 	set name = "Empty Rack"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -209,34 +209,39 @@
 	Fire(A,user,params) //Otherwise, fire normally.
 
 
-/obj/item/gun/resolve_attackby(atom/atom, mob/living/user, click_params)
+/obj/item/gun/use_before(atom/target, mob/living/user, click_parameters)
+	// Suicide check
 	var/suicide = FALSE
-	if (user == atom)
+	if (user == target)
 		suicide = TRUE
 		if (user.zone_sel.selecting == BP_MOUTH && (!user.aiming?.active))
 			user.toggle_gun_mode()
-	if (user.aiming?.active) //if aim mode, don't pistol whip - even on harm intent
-		if (user.aiming.aiming_at != atom)
+
+	// Aim mode override
+	if (user.aiming?.active)
+		if (user.aiming.aiming_at != target)
 			var/checkperm
 			if (suicide)
 				if (!GET_FLAGS(user.aiming.target_permissions, TARGET_CAN_CLICK))
 					user.aiming.toggle_permission(TARGET_CAN_CLICK, TRUE)
 					checkperm = TRUE
-			PreFire(atom, user)
+			PreFire(target, user)
 			if (checkperm)
 				addtimer(new Callback(user.aiming, /obj/aiming_overlay/proc/toggle_permission, TARGET_CAN_CLICK, TRUE), 1)
 		else
 			if (suicide && user.zone_sel.selecting == BP_MOUTH && istype(user, /mob/living/carbon/human))
 				handle_suicide(user)
 			else
-				Fire(atom, user, pointblank = TRUE)
+				Fire(target, user, pointblank = TRUE)
 		return TRUE
-	if (user.a_intent == I_HURT && !user.isEquipped(atom)) //point blank shooting
-		if (safety())
+
+	// Point blank shooting
+	if (user.a_intent == I_HURT && !user.isEquipped(target))
+		if (safety()) // Pistol whip instead of unsafety+fire
 			return ..()
-		else
-			Fire(atom, user, pointblank = TRUE)
-			return TRUE
+		Fire(target, user, pointblank = TRUE)
+		return TRUE
+
 	return ..()
 
 

--- a/code/modules/reagents/reagent_containers/borghypo.dm
+++ b/code/modules/reagents/reagent_containers/borghypo.dm
@@ -301,9 +301,11 @@
 		if (istype(hypo))
 			to_chat(user, "Its contents are available to \the [hypo].")
 
-// Extra message for if you try to pick up beakers
-/obj/item/robot_rack/bottle/resolve_attackby(obj/O, mob/user, click_params)
-	if (!istype(O, object_type) && istype(O, /obj/item/reagent_containers/glass))
-		to_chat(user, SPAN_WARNING("\The [O] is the wrong shape for \the [src]."))
-		return
-	. = ..()
+
+/obj/item/robot_rack/bottle/use_before(atom/target, mob/living/user, click_parameters)
+	// Can't pick up beakers
+	if (istype(target, object_type) && istype(target, /obj/item/reagent_containers/glass))
+		USE_FEEDBACK_FAILURE("\The [target] is the wrong shape for \the [src].")
+		return TRUE
+
+	return ..()


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
refactor: Various resolve_attackby overrides replaced with relevant use_ calls. Shouldn't have any major user facing effects aside from additional feedback messages, removal of double-interactions, or the below listed items.
bugfix: Broken emags now retain all fingerprint and fibre information from their unbroken form.
tweak: Broken emags now remain in your hand instead of dropping to the floor.
tweak: Hacking tools no longer act as multi tools while enabled.
/:cl:

## Bug Fixes
- Fixed a runtime that occured when clicking a deployed roller bed with a roller bed rack.

## Other Changes
- Replaced most overrides of `resolve_attackby()` with the relevant `use_*()` calls.
  - Does not update `/obj/item/gripper/resolve_attackby()` or `/obj/item/grab/resolve_attackby()` because making sure adding parent calls doesn't break anything is a larger task that I'd rather put in a separate PR.
  - Also doesn't update `/obj/item/mech_equipment/clamp/resolve_attackby()` because I currently don't know why that override does what it's doing.