### PR TITLE
Allows Fleet chaplains to refuse small arms training

### DIFF
--- a/maps/torch/job/service_jobs.dm
+++ b/maps/torch/job/service_jobs.dm
@@ -62,7 +62,8 @@
 		/datum/mil_rank/fleet/o2,
 		/datum/mil_rank/ec/o1)
 	min_skill = list( // 1 point
-		SKILL_BUREAUCRACY = SKILL_BASIC // 1 point
+		SKILL_BUREAUCRACY = SKILL_BASIC, // 1 point
+		SKILL_WEAPONS = SKILL_UNSKILLED // Fleet chaplains may refuse weapon training
 	)
 
 	access = list(


### PR DESCRIPTION
:cl:
tweak: Fleet сhaplains can be unskilled in small arms now.
/:cl:

Conscientious objection, yo!

Also I was actually surprised you can easily override branch's skills just like that. Not sure if it's intended but I'm glad it works.