### PR TITLE
Changes to pump and valve layering

### DIFF
--- a/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
+++ b/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
@@ -1,7 +1,6 @@
 /obj/machinery/atmospherics/binary
 	dir = SOUTH
 	initialize_directions = SOUTH|NORTH
-	layer = ABOVE_CATWALK_LAYER
 
 	var/datum/gas_mixture/air1
 	var/datum/gas_mixture/air2

--- a/code/modules/atmospherics/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/components/binary_devices/circulator.dm
@@ -7,6 +7,7 @@
 	icon = 'icons/obj/machines/power/teg.dmi'
 	icon_state = "circ-unassembled"
 	anchored = FALSE
+	layer = ABOVE_CATWALK_LAYER
 
 	var/kinetic_efficiency = 0.04 //combined kinetic and kinetic-to-electric efficiency
 	var/volume_ratio = 0.2

--- a/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
+++ b/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
@@ -12,6 +12,7 @@
 	construct_state = /singleton/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
+	layer = ABOVE_CATWALK_LAYER
 
 	machine_name = "oxygen regenerator"
 	machine_desc = "Catalyzes gaseous CO2 to convert it into gaseous oxygen. The excess carbon is condensed and ejected as graphite sheets."

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -5,7 +5,7 @@
 /obj/machinery/atmospherics/binary/passive_gate
 	icon = 'icons/atmos/passive_gate.dmi'
 	icon_state = "map_off"
-	level = ATOM_LEVEL_UNDER_TILE
+	level = ATOM_LEVEL_OVER_TILE
 
 	name = "pressure regulator"
 	desc = "A one-way air valve that can be used to regulate input or output pressure, and flow rate. Does not require power."

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -15,7 +15,7 @@ Thus, the two variables affect pump operation are set in New():
 /obj/machinery/atmospherics/binary/pump
 	icon = 'icons/atmos/pump.dmi'
 	icon_state = "map_off"
-	level = ATOM_LEVEL_UNDER_TILE
+	level = ATOM_LEVEL_OVER_TILE
 
 	name = "gas pump"
 	desc = "A pump."

--- a/code/modules/atmospherics/components/shutoff.dm
+++ b/code/modules/atmospherics/components/shutoff.dm
@@ -13,6 +13,7 @@
 	var/shutoff_state = 0
 	connect_types = CONNECT_TYPE_REGULAR
 	build_icon_state = "svalve"
+	level = ATOM_LEVEL_UNDER_TILE
 
 /obj/machinery/atmospherics/valve/shutoff/on_update_icon()
 	icon_state = "vclamp[icon_connect_type]"

--- a/code/modules/atmospherics/components/tvalve.dm
+++ b/code/modules/atmospherics/components/tvalve.dm
@@ -5,7 +5,7 @@
 	name = "manual switching valve"
 	desc = "A pipe valve."
 
-	level = ATOM_LEVEL_UNDER_TILE
+	level = ATOM_LEVEL_OVER_TILE
 	dir = SOUTH
 	initialize_directions = SOUTH|NORTH|WEST
 

--- a/code/modules/atmospherics/components/valve.dm
+++ b/code/modules/atmospherics/components/valve.dm
@@ -5,10 +5,9 @@
 	name = "manual valve"
 	desc = "A pipe valve."
 
-	level = ATOM_LEVEL_UNDER_TILE
+	level = ATOM_LEVEL_OVER_TILE
 	dir = SOUTH
 	initialize_directions = SOUTH|NORTH
-	layer = ABOVE_CATWALK_LAYER
 
 	var/open = 0
 	var/openDuringInit = 0


### PR DESCRIPTION
🆑 Hubblenaut
tweak: Pumps and valves are now hidden by catwalks.
tweak: Mapped pumps and valves can be removed without having to pry off the floor tile.
/:cl:

Currently, all pumps and valves are on `level=1` (considered below floor), even though all pumps and valves render above flooring.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->