### PR TITLE
Lighting fix for shuttles and minor fixes

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -47,7 +47,7 @@
 
 	if(silicon_camera.in_camera_mode)
 		silicon_camera.camera_mode_off()
-		if(is_component_functioning("camera"))
+		if(is_component_functioning("diagnosis unit"))
 			silicon_camera.captureimage(A, usr)
 		else
 			to_chat(src, SPAN_CLASS("userdanger", "Your camera isn't functional."))

--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -38,7 +38,6 @@
 	var/old_dynamic_lighting = TURF_IS_DYNAMICALLY_LIT_UNSAFE(src)
 	var/old_affecting_lights = affecting_lights
 	var/old_lighting_overlay = lighting_overlay
-	var/old_corners = corners
 	var/old_ao_neighbors = ao_neighbors
 	var/old_above = above
 	var/old_permit_ao = permit_ao
@@ -106,7 +105,6 @@
 		recalc_atom_opacity()
 		lighting_overlay = old_lighting_overlay
 		affecting_lights = old_affecting_lights
-		corners = old_corners
 		if (old_opacity != opacity || dynamic_lighting != old_dynamic_lighting || force_lighting_update)
 			reconsider_lights()
 			updateVisibility(src)

--- a/code/modules/lighting/lighting_corner.dm
+++ b/code/modules/lighting/lighting_corner.dm
@@ -357,6 +357,18 @@ var/global/list/REVERSE_LIGHTING_CORNER_DIAGONAL = list(0, 0, 0, 0, 3, 4, 0, 0, 
 	needs_update = TRUE
 	SSlighting.corner_queue += src
 
+/datum/lighting_corner/proc/clear_above_ambient()
+	above_ambient_r = 0
+	above_ambient_g = 0
+	above_ambient_b = 0
+
+	UPDATE_APPARENT(src, r)
+	UPDATE_APPARENT(src, g)
+	UPDATE_APPARENT(src, b)
+
+	needs_update = TRUE
+	SSlighting.corner_queue += src
+
 #undef UPDATE_APPARENT
 
 /datum/lighting_corner/proc/update_overlays(now = FALSE)

--- a/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
@@ -154,6 +154,8 @@
 	if(href_list["PRG_deletechannel"])
 		. = TOPIC_HANDLED
 		if(channel && ((channel.operator == src) || netadmin_mode))
+			if(ntnet_global)
+				ntnet_global.chat_channels.Remove(channel)
 			qdel(channel)
 			channel = null
 	if(href_list["PRG_setpassword"])

--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -241,6 +241,8 @@
 					if(get_area(TA) in shuttle_area)
 						continue
 					TA.ChangeTurf(ceiling_type, TRUE, TRUE, TRUE)
+					for (var/datum/lighting_corner/C in TD.corners)
+						C.clear_above_ambient()
 
 	// Remove all powernets that were affected, and rebuild them.
 	var/list/cables = list()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
This PR fixes lighting on shuttle transitions, additionally fixes "delete channel" button for NT chat program and "Take image" verb for borgs.

**1. Lighting fix for shuttles**: lights are changed to abnormal values upon shuttle transitions, because of the old corners on the same turfs and because of the dynamic lighting of turfs from above. Corners are no longer passed in ChangeTurf proc and above ambient is getting cleared for turfs with created shuttle ceiling. (turf_changing.dm, lighting_corner.dm, shuttle.dm)

How it is supposed to look like for most of the time:
![light2](https://github.com/user-attachments/assets/67cc0652-99a8-4715-b2f3-ad7aff6dc4dd)

How it actually looks like after transition:
![light1](https://github.com/user-attachments/assets/4cf9451f-fe77-4970-95a6-6bee29900989)

**2. Fix of the Delete channel button for NTNet Relay Chat Client**: now actually removes the channel. (ntnrc_client.dm)

**3. Cyborg camera fix**: camera as a robot component was removed by this commit https://github.com/Baystation12/Baystation12/commit/d3c7264664591df10432e6b92723029a190fac58, but silicon camera (take image verb) is still linked to a removed component. Of all the current robot components, the diagnosis unit is the most closest in terms of function, so for now it can be replaced by it. (cyborg.dm)

**Changelog**
:cl: Builder13
bugfix: Fixed lighting for shuttles after transition.
bugfix: Fixed Delete channel button for NTNet Relay Chat Client.
bugfix: Fixed Take image verb for borgs.
/:cl: