### PR TITLE
Remove error log on client lacking preferences

### DIFF
--- a/code/modules/client/preference_setup/global/05_settings.dm
+++ b/code/modules/client/preference_setup/global/05_settings.dm
@@ -87,8 +87,6 @@
 			return prefs.preference_values[cp.key]
 		else
 			return null
-	else
-		log_error("Client is lacking preferences: [log_info_line(src)]")
 
 /client/proc/set_preference(preference, set_preference)
 	var/datum/client_preference/cp = get_client_preference(preference)


### PR DESCRIPTION
Because this log hasn't ever come up in a legit situation and constantly appears simply from people connecting to the server, which has turned into alarm fatigue.