### PR TITLE
Atmos fix for late initialized away sites and more

### DIFF
--- a/code/controllers/subsystems/air.dm
+++ b/code/controllers/subsystems/air.dm
@@ -269,6 +269,15 @@ Geometry processing completed in [(Uptime() - start_uptime)/10] seconds!
 		else if (MC_TICK_CHECK)
 			return
 
+
+/datum/controller/subsystem/air/StartLoadingMap()
+	suspend()
+
+
+/datum/controller/subsystem/air/StopLoadingMap()
+	wake()
+
+
 /datum/controller/subsystem/air/proc/add_zone(zone/z)
 	zones += z
 	z.name = "Zone [next_id++]"

--- a/code/controllers/subsystems/airflow.dm
+++ b/code/controllers/subsystems/airflow.dm
@@ -106,6 +106,14 @@ SUBSYSTEM_DEF(airflow)
 #undef CLEAR_OBJECT
 
 
+/datum/controller/subsystem/airflow/StartLoadingMap()
+	suspend()
+
+
+/datum/controller/subsystem/airflow/StopLoadingMap()
+	wake()
+
+
 /atom/movable/var/airflow_xo
 /atom/movable/var/airflow_yo
 /atom/movable/var/airflow_od

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -4211,7 +4211,7 @@
 	bitesize = 2
 /obj/item/reagent_containers/food/snacks/venus/Initialize()
 	.=..()
-	reagents.add_reagent(/datum/reagent/capsaicin = 5)
+	reagents.add_reagent(/datum/reagent/capsaicin, 5)
 
 /obj/item/reagent_containers/food/snacks/oort
 	name = "oort cloud rocks"
@@ -4225,7 +4225,7 @@
 	bitesize = 2
 /obj/item/reagent_containers/food/snacks/oort/Initialize()
 	.=..()
-	reagents.add_reagent(/datum/reagent/frostoil = 5)
+	reagents.add_reagent(/datum/reagent/frostoil, 5)
 
 //weebo vend! So japanese it hurts
 
@@ -4255,7 +4255,7 @@
 	bitesize = 2
 /obj/item/reagent_containers/food/snacks/weebonuts/Initialize()
 	.=..()
-	reagents.add_reagent(/datum/reagent/capsaicin = 1)
+	reagents.add_reagent(/datum/reagent/capsaicin, 1)
 	reagents.add_reagent(/datum/reagent/nutriment/groundpeanuts, 4)
 
 /obj/item/reagent_containers/food/snacks/chocobanana

--- a/code/modules/ventcrawl/ventcrawl.dm
+++ b/code/modules/ventcrawl/ventcrawl.dm
@@ -65,6 +65,11 @@ var/global/list/ventcrawl_machinery = list(
 		return carried_item.w_class <= ITEM_SIZE_NORMAL
 	return ..()
 
+/mob/living/simple_animal/is_allowed_vent_crawl_item(obj/item/carried_item)
+	if(get_natural_weapon() == carried_item)
+		return TRUE
+	return ..()
+
 /mob/living/proc/ventcrawl_carry()
 	for(var/atom/A in contents)
 		if(!is_allowed_vent_crawl_item(A))


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Fix for atmorspherics on map template loaded turfs after a round start, fix for simple animal vent crawl and fix for reagent_add of some snacks.

**1. Atmospherics fix for late loaded away sites**: this is an issue of 'Map Template' verbs (example: Map-Template---Place-In-New-Z). Air for newly created turfs is ticking faster, than walls and glasses are initialized, creating gas leaks before away site can fully load. This change is blocking air for turfs, before whole map is fully initialized. (dmm_suite.dm, map_template.dm)

steps to reproduce this issue:
1) Wait until round starts. (There is no issue, if you are spawning away site before round start)
2) Use Map-Template---Place-In-New-Z verb
3) Choose Skrellian Scout Ship or Vox Scavenger Ship (examples)
4) High probabillity, that there wouldn't be any air on spawned away site turfs, or there would be a high pressure hazard, since nitrogen storage turfs got leaked on Vox Scavenger Ship.

**2. Ventcrawl fix for simple animals**: natural weapon prevents simple animals from crawling in the vents. Try to spawn as a borer, attack something, and then try to ventcrawl after. (ventcrawl.dm)

**3. reagent_add fix for some snacks:** makes it so these reagents are actually added. (snacks.dm)

**Changelog**
:cl: Builder13
bugfix: Fixed atmospherics for late loaded away sites.
bugfix: Fixed ventcrawl for animals once they attacked somebody (example:borers).
bugfix: Fixed a lack of the specific reagents for some of the snacks.
/:cl: