### PR TITLE
pegged all workflows to ubuntu 22.04

### DIFF
--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -14,7 +14,7 @@ jobs:
     name: 'Cancel Redundant Builds'
     permissions:
       actions: write # required to cancel other actions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 3
     steps:
       - uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa

--- a/.github/workflows/changelog_generation.yml
+++ b/.github/workflows/changelog_generation.yml
@@ -12,7 +12,7 @@ jobs:
   CompileCL:
     permissions:
       contents: write # required to push the updated changelog commit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'Baystation12/Baystation12' # to prevent this running on forks
     steps:
       - name: Checkout

--- a/.github/workflows/close_stale.yml
+++ b/.github/workflows/close_stale.yml
@@ -12,7 +12,7 @@ jobs:
   stale:
     permissions:
       issues: write # required to close stale issues
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     permissions:
       actions: read

--- a/.github/workflows/generate_documentation.yml
+++ b/.github/workflows/generate_documentation.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   PreFlight:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -28,7 +28,7 @@ jobs:
   generate_documentation:
     permissions:
       contents: write # required to push the doc commit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: PreFlight
     if: |
       (needs.PreFlight.outputs.dm == 'true') &&

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,7 +13,7 @@ jobs:
     permissions:
       contents: read # may be required due to overwrite/add ambiguity
       pull-requests: write # required to apply labels to PRs
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/labeler@v5
       with:

--- a/.github/workflows/make_changelogs.yml
+++ b/.github/workflows/make_changelogs.yml
@@ -12,7 +12,7 @@ jobs:
   MakeCL:
     permissions:
       contents: write # required to push the changelog chunk yml commit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: github.repository == 'Baystation12/Baystation12' # to prevent this running on forks
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   PreFlight:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
@@ -28,7 +28,7 @@ jobs:
     outputs:
       dm: ${{ steps.filter.outputs.dm }}
   DreamChecker:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: PreFlight
     if: needs.PreFlight.outputs.dm == 'true'
     steps:
@@ -54,7 +54,7 @@ jobs:
           chmod +x send.sh
           ./send.sh failure $WEBHOOK_URL
   Code:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
     - PreFlight
     - DreamChecker
@@ -84,7 +84,7 @@ jobs:
           chmod +x send.sh
           ./send.sh failure $WEBHOOK_URL
   ExampleMap:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
     - PreFlight
     - DreamChecker
@@ -113,7 +113,7 @@ jobs:
           chmod +x send.sh
           ./send.sh failure $WEBHOOK_URL
   TorchMap:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
     - PreFlight
     - DreamChecker
@@ -142,7 +142,7 @@ jobs:
           chmod +x send.sh
           ./send.sh failure $WEBHOOK_URL
   AwaySites:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
     - PreFlight
     - DreamChecker

--- a/.github/workflows/testmerge-blocker.yml
+++ b/.github/workflows/testmerge-blocker.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   testmerge-blocker:
     name: Enforce Test Merge Label
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Enforce Test Merge Label
         if: contains(github.event.pull_request.labels.*.name, 'Test Merge') && !contains(github.event.pull_request.labels.*.name, 'Test Merge Passed')


### PR DESCRIPTION
For our workflows, Ubuntu 24.04 compatibility requires changes to python tests' setup thanks to python virtual environment changes (PEP 668), among other potential issues.

Since live is on 22.04, we may as well match it.
