### PR TITLE
Timestamps for cargo orders

### DIFF
--- a/code/controllers/subsystems/supply.dm
+++ b/code/controllers/subsystems/supply.dm
@@ -266,6 +266,7 @@ SUBSYSTEM_DEF(supply)
 
 /datum/supply_order
 	var/ordernum
+	var/timestamp
 	var/singleton/hierarchy/supply_pack/object = null
 	var/orderedby = null
 	var/comment = null

--- a/code/modules/events/shipping_error.dm
+++ b/code/modules/events/shipping_error.dm
@@ -1,6 +1,9 @@
 /datum/event/shipping_error/start()
 	var/datum/supply_order/O = new /datum/supply_order()
-	O.ordernum = SSsupply.ordernum
+	O.ordernum = rand(1, 9000)
+	var/randomtimeofday = rand(0, 864000) // 24 hours in deciseconds
+	O.timestamp = time2text(randomtimeofday, "hh:mm")
 	O.object = pick(SSsupply.master_supply_list)
 	O.orderedby = random_name(pick(MALE,FEMALE), species = SPECIES_HUMAN)
 	SSsupply.shoppinglist += O
+	SSsupply.points = max(0, SSsupply.points - O.object.cost)

--- a/code/modules/modular_computers/file_system/programs/generic/supply.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/supply.dm
@@ -171,6 +171,7 @@
 
 		var/datum/supply_order/O = new /datum/supply_order()
 		O.ordernum = SSsupply.ordernum
+		O.timestamp = stationtime2text()
 		O.object = P
 		O.orderedby = idname
 		O.reason = reason
@@ -358,6 +359,7 @@
 /datum/nano_module/supply/proc/order_to_nanoui(datum/supply_order/SO, list_id)
 	return list(list(
 		"id" = SO.ordernum,
+		"time" = SO.timestamp,
 		"object" = SO.object.name,
 		"orderer" = SO.orderedby,
 		"cost" = SO.object.cost,
@@ -378,6 +380,7 @@
 	var/t = ""
 	t += "<h3>[GLOB.using_map.station_name] Supply Requisition Reciept</h3><hr>"
 	t += "INDEX: #[O.ordernum]<br>"
+	t += "TIME: [O.timestamp]<br>"
 	t += "REQUESTED BY: [O.orderedby]<br>"
 	t += "RANK: [O.orderedrank]<br>"
 	t += "REASON: [O.reason]<br>"

--- a/nano/templates/supply.tmpl
+++ b/nano/templates/supply.tmpl
@@ -5,7 +5,8 @@
 #}}
 {{##def.common_request_header:
   <th style="width:5%">ID
-  <th style="width:25%">Requested item
+  <th style="width:5%">Time
+  <th style="width:20%">Requested item
   <th style="width:20%">Requested by
   <th style="width:20%">Reason
   <th style="width:10%">Cost
@@ -14,6 +15,7 @@
 {{##def.supply_request_item:
 	<tr class="candystripe">
 	<td>{{:value.id}}
+	<td>{{:value.time}}
 	<td>{{:value.object}}
 	<td>{{:value.orderer}}
 	<td>{{:value.reason || '<i>No reason provided.</i>'}}
@@ -86,7 +88,7 @@
 	{{for data.point_breakdown}}
 		<div class="item">
 			<div class="itemLabel">
-				{{:value.desc}}: 
+				{{:value.desc}}:
 			</div>
 			<div class="itemContent">
 				{{:value.points}} {{:data.currency_short}}
@@ -131,7 +133,7 @@
 		{{if data.is_NTOS}}
 			<div class="item">
 				<div class="itemLabel">
-					Notifications are: 
+					Notifications are:
 				</div>
 				<div class="itemContent">
 					{{:helper.link((data.notifications_enabled ? 'Enabled' : 'Disabled'), null, {'toggle_notifications': 1})}}


### PR DESCRIPTION
:cl: sick trigger
rscadd: Orders from supply now record what time the requst was made
/:cl:
know exactly how long the deck chief has been ignoring your request

Also makes the shipping error event not give free points

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->