### PR TITLE
Beds and chairs are no longer a blackhole of resources (mostly)

### DIFF
--- a/code/game/objects/structures/stool_bed_chair_nest/bed.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/bed.dm
@@ -12,6 +12,8 @@
 	var/material_alteration = MATERIAL_ALTERATION_ALL
 	/// Bitflags. Bed/chair specific flags.
 	var/bed_flags = EMPTY_BITFIELD
+	/// How many sheets should be given when dismantled, based on their stack_recipe datum
+	var/dismantle_return = 2
 
 
 /obj/structure/bed/New(newloc, new_material = DEFAULT_FURNITURE_MATERIAL, new_padding_material)
@@ -184,7 +186,7 @@
 	update_icon()
 
 /obj/structure/bed/proc/dismantle()
-	material.place_sheet(get_turf(src))
+	material.place_sheet(get_turf(src), dismantle_return)
 	if(padding_material)
 		padding_material.place_sheet(get_turf(src))
 

--- a/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
+++ b/code/game/objects/structures/stool_bed_chair_nest/chairs.dm
@@ -9,6 +9,7 @@
 	obj_flags = OBJ_FLAG_ROTATABLE
 	var/propelled = 0 // Check for fire-extinguisher-driven chairs
 	buckle_movable = TRUE
+	dismantle_return = 1
 
 /obj/structure/bed/chair/do_simple_ranged_interaction(mob/user)
 	if(!buckled_mob && user)
@@ -140,6 +141,7 @@
 	desc = "It's a chair. It looks comfy."
 	icon_state = "comfychair_preview"
 	base_icon = "comfychair"
+	dismantle_return = 3
 
 /obj/structure/bed/chair/comfy/brown/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
 	..(newloc, newmaterial, MATERIAL_LEATHER_GENERIC)
@@ -192,6 +194,7 @@
 	icon_state = "armchair_preview"
 	base_icon = "armchair"
 	buckle_movable = FALSE
+	dismantle_return = 4
 
 /obj/structure/bed/chair/armchair/brown/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
 	..(newloc, newmaterial, MATERIAL_LEATHER_GENERIC)
@@ -228,6 +231,7 @@
 	icon_state = "officechair_preview"
 	base_icon = "officechair"
 	anchored = FALSE
+	dismantle_return = 5
 
 /obj/structure/bed/chair/office/Move()
 	. = ..()
@@ -277,6 +281,7 @@
 	desc = "It's an office chair. It looks comfy."
 	icon_state = "comfyofficechair_preview"
 	base_icon = "comfyofficechair"
+	dismantle_return = 7
 
 /obj/structure/bed/chair/office/comfy/brown/New(newloc, newmaterial = DEFAULT_FURNITURE_MATERIAL)
 	..(newloc, newmaterial, MATERIAL_LEATHER_GENERIC)
@@ -351,6 +356,7 @@
 	var/chair_material = MATERIAL_WOOD
 	buckle_movable = FALSE
 	bed_flags = BED_FLAG_CANNOT_BE_PADDED
+	dismantle_return = 3
 
 /obj/structure/bed/chair/wood/New(newloc, _material)
 	..(newloc, _material? _material : chair_material)
@@ -403,6 +409,7 @@
 	var/material/pew_material = MATERIAL_WOOD
 	obj_flags = 0
 	buckle_movable = FALSE
+	dismantle_return = 4
 
 /obj/structure/bed/chair/pew/left
 	icon_state = "pew_left"

--- a/code/modules/materials/recipes_furniture.dm
+++ b/code/modules/materials/recipes_furniture.dm
@@ -15,8 +15,6 @@
 /datum/stack_recipe/furniture/chair/display_name()
 	return modifiers ? jointext(modifiers + ..(), " ") : ..()
 
-/datum/stack_recipe/furniture/chair/padded
-	req_amount = 2
 
 #define PADDED_CHAIR(color) /datum/stack_recipe/furniture/chair/padded/##color{\
 	result_type = /obj/structure/bed/chair/padded/##color;\


### PR DESCRIPTION
:cl:
bugfix: Chairs and beds return their construction cost when deconstructed
tweak: Padded chairs now only cost 1 sheet to make
/:cl:

fixes #34777 

the padded chair cost reduction was mainly because theyre basically just the basic chairs with padding on them, so itd feel a lil silly to get back 2 steel from them, especially if youre just dismantling chairs around the ship instead of making them (or the alternative of making them cost 2 sheets and only giving back 1 being silly to me since it implies you turn steel into cloth padding, and id also have to change the few other chairs that also magically make their own padding to act like this as well)