### PR TITLE
Various supply changes

### DIFF
--- a/code/datums/supplypacks/engineering.dm
+++ b/code/datums/supplypacks/engineering.dm
@@ -248,3 +248,14 @@
 	containername = "engineering voidsuit crate"
 	containertype = /obj/structure/closet/crate/secure/large
 	access = access_engine
+
+/singleton/hierarchy/supply_pack/engineering/robotics
+	name = "Parts - Robotics"
+	contains = list(/obj/item/device/assembly/prox_sensor = 3,
+					/obj/item/storage/toolbox/electrical,
+					/obj/item/device/flash = 4,
+					/obj/item/cell/high = 2)
+	cost = 10
+	containertype = /obj/structure/closet/crate/secure/gear
+	containername = "robotics assembly crate"
+	access = access_robotics

--- a/code/datums/supplypacks/munitions.dm
+++ b/code/datums/supplypacks/munitions.dm
@@ -4,31 +4,31 @@
 	containername = "mass driver munition crate"
 
 /singleton/hierarchy/supply_pack/munition/md_slug
-	name = "Ammo - Mass Driver Slug"
+	name = "Ammunition - Mass Driver Slug"
 	contains = list(/obj/structure/ship_munition/md_slug)
 	cost = 50
 
 /singleton/hierarchy/supply_pack/munition/ap_slug
-	name = "Ammo - Armor Piercing Mass Driver Slug"
+	name = "Ammunition - Armor Piercing Mass Driver Slug"
 	contains = list(/obj/structure/ship_munition/ap_slug)
 	cost = 60
 
 /singleton/hierarchy/supply_pack/munition/fire
-	name = "Ammo - disperser-FR1-ENFER charge"
+	name = "Ammunition - disperser-FR1-ENFER charge"
 	contains = list(/obj/structure/ship_munition/disperser_charge/fire)
 	cost = 40
 
 /singleton/hierarchy/supply_pack/munition/emp
-	name = "Ammo - disperser-EM2-QUASAR charge"
+	name = "Ammunition - disperser-EM2-QUASAR charge"
 	contains = list(/obj/structure/ship_munition/disperser_charge/emp)
 	cost = 40
 
 /singleton/hierarchy/supply_pack/munition/mining
-	name = "Ammo - disperser-MN3-BERGBAU charge"
+	name = "Ammunition - disperser-MN3-BERGBAU charge"
 	contains = list(/obj/structure/ship_munition/disperser_charge/mining)
 	cost = 40
 
 /singleton/hierarchy/supply_pack/munition/explosive
-	name = "Ammo - disperser-XP4-INDARRA charge"
+	name = "Ammunition - disperser-XP4-INDARRA charge"
 	contains = list(/obj/structure/ship_munition/disperser_charge/explosive)
 	cost = 40

--- a/code/datums/supplypacks/operations.dm
+++ b/code/datums/supplypacks/operations.dm
@@ -31,10 +31,9 @@
 	containername = "Ore box crate"
 
 /singleton/hierarchy/supply_pack/operations/webbing
-	name = "Gear - Webbing, vests, holsters."
+	name = "Gear - Webbing, vests"
 	num_contained = 4
-	contains = list(/obj/item/clothing/accessory/storage/holster,
-					/obj/item/clothing/accessory/storage/black_vest,
+	contains = list(/obj/item/clothing/accessory/storage/black_vest,
 					/obj/item/clothing/accessory/storage/brown_vest,
 					/obj/item/clothing/accessory/storage/white_vest,
 					/obj/item/clothing/accessory/storage/black_drop,
@@ -95,3 +94,24 @@
 	cost = 15
 	containertype = /obj/structure/closet/crate/large
 	containername = "office supplies crate"
+
+/singleton/hierarchy/supply_pack/operations/minergear
+	name = "Shaft miner equipment"
+	contains = list(/obj/item/storage/backpack/industrial,
+					/obj/item/storage/backpack/satchel/eng,
+					/obj/item/device/radio/headset/headset_cargo,
+					/obj/item/clothing/under/rank/miner,
+					/obj/item/clothing/gloves/thick,
+					/obj/item/clothing/shoes/black,
+					/obj/item/device/scanner/gas,
+					/obj/item/storage/ore,
+					/obj/item/device/flashlight/lantern,
+					/obj/item/shovel,
+					/obj/item/pickaxe,
+					/obj/item/device/scanner/mining,
+					/obj/item/clothing/glasses/material,
+					/obj/item/clothing/glasses/meson)
+	cost = 15
+	containertype = /obj/structure/closet/crate/secure
+	containername = "shaft miner equipment crate"
+	access = access_mining

--- a/code/datums/supplypacks/science.dm
+++ b/code/datums/supplypacks/science.dm
@@ -17,55 +17,6 @@
 	containertype = /obj/structure/largecrate
 	containername = "coolant tank crate"
 
-/singleton/hierarchy/supply_pack/science/robotics
-	name = "Parts - Robotics"
-	contains = list(/obj/item/device/assembly/prox_sensor = 3,
-					/obj/item/storage/toolbox/electrical,
-					/obj/item/device/flash = 4,
-					/obj/item/cell/high = 2)
-	cost = 10
-	containertype = /obj/structure/closet/crate/secure/gear
-	containername = "robotics assembly crate"
-	access = access_robotics
-
-/singleton/hierarchy/supply_pack/science/phoron
-	name = "Parts - Phoron device kit"
-	contains = list(/obj/item/tank/phoron = 3,
-					/obj/item/device/assembly/igniter = 3,
-					/obj/item/device/assembly/prox_sensor = 3,
-					/obj/item/device/assembly/timer = 3)
-	cost = 10
-	containertype = /obj/structure/closet/crate/secure/phoron
-	containername = "phoron assembly crate"
-	access = access_tox_storage
-
-/singleton/hierarchy/supply_pack/science/scanner_module
-	name = "Electronics - Reagent scanner modules"
-	contains = list(/obj/item/stock_parts/computer/scanner/reagent = 4)
-	cost = 20
-	containername = "reagent scanner module crate"
-
-/singleton/hierarchy/supply_pack/science/minergear
-	name = "Shaft miner equipment"
-	contains = list(/obj/item/storage/backpack/industrial,
-					/obj/item/storage/backpack/satchel/eng,
-					/obj/item/device/radio/headset/headset_cargo,
-					/obj/item/clothing/under/rank/miner,
-					/obj/item/clothing/gloves/thick,
-					/obj/item/clothing/shoes/black,
-					/obj/item/device/scanner/gas,
-					/obj/item/storage/ore,
-					/obj/item/device/flashlight/lantern,
-					/obj/item/shovel,
-					/obj/item/pickaxe,
-					/obj/item/device/scanner/mining,
-					/obj/item/clothing/glasses/material,
-					/obj/item/clothing/glasses/meson)
-	cost = 15
-	containertype = /obj/structure/closet/crate/secure
-	containername = "shaft miner equipment crate"
-	access = access_mining
-
 /singleton/hierarchy/supply_pack/science/flamps
 	num_contained = 3
 	contains = list(/obj/item/device/flashlight/lamp/floodlamp,

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -176,7 +176,9 @@
 		/obj/item/tank/oxygen_emergency_extended,
 		/obj/item/tank/nitrogen_emergency,
 		/obj/item/clothing/mask/gas,
-		/obj/item/taperoll/engineering
+		/obj/item/taperoll/engineering,
+		/obj/item/clothing/head/deckcrew,
+		/obj/item/clothing/head/hardhat
 	)
 	body_parts_covered = UPPER_TORSO
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)

--- a/maps/torch/datums/supplypacks/security.dm
+++ b/maps/torch/datums/supplypacks/security.dm
@@ -19,15 +19,6 @@
 	containername = "security armor crate"
 	access = access_security
 
-/singleton/hierarchy/supply_pack/security/solarmor
-	name = "Armor - Peacekeeper"
-	contains = list(/obj/item/clothing/suit/armor/pcarrier/blue/sol = 2,
-					/obj/item/clothing/head/helmet/solgov =2)
-	cost = 30
-	containertype = /obj/structure/closet/crate/secure
-	containername = "peacekeeper armor crate"
-	access = access_emergency_armory
-
 /singleton/hierarchy/supply_pack/security/comarmor
 	name = "Armor - Command"
 	contains = list(/obj/item/clothing/suit/armor/pcarrier/medium/command = 2,
@@ -36,24 +27,6 @@
 	containertype = /obj/structure/closet/crate/secure
 	containername = "command armor crate"
 	access = access_heads
-
-/singleton/hierarchy/supply_pack/security/nanoarmor
-	name = "Armor - Corporate"
-	contains = list(/obj/item/clothing/suit/armor/pcarrier/medium/nt = 2,
-					/obj/item/clothing/head/helmet/nt/guard =2)
-	cost = 20
-	containertype = /obj/structure/closet/crate/secure
-	containername = "corporate armor crate"
-	access = access_nanotrasen
-
-/singleton/hierarchy/supply_pack/security/lightnanoarmor
-	name = "Armor - Corporate light"
-	contains = list(/obj/item/clothing/suit/armor/pcarrier/light/nt = 2,
-					/obj/item/clothing/head/helmet/nt/guard =2)
-	cost = 15
-	containertype = /obj/structure/closet/crate/secure
-	containername = "corporate light armor crate"
-	access = access_nanotrasen
 
 /singleton/hierarchy/supply_pack/security/pistol
 	name = "Weapons - Ballistic sidearms"

--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -3764,15 +3764,6 @@
 /obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/exploration)
-"iR" = (
-/obj/floor_decal/industrial/outline/yellow,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/machinery/mech_recharger,
-/mob/living/exosuit/premade/powerloader/old,
-/turf/simulated/floor/tiled/dark/monotile,
-/area/quartermaster/storage)
 "iS" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/green{
@@ -3849,8 +3840,8 @@
 /obj/floor_decal/industrial/warning{
 	dir = 8
 	},
-/obj/machinery/computer/guestpass{
-	pixel_y = 32
+/obj/machinery/light/spot{
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
@@ -3969,11 +3960,11 @@
 /obj/random/maintenance/solgov,
 /obj/random/maintenance/solgov,
 /obj/item/tape_roll,
-/obj/machinery/light/small,
 /obj/machinery/alarm{
 	dir = 1;
 	pixel_y = -25
 	},
+/obj/machinery/light/spot,
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "jo" = (
@@ -3992,8 +3983,8 @@
 /area/maintenance/fifthdeck/fore)
 "jp" = (
 /obj/floor_decal/industrial/outline/yellow,
-/obj/machinery/light/small,
 /obj/structure/closet/crate/freezer/rations,
+/obj/machinery/light/spot,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/storage)
 "jq" = (
@@ -14302,9 +14293,6 @@
 /obj/structure/closet/medical_wall/filled{
 	pixel_y = 32
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/storage)
 "MX" = (
@@ -16160,13 +16148,9 @@
 /obj/item/stack/material/glass/reinforced{
 	amount = 30
 	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 30
-	},
-/obj/item/stack/material/glass/reinforced{
-	amount = 30
-	},
 /obj/floor_decal/industrial/outline/yellow,
+/obj/item/stack/material/glass,
+/obj/item/stack/material/glass,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/storage)
 "UM" = (
@@ -38392,7 +38376,7 @@ Fk
 Em
 Em
 Em
-Em
+hy
 hE
 hE
 Em
@@ -38591,8 +38575,8 @@ lh
 Vz
 xl
 TL
-hy
-iR
+Em
+ou
 ou
 oy
 if

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -105,7 +105,7 @@
 /obj/machinery/door/blast/shutters{
 	dir = 2;
 	id_tag = "do_office";
-	name = "DO Office Shutters"
+	name = "privacy shutters"
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/deckchief)
@@ -4644,8 +4644,8 @@
 /obj/floor_decal/corner/brown{
 	dir = 5
 	},
-/obj/machinery/computer/guestpass{
-	pixel_y = 32
+/obj/structure/bed/chair/comfy/brown{
+	dir = 8
 	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/deckchief)
@@ -4962,6 +4962,9 @@
 "ru" = (
 /obj/floor_decal/corner/brown/half{
 	dir = 1
+	},
+/obj/machinery/computer/guestpass{
+	pixel_y = 32
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
@@ -7698,9 +7701,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/security/hangcheck)
 "zM" = (
-/obj/structure/bed/chair/padded/brown{
-	dir = 8
-	},
 /turf/simulated/floor/tiled,
 /area/quartermaster/deckchief)
 "zP" = (
@@ -12170,9 +12170,9 @@
 /obj/machinery/door/blast/shutters{
 	dir = 2;
 	id_tag = "do_office";
-	name = "DO Office Shutters"
+	name = "privacy shutters"
 	},
-/obj/wallframe_spawn/no_grille,
+/obj/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/quartermaster/deckchief)
 "Pc" = (
@@ -12683,7 +12683,7 @@
 /area/crew_quarters/lounge)
 "Qu" = (
 /obj/structure/table/standard,
-/obj/item/device/megaphone,
+/obj/item/folder/envelope/dcorder,
 /turf/simulated/floor/tiled,
 /area/quartermaster/deckchief)
 "Qy" = (
@@ -13428,7 +13428,6 @@
 	pixel_x = 32
 	},
 /obj/random_multi/single_item/memo_supply,
-/obj/item/folder/envelope/dcorder,
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/deckchief)
 "Sz" = (
@@ -13665,7 +13664,6 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/random/clipboard,
 /obj/item/stamp/deckoff,
 /obj/item/pen{
 	pixel_x = 4;
@@ -13682,9 +13680,9 @@
 	pixel_y = 24
 	},
 /obj/floor_decal/corner/brown/mono,
-/obj/item/device/radio/intercom/department/security{
+/obj/item/device/radio/intercom{
 	dir = 8;
-	pixel_x = 21
+	pixel_x = 22
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/deckchief)
@@ -38893,7 +38891,7 @@ bx
 MI
 Vi
 vK
-qf
+xn
 PT
 Pj
 ZQ
@@ -39297,7 +39295,7 @@ gq
 SO
 WS
 au
-xn
+qf
 zM
 Ad
 Lx


### PR DESCRIPTION
- Made it possible to carry hardhats and deck crew helmets in the hazard vest's slot.
- Made the deck chief's office slightly less terrible, removed double items, better chair, and so on. Did you know that it had a security radio?
- Added SPOTLIGHTS to the warehouse.
- Removed some goods that didn't make sense. Looking at you, DIY phoron bomb kit.
- Moved _some_ goods to more fitting categories (mining stuff and robotics). Not exhaustive **at all**, literally all of that requires a well thought out rework.

:cl:
maptweak: Various changes to the supply department, most notable: DC office and the warehouse lights.
tweak: Deck crew helmets and hardhats can be worn in the hazard vest's suit slot.
tweak: Minor shuffles in the orderable goods.
/:cl: