### PR TITLE
Sugar now causes brain damage in extremely high doses for unathi

### DIFF
--- a/code/datums/traits/trait_helpers.dm
+++ b/code/datums/traits/trait_helpers.dm
@@ -31,3 +31,6 @@
 		C.emote(pick("twitch", "drool"))
 	if(effective_dose > 20 && prob(10))
 		C.SelfMove(pick(GLOB.cardinal))
+	if(effective_dose > 50 && prob(60))
+		var/obj/item/organ/internal/brain/O = C.internal_organs_by_name[BP_BRAIN]
+		O?.take_internal_damage(10, FALSE)


### PR DESCRIPTION
This PR makes it so doses of over 50 sugar units causes brain damage  with high probability (60%) for unathi and the unathi monkey subtype.
I believe it is a cool feature to have (For rp reasons), considering they already get hallucinations & dizzyness from small doses.


:cl: MLGTASTICa
balance: Sugar doses over 50 units now cause brain damage for species with the sugar malus(unathi and unathi-homeworld monkeys)
/:cl: