### PR TITLE
Multiple fixes for a wizard

### DIFF
--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -38,6 +38,10 @@ var/global/list/ghost_traps
 
 // Check for bans, proper atom types, etc.
 /datum/ghosttrap/proc/assess_candidate(mob/observer/ghost/candidate, mob/target, feedback = TRUE)
+	if (!target)
+		to_chat(candidate, "This occupation request is no longer valid.")
+		return FALSE
+
 	if(!candidate.MayRespawn(feedback, minutes_since_death))
 		return FALSE
 

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -109,6 +109,9 @@
 		if(client.get_preference_value(/datum/client_preference/goonchat) == GLOB.PREF_YES)
 			client.chatOutput.start()
 
+	if(ability_master && ability_master.ability_objects)
+		ability_master.update_abilities(TRUE, src)
+
 	//set macro to normal incase it was overriden (like cyborg currently does)
 	winset(src, null, "mainwindow.macro=macro hotkey_toggle.is-checked=false input.focus=true input.background-color=#d3b5b5")
 

--- a/code/modules/spells/artifacts/storage.dm
+++ b/code/modules/spells/artifacts/storage.dm
@@ -5,11 +5,8 @@
 
 /obj/structure/closet/wizard/New()
 	..()
-	var/obj/structure/bigDelivery/package/package = new /obj/structure/bigDelivery/package(get_turf(src))
-	package.wrapped = src
+	var/obj/structure/bigDelivery/package/package = new (get_turf(src), src, "parcel")
 	package.examtext = "Imported straight from the Wizard Acadamy. Do not lose the contents or suffer a demerit."
-	src.forceMove(package)
-	package.update_icon()
 
 /obj/structure/closet/wizard/armor
 	name = "Mastercrafted Armor Set"

--- a/code/modules/spells/general/portal_teleport.dm
+++ b/code/modules/spells/general/portal_teleport.dm
@@ -50,6 +50,9 @@
 
 	return
 
+/spell/portal_teleport/check_valid_targets(list/targets)
+	return islist(targets) && length(targets)
+
 /spell/portal_teleport/after_cast()
 	return
 

--- a/code/modules/spells/hand/hand.dm
+++ b/code/modules/spells/hand/hand.dm
@@ -25,7 +25,7 @@
 	if(user.get_active_hand())
 		to_chat(user, SPAN_WARNING("You need an empty hand to cast this spell."))
 		return FALSE
-	current_hand = new(src)
+	current_hand = new(null, src)
 	if(!user.put_in_active_hand(current_hand))
 		QDEL_NULL(current_hand)
 		return FALSE
@@ -64,7 +64,8 @@
 	if(..())
 		casts--
 		to_chat(holder, SPAN_NOTICE("The [name] spell has [casts] out of [max_casts] charges left"))
-		cancel_hand()
+		if(!casts)
+			cancel_hand()
 		return TRUE
 	return FALSE
 

--- a/code/modules/spells/hand/hand_item.dm
+++ b/code/modules/spells/hand/hand_item.dm
@@ -44,11 +44,12 @@ Basically: I can use it to target things where I click. I can then pass these ta
 	if(hand_spell.show_message)
 		user.visible_message("\The [user][hand_spell.show_message]")
 	if(hand_spell.cast_hand(A,user))
-		next_spell_time = world.time + hand_spell.spell_delay
-		if(hand_spell.move_delay)
-			user.ExtraMoveCooldown(hand_spell.move_delay)
-		if(hand_spell.click_delay)
-			user.setClickCooldown(hand_spell.move_delay)
+		if(hand_spell)
+			next_spell_time = world.time + hand_spell.spell_delay
+			if(hand_spell.move_delay)
+				user.ExtraMoveCooldown(hand_spell.move_delay)
+			if(hand_spell.click_delay)
+				user.setClickCooldown(hand_spell.move_delay)
 
 /obj/item/magic_hand/afterattack(atom/A, mob/user, proximity)
 	if(hand_spell)
@@ -59,7 +60,8 @@ Basically: I can use it to target things where I click. I can then pass these ta
 
 /obj/item/magic_hand/dropped() //gets deleted on drop
 	..()
-	qdel(src)
+	if(!QDESTROYING(src))
+		qdel(src)
 
 /obj/item/magic_hand/Destroy() //better save than sorry.
 	hand_spell.current_hand = null

--- a/code/modules/spells/racial_wizard.dm
+++ b/code/modules/spells/racial_wizard.dm
@@ -89,6 +89,8 @@
 
 	drop_items = 0
 
+/spell/targeted/shapeshift/true_form/check_valid_targets(list/targets)
+	return TRUE
 
 //UNATHI
 /spell/moghes_blessing

--- a/code/modules/spells/targeted/equip/dyrnwyn.dm
+++ b/code/modules/spells/targeted/equip/dyrnwyn.dm
@@ -29,6 +29,9 @@
 	W.slowdown_per_slot[slot_r_hand] = 0.25
 	return W
 
+/spell/targeted/equip_item/dyrnwyn/check_valid_targets(list/targets)
+	return TRUE
+
 /spell/targeted/equip_item/dyrnwyn/empower_spell()
 	if(!..())
 		return 0

--- a/code/modules/spells/targeted/equip/seed.dm
+++ b/code/modules/spells/targeted/equip/seed.dm
@@ -19,3 +19,6 @@
 	max_targets = 1
 
 	hud_state = "wiz_seed"
+
+/spell/targeted/equip_item/seed/check_valid_targets(list/targets)
+	return TRUE

--- a/code/modules/spells/targeted/equip/shield.dm
+++ b/code/modules/spells/targeted/equip/shield.dm
@@ -31,6 +31,9 @@
 	I.base_block_chance = block_chance
 	return I
 
+/spell/targeted/equip_item/shield/check_valid_targets(list/targets)
+	return TRUE
+
 /spell/targeted/equip_item/shield/empower_spell()
 	if(!..())
 		return 0

--- a/code/modules/spells/targeted/shapeshift.dm
+++ b/code/modules/spells/targeted/shapeshift.dm
@@ -142,6 +142,9 @@
 	level_max = list(Sp_TOTAL = 1, Sp_SPEED = 1, Sp_POWER = 0)
 	hud_state = "wiz_parrot"
 
+/spell/targeted/shapeshift/avian/check_valid_targets(list/targets)
+	return TRUE
+
 /spell/targeted/shapeshift/corrupt_form
 	name = "Corrupt Form"
 	desc = "This spell shapes the wizard into a terrible, terrible beast."
@@ -164,6 +167,9 @@
 
 	hud_state = "wiz_corrupt"
 	cast_sound = 'sound/magic/disintegrate.ogg'
+
+/spell/targeted/shapeshift/corrupt_form/check_valid_targets(list/targets)
+	return TRUE
 
 /spell/targeted/shapeshift/corrupt_form/empower_spell()
 	if(!..())
@@ -197,3 +203,6 @@
 	toggle = 1
 
 	hud_state = "wiz_carp"
+
+/spell/targeted/shapeshift/familiar/check_valid_targets(list/targets)
+	return TRUE


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
A bunch of fixes for a wizard.

**Changes:**
1. **code/modules/mob/login.dm** - redraws wizard spells, once player gets to it's original body (Reenter corpse after using scrying orb or transformative spells). At this moment, wizard might lose the abillity to cast spells without this change (cause they won't be able to click on these spell buttons), unless they are purchasing another spell.

2. **code/modules/ghosttrap/trap.dm** - spawn of the familiar through a summoning stone might fail at times with a runtime at target.key. If there is no target, then there is no reason to check if its occupied.

3.  **code/modules/spells/artifacts/storage.dm** - changed to the new parcel logic. Without these changes, crates are just quick deleting themselves after creation, basically giving nothing to the player who purchased them.

4. **code/modules/spells/hand/hand.dm** - makes 'magic hand' type of spells usable. (The one you can use on any target on click, rather than with list selections) (ex: Entangle in druid spellbook)

All other files with check_valid_targets() changes - makes so these spells are actually castable. (Otherwise, they will always fail with 'There are no valid targets nearby.' message)

**Changelog**
:cl: Builder13
bugfix: Wizard retains all the spells in the hud upon changing/getting body.
bugfix: It is now possible to spawn wizard packages (examples: scrying orb, mastercrafted armor).
bugfix: Fixes for some of the spells, so they are castable again.
/:cl: