### PR TITLE
Add "fireman" carry

### DIFF
--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -280,6 +280,9 @@
 				var/mob/living/L = A
 				if(L.pulling)
 					L.pulling.forceMove(target)
+				for (var/obj/item/grab/G in list(L.l_hand, L.r_hand))
+					var/mob/living/T = G.affecting
+					T.forceMove(target)
 			if(ishuman(A))
 				var/mob/living/carbon/human/H = A
 				if(H.has_footsteps())


### PR DESCRIPTION
:cl:
rscadd: Carry people by getting them in a blue-grab and clicking them with an open hand on grab intent.
tweak: Grabs transfer past stairs, now.
/:cl:

Slower than a roller-bed, faster than the normal grab. You cannot carry people wearing a rigsuit unless you have one, too.
Humans cannot carry Adherent, or GAS.
Humans cannot carry Unathi or IPC/FBP or GravAdapts without wearing a rigsuit (the opposite of course works).

The sprite alignment is something I cannot figure out properly. Help would be appreciated.