### PR TITLE
Don't disable statusbar in fullscreen (fix #34553)

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -437,14 +437,12 @@
 		winset(usr, "mainwindow", "can-resize=false")
 		winset(usr, "mainwindow", "is-maximized=false")
 		winset(usr, "mainwindow", "is-maximized=true")
-		winset(usr, "mainwindow", "statusbar=false")
 		winset(usr, "mainwindow", "menu=")
 //		winset(usr, "mainwindow.mainvsplit", "size=0x0")
 	else
 		winset(usr, "mainwindow", "is-maximized=false")
 		winset(usr, "mainwindow", "titlebar=true")
 		winset(usr, "mainwindow", "can-resize=true")
-		winset(usr, "mainwindow", "statusbar=true")
 		winset(usr, "mainwindow", "menu=menu")
 
 	fit_viewport()


### PR DESCRIPTION
:cl:
bugfix: Toggling fullscreen no longer adds a line of empty space to the window.
/:cl:

Fixes #34553.

Disabling the status bar removes it, but not the window space allocated for it. Enabling the status bar adds a new one and allocates additional window space for it, ignoring any space that already exists. Combine these two facts and you get a dead status bar tumor every time you toggle fullscreen.
I'm not sure why you would want to disable the status bar anyway, it's useful.