### PR TITLE
add view byond account link to player panel for mobs with a ckey

### DIFF
--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -90,6 +90,8 @@ var/global/floorIsLava = 0
 		<A HREF='?src=\ref[src];connections=\ref[M]'>Check Connections</A> |
 		<A HREF='?src=\ref[src];bans=\ref[M]'>Check Bans</A> |
 	"}
+	if (M.ckey)
+		body += {"<a target="_blank" href="https://www.byond.com/members/[M.ckey]">View Byond Account</a> | "}
 
 	if (!istype(M, /mob/new_player) && !istype(M, /mob/observer))
 		body += "<A HREF='?src=\ref[src];cryo=\ref[M]'>Cryo Character</A> | "


### PR DESCRIPTION
:cl:
admin: Added a "View Byond Account" link to player panel when the mob has a ckey.
/:cl:

Opens in a new window. Sadly, the window can't not be IE.
