### PR TITLE
increase traitor scaling coeff to 7

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -14,6 +14,6 @@
 	required_players = 0
 	required_enemies = 0
 	antag_tags = list(MODE_TRAITOR)
-	antag_scaling_coeff = 5
+	antag_scaling_coeff = 7
 	end_on_antag_death = FALSE
 	latejoin_antag_tags = list(MODE_TRAITOR)


### PR DESCRIPTION
:cl: Mucker
tag: Increased traitor scaling coefficient to 7, meaning fewer traitors will be selected with smaller in-game player counts.
/:cl: