### PR TITLE
Enable extending loadout descriptions

### DIFF
--- a/code/modules/client/preference_setup/loadout/_defines.dm
+++ b/code/modules/client/preference_setup/loadout/_defines.dm
@@ -2,3 +2,6 @@
 #define GEAR_HAS_TYPE_SELECTION FLAG(1)
 #define GEAR_HAS_SUBTYPE_SELECTION FLAG(2)
 #define GEAR_HAS_NO_CUSTOMIZATION FLAG(3)
+/// This flag is discouraged for loadout items with random contents.
+/// Extended descriptions are cached and even if they weren't, seeing random descriptions every refresh of the loadout would be odd as well.
+#define GEAR_HAS_EXTENDED_DESCRIPTION FLAG(4)

--- a/code/modules/client/preference_setup/loadout/lists/accessories.dm
+++ b/code/modules/client/preference_setup/loadout/lists/accessories.dm
@@ -65,7 +65,7 @@
 	description = "A medal or ribbon awarded to corporate personnel for significant accomplishments."
 	path = /obj/item/storage/medalbox
 	cost = 6
-	flags = GEAR_HAS_NO_CUSTOMIZATION
+	flags = GEAR_HAS_NO_CUSTOMIZATION | GEAR_HAS_EXTENDED_DESCRIPTION
 
 
 /datum/gear/accessory/ntaward/New()

--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -178,7 +178,7 @@ var/global/list/gear_datums = list()
 		var/ticked = (G.display_name in pref.gear_list[pref.gear_slot])
 		entry += "<tr style='vertical-align:top;'><td width=25%><a style='white-space:normal;' [ticked ? "class='linkOn' " : ""]href='?src=\ref[src];toggle_gear=\ref[G]'>[G.display_name]</a></td>"
 		entry += "<td width = 10% style='vertical-align:top'>[G.cost]</td>"
-		entry += "<td>[FONT_NORMAL(G.get_description(get_gear_metadata(G,1)))]"
+		entry += "<td>[FONT_NORMAL(G.get_description(get_gear_metadata(G,1), ticked))]"
 		var/allowed = 1
 		if(allowed && G.allowed_roles)
 			var/good_job = 0
@@ -350,10 +350,10 @@ var/global/list/gear_datums = list()
 	if(custom_setup_proc)
 		gear_tweaks += new/datum/gear_tweak/custom_setup(custom_setup_proc)
 
-/datum/gear/proc/get_description(metadata)
+/datum/gear/proc/get_description(metadata, include_extended_description)
 	. = description
 	for(var/datum/gear_tweak/gt in gear_tweaks)
-		. = gt.tweak_description(., metadata["[gt]"])
+		. = gt.tweak_description(., metadata["[gt]"], include_extended_description && (flags & GEAR_HAS_EXTENDED_DESCRIPTION))
 
 /datum/gear_data
 	var/path

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -4,7 +4,7 @@
 	path = /obj/item/storage/medalbox/sol
 	cost = 6
 	allowed_branches = SOLGOV_BRANCHES
-	flags = GEAR_HAS_NO_CUSTOMIZATION
+	flags = GEAR_HAS_NO_CUSTOMIZATION | GEAR_HAS_EXTENDED_DESCRIPTION
 
 /datum/gear/accessory/solgov_award_military/New()
 	..()
@@ -24,7 +24,7 @@
 	description = "A selection of civilian awards awarded by the Sol Central Government."
 	path = /obj/item/storage/medalbox/sol
 	cost = 3
-	flags = GEAR_HAS_NO_CUSTOMIZATION
+	flags = GEAR_HAS_NO_CUSTOMIZATION | GEAR_HAS_EXTENDED_DESCRIPTION
 
 /datum/gear/accessory/solgov_award_civilian/New()
 	..()


### PR DESCRIPTION
:cl:
tweak: Select loadout items again display an extended description when selected for use.
/:cl:

Two different selected loadout items with extended descriptions:
![This image displays the extended description of two different, selected loadout items.](https://github.com/user-attachments/assets/d52fb992-6e07-44d3-9391-489b7c5d57d3)

Compare with what it looks like when unselected:
![This image shows the difference for a loadout items that's no longer selected.](https://github.com/user-attachments/assets/936c045f-a7c9-493e-b136-c11c52b6e57e)