### PR TITLE
Fix admin logs user logging and add more location logging

### DIFF
--- a/code/controllers/evacuation/evacuation_pods.dm
+++ b/code/controllers/evacuation/evacuation_pods.dm
@@ -85,7 +85,7 @@
 		to_chat(user, "Escape procedures already in progress.")
 		return
 	if (evacuation_controller.call_evacuation(user, 1))
-		log_and_message_admins("[user? key_name(user) : "Autotransfer"] has initiated abandonment of the spacecraft.")
+		log_and_message_admins("has initiated abandonment of the spacecraft.", user)
 
 /datum/evacuation_option/bluespace_jump
 	option_text = "Initiate bluespace jump"
@@ -107,7 +107,7 @@
 		to_chat(user, "Jump preparation already in progress.")
 		return
 	if (evacuation_controller.call_evacuation(user, 0))
-		log_and_message_admins("[user? key_name(user) : "Autotransfer"] has initiated bluespace jump preparation.")
+		log_and_message_admins("has initiated bluespace jump preparation.", user)
 
 /datum/evacuation_option/cancel_abandon_ship
 	option_text = "Cancel abandonment"
@@ -118,7 +118,7 @@
 
 /datum/evacuation_option/cancel_abandon_ship/execute(mob/user)
 	if (evacuation_controller && evacuation_controller.cancel_evacuation())
-		log_and_message_admins("[key_name(user)] has cancelled abandonment of the spacecraft.")
+		log_and_message_admins("has cancelled abandonment of the spacecraft.", user)
 
 /datum/evacuation_option/cancel_bluespace_jump
 	option_text = "Cancel bluespace jump"
@@ -129,7 +129,7 @@
 
 /datum/evacuation_option/cancel_bluespace_jump/execute(mob/user)
 	if (evacuation_controller && evacuation_controller.cancel_evacuation())
-		log_and_message_admins("[key_name(user)] has cancelled the bluespace jump.")
+		log_and_message_admins("has cancelled the bluespace jump.", user)
 
 #undef EVAC_OPT_ABANDON_SHIP
 #undef EVAC_OPT_BLUESPACE_JUMP

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -172,7 +172,7 @@ SUBSYSTEM_DEF(jobs)
 			return FALSE
 		else
 			// Let the staff know, in case the person complains about dying due to this later. They've been warned.
-			log_and_message_admins("User [spawner] spawned at spawn point with dangerous atmosphere.")
+			log_and_message_admins("spawned at spawn point with dangerous atmosphere.", spawner)
 	return TRUE
 
 /datum/controller/subsystem/jobs/proc/assign_role(mob/new_player/player, rank, latejoin = 0, datum/game_mode/mode = SSticker.mode)

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -199,7 +199,7 @@ SUBSYSTEM_DEF(ticker)
 	else if(mode_finished && (end_game_state <= END_GAME_NOT_OVER))
 		end_game_state = END_GAME_MODE_FINISH_DONE
 		mode.cleanup()
-		log_and_message_admins(": All antagonists are deceased or the gamemode has ended.") //Outputs as "Event: All antagonists are deceased or the gamemode has ended."
+		log_and_message_admins("All antagonists are deceased or the gamemode has ended.", null) //Outputs as "EVENT All antagonists are deceased or the gamemode has ended."
 		SSvote.initiate_vote(/datum/vote/transfer, automatic = 1)
 
 /datum/controller/subsystem/ticker/proc/post_game_tick()

--- a/code/datums/extensions/on_click/on_alt_click.dm
+++ b/code/datums/extensions/on_click/on_alt_click.dm
@@ -24,7 +24,7 @@
 		return FALSE
 
 	call(living_holder, death_proc)()
-	log_and_message_admins("killed [key_name]")
+	log_and_message_admins("killed [key_name]", user)
 
 	return TRUE
 

--- a/code/datums/uplink/uplink_items.dm
+++ b/code/datums/uplink/uplink_items.dm
@@ -105,7 +105,7 @@ var/global/datum/uplink/uplink = new()
 	return
 
 /datum/uplink_item/proc/purchase_log(obj/item/device/uplink/U, mob/user, cost)
-	log_and_message_admins("used \the [U.loc] to buy \a [src]")
+	log_and_message_admins("used \the [U.loc] to buy \a [src]", user)
 	if(user)
 		uplink_purchase_repository.add_entry(user.mind, src, cost)
 

--- a/code/game/gamemodes/meteor/meteor.dm
+++ b/code/game/gamemodes/meteor/meteor.dm
@@ -74,7 +74,7 @@
 	if((round_duration_in_ticks >= next_wave) && (alert_sent == 1))
 		on_enter_field()
 	if((round_duration_in_ticks >= METEOR_FAILSAFE_THRESHOLD) && (meteor_severity < 15) && !failsafe_triggered)
-		log_and_message_admins("Meteor mode severity failsafe triggered: Severity forced to 15.")
+		log_and_message_admins("Meteor mode severity failsafe triggered: Severity forced to 15.", null)
 		meteor_severity = 15
 		failsafe_triggered = 1
 
@@ -88,7 +88,7 @@
 			meteor_severity++
 			escalated = TRUE
 		if(send_admin_broadcasts)
-			log_and_message_admins("Meteor: Wave fired. Escalation: [escalated ? "Yes" : "No"]. Severity: [meteor_severity]/[maximal_severity]")
+			log_and_message_admins("Meteor: Wave fired. Escalation: [escalated ? "Yes" : "No"]. Severity: [meteor_severity]/[maximal_severity]",  null)
 
 /datum/game_mode/meteor/proc/get_meteor_types()
 	switch(meteor_severity)

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -254,7 +254,7 @@
 	if(href_list["toggle"])
 		if (!valve_open)
 			if(!holding)
-				log_open()
+				log_open(user)
 		valve_open = !valve_open
 		. = TOPIC_REFRESH
 

--- a/code/game/machinery/atmoalter/portable_atmospherics.dm
+++ b/code/game/machinery/atmoalter/portable_atmospherics.dm
@@ -155,7 +155,7 @@
 /obj/machinery/portable_atmospherics/powered/components_are_accessible(path)
 	return panel_open
 
-/obj/machinery/portable_atmospherics/proc/log_open()
+/obj/machinery/portable_atmospherics/proc/log_open(mob/user)
 	if(length(air_contents.gas) == 0)
 		return
 
@@ -165,7 +165,7 @@
 			gases += ", [gas]"
 		else
 			gases = gas
-	log_and_message_admins("opened [src.name], containing [gases].")
+	log_and_message_admins("opened [src.name], containing [gases].", user)
 
 /obj/machinery/portable_atmospherics/powered/dismantle()
 	if(isturf(loc))

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -203,7 +203,7 @@
 			if(emagged)
 				new /obj/spawner/newbomb/timer/syndicate(src.loc)
 				new /obj/item/clothing/head/collectable/petehat(src.loc)
-				log_and_message_admins("has outbombed Cuban Pete and been awarded a bomb.")
+				log_and_message_admins("has outbombed Cuban Pete and been awarded a bomb.", user)
 				SetupGame()
 				emagged = FALSE
 			else

--- a/code/game/machinery/computer/arcade_orion.dm
+++ b/code/game/machinery/computer/arcade_orion.dm
@@ -187,7 +187,7 @@
 				event_desc = "You and your crew were killed on the way to Orion, your ship left abandoned for scavengers to find."
 				next_event = ORION_TRAIL_GAMEOVER
 			if(port == 9)
-				win()
+				win(user)
 				return TOPIC_REFRESH
 			var/travel = min(rand(1000,10000),distance)
 			if(href_list["fix"])
@@ -461,11 +461,11 @@
 		newgame(1)
 		src.updateUsrDialog()
 
-/obj/machinery/computer/arcade/orion_trail/proc/win()
+/obj/machinery/computer/arcade/orion_trail/proc/win(mob/user)
 	src.visible_message("\The [src] plays a triumpant tune, stating 'CONGRATULATIONS, YOU HAVE MADE IT TO ORION.'")
 	if(emagged)
 		new /obj/item/orion_ship(src.loc)
-		log_and_message_admins("made it to Orion on an emagged machine and got an explosive toy ship.")
+		log_and_message_admins("made it to Orion on an emagged machine and got an explosive toy ship.", user)
 	else
 		prizevend()
 	event = null

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -54,7 +54,7 @@
 			return TOPIC_HANDLED
 
 		if(target.SetLockdown(!target.lockcharge))
-			log_and_message_admins("[target.lockcharge ? "locked down" : "released"] [target.name]!")
+			log_and_message_admins("[target.lockcharge ? "locked down" : "released"] [target.name]!", user)
 			if(target.lockcharge)
 				to_chat(target, SPAN_DANGER("You have been locked down!"))
 			else
@@ -85,7 +85,7 @@
 		if(!target || !istype(target))
 			return TOPIC_HANDLED
 
-		log_and_message_admins("emagged [target.name] using robotic console!")
+		log_and_message_admins("emagged [target.name] using robotic console!", user)
 		target.emagged = TRUE
 		to_chat(target, SPAN_NOTICE("Failsafe protocols overriden. New tools available."))
 		. = TOPIC_REFRESH
@@ -99,7 +99,7 @@
 		if(!message || !istype(target))
 			return
 
-		log_and_message_admins("sent message '[message]' to [target.name] using robotics control console!")
+		log_and_message_admins("sent message '[message]' to [target.name] using robotics control console!", user)
 		to_chat(target, SPAN_NOTICE("New remote message received using R-SSH protocol:"))
 		to_chat(target, message)
 		. = TOPIC_REFRESH

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -270,7 +270,7 @@
 
 	// Don't send messages unless we *need* the computer, and less than five minutes have passed since last time we messaged
 	if(!control_computer && urgent && last_no_computer_message + 5*60*10 < world.time)
-		log_and_message_admins("Cryopod in [src.loc.loc] could not find control computer!")
+		log_and_message_admins("Cryopod in [src.loc.loc] could not find control computer!", null, src)
 		last_no_computer_message = world.time
 
 	return control_computer != null
@@ -320,7 +320,7 @@
 	SHOULD_NOT_SLEEP(TRUE) // Sleeping causes the double-despawn bug
 
 	if (QDELETED(occupant))
-		log_and_message_admins("A mob was deleted while in a cryopod, or the cryopod double-processed. This may cause errors!")
+		log_and_message_admins("A mob was deleted while in a cryopod, or the cryopod double-processed. This may cause errors!", null)
 		return
 
 	if (istype(occupant, /mob/living/carbon/human))
@@ -405,7 +405,7 @@
 	if(control_computer)
 		control_computer.frozen_crew += "[occupant.real_name], [role_alt_title] - [stationtime2text()]"
 		control_computer._admin_logs += "[key_name(occupant)] ([role_alt_title]) at [stationtime2text()]"
-	log_and_message_admins("[key_name(occupant)] ([role_alt_title]) entered cryostorage.")
+	log_and_message_admins("([role_alt_title]) entered cryostorage.", occupant)
 
 	if(announce_despawn)
 		invoke_async(announce, /obj/item/device/radio/proc/autosay, "[occupant.real_name], [role_alt_title], [on_store_message]", "[on_store_name]")
@@ -452,7 +452,7 @@
 	set_occupant(target)
 	if (user != target)
 		add_fingerprint(target) //Add fingerprints of the person stuffed in.
-	log_and_message_admins("placed [target == user ? "themself" : key_name_admin(target)] into \a [src]")
+	log_and_message_admins("placed [target == user ? "themself" : key_name_admin(target)] into \a [src]", user)
 	target.remove_grabs_and_pulls()
 
 /obj/machinery/cryopod/user_can_move_target_inside(mob/target, mob/user)

--- a/code/game/machinery/doors/brigdoors.dm
+++ b/code/game/machinery/doors/brigdoors.dm
@@ -190,7 +190,7 @@
 		else
 			timer_start()
 			if(timetoset > 18000)
-				log_and_message_admins("has started a brig timer over 30 minutes in length!")
+				log_and_message_admins("has started a brig timer over 30 minutes in length!", user)
 		. =  TOPIC_REFRESH
 
 	if (href_list["flash"])

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -412,9 +412,9 @@ var/global/bomb_set
 		var/turf/T = pick_area_turf(/area/maintenance, list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))
 		if(T)
 			var/obj/D = new /obj/item/disk/nuclear(T)
-			log_and_message_admins("[src], the last authentication disk, has been destroyed. Spawning [D] at ([D.x], [D.y], [D.z]).", location = T)
+			log_and_message_admins("[src], the last authentication disk, has been destroyed. Spawning [D] at ([D.x], [D.y], [D.z]).", user = null, location = T)
 		else
-			log_and_message_admins("[src], the last authentication disk, has been destroyed. Failed to respawn disc!")
+			log_and_message_admins("[src], the last authentication disk, has been destroyed. Failed to respawn disc!", user = null)
 	return ..()
 
 //====the nuclear football (holds the disk and instructions)====

--- a/code/game/objects/effects/chem/chemsmoke.dm
+++ b/code/game/objects/effects/chem/chemsmoke.dm
@@ -111,18 +111,15 @@
 	var/contained = carry.get_reagents()
 	var/area/A = get_area(location)
 
-	var/where = "[A.name] | [location.x], [location.y]"
-	var/whereLink = "<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[location.x];Y=[location.y];Z=[location.z]'>[where]</a>"
-
 	if(show_log)
 		if(carry.my_atom.fingerprintslast)
 			var/mob/M = get_mob_by_key(carry.my_atom.fingerprintslast)
 			var/more = ""
 			if(M)
 				more = "(<A HREF='?_src_=holder;adminmoreinfo=\ref[M]'>?</a>)"
-			log_and_message_admins("A chemical smoke reaction has taken place in ([whereLink])[contained]. Last associated key is [carry.my_atom.fingerprintslast][more].")
+			log_and_message_admins("A chemical smoke reaction has taken place in [A.name] ([location.x],[location.y],[location.z]) [contained]. Last associated key is [carry.my_atom.fingerprintslast][more].", null, location)
 		else
-			log_and_message_admins("A chemical smoke reaction has taken place in ([whereLink]). No associated key.")
+			log_and_message_admins("A chemical smoke reaction has taken place in [A.name] ([location.x],[location.y],[location.z]). No associated key.", null, location)
 
 //Runs the chem smoke effect
 // Spawns damage over time loop for each reagent held in the cloud.

--- a/code/game/objects/effects/decals/Cleanable/fuel.dm
+++ b/code/game/objects/effects/decals/Cleanable/fuel.dm
@@ -27,7 +27,7 @@
 
 /obj/decal/cleanable/liquid_fuel/Initialize(mapload, amt=1, nologs=FALSE)
 	if(!nologs && !mapload)
-		log_and_message_admins(" - Liquid fuel has been spilled in [get_area(loc)]", location = loc)
+		log_and_message_admins(" - Liquid fuel has been spilled in [get_area(loc)].", user = null, location = loc)
 	src.amount = amt
 	var/has_spread = 0
 	//Be absorbed by any other liquid fuel in the tile.

--- a/code/game/objects/empulse.dm
+++ b/code/game/objects/empulse.dm
@@ -28,7 +28,7 @@
 		return FALSE
 
 	if (log)
-		log_and_message_admins(append_admin_tools("EMP with size ([heavy_range], [light_range]) in area [get_area(origin)]", location = epicenter))
+		log_and_message_admins("EMP with size ([heavy_range], [light_range]) in area [get_area(origin)].", null, epicenter)
 
 	if (heavy_range > 1)
 		new /obj/overlay/self_deleting/emppulse(epicenter)
@@ -57,6 +57,6 @@
 			T.emp_act(EMP_ACT_LIGHT)
 		#ifdef EMPDEBUG
 		if ((world.timeofday - time) >= EMPDEBUG)
-			log_and_message_admins("EMPDEBUG: [T.name] - [T.type] - took [world.timeofday - time]ds to process emp_act()!")
+			log_and_message_admins("EMPDEBUG: [T.name] - [T.type] - took [world.timeofday - time]ds to process emp_act()!", null)
 		#endif
 	return TRUE

--- a/code/game/objects/explosion.dm
+++ b/code/game/objects/explosion.dm
@@ -78,7 +78,7 @@
 				M.playsound_local(epicenter, 'sound/effects/explosionfar.ogg', far_volume, 1, frequency, falloff = 5)
 
 	if(adminlog)
-		log_and_message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z]) (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[epicenter.x];Y=[epicenter.y];Z=[epicenter.z]'>JMP</a>)")
+		log_and_message_admins("Explosion with size ([devastation_range], [heavy_impact_range], [light_impact_range]) in area [epicenter.loc.name] ([epicenter.x],[epicenter.y],[epicenter.z]).", null, epicenter)
 	var/approximate_intensity = (devastation_range * 3) + (heavy_impact_range * 2) + light_impact_range
 	// Large enough explosion. For performance reasons, powernets will be rebuilt manually
 	if(!GLOB.defer_powernet_rebuild && (approximate_intensity > 25))

--- a/code/game/objects/items/blueprints.dm
+++ b/code/game/objects/items/blueprints.dm
@@ -47,7 +47,7 @@
 			edit_area()
 		if ("delete_area")
 			//skip the sanity checking, delete_area() does it anyway
-			delete_area()
+			delete_area(user)
 
 /obj/item/blueprints/proc/get_header()
 	return "<h2>[station_name()] blueprints</h2><small>Property of [GLOB.using_map.company_name]. For heads of staff only. Store in high-secure storage.</small><hr>"
@@ -130,13 +130,13 @@
 	to_chat(usr, SPAN_NOTICE("You set the area '[prevname]' title to '[str]'."))
 	interact()
 
-/obj/item/blueprints/proc/delete_area()
+/obj/item/blueprints/proc/delete_area(mob/user)
 	var/area/A = get_area(src)
 	if (get_area_type(A)!=AREA_STATION || A.apc) //let's just check this one last time, just in case
 		interact()
 		return
 	to_chat(usr, SPAN_NOTICE("You scrub [A.name] off the blueprint."))
-	log_and_message_admins("deleted area [A.name] via station blueprints.")
+	log_and_message_admins("deleted area [A.name] via station blueprints.", user)
 	qdel(A)
 	interact()
 

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -72,7 +72,7 @@ AI MODULES
 /obj/item/aiModule/proc/log_law_changes(mob/living/silicon/target, mob/sender)
 	var/time = time2text(world.realtime,"hh:mm:ss")
 	GLOB.lawchanges.Add("[time] <B>:</B> [sender.name]([sender.key]) used [src.name] on [target.name]([target.key])")
-	log_and_message_admins("used [src.name] on [target.name]([target.key])")
+	log_and_message_admins("used [src.name] on [target.name]([target.key]).", sender)
 
 /obj/item/aiModule/proc/addAdditionalLaws(mob/living/silicon/ai/target, mob/sender)
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -171,7 +171,7 @@ var/global/const/NO_EMAG_ACT = -50
 	uses -= used_uses
 	target.add_fingerprint(user, tool = src)
 	if (used_uses)
-		log_and_message_admins("emagged \a [target].")
+		log_and_message_admins("emagged \a [target].", user)
 
 	if (uses < 1)
 		user.visible_message(

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -386,7 +386,7 @@
 		var/obj/item/cell/C = potato.cell
 		C.give(chargecost)
 	H.AdjustSleeping(-60)
-	log_and_message_admins("used \a [src] to revive [key_name(H)].")
+	log_and_message_admins("used \a [src] to revive [key_name(H)].", user)
 
 /obj/item/shockpaddles/proc/lowskill_revive(mob/living/carbon/human/H, mob/living/user)
 	if(prob(60))

--- a/code/game/objects/items/weapons/explosives.dm
+++ b/code/game/objects/items/weapons/explosives.dm
@@ -66,7 +66,7 @@
 			log_game("[key_name(user)] planted [src.name] on [key_name(target)] with [timer] second fuse")
 
 		else
-			log_and_message_admins("planted \a [src] with a [timer] second fuse on \the [target].")
+			log_and_message_admins("planted \a [src] with a [timer] second fuse on \the [target].", user)
 
 		target.AddOverlays(image_overlay)
 		to_chat(user, "Bomb has been planted. Timer counting down from [timer].")

--- a/code/game/objects/items/weapons/grenades/chem_grenade.dm
+++ b/code/game/objects/items/weapons/grenades/chem_grenade.dm
@@ -38,7 +38,7 @@
 		SetName("unsecured grenade with [length(beakers)] containers[detonator?" and detonator":""]")
 	if(stage > 1 && !active && clown_check(user))
 		to_chat(user, SPAN_WARNING("You prime \the [name]!"))
-		log_and_message_admins("has primed \a [src].")
+		log_and_message_admins("has primed \a [src].", user)
 		activate()
 		add_fingerprint(user)
 		if(iscarbon(user))
@@ -59,7 +59,7 @@
 			FEEDBACK_UNEQUIP_FAILURE(user, det)
 			return TRUE
 		path = 1
-		log_and_message_admins("has attached \a [W] to \the [src].")
+		log_and_message_admins("has attached \a [W] to \the [src].", user)
 		to_chat(user, SPAN_NOTICE("You add [W] to the metal casing."))
 		playsound(loc, 'sound/items/Screwdriver2.ogg', 25, -3)
 		detonator = det
@@ -136,7 +136,7 @@
 	if(active)
 		icon_state = initial(icon_state) + "_active"
 		if(user)
-			log_and_message_admins("has primed \a [src].")
+			log_and_message_admins("has primed \a [src].", user)
 	return
 
 

--- a/code/game/objects/items/weapons/implants/implants/explosive.dm
+++ b/code/game/objects/items/weapons/implants/implants/explosive.dm
@@ -120,10 +120,10 @@
 	playsound(loc, 'sound/items/countdown.ogg', 75, 1, -3)
 	if(ismob(imp_in))
 		imp_in.audible_message(SPAN_WARNING("Something beeps inside [imp_in][part ? "'s [part.name]" : ""]!"))
-		log_and_message_admins("Explosive implant triggered in [imp_in] ([imp_in.key]). (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[imp_in.x];Y=[imp_in.y];Z=[imp_in.z]'>JMP</a>) ")
+		log_and_message_admins("Explosive implant triggered in [imp_in] ([imp_in.key])", null, imp_in)
 	else
 		audible_message(SPAN_WARNING("[src] beeps omniously!"))
-		log_and_message_admins("Explosive implant triggered in [T.loc]. (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>) ")
+		log_and_message_admins("Explosive implant triggered in [T.loc]", null, imp_in)
 
 	if(!elevel)
 		elevel = "Full Explosion"

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -440,7 +440,7 @@ var/global/list/tank_gauge_cache = list()
 	if(pressure > TANK_FRAGMENT_PRESSURE)
 		if(integrity <= 7)
 			if(!istype(loc,/obj/item/device/transfer_valve))
-				log_and_message_admins("Explosive tank rupture! last key to touch the tank was [fingerprintslast].")
+				log_and_message_admins("Explosive tank rupture! last key to touch the tank was [fingerprintslast].", null, src)
 
 			//Give the gas a chance to build up more pressure through reacting
 			air_contents.react()

--- a/code/modules/admin/callproc/callproc.dm
+++ b/code/modules/admin/callproc/callproc.dm
@@ -223,13 +223,13 @@
 		if(!target)
 			to_chat(usr, "Your callproc target no longer exists.")
 			return
-		log_and_message_admins("[key_name(C)] called \the [target]'s [procname]() with [LAZYLEN(arguments) ? "the arguments [list2params(arguments)]" : "no arguments"].", location = get_turf(target))
+		log_and_message_admins("called \the [target]'s [procname]() with [LAZYLEN(arguments) ? "the arguments [list2params(arguments)]" : "no arguments"].", user = C, location = get_turf(target))
 		if(LAZYLEN(arguments))
 			returnval = call(target, procname)(arglist(arguments))
 		else
 			returnval = call(target, procname)()
 	else
-		log_and_message_admins("[key_name(C)] called [procname]() with [LAZYLEN(arguments)? "the arguments [list2params(arguments)]" : "no arguments"].", location = get_turf(target))
+		log_and_message_admins("called [procname]() with [LAZYLEN(arguments)? "the arguments [list2params(arguments)]" : "no arguments"].", user = C, location = get_turf(target))
 
 		var/P = text2path("/proc/[procname]")
 		returnval = call(P)(arglist(arguments))

--- a/code/modules/admin/secrets/admin_secrets/jump_shuttle.dm
+++ b/code/modules/admin/secrets/admin_secrets/jump_shuttle.dm
@@ -29,7 +29,7 @@
 		var/move_duration = input(user, "How many seconds will this jump take?") as num
 
 		S.long_jump(destination, transition, move_duration)
-		log_and_message_admins("has initiated a jump to [destination] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[destination.x];Y=[destination.y];Z=[destination.z]'>JMP</a>) lasting [move_duration] seconds in transit at [transition] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[transition.x];Y=[transition.y];Z=[transition.z]'>JMP</a>) for the [shuttle_tag] shuttle")
+		log_and_message_admins("has initiated a jump to [destination] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[destination.x];Y=[destination.y];Z=[destination.z]'>JMP</a>) lasting [move_duration] seconds in transit at [transition] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[transition.x];Y=[transition.y];Z=[transition.z]'>JMP</a>) for the [shuttle_tag] shuttle", user)
 	else
 		S.short_jump(destination)
-		log_and_message_admins("has initiated a jump to [destination] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[destination.x];Y=[destination.y];Z=[destination.z]'>JMP</a>) for the [shuttle_tag] shuttle")
+		log_and_message_admins("has initiated a jump to [destination] (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[destination.x];Y=[destination.y];Z=[destination.z]'>JMP</a>) for the [shuttle_tag] shuttle", user)

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -1038,4 +1038,4 @@ Ccomp's first proc.
 			S.shuttle_tag = name
 			S.name = "[name] Control Console"
 
-	log_and_message_admins("renamed \the [original_name] ship to [name].", )
+	log_and_message_admins("renamed \the [original_name] ship to [name].")

--- a/code/modules/clothing/spacesuits/rig/modules/combat.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/combat.dm
@@ -153,7 +153,7 @@
 	charge.charges--
 	var/obj/item/grenade/new_grenade = new charge.product_type(get_turf(H))
 	H.visible_message(SPAN_DANGER("[H] launches \a [new_grenade]!"))
-	log_and_message_admins("fired a grenade ([new_grenade.name]) from a rigsuit grenade launcher.")
+	log_and_message_admins("fired a grenade ([new_grenade.name]) from a rigsuit grenade launcher.", H)
 	new_grenade.activate(H)
 	new_grenade.throw_at(target,fire_force,fire_distance)
 

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -9,11 +9,11 @@
 /datum/event/blob/start()
 	var/turf/T = pick_subarea_turf(/area/maintenance, list(/proc/is_station_turf, /proc/not_turf_contains_dense_objects))
 	if(!T)
-		log_and_message_admins("Blob failed to find a viable turf.")
+		log_and_message_admins("Blob failed to find a viable turf.", null)
 		kill()
 		return
 
-	log_and_message_admins("Blob spawned in \the [get_area(T)]", location = T)
+	log_and_message_admins("Blob spawned in \the [get_area(T)]", user = null, location = T)
 	Blob = new /obj/blob/core(T)
 	for(var/i = 1; i < rand(3, 4), i++)
 		Blob.Process()

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -54,7 +54,7 @@
 		var/num = 0
 		for(var/i = 1 to severity)
 			num += rand(2,max_number)
-		log_and_message_admins("Vermin infestation spawned ([vermstring] x[num]) in \the [location]", location = pick_area_turf(location))
+		log_and_message_admins("Vermin infestation spawned ([vermstring] x[num]) in \the [location]", user = null, location = pick_area_turf(location))
 		while(length(vermin_turfs) && num > 0)
 			var/turf/simulated/floor/T = pick(vermin_turfs)
 			vermin_turfs.Remove(T)

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -18,9 +18,9 @@
 			//make vine zero start off fully matured
 			new /obj/vine(T,seed, start_matured = 1)
 
-			log_and_message_admins("Spacevines spawned in \the [get_area(T)]", location = T)
+			log_and_message_admins("Spacevines spawned in \the [get_area(T)]", user = null, location = T)
 			return
-		log_and_message_admins(SPAN_NOTICE("Event: Spacevines failed to find a viable turf."))
+		log_and_message_admins(SPAN_NOTICE("Event: Spacevines failed to find a viable turf."), null)
 
 /obj/dead_plant
 	anchored = TRUE

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -215,7 +215,7 @@
 			dt = 15
 		addtimer(new Callback(attached_grenade, /obj/item/grenade.proc/activate), dt)
 		var/atom/holder = loc
-		log_and_message_admins("activated a grenade assembly. Last touches: Assembly: [holder.fingerprintslast] Circuit: [fingerprintslast] Grenade: [attached_grenade.fingerprintslast]")
+		log_and_message_admins("activated a grenade assembly. Last touches: Assembly: [holder.fingerprintslast] Circuit: [fingerprintslast] Grenade: [attached_grenade.fingerprintslast]", null)
 
 // These procs do not relocate the grenade, that's the callers responsibility
 /obj/item/integrated_circuit/manipulation/grenade/proc/attach_grenade(obj/item/grenade/G)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -28,7 +28,7 @@
 	//Being hit while using a deadman switch
 	var/obj/item/device/assembly/signaler/signaler = get_active_hand()
 	if(istype(signaler) && signaler.deadman)
-		log_and_message_admins("has triggered a signaler deadman's switch")
+		log_and_message_admins("has triggered a signaler deadman's switch", src)
 		visible_message(SPAN_WARNING("[src] triggers their deadman's switch"))
 		signaler.signal()
 

--- a/code/modules/mob/living/silicon/ai/latejoin.dm
+++ b/code/modules/mob/living/silicon/ai/latejoin.dm
@@ -17,7 +17,7 @@
 		return
 
 	if(is_special_character(src))
-		log_and_message_admins("removed themselves from the round via Wipe Core")
+		log_and_message_admins("removed themselves from the round via Wipe Core", src)
 
 	GLOB.global_announcer.autosay("[src] has been moved to intelligence storage.", "Artificial Intelligence Oversight")
 	despawn()

--- a/code/modules/mob/living/silicon/laws.dm
+++ b/code/modules/mob/living/silicon/laws.dm
@@ -120,5 +120,5 @@
 	laws.sort_laws()
 
 /mob/living/silicon/proc/log_law(law_message)
-	log_and_message_admins(law_message)
+	log_and_message_admins(law_message, src)
 	GLOB.lawchanges += "[stationtime2text()] - [usr ? "[key_name(usr)]" : "EVENT"] [law_message]"

--- a/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_manufacturer.dm
@@ -133,7 +133,7 @@
 		fabricator = all_fabricators[choice]
 
 	if(user && fabricator && !(!fabricator.is_powered() || !fabricator.produce_drones || fabricator.drone_progress < 100))
-		log_and_message_admins("has joined the round as a maintenance drone.")
+		log_and_message_admins("has joined the round as a maintenance drone.", user)
 		var/mob/drone = fabricator.create_drone(user.client)
 		if(drone)
 			drone.status_flags |= NO_ANTAG

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -468,7 +468,7 @@
 	if (.)
 		return
 	if (href_list["flavor_change"] && !isadmin(usr) && (usr != src))
-		log_and_message_admins(usr, "is suspected of trying to change flavor text on [key_name_admin(src)] via Topic exploits.")
+		log_and_message_admins("is suspected of trying to change flavor text on [key_name_admin(src)] via Topic exploits.")
 	return ..()
 
 /mob/proc/pull_damage()

--- a/code/modules/modular_computers/file_system/programs/command/comm.dm
+++ b/code/modules/modular_computers/file_system/programs/command/comm.dm
@@ -362,7 +362,7 @@ var/global/last_message_id = 0
 		return
 
 	if(evacuation_controller.call_evacuation(user, _emergency_evac = emergency))
-		log_and_message_admins("[user? key_name(user) : "Autotransfer"] has called the shuttle.")
+		log_and_message_admins("has called the shuttle.", user)
 
 /proc/init_autotransfer()
 

--- a/code/modules/overmap/disperser/disperser_fire.dm
+++ b/code/modules/overmap/disperser/disperser_fire.dm
@@ -15,7 +15,7 @@
  * Finally checks type of target to fire the specific proc (event, ship, empty).
  */
 /obj/machinery/computer/ship/disperser/proc/fire(mob/user)
-	log_and_message_admins("attempted to launch a disperser beam.")
+	log_and_message_admins("attempted to launch a disperser beam.", user)
 	if(!link_parts())
 		return FALSE
 	if(!front.powered() || !middle.powered() || !back.powered())
@@ -110,7 +110,7 @@
 		return TRUE
 
 	var/obj/overmap/finaltarget = pick(candidates)
-	log_and_message_admins("A type [chargetype] disperser beam was launched at [finaltarget].", location=finaltarget)
+	log_and_message_admins("A type [chargetype] disperser beam was launched at [finaltarget].", user=user, location=finaltarget)
 
 	// Deletion of the overmap effect and the actual event trigger. Bye bye pesky meteors.
 	if(istype(finaltarget, /obj/overmap/event))
@@ -153,7 +153,7 @@
 	else if (tx == 0 && ty == 0 && tz == 0)
 		targetturf = areaturf
 
-	log_and_message_admins("Disperser beam hit sector at [targetturf.loc.name].", location=targetturf)
+	log_and_message_admins("Disperser beam hit sector at [targetturf.loc.name].", user=null, location=targetturf)
 	charge.fire(targetturf, strength, range)
 	qdel(charge)
 

--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -880,7 +880,7 @@
 				SPAN_DANGER("\The [src] flares brilliantly!"),
 				SPAN_DANGER("You hear a loud crack!")
 			)
-			log_and_message_admins("Rigged light explosion, last touched by [fingerprintslast]")
+			log_and_message_admins("Rigged light explosion, last touched by [fingerprintslast]", null, src)
 			var/turf/T = get_turf(loc)
 			set_status(LIGHT_BROKEN)
 			addtimer(new Callback(GLOBAL_PROC, /proc/explosion, T, 3, EX_ACT_LIGHT), 0.5 SECONDS)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -54,7 +54,7 @@
 		connect_to_network()
 
 /obj/machinery/power/emitter/Destroy()
-	log_and_message_admins("deleted \the [src]")
+	log_and_message_admins("deleted \the [src]", location = src)
 	investigate_log("[SPAN_COLOR("red", "deleted")] at ([x],[y],[z])","singulo")
 	return ..()
 

--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -178,7 +178,7 @@
 		var/obj/item/clothing/gloves/G = h_user.gloves
 		if(G.siemens_coefficient == 0)
 			user_protected = 1
-	log_and_message_admins("SMES FAILURE: <b>[src.x]X [src.y]Y [src.z]Z</b> User: [usr.ckey], Intensity: [intensity]/100 - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[src.x];Y=[src.y];Z=[src.z]'>JMP</a>")
+	log_and_message_admins("SMES FAILURE: <b>[src.x]X [src.y]Y [src.z]Z</b> User: [user.ckey], Intensity: [intensity]/100", user, src)
 
 
 	switch (intensity)
@@ -250,7 +250,7 @@
 
 			if (prob(50))
 				// Added admin-notifications so they can stop it when griffed.
-				log_and_message_admins("SMES explosion imminent.")
+				log_and_message_admins("SMES explosion imminent.", user)
 				src.ping("DANGER! Magnetic containment field unstable! Containment field failure imminent!")
 				failing = 1
 				// 30 - 60 seconds and then BAM!

--- a/code/modules/projectiles/guns/launcher/grenade_launcher.dm
+++ b/code/modules/projectiles/guns/launcher/grenade_launcher.dm
@@ -99,7 +99,7 @@
 	return chambered
 
 /obj/item/gun/launcher/grenade/handle_post_fire(mob/user)
-	log_and_message_admins("fired a grenade ([chambered.name]) from a grenade launcher.")
+	log_and_message_admins("fired a grenade ([chambered.name]) from a grenade launcher.", user)
 
 	chambered = null
 	..()

--- a/code/modules/projectiles/guns/launcher/rocket.dm
+++ b/code/modules/projectiles/guns/launcher/rocket.dm
@@ -55,5 +55,5 @@
 	return null
 
 /obj/item/gun/launcher/rocket/handle_post_fire(mob/user, atom/target)
-	log_and_message_admins("fired a rocket from a rocket launcher ([src.name]) at [target].")
+	log_and_message_admins("fired a rocket from a rocket launcher ([src.name]) at [target].", user)
 	..()

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -253,7 +253,7 @@
 			SPAN_NOTICE("You [user] [modded ? "open" : "close"] \the [src]'s valve with \the [tool].")
 		)
 		if (modded)
-			log_and_message_admins("opened a fuel tank at [get_area(src)], leaking fuel.")
+			log_and_message_admins("opened a fuel tank at [get_area(src)], leaking fuel.", user, src)
 			leak_fuel(amount_per_transfer_from_this)
 		return TRUE
 
@@ -275,9 +275,9 @@
 			var/turf/turf = get_turf(src)
 			if(turf)
 				var/area/area = turf.loc || "*unknown area*"
-				log_and_message_admins("[key_name_admin(Proj.firer)] shot a fuel tank in \the [area].")
+				log_and_message_admins("shot a fuel tank in \the [area].", Proj.firer, loc)
 			else
-				log_and_message_admins("shot a fuel tank outside the world.")
+				log_and_message_admins("shot a fuel tank outside the world.", Proj.firer, loc)
 
 		if(!istype(Proj ,/obj/item/projectile/beam/lastertag) && !istype(Proj ,/obj/item/projectile/beam/practice) )
 			explode()

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -550,7 +550,7 @@
 
 	var/mob/living/L = AM
 	if (istype(L) && L.ckey)
-		log_and_message_admins("has flushed themselves down \the [src].", L)
+		log_and_message_admins("has flushed themselves down \the [src].", L, src)
 	if(istype(AM, /obj))
 		var/obj/O = AM
 		O.forceMove(src)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -193,7 +193,7 @@
 	if(exploded)
 		return
 
-	log_and_message_admins("Supermatter delaminating at [x] [y] [z]")
+	log_and_message_admins("Supermatter delaminating at [x] [y] [z]", null, src)
 	anchored = TRUE
 	grav_pulling = 1
 	exploded = 1
@@ -589,7 +589,7 @@
 			power *= 3
 		if(EX_ACT_LIGHT)
 			power *= 2
-	log_and_message_admins("WARN: Explosion near the Supermatter! New EER: [power].")
+	log_and_message_admins("WARN: Explosion near the Supermatter! New EER: [power].", null, src)
 
 /obj/machinery/power/supermatter/shard //Small subtype, less efficient and more sensitive, but less boom.
 	name = "supermatter shard"

--- a/code/unit_tests/test_obj.dm
+++ b/code/unit_tests/test_obj.dm
@@ -6,5 +6,5 @@
 	..()
 	if(!is_test)
 		error("[src] as created at [loc] - [loc.x]-[loc.y]-[loc.z]")
-		log_and_message_admins("created \a [src] at [loc]")
+		log_and_message_admins("created \a [src] at [loc]", usr, src)
 		qdel(src)

--- a/packs/legion/structure.dm
+++ b/packs/legion/structure.dm
@@ -212,7 +212,7 @@
 	forceMove(target_turf)
 	effect_warp()
 	visible_message(SPAN_DANGER("\The [src] warps in!"))
-	log_and_message_admins("\The [src] has teleported to a new location at [get_area(target_turf)]", location = target_turf)
+	log_and_message_admins("\The [src] has teleported to a new location at [get_area(target_turf)]", null, location = target_turf)
 
 
 	for (var/mob/living/child in linked_mobs)


### PR DESCRIPTION
Sometimes you get logs like these:
![image](https://github.com/user-attachments/assets/e3d1e7d7-5961-4ffc-aea7-f1662e0a6339)

In this case the ckey is random. He didn't do any explosion. And in the code it meant to be an event, but by default admin log user is `usr`.

This PR fixes this.

Also this PR adds some locations for events that not have any user to give location of.