### PR TITLE
Increasing Infection Rates and Adjustments to Infections and Spaceacillin

### DIFF
--- a/code/__defines/damage_organs.dm
+++ b/code/__defines/damage_organs.dm
@@ -76,8 +76,8 @@
 #define GERM_LEVEL_AMBIENT  275 // Maximum germ level you can reach by standing still.
 #define GERM_LEVEL_MOVE_CAP 300 // Maximum germ level you can reach by running around.
 
-#define INFECTION_LEVEL_ONE   250
-#define INFECTION_LEVEL_TWO   500  // infections grow from ambient to two in ~5 minutes
+#define INFECTION_LEVEL_ONE   300
+#define INFECTION_LEVEL_TWO   550  // infections grow from ambient to two in ~5 minutes
 #define INFECTION_LEVEL_THREE 1000 // infections grow from two to three in ~10 minutes
 
 //Blood levels. These are percentages based on the species blood_volume far.

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -630,7 +630,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 		for(var/datum/wound/W in wounds)
 			//Infected wounds raise the organ's germ level
 			if (W.germ_level > germ_level || prob(min(W.germ_level, 30)))
-				germ_level += 4
+				germ_level += 3
 				break	//limit increase to a maximum of four per second
 
 /obj/item/organ/external/handle_germ_effects()
@@ -658,19 +658,19 @@ Note that amputating the affected organ does in fact remove the infection from t
 				target_organ = pick(candidate_organs)
 
 		if (target_organ)
-			target_organ.germ_level += 5
+			target_organ.germ_level += 4
 
 		//spread the infection to child and parent organs
 		if (children)
 			for (var/obj/item/organ/external/child in children)
 				if (child.germ_level < germ_level && !BP_IS_ROBOTIC(child))
 					if (child.germ_level < INFECTION_LEVEL_ONE*2 || prob(30))
-						child.germ_level += 5
+						child.germ_level += 4
 
 		if (parent)
 			if (parent.germ_level < germ_level && !BP_IS_ROBOTIC(parent))
 				if (parent.germ_level < INFECTION_LEVEL_ONE*2 || prob(30))
-					parent.germ_level += 5
+					parent.germ_level += 4
 
 	if(germ_level >= INFECTION_LEVEL_THREE && antibiotics < REAGENTS_OVERDOSE)	//overdosing is necessary to stop severe infections
 		if (!(status & ORGAN_DEAD))

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -630,8 +630,8 @@ Note that amputating the affected organ does in fact remove the infection from t
 		for(var/datum/wound/W in wounds)
 			//Infected wounds raise the organ's germ level
 			if (W.germ_level > germ_level || prob(min(W.germ_level, 30)))
-				germ_level++
-				break	//limit increase to a maximum of one per second
+				germ_level += 4
+				break	//limit increase to a maximum of four per second
 
 /obj/item/organ/external/handle_germ_effects()
 
@@ -658,19 +658,19 @@ Note that amputating the affected organ does in fact remove the infection from t
 				target_organ = pick(candidate_organs)
 
 		if (target_organ)
-			target_organ.germ_level++
+			target_organ.germ_level += 5
 
 		//spread the infection to child and parent organs
 		if (children)
 			for (var/obj/item/organ/external/child in children)
 				if (child.germ_level < germ_level && !BP_IS_ROBOTIC(child))
 					if (child.germ_level < INFECTION_LEVEL_ONE*2 || prob(30))
-						child.germ_level++
+						child.germ_level += 5
 
 		if (parent)
 			if (parent.germ_level < germ_level && !BP_IS_ROBOTIC(parent))
 				if (parent.germ_level < INFECTION_LEVEL_ONE*2 || prob(30))
-					parent.germ_level++
+					parent.germ_level += 5
 
 	if(germ_level >= INFECTION_LEVEL_THREE && antibiotics < REAGENTS_OVERDOSE)	//overdosing is necessary to stop severe infections
 		if (!(status & ORGAN_DEAD))
@@ -679,7 +679,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			owner.update_body(1)
 
 		germ_level++
-		owner.adjustToxLoss(1)
+		owner.adjustToxLoss(0.15)
 
 //Updating wounds. Handles wound natural I had some free spachealing, internal bleedings and infections
 /obj/item/organ/external/proc/update_wounds()

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -631,7 +631,7 @@ Note that amputating the affected organ does in fact remove the infection from t
 			//Infected wounds raise the organ's germ level
 			if (W.germ_level > germ_level || prob(min(W.germ_level, 30)))
 				germ_level += 3
-				break	//limit increase to a maximum of four per second
+				break	//limit increase to a maximum of three per second
 
 /obj/item/organ/external/handle_germ_effects()
 

--- a/code/modules/organs/organ.dm
+++ b/code/modules/organs/organ.dm
@@ -184,8 +184,8 @@ var/global/list/organ_cache = list()
 		if (antibiotics < 5 && parent.germ_level < germ_level && ( parent.germ_level < INFECTION_LEVEL_ONE*2 || prob(owner.immunity_weakness() * 0.3) ))
 			parent.germ_level++
 
-		if (prob(3))	//about once every 30 seconds
-			take_general_damage(1,silent=prob(30))
+		if (prob(30))	//2 organ damage that has a 30% chance of occuring every tick
+			take_general_damage(2,silent=prob(30))
 
 /obj/item/organ/proc/handle_rejection()
 	// Process unsuitable transplants. TODO: consider some kind of

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -564,7 +564,7 @@
 	taste_description = "bitterness"
 	reagent_state = LIQUID
 	color = "#c1c1c1"
-	metabolism = REM * 0.1
+	metabolism = REM * 0.5
 	overdose = REAGENTS_OVERDOSE/2
 	scannable = 1
 	value = 2.5


### PR DESCRIPTION
Infections currently progress too slowly to pose any serious issue for players during a vast majority of rounds, almost never getting to the point of sepsis. Infections will need to be changed so that they can be lethal in normal rounds.

Changes:
- Infections grow and spread faster, growing on the source limb by ~3x and spreading to adjacent limbs and organs by ~4x. 
- Liver damage due to septic limbs/organs is greatly reduced to ~0.15x so the person does not die immediately after a limb/organ goes septic.
- Increased damage that organs take from a acute infection so that the affected organ now takes noticeable damage before dying from sepsis.
- Changed spaceacillin's 0.02u metabolism rate to 0.1u metabolism rate. A full syringe of the updated spaceacillin should be able to just barely treat a patient who is nearly septic (near germ_level=1000). 
- Increased the define values for INFECTIONLEVELONE and INFECTIONLEVELTWO slightly so that people don't get infected too often from the new changes.

Several tests were done on a private server that had infection rate set to ~4x and infection spread to ~5x and on average, a person who was hit by a laser carbine shot had their original limb go septic in **~26 minutes**, with death coming around **~35 minutes** (depending on the source of the infection). The changes in this PR are 3x for infection rate and 4x for infection spread, which means that it should take a bit longer than the recorded times to cause sepsis and cause death.

A special thank you to Azlan for helping me with this project, showing me the files that code for infections, and answering questions I had about byond coding. 

:cl: JebediahTechnic
balance: Increased infection rate by roughly ~3x.
balance: Increased spread of infection rate to adjacent limbs/organs by roughly ~4x.
tweak: Increased define values for INFECTIONLEVELONE and INFECTIONLEVELTWO (300 and 550 respectively).
tweak: Liver damage from sepsis reduced to ~0.15x.
tweak: Increased spaceacillin reagent consumption per tick to ~5x (updated to 0.1u).
/:cl:
