### PR TITLE
Plant potency affects bioluminescence

### DIFF
--- a/code/modules/hydroponics/seed.dm
+++ b/code/modules/hydroponics/seed.dm
@@ -89,6 +89,11 @@
 	if(trait == TRAIT_PLANT_ICON)
 		update_growth_stages()
 
+/// Returns between 0 and 1 along an approximate log curve for potency up to 200
+/datum/seed/proc/get_potency_curve()
+	var/scale = clamp(get_trait(TRAIT_POTENCY), 1, 200) / 200
+	return (1.2 * scale) / (0.2 + scale)
+
 /datum/seed/proc/create_spores(turf/T)
 	if(!T)
 		return
@@ -202,9 +207,10 @@
 			splat.SetName("[thrown.name] [pick("smear","smudge","splatter")]")
 			if(get_trait(TRAIT_BIOLUM))
 				var/clr
+				var/biolum_power = get_potency_curve()
 				if(get_trait(TRAIT_BIOLUM_COLOUR))
 					clr = get_trait(TRAIT_BIOLUM_COLOUR)
-				splat.set_light(3, 0.5, l_color = clr)
+				splat.set_light(6 * biolum_power, biolum_power, l_color = clr)
 			var/flesh_colour = get_trait(TRAIT_FLESH_COLOUR)
 			if(!flesh_colour) flesh_colour = get_trait(TRAIT_PRODUCT_COLOUR)
 			if(flesh_colour) splat.color = get_trait(TRAIT_PRODUCT_COLOUR)
@@ -785,9 +791,10 @@
 
 			if(get_trait(TRAIT_BIOLUM))
 				var/clr
+				var/biolum_power = get_potency_curve()
 				if(get_trait(TRAIT_BIOLUM_COLOUR))
 					clr = get_trait(TRAIT_BIOLUM_COLOUR)
-				product.set_light(3, 0.5, l_color = clr)
+				product.set_light(6 * biolum_power, biolum_power, l_color = clr)
 
 			//Handle spawning in living, mobile products (like dionaea).
 			if(istype(product,/mob/living))

--- a/code/modules/hydroponics/spreading/spreading.dm
+++ b/code/modules/hydroponics/spreading/spreading.dm
@@ -157,7 +157,8 @@
 
 	// Apply colour and light from seed datum.
 	if(seed.get_trait(TRAIT_BIOLUM))
-		set_light(3, 0.5, l_color = seed.get_trait(TRAIT_BIOLUM_COLOUR))
+		var/biolum_power = seed.get_potency_curve()
+		set_light(6 * biolum_power, biolum_power, l_color = seed.get_trait(TRAIT_BIOLUM_COLOUR))
 	else
 		set_light(0)
 

--- a/code/modules/hydroponics/trays/tray_update_icons.dm
+++ b/code/modules/hydroponics/trays/tray_update_icons.dm
@@ -71,7 +71,8 @@
 
 	// Update bioluminescence.
 	if(seed && seed.get_trait(TRAIT_BIOLUM))
-		set_light(3, 0.5, l_color = seed.get_trait(TRAIT_BIOLUM_COLOUR))
+		var/biolum_power = seed.get_potency_curve()
+		set_light(6 * biolum_power, biolum_power, l_color = seed.get_trait(TRAIT_BIOLUM_COLOUR))
 	else
 		set_light(0)
 


### PR DESCRIPTION
:cl: sick trigger
rscadd: Plant potency affects the brightness of bioluminescent plants
/:cl:

At max potency has the same range as an LED flashlight, while not being quite as bright. Glowshrooms and the most potent generated plants (30 potency) end up about the same as the old values
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->