### PR TITLE
Add global list for shield generators

### DIFF
--- a/code/_global_vars/lists/objects.dm
+++ b/code/_global_vars/lists/objects.dm
@@ -20,3 +20,5 @@ GLOBAL_DATUM_INIT(universe, /datum/universal_state, new)
 GLOBAL_LIST_INIT(full_alphabet, list("a","b","c","d","e","f","g","h","i","j","k","l","m","n","o","p","q","r","s","t","u","v","w","x","y","z"))
 
 GLOBAL_LIST_EMPTY(meteor_list)
+
+GLOBAL_LIST_EMPTY(shield_generators) // All shield generators

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -35,7 +35,7 @@
 	..()
 	//See if shields can stop it first
 	var/list/shields = list()
-	for(var/obj/machinery/power/shield_generator/G in SSmachines.machinery)
+	for(var/obj/machinery/power/shield_generator/G as anything in GLOB.shield_generators)
 		if((G.z in affecting_z) && G.running && G.check_flag(MODEFLAG_EM))
 			shields += G
 	if(length(shields))

--- a/code/modules/modular_computers/file_system/programs/engineering/shields_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/shields_monitor.dm
@@ -23,7 +23,7 @@
 /datum/nano_module/shields_monitor/proc/get_shields()
 	var/list/shields = list()
 	var/connected_z_levels = GetConnectedZlevels(get_host_z())
-	for(var/obj/machinery/power/shield_generator/S in SSmachines.machinery)
+	for(var/obj/machinery/power/shield_generator/S as anything in GLOB.shield_generators)
 		if(!(S.z in connected_z_levels))
 			continue
 		shields.Add(S)

--- a/code/modules/overmap/contacts/_contacts.dm
+++ b/code/modules/overmap/contacts/_contacts.dm
@@ -85,7 +85,7 @@
 	var/obj/overmap/visitable/visitable_effect = effect
 	if (!visitable_effect || !istype(visitable_effect))
 		return FALSE
-	for (var/obj/machinery/power/shield_generator/S in SSmachines.machinery)
+	for (var/obj/machinery/power/shield_generator/S as anything in GLOB.shield_generators)
 		if (S.z in visitable_effect.map_z)
 			if (S.running == SHIELD_RUNNING)
 				return TRUE

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -48,6 +48,9 @@
 	else
 		icon_state = "generator0"
 
+/obj/machinery/power/shield_generator/Initialize()
+	. = ..()
+	GLOB.shield_generators += src
 
 /obj/machinery/power/shield_generator/New()
 	..()
@@ -64,6 +67,7 @@
 	field_segments = null
 	damaged_segments = null
 	mode_list = null
+	GLOB.shield_generators -= src
 	. = ..()
 
 


### PR DESCRIPTION
Sensors ask for every shield generator from the global machine list every SSmachine tick, which is a ~20k size list, which is 7ms per list iteration, per ship sensor. Move it to be a global list instead.