### PR TITLE
Refactor: Items update holding mob overlays on `update_icon()`

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -165,6 +165,12 @@
 			return TRUE
 	return FALSE
 
+
+/obj/item/update_icon()
+	..()
+	update_twohanding()
+
+
 /obj/item/ex_act(severity)
 	..()
 	if (get_max_health())

--- a/code/game/objects/items/devices/oxycandle.dm
+++ b/code/game/objects/items/devices/oxycandle.dm
@@ -47,7 +47,6 @@
 		STOP_PROCESSING(SSprocessing, src)
 		on = 2
 		update_icon()
-		update_held_icon()
 		SetName("burnt oxygen candle")
 		desc += "This tube has exhausted its chemicals."
 		return
@@ -79,7 +78,6 @@
 		icon_state = "oxycandle"
 		item_state = icon_state
 		set_light(0)
-	update_held_icon()
 
 /obj/item/device/oxycandle/Destroy()
 	QDEL_NULL(air_contents)

--- a/code/game/objects/items/devices/paint_sprayer.dm
+++ b/code/game/objects/items/devices/paint_sprayer.dm
@@ -83,7 +83,6 @@
 /obj/item/device/paint_sprayer/on_update_icon()
 	ClearOverlays()
 	AddOverlays(overlay_image(icon, "paint_sprayer_color", paint_color))
-	update_held_icon()
 
 /obj/item/device/paint_sprayer/get_mob_overlay(mob/user_mob, slot, bodypart)
 	var/image/ret = ..()

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -245,7 +245,6 @@
 	else
 		wielded = 0
 		SetName(initial(name))
-	update_icon()
 	..()
 
 /obj/item/shockpaddles/on_update_icon()

--- a/code/game/objects/items/weapons/material/twohanded.dm
+++ b/code/game/objects/items/weapons/material/twohanded.dm
@@ -37,7 +37,6 @@
 	else
 		wielded = 0
 		force = force_unwielded
-	update_icon()
 	..()
 
 /obj/item/material/twohanded/update_force()

--- a/code/game/objects/items/weapons/swords_axes_etc.dm
+++ b/code/game/objects/items/weapons/swords_axes_etc.dm
@@ -63,7 +63,6 @@
 	playsound(src.loc, 'sound/weapons/empty.ogg', 50, 1)
 	add_fingerprint(user)
 	update_icon()
-	update_held_icon()
 
 /obj/item/melee/telebaton/on_update_icon()
 	if(on)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -139,11 +139,6 @@
 	if(scope_zoom)
 		verbs += /obj/item/gun/proc/scope
 
-/obj/item/gun/update_twohanding()
-	if(one_hand_penalty)
-		update_icon() // In case item_state is set somewhere else.
-	..()
-
 /obj/item/gun/on_update_icon()
 	var/mob/living/M = loc
 	ClearOverlays()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -94,7 +94,6 @@
 			icon_state = "[modifystate][ratio]"
 		else
 			icon_state = "[initial(icon_state)][ratio]"
-		update_held_icon()
 
 /obj/item/gun/energy/handle_post_fire(mob/user, atom/target, pointblank, reflex, obj/projectile)
 	..()

--- a/code/modules/projectiles/guns/launcher/pneumatic.dm
+++ b/code/modules/projectiles/guns/launcher/pneumatic.dm
@@ -152,8 +152,6 @@
 		icon_state = "pneumatic"
 		item_state = "pneumatic"
 
-	update_held_icon()
-
 /obj/item/gun/launcher/pneumatic/small
 	name = "small pneumatic cannon"
 	desc = "It looks smaller than your garden variety cannon."

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -45,7 +45,7 @@ exactly 2 "<< uses" '(?<!<)<<(?!<)' -P
 exactly 2 ">> uses" '(?<!>)>>(?!>)' -P
 exactly 0 "incorrect indentations" '^( {4,})' -P
 exactly 24 "text2path uses" 'text2path'
-exactly 4 "update_icon() override" '/update_icon\((.*)\)'  -P
+exactly 5 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 4 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
 exactly 338 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P


### PR DESCRIPTION
## Changelog
No user facing changes, aside from maybe some previously unknown bugs with held items not updating their held state.

## Other Changes
- `/obj/item/update_icon()` now calls `update_twohanding()` and `update_held_icon()` after resolving `on_icon_update()`.