### PR TITLE
Supply radio rearrange

### DIFF
--- a/maps/torch/items/encryption_keys.dm
+++ b/maps/torch/items/encryption_keys.dm
@@ -28,6 +28,11 @@
 	icon_state = "qm_cypherkey"
 	channels = list("Supply" = 1, "Command" = 1, "Exploration" = 1, "Hailing" = 1)
 
+/obj/item/device/encryptionkey/headset_deck
+	name = "deck technician's encryption key"
+	icon_state = "qm_cypherkey"
+	channels = list("Supply" = 1, "Hailing" = 1)
+
 /obj/item/device/encryptionkey/headset_chief_steward
 	name = "chief steward's encryption key"
 	icon_state = "srv_cypherkey"
@@ -57,7 +62,7 @@
 /obj/item/device/encryptionkey/headset_mining
 	name = "prospector radio encryption key"
 	icon_state = "srv_cypherkey"
-	channels = list("Supply" = 1, "Exploration" = 1)
+	channels = list("Supply" = 1)
 
 /obj/item/storage/box/encryptionkey/exploration
 	name = "box of spare exploration radio keys"
@@ -67,7 +72,7 @@
 /obj/item/device/encryptionkey/pathfinder
 	name = "pathfinder's encryption key"
 	icon_state = "com_cypherkey"
-	channels = list("Exploration" = 1, "Command" = 1, "Science" = 1, "Hailing" = 1)
+	channels = list("Exploration" = 1, "Supply" = 1, "Command" = 1, "Science" = 1, "Hailing" = 1)
 
 /obj/item/storage/box/radiokeys
 	name = "box of radio encryption keys"

--- a/maps/torch/items/headsets.dm
+++ b/maps/torch/items/headsets.dm
@@ -151,10 +151,11 @@
 	item_state = "exp_headset_alt"
 
 /obj/item/device/radio/headset/headset_cargo
-	desc = "A headset used by the Deck Chief and his slaves."
+	desc = "A headset used by the hangar dwellers."
+	ks1type = /obj/item/device/encryptionkey/headset_deck
 
 /obj/item/device/radio/headset/headset_cargo/alt
-	desc = "A bowman headset used by the Deck Chief and his slaves."
+	desc = "A bowman headset used by the hangar dwellers."
 
 /obj/item/device/radio/headset/headset_corpsman
 	name = "medical headset"

--- a/maps/torch/job/exploration_jobs.dm
+++ b/maps/torch/job/exploration_jobs.dm
@@ -33,7 +33,8 @@
 		access_guppy_helm, access_solgov_crew, access_expedition_shuttle, access_expedition_shuttle_helm,
 		access_guppy, access_hangar, access_petrov, access_petrov_helm, access_petrov_analysis, access_petrov_phoron,
 		access_petrov_toxins, access_petrov_chemistry, access_petrov_maint, access_tox, access_tox_storage, access_research,
-		access_xenobiology, access_xenoarch, access_torch_fax, access_radio_comm, access_radio_exp, access_radio_sci, access_research_storage
+		access_xenobiology, access_xenoarch, access_torch_fax, access_radio_comm,
+		access_radio_exp, access_radio_sci, access_research_storage, access_radio_sup
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/deck_management,

--- a/maps/torch/job/supply_jobs.dm
+++ b/maps/torch/job/supply_jobs.dm
@@ -112,6 +112,5 @@
 	access = list(
 		access_mining, access_mining_office, access_mining_station,
 		access_expedition_shuttle, access_guppy, access_hangar,
-		access_guppy_helm, access_solgov_crew, access_eva,
-		access_radio_exp, access_radio_sup
+		access_guppy_helm, access_solgov_crew, access_eva, access_radio_sup
 	)


### PR DESCRIPTION
:cl:
tweak: Miners lose access to the exploration freq, deck technicians gain access to the hailing freq and the Pathfinder gains access to the supply freq.
/:cl:

Initially I thought about giving deck technicians the exploration channel but it's a bit useless since the pilot (or PF) already has access to the supply channel.

Also the initial idea was to rename "Supply" to "Deck" but it failed after I'd taken a look at the radio defines and how channels are set in the headset code. It's... interesting, to say the least.

As for the changes that went through:

- The miners simply don't need the exploration channel. 'Nuff said.
- The deck technicians are supposed to work with docked vessels, including those docked to the external ports, it's entirely in the deck department's jurisdiction, so they should have the hailing channel.
- The Pathfinder is given the supply channel as they can serve as pilot and so need a way to communicate with the deck personnel.