### PR TITLE
Unathi regeneration gets lowered by taking damage.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -277,7 +277,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 	if (weapon.force > 0 && get_max_health() && !HAS_FLAGS(weapon.item_flags, ITEM_FLAG_NO_BLUDGEON))
 		user.setClickCooldown(user.get_attack_speed(weapon))
 		user.do_attack_animation(src)
-		if (!aura_check(AURA_TYPE_WEAPON, weapon, user))
+		if (!aura_check(AURA_TYPE_WEAPON, weapon, user, click_params))
 			return TRUE
 		var/damage_flags = weapon.damage_flags()
 		var/weapon_mention
@@ -328,9 +328,10 @@ avoid code duplication. This includes items that may sometimes act as a standard
 		if (istype(result))
 			if (result.hit_zone)
 				var/mob/living/victim = result.attackee ? result.attackee : src
-				weapon.apply_hit_effect(victim, user, result.hit_zone)
+				aura_post_check(AURA_TYPE_WEAPON, weapon, user, click_params, weapon.apply_hit_effect(victim, user, result.hit_zone))
 				return TRUE
 		if (hit_zone)
+			aura_post_check(AURA_TYPE_WEAPON, weapon, user, click_params, weapon.apply_hit_effect(src, user, hit_zone))
 			weapon.apply_hit_effect(src, user, hit_zone)
 		return TRUE
 	return ..()

--- a/code/game/objects/auras/aura.dm
+++ b/code/game/objects/auras/aura.dm
@@ -49,6 +49,10 @@ They should also be used for when you want to effect the ENTIRE mob, like having
 /obj/aura/proc/aura_check_weapon(obj/item/weapon, mob/attacker, click_params)
 	return EMPTY_BITFIELD
 
+/// Called after a succesfull weapon hit on the owner
+/obj/aura/proc/aura_post_weapon(obj/item/weapon, mob/attacker, click_params, damage_dealt)
+	return EMPTY_BITFIELD
+
 /**
  * Called when the associated mob is impacted by a projectile.
  *
@@ -63,6 +67,10 @@ They should also be used for when you want to effect the ENTIRE mob, like having
 /obj/aura/proc/aura_check_bullet(obj/item/projectile/proj, def_zone)
 	return EMPTY_BITFIELD
 
+/// Called after a succesfull bullet hit on the owner
+/obj/aura/proc/aura_post_bullet(obj/item/projectile/proj , def_zone, damage_dealt)
+	return EMPTY_BITFIELD
+
 /**
  * Called when the associated mob is hit by a thrown atom.
  *
@@ -75,6 +83,10 @@ They should also be used for when you want to effect the ENTIRE mob, like having
  * Returns bitfield (Any of `AURA_*`). See `code\__defines\mobs.dm`.
  */
 /obj/aura/proc/aura_check_thrown(atom/movable/thrown_atom, datum/thrownthing/thrown_datum)
+	return EMPTY_BITFIELD
+
+/// Calle after something thrown hits the owner
+/obj/aura/proc/aura_post_thrown(atom/movable/thrown_atom, datum/thrownthing/thrown_datum, damage_dealt)
 	return EMPTY_BITFIELD
 
 /obj/aura/debug

--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -154,6 +154,7 @@
 		H.adjust_nutrition(3)
 		return AURA_FALSE
 	// min of 25% guaranteed
+	regeneration_malus = min(regeneration_malus,  regeneration_malus_cap)
 	var/regen_mult = max(0.25, 1 - (regeneration_malus ? 0 : (regeneration_malus / regeneration_malus_cap)))
 	regeneration_malus = max(0, regeneration_malus - 1)
 	// Yes you can.. damage yourself to avoid regen damage ? call it unathi adrenaline!

--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -145,6 +145,8 @@
 		H.apply_damage(5, DAMAGE_TOXIN)
 		H.adjust_nutrition(3)
 		return AURA_FALSE
+	if(toggle_blocked_until > world.time)
+		return AURA_CANCEL
 	nutrition_damage_mult = 2
 	brute_mult = 2
 	organ_mult = 4

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -6,6 +6,7 @@
 
 	Returns
 	standard 0 if fail
+	damage dealt if succesfull
 */
 /mob/living/proc/apply_damage(damage = 0, damagetype = DAMAGE_BRUTE, def_zone = null, damage_flags = EMPTY_BITFIELD, used_weapon, armor_pen, silent = FALSE)
 	if(!damage)
@@ -49,7 +50,7 @@
 			adjustBrainLoss(damage)
 
 	updatehealth()
-	return TRUE
+	return damage
 
 
 /mob/living/proc/apply_radiation(damage = 0)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -246,11 +246,12 @@
 	var/hit_zone = get_zone_with_miss_chance(def_zone, target_mob, miss_modifier, ranged_attack=(distance > 1 || original != target_mob)) //if the projectile hits a target we weren't originally aiming at then retain the chance to miss
 
 	var/result = PROJECTILE_FORCE_MISS
+	var/damage_dealt = 0
 	if(hit_zone)
 		def_zone = hit_zone //set def_zone, so if the projectile ends up hitting someone else later (to be implemented), it is more likely to hit the same part
 		if(!target_mob.aura_check(AURA_TYPE_BULLET, src,def_zone))
 			return 1
-		result = target_mob.bullet_act(src, def_zone)
+		result = target_mob.bullet_act(src, def_zone, &damage_dealt)
 
 	if(result == PROJECTILE_FORCE_MISS)
 		if(!silenced)
@@ -258,6 +259,9 @@
 			if(LAZYLEN(miss_sounds))
 				playsound(target_mob.loc, pick(miss_sounds), 60, 1)
 		return 0
+
+	if(damage_dealt)
+		target_mob.aura_post_check(AURA_TYPE_BULLET, src, def_zone, damage_dealt)
 
 	//hit messages
 	if(silenced)


### PR DESCRIPTION
This PR adds the necesarry framework for aura behaviour after a damage has been dealt to a mob (By means of throwing , hitting or bullets), also modifies existing code to support passing damage dealt up the chain.
Unathi regeneration aura now has a regeneration malus that gets incremented by amount of damage dealt , right now , the limit is 20 , and the incrementation formula is damage dealt / 10. Reaching the maximum malus will reduce regeneration by 75%
The malus multiplier applies to all aspects , this also includes the nutrition damage mult and organ damage mult.

This change is aimed at making unathi less good at sprintmaxxing and embracing bullet hits (the organ healing is so good) , without reducing its effectiveness in any major way in other situations

🆑 MLGTASTICA
balance: Unathi regeneration now has a malus applied to it , being reduced by up to 75% if enough malus stacks are acquired. Malus stacks are acquired by taking damage above the threshold (15) and are scaled based off how much damage was dealt (damage/10). The maximum is currently 20 malus stacks.
/ 🆑 