### PR TITLE
Fixes disarm intent combat

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -53,7 +53,7 @@ avoid code duplication. This includes items that may sometimes act as a standard
 
 	use_call = "use"
 	. = use_before(atom, user, click_params)
-	if (!. && user.a_intent == I_HURT)
+	if (!. && (user.a_intent == I_HURT || user.a_intent == I_DISARM))
 		use_call = "weapon"
 		. = atom.use_weapon(src, user, click_params)
 	if (!.)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -237,8 +237,6 @@
 
 	// Point blank shooting
 	if (user.a_intent == I_HURT && !user.isEquipped(target))
-		if (safety()) // Pistol whip instead of unsafety+fire
-			return ..()
 		Fire(target, user, pointblank = TRUE)
 		return TRUE
 


### PR DESCRIPTION
🆑PurplePineapple
bugfix: Clicking a victim with an item on disarm intent calls use_weapon(). Disarm intent/Dislocation combat for melee works again. 
/🆑
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->