### PR TITLE
Assorted pride pin/badge selection changes

### DIFF
--- a/code/datums/supplypacks/nonessent.dm
+++ b/code/datums/supplypacks/nonessent.dm
@@ -295,14 +295,7 @@
 /singleton/hierarchy/supply_pack/nonessent/pronounbadges
 	name = "Costume - Pronoun Badge Crate"
 	contains = list(
-		/obj/item/clothing/accessory/pronouns/they = 2,
-		/obj/item/clothing/accessory/pronouns/hehim = 2,
-		/obj/item/clothing/accessory/pronouns/sheher = 2,
-		/obj/item/clothing/accessory/pronouns/hethey = 2,
-		/obj/item/clothing/accessory/pronouns/shethey = 2,
-		/obj/item/clothing/accessory/pronouns/heshe = 2,
-		/obj/item/clothing/accessory/pronouns/zehir = 2,
-		/obj/item/clothing/accessory/pronouns/ask = 2
+		/obj/item/clothing/accessory/pronouns = 5
 	)
-	cost = 20
+	cost = 10
 	containername = "pronoun badge crate"

--- a/code/modules/client/preference_setup/loadout/lists/accessories.dm
+++ b/code/modules/client/preference_setup/loadout/lists/accessories.dm
@@ -171,32 +171,40 @@
 
 
 /datum/gear/accessory/pronouns
-	display_name = "pronoun badge selection"
-	description = "A selection of badges used to indicate the preferred pronouns of the wearer."
+	display_name = "pronoun badge, customisable"
+	description = "A badge used to indicate the preferred pronouns of the wearer."
 	path = /obj/item/clothing/accessory/pronouns
 
 
-/datum/gear/accessory/pronouns/New()
+/datum/gear/accessory/pride_pins
+	display_name = "pride pin selection, primary"
+	description = "A selection of pins used to signal membership or support of an identity or sexuality."
+	path = /obj/item/clothing/accessory/pride_pin
+	flags = GEAR_HAS_NO_CUSTOMIZATION
+
+
+/datum/gear/accessory/pride_pins/New()
 	..()
 	var/list/options = list()
-	options["they/them badge"] = /obj/item/clothing/accessory/pronouns/they
-	options["he/him badge"] = /obj/item/clothing/accessory/pronouns/hehim
-	options["she/her badge"] = /obj/item/clothing/accessory/pronouns/sheher
-	options["he/they badge"] = /obj/item/clothing/accessory/pronouns/hethey
-	options["she/they badge"] = /obj/item/clothing/accessory/pronouns/shethey
-	options["he/she badge"] = /obj/item/clothing/accessory/pronouns/heshe
-	options["ze/hir badge"] = /obj/item/clothing/accessory/pronouns/zehir
-	options["ask me badge"] = /obj/item/clothing/accessory/pronouns/ask
+	options["transgender pride pin"] = /obj/item/clothing/accessory/pride_pin/transgender
+	options["lesbian pride pin"] = /obj/item/clothing/accessory/pride_pin/lesbian
+	options["bisexual pride pin"] = /obj/item/clothing/accessory/pride_pin/bisexual
+	options["gay pride pin"] = /obj/item/clothing/accessory/pride_pin/gay
+	options["pansexual pride pin"] = /obj/item/clothing/accessory/pride_pin/pansexual
+	options["nonbinary pride pin"] = /obj/item/clothing/accessory/pride_pin/nonbinary
+	options["asexual pride pin"] = /obj/item/clothing/accessory/pride_pin/asexual
+	options["intersex pride pin"] = /obj/item/clothing/accessory/pride_pin/intersex
+	options["aromantic pride pin"] = /obj/item/clothing/accessory/pride_pin/aromantic
 	gear_tweaks += new /datum/gear_tweak/path (options)
 
 
-/datum/gear/accessory/pride_pins
-	display_name = "pride pin selection"
+/datum/gear/accessory/pride_pins_secondary
+	display_name = "pride pin selection, secondary"
 	description = "A selection of pins used to signal membership or support of an identity or sexuality."
 	path = /obj/item/clothing/accessory/pride_pin
 
 
-/datum/gear/accessory/pride_pins/New()
+/datum/gear/accessory/pride_pins_secondary/New()
 	..()
 	var/list/options = list()
 	options["transgender pride pin"] = /obj/item/clothing/accessory/pride_pin/transgender

--- a/code/modules/clothing/under/accessories/pronouns.dm
+++ b/code/modules/clothing/under/accessories/pronouns.dm
@@ -1,47 +1,8 @@
 /obj/item/clothing/accessory/pronouns
-	abstract_type = /obj/item/clothing/accessory/pronouns
-	name = "base pronouns badge"
+	name = "customisable pronouns badge"
+	desc = "A badge showing the wearer's pronouns. Customisable!"
 	icon_state = "pronounpin"
 	item_state = "pronouns"
 	on_rolled_down = ACCESSORY_ROLLED_NONE
 	slot = ACCESSORY_SLOT_INSIGNIA
 	accessory_flags = ACCESSORY_REMOVABLE | ACCESSORY_HIGH_VISIBILITY
-
-
-/obj/item/clothing/accessory/pronouns/they
-	name = "they/them pronouns badge"
-	desc = "A badge showing the wearer's pronouns: they, them and theirs."
-
-
-/obj/item/clothing/accessory/pronouns/hehim
-	name = "he/him pronouns badge"
-	desc = "A badge showing the wearer's pronouns: he, him and his."
-
-
-/obj/item/clothing/accessory/pronouns/sheher
-	name = "she/her pronouns badge"
-	desc = "A badge showing the wearer's pronouns: she, her and hers."
-
-
-/obj/item/clothing/accessory/pronouns/hethey
-	name = "he/they pronouns badge"
-	desc = "A badge showing the wearer's pronouns: he, him and his or they, them and theirs."
-
-
-/obj/item/clothing/accessory/pronouns/shethey
-	name = "she/they pronouns badge"
-	desc = "A badge showing the wearer's pronouns: she, her and hers or they, them and theirs."
-
-/obj/item/clothing/accessory/pronouns/heshe
-	name = "he/she pronouns badge"
-	desc = "A badge showing the wearer's pronouns: he, him and his or she, her and hers."
-
-
-/obj/item/clothing/accessory/pronouns/zehir
-	name = "ze/hir pronouns badge"
-	desc = "A badge showing the wearer's pronouns: ze, hir and hirs."
-
-
-/obj/item/clothing/accessory/pronouns/ask
-	name = "ask my pronouns badge"
-	desc = "A badge asking others to ask for the wearer's pronouns."


### PR DESCRIPTION
:cl:
tweak: Removes the preset pronoun badge types, people can now customise them to their wish.
tweak: Adds another entry for the pride pins. Letting people take two now.
/:cl:

Arguably a cheap and shoddy implementation of having a second pride pin selector. If the implementation isn't good, can change and think up of an alternate.