### PR TITLE
fix shuttle console not connecting after rebuild

### DIFF
--- a/code/modules/shuttles/shuttle_console.dm
+++ b/code/modules/shuttles/shuttle_console.dm
@@ -14,10 +14,8 @@
 	var/ui_template = "shuttle_control_console.tmpl"
 
 
-/obj/machinery/computer/shuttle_control/Initialize(mapload, init_shuttle_tag)
+/obj/machinery/computer/shuttle_control/Initialize(mapload)
 	. = ..()
-	if (init_shuttle_tag)
-		shuttle_tag = init_shuttle_tag
 	if (!shuttle_tag)
 		sync_shuttle()
 


### PR DESCRIPTION
:cl: Mucker
bugfix: Shuttle control consoles will once again reconnect to their shuttle if dismantled and rebuilt.
/:cl: