### PR TITLE
Disposable Energy Weapons

### DIFF
--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -122,9 +122,16 @@
 	name = "Weapons - Security basic"
 	contains = list(/obj/item/device/flash = 4,
 					/obj/item/reagent_containers/spray/pepper = 4,
-					/obj/item/melee/baton/loaded = 4,
-					/obj/item/gun/energy/taser = 4)
-	cost = 50
+					/obj/item/melee/baton/loaded = 4)
+	cost = 30
+	containertype = /obj/structure/closet/crate/secure/weapon
+	containername = "weapons crate"
+	access = access_security
+
+/singleton/hierarchy/supply_pack/security/weapons
+	name = "Weapons - Disposable tasers"
+	contains = list(/obj/item/gun/energy/taser/disposable = 4)
+	cost = 30
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "weapons crate"
 	access = access_security

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -31,7 +31,7 @@
 			return TRUE
 		if (istype(G, /obj/item/gun/energy))
 			var/obj/item/gun/energy/E = G
-			if(E.self_recharge)
+			if(E.self_recharge || E.disposable)
 				to_chat(user, SPAN_NOTICE("You can't find a charging port on \the [E]."))
 				return TRUE
 		if(!G.get_cell())

--- a/code/game/objects/items/devices/inducer.dm
+++ b/code/game/objects/items/devices/inducer.dm
@@ -110,6 +110,10 @@
 			SPAN_NOTICE("You start recharging \the [A] with \the [src].")
 		)
 		if (istype(A, /obj/item/gun/energy))
+			var/obj/item/gun/energy/gun = A
+			if(gun.disposable)
+				to_chat(user, SPAN_WARNING("There is no charging port on \the [gun]!"))
+				return TRUE
 			length = 3 SECONDS
 			if (user.get_skill_value(SKILL_WEAPONS) <= SKILL_TRAINED)
 				length += rand(1, 3) SECONDS

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -14,6 +14,7 @@
 	var/projectile_type = /obj/item/projectile/beam/practice
 	var/modifystate
 	var/charge_meter = 1	//if set, the icon state will be chosen based on the current charge
+	var/disposable = FALSE //If set, this weapon cannot be recharged
 
 	//self-recharging
 	var/self_recharge = 0	//if set, the weapon will recharge itself

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -13,6 +13,11 @@
 		list(mode_name="shock", projectile_type=/obj/item/projectile/beam/stun/shock),
 		)
 
+/obj/item/gun/energy/taser/disposable
+	name = "disposable electrolaser"
+	desc = "The NT Mk30 NL is a small, low capacity gun used for non-lethal takedowns. This is a cheap, disposable model commonly issued to police forces to supplement their service weapons. It can switch between high and low intensity stun shots."
+	disposable = TRUE
+
 /obj/item/gun/energy/taser/carbine
 	name = "electrolaser carbine"
 	desc = "The NT Mk44 NL is a high capacity gun used for non-lethal takedowns. It can switch between high and low intensity stun shots."


### PR DESCRIPTION
🆑 PurplePineapple
rscadd: Adds a variable to energy weapons allowing them to be marked as "disposable" guns. Energy guns with disposable set to true are not able to be charged or used with an inducer.
tweak: Security basic supply packs no longer contain electrolasers. They can be purchased separately with a cheaper supply pack that contains disposable electrolasers.
/🆑

Basically, makes it so that you can mark an energy weapon as disposable. Can be used for some fun things in the future like single use Spartan laser type weapons. I considered giving security disposable electrolasers in their lockers to go with their pistols but that may be a step too far for now. Would like some input from developers on whether or not to include that.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->