### PR TITLE
adjust spawn targets for merc, raider, traitor

### DIFF
--- a/code/game/antagonist/outsider/mercenary.dm
+++ b/code/game/antagonist/outsider/mercenary.dm
@@ -14,7 +14,7 @@ GLOBAL_DATUM_INIT(mercs, /datum/antagonist/mercenary, new)
 	hard_cap = 4
 	hard_cap_round = 8
 	initial_spawn_req = 3
-	initial_spawn_target = 5
+	initial_spawn_target = 3
 	min_player_age = 14
 
 	faction = "mercenary"

--- a/code/game/antagonist/outsider/raider.dm
+++ b/code/game/antagonist/outsider/raider.dm
@@ -13,7 +13,7 @@ GLOBAL_DATUM_INIT(raiders, /datum/antagonist/raider, new)
 	hard_cap = 6
 	hard_cap_round = 10
 	initial_spawn_req = 3
-	initial_spawn_target = 4
+	initial_spawn_target = 3
 	min_player_age = 14
 
 	id_type = /obj/item/card/id/syndicate

--- a/code/game/antagonist/station/traitor.dm
+++ b/code/game/antagonist/station/traitor.dm
@@ -6,6 +6,7 @@ GLOBAL_DATUM_INIT(traitors, /datum/antagonist/traitor, new)
 	antaghud_indicator = "hud_traitor"
 	blacklisted_jobs = list(/datum/job/ai, /datum/job/submap)
 	restricted_jobs = list(/datum/job/captain, /datum/job/lawyer, /datum/job/hos)
+	initial_spawn_target = 1
 	flags = ANTAG_SUSPICIOUS | ANTAG_RANDSPAWN | ANTAG_VOTABLE
 	skill_setter = /datum/antag_skill_setter/station
 


### PR DESCRIPTION
:cl: Mucker
tweak: Adjusted the spawn target for merc and raider to 3, and traitor to 1. 
/:cl:

Turns out scaling doesn't apply to the game mode if the initial spawn target is higher than the scaling would otherwise target. This should prevent further instances of low-ish pop ship going up against a full 5-stack merc/raider team, and keep traitor numbers at lower pop manageable.