### PR TITLE
Remove unnecessary attackby test

### DIFF
--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -57,7 +57,6 @@ exactly 0 "simulated = 0/1" 'simulated\s*=\s*\d' -P
 exactly 2 "var/ in proc arguments" '(^/[^/].+/.+?\(.*?)var/' -P
 exactly 0 "tmp/ vars" 'var.*/tmp/' -P
 exactly 7 "uses of .len" '\.len\b' -P
-exactly 12 "attackby() override" '\/attackby\((.*)\)'  -P
 exactly 15 "uses of examine()" '[.|\s]examine\(' -P # If this fails it's likely because you used '/atom/proc/examine(mob)' instead of '/proc/examinate(mob, atom)' - Exception: An examine()-proc may call other examine()-procs
 exactly 7 "direct modifications of overlays list" '\boverlays((\s*[|^=+&-])|(\.(Cut)|(Add)|(Copy)|(Remove)|(Remove)))' -P
 exactly 0 "new/list list instantiations" 'new\s*/list' -P


### PR DESCRIPTION
No user facing changes.

Removes the `attackby()` uses test, which is no longer needed with the removal of the main attackby proc itself.