### PR TITLE
adds photograph to loadout

### DIFF
--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -100,6 +100,13 @@ var/global/photo_count = 0
 	add_fingerprint(usr)
 	return
 
+/obj/item/phototrinket
+	name = "photo"
+	icon = 'icons/obj/tools/photography.dmi'
+	desc = "A blank photograph. You feel, for some reason, that someone (or something) has forgotten to... describe it?"
+	icon_state = "photo"
+	item_state = "paper"
+	w_class = ITEM_SIZE_TINY
 
 /**************
 * photo album *

--- a/maps/torch/loadout/loadout_misc.dm
+++ b/maps/torch/loadout/loadout_misc.dm
@@ -1,6 +1,11 @@
+/datum/gear/trinket/photograph
+	display_name = "photo"
+	description = "A definable photograph. The only limit is your imagination."
+	path = /obj/item/phototrinket
+
 /datum/gear/trinket/scg_challenge_coin
 	display_name = "sol challenge coin selection"
-	description = "A selection of challenge coins for identification, collection or simply bragging rights"
+	description = "A selection of challenge coins for identification, collection or simply bragging rights."
 	path = /obj/item/material/coin/challenge
 	cost = 1
 
@@ -20,7 +25,7 @@
 
 /datum/gear/trinket/misc_challenge_coin
 	display_name = "misc challenge coin selection"
-	description = "A selection of challenge coins for identification, collection or simply bragging rights"
+	description = "A selection of challenge coins for identification, collection or simply bragging rights."
 	path = /obj/item/material/coin/challenge/misc
 	cost = 1
 


### PR DESCRIPTION
🆑 Gy1ta23
rscadd: you can now select photographs in loadout with changeable descriptions
/🆑

I was going to make fun of Joey for not doing his trinket PR (that this was supposed to be part of) for 2 years. But then I found out I got tired of waiting for him to do that a year ago, and did something remarkably similar to this, although worse, and then never put it up. So, in the end, who is the bigger joke? The man who hasn't done it yet (and probably never will) or the man who has the gall to be prissy about it after doing the exact same thing?

The man who isn't me, of course. Anyways, it's a different object in photography.dm as opposed to an actual photo object because otherwise you can't examine it at all and that's not good for something meant to be examined. If anyone wants to figure out how to make this without making another object, be my guest, because the sanity check that stops a pure loadout photo object from working is remarkably similar to the sanity check stopping me from keeping on at my attempts to do so. 

That being said, I am proud to open new frontiers in loadout items that people can invest minutes to hours into writing that will be read by, like, six people. Also, thanks Ryan, for telling me to put this in photography.dm.

Also, also, I added periods to the coin things in loadout_misc because it irked me.