### PR TITLE
The AUF Arrives/Badge Distribution

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3329,7 +3329,6 @@
 #include "interface\skin.dmf"
 #include "maps\_map_include.dm"
 #include "maps\_maps.dm"
-#include "packs\factions\fa\faction.dm"
 #include "packs\legion\_pack.dm"
 #include "~code\global_init.dm"
 // END_INCLUDE

--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3329,6 +3329,7 @@
 #include "interface\skin.dmf"
 #include "maps\_map_include.dm"
 #include "maps\_maps.dm"
+#include "packs\factions\fa\faction.dm"
 #include "packs\legion\_pack.dm"
 #include "~code\global_init.dm"
 // END_INCLUDE

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -14,7 +14,8 @@
 		/datum/mil_branch/alien,
 		/datum/mil_branch/skrell_fleet,
 		/datum/mil_branch/iccgn,
-		/datum/mil_branch/scga
+		/datum/mil_branch/scga,
+		/datum/mil_branch/auf
 	)
 
 	spawn_branch_types = list(
@@ -25,7 +26,8 @@
 		/datum/mil_branch/alien,
 		/datum/mil_branch/skrell_fleet,
 		/datum/mil_branch/iccgn,
-		/datum/mil_branch/scga
+		/datum/mil_branch/scga,
+		/datum/mil_branch/auf
 	)
 
 	species_to_branch_blacklist = list(

--- a/packs/factions/fa/_pack.dm
+++ b/packs/factions/fa/_pack.dm
@@ -1,5 +1,6 @@
 #include "badges.dm"
 #include "clothing.dm"
+#include "faction.dm"
 #include "misc.dm"
 #include "outfits.dm"
 #include "tweaks.dm"

--- a/packs/factions/fa/faction.dm
+++ b/packs/factions/fa/faction.dm
@@ -1,0 +1,50 @@
+/datum/mil_branch/auf
+	name = "Alliance United Flotillas"
+	name_short = "AUF"
+	email_domain = "flot.freeiolaus.int"
+	assistant_job = null
+	min_skill = list( // 5 points
+		SKILL_HAULING = SKILL_BASIC, // 1 point
+		SKILL_WEAPONS = SKILL_BASIC, // 2 points
+		SKILL_EVA = SKILL_TRAINED // 2 point
+	)
+
+	rank_types = list(
+		/datum/mil_rank/auf/ga,
+		/datum/mil_rank/auf/wa,
+		/datum/mil_rank/auf/sa
+	)
+
+	spawn_rank_types = list(
+		/datum/mil_rank/auf/ga,
+		/datum/mil_rank/auf/wa,
+		/datum/mil_rank/auf/sa
+	)
+
+/datum/mil_branch/auf/New()
+	rank_types = subtypesof(/datum/mil_rank/auf)
+	..()
+
+/datum/mil_rank/auf/ga
+	name = "Guardsman of the Frontier Alliance"
+	name_short = "GdMn"
+	accessory = list(
+		/obj/item/clothing/accessory/fa_badge/guardsman
+	)
+	sort_order = 5
+
+/datum/mil_rank/auf/wa
+	name = "Warden of the Frontier Alliance"
+	name_short = "Wrd"
+	accessory = list(
+		/obj/item/clothing/accessory/fa_badge/warden
+	)
+	sort_order = 13
+
+/datum/mil_rank/auf/sa
+	name = "Star Marshal of the Frontier Alliance"
+	name_short = "Mrshl"
+	accessory = list(
+		/obj/item/clothing/accessory/fa_badge/marshal
+	)
+	sort_order = 20

--- a/packs/factions/iccgn/faction.dm
+++ b/packs/factions/iccgn/faction.dm
@@ -63,7 +63,8 @@
 	name = "Eleve Sailor"
 	name_short = "Elv"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/or1
+		/obj/item/clothing/accessory/iccgn_rank/or1,
+		/obj/item/clothing/accessory/iccgn_badge/enlisted
 	)
 	sort_order = 10
 
@@ -72,7 +73,8 @@
 	name = "Sailor"
 	name_short = "Slr"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/or3
+		/obj/item/clothing/accessory/iccgn_rank/or3,
+		/obj/item/clothing/accessory/iccgn_badge/enlisted
 	)
 	sort_order = 30
 
@@ -81,7 +83,8 @@
 	name = "Bosman"
 	name_short = "Bsn"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/or4
+		/obj/item/clothing/accessory/iccgn_rank/or4,
+		/obj/item/clothing/accessory/iccgn_badge/enlisted
 	)
 	sort_order = 40
 
@@ -90,7 +93,8 @@
 	name = "Starszy Bosman"
 	name_short = "SBsn"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/or5
+		/obj/item/clothing/accessory/iccgn_rank/or5,
+		/obj/item/clothing/accessory/iccgn_badge/enlisted
 	)
 	sort_order = 50
 
@@ -99,7 +103,8 @@
 	name = "Sierzant"
 	name_short = "Szt"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/or6
+		/obj/item/clothing/accessory/iccgn_rank/or6,
+		/obj/item/clothing/accessory/iccgn_badge/enlisted
 	)
 	sort_order = 60
 
@@ -108,7 +113,8 @@
 	name = "Starshyna"
 	name_short = "Strs"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/or7
+		/obj/item/clothing/accessory/iccgn_rank/or7,
+		/obj/item/clothing/accessory/iccgn_badge/enlisted
 	)
 	sort_order = 70
 
@@ -117,7 +123,8 @@
 	name = "Adjutant"
 	name_short = "Adj"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/or8
+		/obj/item/clothing/accessory/iccgn_rank/or8,
+		/obj/item/clothing/accessory/iccgn_badge/enlisted
 	)
 	sort_order = 80
 
@@ -126,7 +133,8 @@
 	name = "Major"
 	name_short = "Mjr"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/or9
+		/obj/item/clothing/accessory/iccgn_rank/or9,
+		/obj/item/clothing/accessory/iccgn_badge/enlisted
 	)
 	sort_order = 90
 
@@ -135,7 +143,8 @@
 	name = "Major of the Confederation Navy"
 	name_short = "MjN"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/or9_alt
+		/obj/item/clothing/accessory/iccgn_rank/or9_alt,
+		/obj/item/clothing/accessory/iccgn_badge/enlisted
 	)
 	sort_order = 100
 
@@ -144,7 +153,8 @@
 	name = "Michman"
 	name_short = "Mch"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/of1
+		/obj/item/clothing/accessory/iccgn_rank/of1,
+		/obj/item/clothing/accessory/iccgn_badge/officer
 	)
 	sort_order = 110
 
@@ -153,7 +163,8 @@
 	name = "Sous-Leytenant"
 	name_short = "SLyt"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/of2
+		/obj/item/clothing/accessory/iccgn_rank/of2,
+		/obj/item/clothing/accessory/iccgn_badge/officer
 	)
 	sort_order = 120
 
@@ -162,7 +173,8 @@
 	name = "Leytenant"
 	name_short = "Lyt"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/of3
+		/obj/item/clothing/accessory/iccgn_rank/of3,
+		/obj/item/clothing/accessory/iccgn_badge/officer
 	)
 	sort_order = 130
 
@@ -171,7 +183,8 @@
 	name = "Sub-Komandor"
 	name_short = "SKdr"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/of4
+		/obj/item/clothing/accessory/iccgn_rank/of4,
+		/obj/item/clothing/accessory/iccgn_badge/officer
 	)
 	sort_order = 140
 
@@ -180,7 +193,8 @@
 	name = "Komandor"
 	name_short = "Kdr"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/of5
+		/obj/item/clothing/accessory/iccgn_rank/of5,
+		/obj/item/clothing/accessory/iccgn_badge/officer
 	)
 	sort_order = 150
 
@@ -189,7 +203,8 @@
 	name = "Kapitan"
 	name_short = "Kpt"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/of6
+		/obj/item/clothing/accessory/iccgn_rank/of6,
+		/obj/item/clothing/accessory/iccgn_badge/officer
 	)
 	sort_order = 160
 
@@ -198,7 +213,8 @@
 	name = "Starshy Kapitan"
 	name_short = "SKpt"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/of7
+		/obj/item/clothing/accessory/iccgn_rank/of7,
+		/obj/item/clothing/accessory/iccgn_badge/officer
 	)
 	sort_order = 170
 
@@ -207,7 +223,8 @@
 	name = "Vice-Admiral"
 	name_short = "VAdm"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/of8
+		/obj/item/clothing/accessory/iccgn_rank/of8,
+		/obj/item/clothing/accessory/iccgn_badge/officer
 	)
 	sort_order = 180
 
@@ -216,7 +233,8 @@
 	name = "Admiral"
 	name_short = "Adm"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/of9
+		/obj/item/clothing/accessory/iccgn_rank/of9,
+		/obj/item/clothing/accessory/iccgn_badge/officer
 	)
 	sort_order = 190
 
@@ -225,6 +243,7 @@
 	name = "Marshal of the Confederation Navy"
 	name_short = "Mshl"
 	accessory = list(
-		/obj/item/clothing/accessory/iccgn_rank/of9_alt
+		/obj/item/clothing/accessory/iccgn_rank/of9_alt,
+		/obj/item/clothing/accessory/iccgn_badge/officer
 	)
 	sort_order = 200

--- a/packs/factions/scga/faction.dm
+++ b/packs/factions/scga/faction.dm
@@ -69,7 +69,8 @@
 	name = "Private"
 	name_short = "Pvt"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/e1
+		/obj/item/clothing/accessory/scga_rank/e1,
+		/obj/item/clothing/accessory/scga_badge/enlisted
 	)
 	sort_order = 10
 
@@ -78,7 +79,8 @@
 	name = "Private Second Class"
 	name_short = "Pv2"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/e2
+		/obj/item/clothing/accessory/scga_rank/e2,
+		/obj/item/clothing/accessory/scga_badge/enlisted
 	)
 	sort_order = 20
 
@@ -87,7 +89,8 @@
 	name = "Private First Class"
 	name_short = "PFC"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/e3
+		/obj/item/clothing/accessory/scga_rank/e3,
+		/obj/item/clothing/accessory/scga_badge/enlisted
 	)
 	sort_order = 30
 
@@ -96,7 +99,8 @@
 	name = "Corporal"
 	name_short = "Cpl"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/e4
+		/obj/item/clothing/accessory/scga_rank/e4,
+		/obj/item/clothing/accessory/scga_badge/enlisted
 	)
 	sort_order = 40
 
@@ -105,7 +109,8 @@
 	name = "Sergeant"
 	name_short = "Sgt"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/e5
+		/obj/item/clothing/accessory/scga_rank/e5,
+		/obj/item/clothing/accessory/scga_badge/enlisted
 	)
 	sort_order = 50
 
@@ -114,7 +119,8 @@
 	name = "Staff Sergeant"
 	name_short = "SSgt"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/e6
+		/obj/item/clothing/accessory/scga_rank/e6,
+		/obj/item/clothing/accessory/scga_badge/enlisted
 	)
 	sort_order = 60
 
@@ -123,7 +129,8 @@
 	name = "Sergeant First Class"
 	name_short = "SFC"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/e7
+		/obj/item/clothing/accessory/scga_rank/e7,
+		/obj/item/clothing/accessory/scga_badge/enlisted
 	)
 	sort_order = 70
 
@@ -132,7 +139,8 @@
 	name = "Master Sergeant"
 	name_short = "MSgt"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/e8
+		/obj/item/clothing/accessory/scga_rank/e8,
+		/obj/item/clothing/accessory/scga_badge/enlisted
 	)
 	sort_order = 80
 
@@ -141,7 +149,8 @@
 	name = "First Sergeant"
 	name_short = "1Sgt"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/e8_alt
+		/obj/item/clothing/accessory/scga_rank/e8_alt,
+		/obj/item/clothing/accessory/scga_badge/enlisted
 	)
 	sort_order = 90
 
@@ -150,7 +159,8 @@
 	name = "Sergeant Major"
 	name_short = "SgtM"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/e9
+		/obj/item/clothing/accessory/scga_rank/e9,
+		/obj/item/clothing/accessory/scga_badge/enlisted
 	)
 	sort_order = 100
 
@@ -159,7 +169,8 @@
 	name = "Command Sergeant Major"
 	name_short = "CSM"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/e9_alt1
+		/obj/item/clothing/accessory/scga_rank/e9_alt1,
+		/obj/item/clothing/accessory/scga_badge/enlisted
 	)
 	sort_order = 110
 
@@ -168,7 +179,8 @@
 	name = "Sergeant Major of the Army"
 	name_short = "SMA"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/e9_alt2
+		/obj/item/clothing/accessory/scga_rank/e9_alt2,
+		/obj/item/clothing/accessory/scga_badge/enlisted
 	)
 	sort_order = 120
 
@@ -177,7 +189,8 @@
 	name = "Second Lieutenant"
 	name_short = "2Lt"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/o1
+		/obj/item/clothing/accessory/scga_rank/o1,
+		/obj/item/clothing/accessory/scga_badge/officer
 	)
 	sort_order = 130
 
@@ -186,7 +199,8 @@
 	name = "First Lieutenant"
 	name_short = "1Lt"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/o2
+		/obj/item/clothing/accessory/scga_rank/o2,
+		/obj/item/clothing/accessory/scga_badge/officer
 	)
 	sort_order = 140
 
@@ -195,7 +209,8 @@
 	name = "Captain"
 	name_short = "Cpt"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/o3
+		/obj/item/clothing/accessory/scga_rank/o3,
+		/obj/item/clothing/accessory/scga_badge/officer
 	)
 	sort_order = 150
 
@@ -204,7 +219,8 @@
 	name = "Major"
 	name_short = "Mjr"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/o4
+		/obj/item/clothing/accessory/scga_rank/o4,
+		/obj/item/clothing/accessory/scga_badge/officer
 	)
 	sort_order = 160
 
@@ -213,7 +229,8 @@
 	name = "Lieutenant Colonel"
 	name_short = "LtC"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/o5
+		/obj/item/clothing/accessory/scga_rank/o5,
+		/obj/item/clothing/accessory/scga_badge/officer
 	)
 	sort_order = 170
 
@@ -222,7 +239,8 @@
 	name = "Colonel"
 	name_short = "Col"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/o6
+		/obj/item/clothing/accessory/scga_rank/o6,
+		/obj/item/clothing/accessory/scga_badge/officer
 	)
 	sort_order = 180
 
@@ -231,7 +249,8 @@
 	name = "Brigadier General"
 	name_short = "BrgG"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/o7
+		/obj/item/clothing/accessory/scga_rank/o7,
+		/obj/item/clothing/accessory/scga_badge/officer
 	)
 	sort_order = 190
 
@@ -240,7 +259,8 @@
 	name = "Major General"
 	name_short = "MjrG"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/o8
+		/obj/item/clothing/accessory/scga_rank/o8,
+		/obj/item/clothing/accessory/scga_badge/officer
 	)
 	sort_order = 200
 
@@ -249,7 +269,8 @@
 	name = "Lieutenant General"
 	name_short = "LtG"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/o9
+		/obj/item/clothing/accessory/scga_rank/o9,
+		/obj/item/clothing/accessory/scga_badge/officer
 	)
 	sort_order = 210
 
@@ -258,7 +279,8 @@
 	name = "General"
 	name_short = "Gen"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/o10
+		/obj/item/clothing/accessory/scga_rank/o10,
+		/obj/item/clothing/accessory/scga_badge/officer
 	)
 	sort_order = 220
 
@@ -267,6 +289,7 @@
 	name = "Field-Marshal"
 	name_short = "FldM"
 	accessory = list(
-		/obj/item/clothing/accessory/scga_rank/o10_alt
+		/obj/item/clothing/accessory/scga_rank/o10_alt,
+		/obj/item/clothing/accessory/scga_badge/officer
 	)
 	sort_order = 230


### PR DESCRIPTION
:cl: JuneauQT
rscadd: Added the Alliance United Flotillas Branch and three ranks for it to ID cards (and all other places Branch can be set.)
tweak: ICCGN and SCGA ranks now have their officer/enlisted badge included in their define.
/:cl:

Figuring this out was more for my benefit than anything else, but I figured that since I'd done the work I might as well try to put the branch up so that it can be applied to Antagonist IDs (I know the FA 'Ranks' aren't _real_ ranks, and that in a lot of cases fleet ranks and one of the three already-existing medals serves the same purpose, but for something like, say, a Raider crew wanting to RP as Alliance "Privateers" this would be useful) The sort_orders are arranged relative to the fleet or corps branch ones, but this can be altered easily.

I've also added the enlisted/officer badges for the SCGA and ICCGN to their ranks in the same manner that the Fleet has them, more or less. As far as I'm aware this changes nothing player-facing right now, but might be useful for future developments. I've left the sort_orders for those branches unchanged since I don't know why they're set up differently to the torch_ranks ones, so I'm assuming it's probably for a reason.