### PR TITLE
Exoplanets with fancy coloured clouds actually work now

### DIFF
--- a/code/modules/overmap/exoplanets/planet_types/chlorine.dm
+++ b/code/modules/overmap/exoplanets/planet_types/chlorine.dm
@@ -18,7 +18,7 @@
 
 /obj/overmap/visitable/sector/exoplanet/chlorine/get_atmosphere_color()
 	var/air_color = ..()
-	return MixColors("#e5f2bd", air_color)
+	return MixColors(list("#e5f2bd", air_color))
 
 /obj/overmap/visitable/sector/exoplanet/chlorine/generate_atmosphere()
 	..()

--- a/code/modules/overmap/exoplanets/planet_types/shrouded.dm
+++ b/code/modules/overmap/exoplanets/planet_types/shrouded.dm
@@ -26,7 +26,7 @@
 
 /obj/overmap/visitable/sector/exoplanet/shrouded/get_atmosphere_color()
 	var/air_color = ..()
-	return MixColors(COLOR_BLACK, air_color)
+	return MixColors(list(COLOR_BLACK, air_color))
 
 /datum/random_map/noise/exoplanet/shrouded
 	descriptor = "shrouded exoplanet"

--- a/code/modules/overmap/exoplanets/planet_types/volcanic.dm
+++ b/code/modules/overmap/exoplanets/planet_types/volcanic.dm
@@ -17,7 +17,7 @@
 
 /obj/overmap/visitable/sector/exoplanet/volcanic/get_atmosphere_color()
 	var/air_color = ..()
-	return MixColors(COLOR_GRAY20, air_color)
+	return MixColors(list(COLOR_GRAY20, air_color))
 
 /obj/overmap/visitable/sector/exoplanet/volcanic/generate_atmosphere()
 	..()


### PR DESCRIPTION
:cl: JuneauQT
bugfix: Shrouded, Chlorine, and Volcanic exoplanet clouds now generate the way they were intended to instead of being solid black
/:cl:
![Literally Unplayable](https://github.com/user-attachments/assets/3055e80c-8d68-4caa-9db1-976ffa4710e5)
Them being black was apparently unintended behavior, as evidenced by any attempt to figure out how they produced black clouds by following the codes usually giving me a shade of green. This has been fixed. Please enjoy our new (old) pretty skybox baubles.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->