### PR TITLE
Round end reports highest profits/losses, not biggest/smallest balance

### DIFF
--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -539,19 +539,19 @@ Helpers
 			if(D == vendor_account) //yes we know you get lots of money
 				continue
 			var/saldo = D.get_profit()
-			if(saldo > max_profit)
+			if (saldo > max_profit)
 				max_profit = saldo
 				max_profit_owner = D.owner_name
-			if(saldo < max_loss)
+			if (saldo < max_loss)
 				max_loss = saldo
 				max_loss_owner = D.owner_name
 
-		if(max_profit > 0)
+		if (max_profit > 0)
 			to_world("<b>[max_profit_owner]</b> received most [SPAN_COLOR("green", "<B>PROFIT</B>")] today, with net profit of <b>[GLOB.using_map.local_currency_name_short][max_profit]</b>.")
 		else
 			to_world("[SPAN_BAD("Nobody")] earned any extra profit today!")
 
-		if(max_loss < 0)
+		if (max_loss < 0)
 			to_world("[max_profit > 0 ? "On the other hand," : "On top of that,"] <b>[max_loss_owner]</b> had most [SPAN_BAD("LOSS")], with total loss of <b>[GLOB.using_map.local_currency_name_short][max_loss]</b>.")
 		else
 			to_world("[SPAN_COLOR("green", "<B>Nobody</B>")] suffered any extra losses today!")

--- a/code/controllers/subsystems/ticker.dm
+++ b/code/controllers/subsystems/ticker.dm
@@ -530,18 +530,31 @@ Helpers
 		to_world("<b>There [dronecount>1 ? "were" : "was"] [dronecount] industrious maintenance [dronecount>1 ? "drones" : "drone"] at the end of this round.</b>")
 
 	if(length(all_money_accounts))
-		var/datum/money_account/max_profit = all_money_accounts[1]
-		var/datum/money_account/max_loss = all_money_accounts[1]
+		var/max_profit = 0
+		var/max_profit_owner = "Greedy Profiteer"
+		var/max_loss = 0
+		var/max_loss_owner = "Thriftless Wastrel"
+
 		for(var/datum/money_account/D in all_money_accounts)
 			if(D == vendor_account) //yes we know you get lots of money
 				continue
-			var/saldo = D.get_balance()
-			if(saldo >= max_profit.get_balance())
-				max_profit = D
-			if(saldo <= max_loss.get_balance())
-				max_loss = D
-		to_world("<b>[max_profit.owner_name]</b> received most [SPAN_COLOR("green", "<B>PROFIT</B>")] today, with net profit of <b>[GLOB.using_map.local_currency_name_short][max_profit.get_balance()]</b>.")
-		to_world("On the other hand, <b>[max_loss.owner_name]</b> had most [SPAN_COLOR("red", "<B>LOSS</B>")], with total loss of <b>[GLOB.using_map.local_currency_name_short][max_loss.get_balance()]</b>.")
+			var/saldo = D.get_profit()
+			if(saldo > max_profit)
+				max_profit = saldo
+				max_profit_owner = D.owner_name
+			if(saldo < max_loss)
+				max_loss = saldo
+				max_loss_owner = D.owner_name
+
+		if(max_profit > 0)
+			to_world("<b>[max_profit_owner]</b> received most [SPAN_COLOR("green", "<B>PROFIT</B>")] today, with net profit of <b>[GLOB.using_map.local_currency_name_short][max_profit]</b>.")
+		else
+			to_world("[SPAN_BAD("Nobody")] earned any extra profit today!")
+
+		if(max_loss < 0)
+			to_world("[max_profit > 0 ? "On the other hand," : "On top of that,"] <b>[max_loss_owner]</b> had most [SPAN_BAD("LOSS")], with total loss of <b>[GLOB.using_map.local_currency_name_short][max_loss]</b>.")
+		else
+			to_world("[SPAN_COLOR("green", "<B>Nobody</B>")] suffered any extra losses today!")
 
 	mode.declare_completion()//To declare normal completion.
 

--- a/code/modules/economy/Accounts.dm
+++ b/code/modules/economy/Accounts.dm
@@ -4,6 +4,7 @@
 	var/account_number = 0
 	var/remote_access_pin = 0
 	var/money = 0
+	var/opening_balance = 0
 	var/list/transaction_log = list()
 	var/suspended = 0
 	var/security_level = 0	//0 - auto-identify from worn ID, require only account number
@@ -21,6 +22,9 @@
 
 /datum/money_account/proc/get_balance()
 	return money
+
+/datum/money_account/proc/get_profit()
+	return money - opening_balance
 
 /datum/money_account/proc/log_msg(msg, machine_id)
 	var/datum/transaction/log/T = new(src, msg, machine_id)
@@ -88,6 +92,7 @@
 
 	//add the account
 	T.perform()
+	M.opening_balance = M.money
 	all_money_accounts.Add(M)
 
 	return M

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -34,7 +34,7 @@ exactly 2 "/datum text paths" '"/datum'
 exactly 2 "/mob text paths" '"/mob'
 exactly 10 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
-exactly 115 "to_world uses" '\sto_world\('
+exactly 117 "to_world uses" '\sto_world\('
 exactly 0 "globals with leading /" '^/var' -P
 exactly 0 "globals without global sugar" '^var/(?!global/)' -P
 exactly 0 "apparent paths with trailing /" '\w/[,\)\n]' -P


### PR DESCRIPTION
🆑 sick trigger
tweak: Round end reports highest profits/losses made during the round, not biggest/smallest total balance
/ 🆑
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->