### PR TITLE
Let FT/CI have labcoats

### DIFF
--- a/maps/torch/loadout/_defines.dm
+++ b/maps/torch/loadout/_defines.dm
@@ -19,7 +19,7 @@
 #define MEDICAL_ROLES list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/junior_doctor, /datum/job/doctor, /datum/job/psychiatrist, /datum/job/chemist, /datum/job/medical_trainee)
 
 //For members of the medical department, roboticists, and some Research
-#define STERILE_ROLES list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/junior_doctor, /datum/job/doctor, /datum/job/chemist, /datum/job/psychiatrist, /datum/job/roboticist, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant, /datum/job/medical_trainee)
+#define STERILE_ROLES list(/datum/job/cmo, /datum/job/senior_doctor, /datum/job/junior_doctor, /datum/job/doctor, /datum/job/chemist, /datum/job/psychiatrist, /datum/job/roboticist, /datum/job/rd, /datum/job/senior_scientist, /datum/job/scientist, /datum/job/scientist_assistant, /datum/job/medical_trainee, /datum/job/detective)
 
 //For members of the engineering department
 #define ENGINEERING_ROLES list(/datum/job/chief_engineer, /datum/job/senior_engineer, /datum/job/engineer, /datum/job/roboticist, /datum/job/engineer_trainee)

--- a/maps/torch/loadout/loadout_suit.dm
+++ b/maps/torch/loadout/loadout_suit.dm
@@ -99,24 +99,33 @@
 /datum/gear/suit/zipper
 	allowed_roles = CASUAL_ROLES
 	allowed_branches = CIVILIAN_BRANCHES
-/datum/gear/suit/labcoat
-	allowed_roles = DOCTOR_ROLES
+
+/datum/gear/suit/labcoat/New()
+	allowed_roles = DOCTOR_ROLES + STERILE_ROLES
+	..()
 
 /datum/gear/suit/labcoat_corp
-	allowed_roles = DOCTOR_ROLES
 	allowed_branches = CIVILIAN_BRANCHES
 
-/datum/gear/suit/labcoat_blue
-	allowed_roles = DOCTOR_ROLES
+/datum/gear/suit/labcoat_corp/New()
+	allowed_roles = DOCTOR_ROLES + STERILE_ROLES
+	..()
+
+/datum/gear/suit/labcoat_blue/New()
+	allowed_roles = DOCTOR_ROLES + STERILE_ROLES
+	..()
 
 /datum/gear/suit/labcoat_ec
 	display_name = "labcoat, Expeditionary Corps"
 	path = /obj/item/clothing/suit/storage/toggle/labcoat/science/ec
-	allowed_roles = DOCTOR_ROLES
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps
 	)
 	flags = GEAR_HAS_NO_CUSTOMIZATION
+
+/datum/gear/suit/labcoat_ec/New()
+	allowed_roles = DOCTOR_ROLES + STERILE_ROLES
+	..()
 
 /datum/gear/suit/labcoat_cmo
 	display_name = "labcoat, chief medical officer"


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl:
tweak: Investigators can now take labcoats and sterile gear from the loadout menu.
/:cl:

They get a labcoat in their locker, so why not let them bring their own?
I can add CI/FT specifically as an allowed role for labcoats if adding them to `DOCTOR_ROLES` is for some reason undesirable, but this way seemed better to me.