### PR TITLE
added preference to toggle run/walk on shift

### DIFF
--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -304,6 +304,13 @@ var/global/list/_client_preferences_by_type
 	default_value = GLOB.PREF_NO
 
 
+/datum/client_preference/toggle_run
+	description = "Shift toggles run (vs hold to run)"
+	key = "TOGGLE_RUN"
+	options = list(GLOB.PREF_YES, GLOB.PREF_NO)
+	default_value = GLOB.PREF_NO
+
+
 /********************
 * General Staff Preferences *
 ********************/

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -352,26 +352,46 @@
 		to_chat(src, "You will now default to [default_run_intent] when moving quickly.")
 
 /client/verb/setmovingslowly()
-	set hidden = 1
-	if(mob)
+	set hidden = TRUE
+	if (!mob)
+		return
+	if (mob.get_preference_value(/datum/client_preference/toggle_run) == GLOB.PREF_NO)
 		mob.set_moving_slowly()
 
+
 /mob/proc/set_moving_slowly()
-	if(!default_walk_intent)
+	if (!default_walk_intent)
 		default_walk_intent = get_movement_datum_by_missing_flag(MOVE_INTENT_QUICK)
-	if(default_walk_intent && move_intent != default_walk_intent)
+	if (default_walk_intent && move_intent != default_walk_intent)
 		set_move_intent(default_walk_intent)
 
+
 /client/verb/setmovingquickly()
-	set hidden = 1
-	if(mob)
+	set hidden = TRUE
+	if (!mob)
+		return
+	if (mob.get_preference_value(/datum/client_preference/toggle_run) == GLOB.PREF_NO)
 		mob.set_moving_quickly()
+	else
+		mob.toggle_moving_quickly()
+
 
 /mob/proc/set_moving_quickly()
-	if(!default_run_intent)
+	if (!default_run_intent)
 		default_run_intent = get_movement_datum_by_flag(MOVE_INTENT_QUICK)
-	if(default_run_intent && move_intent != default_run_intent)
+	if (default_run_intent && move_intent != default_run_intent)
 		set_move_intent(default_run_intent)
+
+
+/mob/proc/toggle_moving_quickly()
+	var/quick = get_movement_datum_by_flag(MOVE_INTENT_QUICK)
+	if (move_intent == quick)
+		var/slow = get_movement_datum_by_missing_flag(MOVE_INTENT_QUICK)
+		if (slow && move_intent != slow)
+			set_move_intent(slow)
+	else if (quick)
+		set_move_intent(quick)
+
 
 /mob/proc/can_sprint()
 	return FALSE


### PR DESCRIPTION
:cl:
tweak: Added a preference option for toggling run on shift.
/:cl:

The existing behavior is, when on hotkey mode and holding shift, you run if running is available.
This allows you to instead tap shift to toggle run on or off, given the same conditions, so long as you swap the pref to "Yes".