### PR TITLE
the draggening - making cigarette drags visible to others

### DIFF
--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -54,7 +54,7 @@
 	set_light(0)
 
 /obj/item/flame/lighter/proc/shutoff_effects(mob/user)
-	user.visible_message(SPAN_NOTICE("[user] quietly shuts off the [src]."))
+	user.visible_message(SPAN_NOTICE("\The [user] quietly shuts off \the [src]."))
 
 /obj/item/flame/lighter/attack_self(mob/living/user)
 	if(!lit)

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -186,10 +186,10 @@
 	chem_volume = 5
 	smoketime = 300
 	matchmes = "<span class='notice'>USER lights their NAME with their FLAME.</span>"
-	lightermes = "<span class='notice'>USER manages to light their NAME with FLAME.</span>"
+	lightermes = "<span class='notice'>USER manages to light their NAME with their FLAME.</span>"
 	zippomes = "<span class='rose'>With a flick of their wrist, USER lights their NAME with their FLAME.</span>"
-	weldermes = "<span class='notice'>USER casually lights the NAME with FLAME.</span>"
-	ignitermes = "<span class='notice'>USER fiddles with FLAME, and manages to light their NAME.</span>"
+	weldermes = "<span class='notice'>USER casually lights their NAME with their FLAME.</span>"
+	ignitermes = "<span class='notice'>USER fiddles with their FLAME, and manages to light their NAME.</span>"
 	brand = "\improper Trans-Stellar Duty-free"
 	var/list/filling = list(/datum/reagent/tobacco = 1)
 
@@ -336,7 +336,7 @@
 		if (blocked)
 			to_chat(H, SPAN_WARNING("\The [blocked] is in the way!"))
 			return TRUE
-		to_chat(H, SPAN_NOTICE("You take a drag on your [name]."))
+		user.visible_message(SPAN_NOTICE("\The [user] takes a drag from their [name]."))
 		smoke(5)
 		add_trace_DNA(H)
 		return TRUE
@@ -391,10 +391,10 @@
 	smoketime = 1500
 	chem_volume = 15
 	matchmes = "<span class='notice'>USER lights their NAME with their FLAME.</span>"
-	lightermes = "<span class='notice'>USER manages to offend their NAME by lighting it with FLAME.</span>"
+	lightermes = "<span class='notice'>USER manages to offend their NAME by lighting it with their FLAME.</span>"
 	zippomes = "<span class='rose'>With a flick of their wrist, USER lights their NAME with their FLAME.</span>"
-	weldermes = "<span class='notice'>USER insults NAME by lighting it with FLAME.</span>"
-	ignitermes = "<span class='notice'>USER fiddles with FLAME, and manages to light their NAME with the power of science.</span>"
+	weldermes = "<span class='notice'>USER insults their NAME by lighting it with their FLAME.</span>"
+	ignitermes = "<span class='notice'>USER fiddles with their FLAME, and manages to light their NAME with the power of science.</span>"
 	brand = null
 	filling = list(/datum/reagent/tobacco/fine = 5)
 
@@ -472,10 +472,10 @@
 	smoketime = 0
 	chem_volume = 50
 	matchmes = "<span class='notice'>USER lights their NAME with their FLAME.</span>"
-	lightermes = "<span class='notice'>USER manages to light their NAME with FLAME.</span>"
+	lightermes = "<span class='notice'>USER manages to light their NAME with their FLAME.</span>"
 	zippomes = "<span class='rose'>With much care, USER lights their NAME with their FLAME.</span>"
-	weldermes = "<span class='notice'>USER recklessly lights NAME with FLAME.</span>"
-	ignitermes = "<span class='notice'>USER fiddles with FLAME, and manages to light their NAME with the power of science.</span>"
+	weldermes = "<span class='notice'>USER recklessly lights their NAME with their FLAME.</span>"
+	ignitermes = "<span class='notice'>USER fiddles with their FLAME, and manages to light their NAME with the power of science.</span>"
 
 /obj/item/clothing/mask/smokable/pipe/New()
 	..()


### PR DESCRIPTION
🆑 Gy1ta23
tweak: people can now see you drag on your cigarettes
/🆑

Taking a drag from your cigarette is a visible action, but the game treats it like it is not and only tells the player taking a drag that they have done so. This PR makes it so that the message is visible to everyone in proximity. Why? Because they should be able to see it, and I'm tired of writing _me "takes a drag from her cigarette."_ every time I do it.

![image](https://github.com/Baystation12/Baystation12/assets/44277885/ea2b6c22-4ada-47f2-9262-876fe3d894eb)
I also got tired of recurring hits like "the the lighter" so I went through and fixed as many instances of improper lighting messages as I could find.

Yeah, that's it. It's the 4th of July. I have better things to do than write as I usually do. Thank youuuu