### PR TITLE
Fix antag scaling considering ghosts and off-ship players

### DIFF
--- a/code/game/antagonist/antagonist_update.dm
+++ b/code/game/antagonist/antagonist_update.dm
@@ -87,9 +87,13 @@
 	if(mode.antag_scaling_coeff)
 
 		var/count = 0
-		for(var/mob/living/M in GLOB.player_list)
-			if(M.client)
-				count++
+		if (GAME_STATE < RUNLEVEL_GAME)
+			count = length(GLOB.player_list)
+		else
+			for(var/mob/M in GLOB.living_players)
+				var/datum/job/job = SSjobs.get_by_title(M.mind.assigned_role)
+				if(job.create_record)
+					count++
 
 		// Minimum: initial_spawn_target
 		// Maximum: hard_cap or hard_cap_round


### PR DESCRIPTION
:cl: Mucker
bugfix: Antag latespawn scaling no longer considers players that aren't alive or are offship when deciding maximum antags.
/:cl: