### PR TITLE
Fix familiars being unable to stop resting

### DIFF
--- a/code/modules/mob/living/simple_animal/familiars/familiars.dm
+++ b/code/modules/mob/living/simple_animal/familiars/familiars.dm
@@ -132,8 +132,11 @@
 		return FALSE
 	if(!icon_rest)
 		return
-	if(stat == UNCONSCIOUS || resting)
-		icon_state = icon_rest
+	if(stat != DEAD)
+		if(stat == UNCONSCIOUS || resting)
+			icon_state = icon_rest
+		else
+			icon_state = icon_living
 
 /mob/living/simple_animal/familiar/pet/mouse
 	name = "mouse"


### PR DESCRIPTION
:cl: Zenithstar
bugfix: Familiars now use the appropriate sprite when they stop resting or die while resting.
/:cl:

fixes #34689 