### PR TITLE
Add envelopes crafting and sealing

### DIFF
--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -423,7 +423,7 @@ var/global/bomb_set
 	startswith = list(
 		/obj/item/disk/nuclear,
 		/obj/item/pinpointer,
-		/obj/item/folder/envelope/nuke_instructions,
+		/obj/item/folder/envelope/preset/nuke_instructions,
 		/obj/item/modular_computer/laptop/preset/custom_loadout/cheap
 	)
 
@@ -431,11 +431,11 @@ var/global/bomb_set
 	. = ..()
 	to_chat(user,"On closer inspection, you see \a [GLOB.using_map.company_name] emblem is etched into the front of it.")
 
-/obj/item/folder/envelope/nuke_instructions
+/obj/item/folder/envelope/preset/nuke_instructions
 	name = "instructions envelope"
 	desc = "A small envelope. The label reads 'open only in event of high emergency'."
 
-/obj/item/folder/envelope/nuke_instructions/Initialize()
+/obj/item/folder/envelope/preset/nuke_instructions/Initialize()
 	. = ..()
 	var/obj/item/paper/R = new(src)
 	R.set_content("<center><img src=sollogo.png><br><br>\

--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -172,6 +172,7 @@
 	. += create_recipe_list(/datum/stack_recipe/box)
 	. += new/datum/stack_recipe/cardborg_suit(src)
 	. += new/datum/stack_recipe/cardborg_helmet(src)
+	. += new/datum/stack_recipe/envelope(src)
 	. += new/datum/stack_recipe_list("folders", create_recipe_list(/datum/stack_recipe/folder))
 
 /material/aluminium/generate_recipes(reinforce_material)

--- a/code/modules/materials/recipes_storage.dm
+++ b/code/modules/materials/recipes_storage.dm
@@ -38,6 +38,10 @@
 	req_amount = 3
 	on_floor = 1
 
+/datum/stack_recipe/envelope
+	title = "envelope"
+	result_type = /obj/item/folder/envelope
+
 /datum/stack_recipe/folder
 	title = "folder"
 	result_type = /obj/item/folder

--- a/code/modules/paperwork/folders.dm
+++ b/code/modules/paperwork/folders.dm
@@ -114,9 +114,15 @@
 
 /obj/item/folder/envelope
 	name = "envelope"
-	desc = "A thick envelope. You can't see what's inside."
+	desc = "A thick envelope."
+	icon_state = "envelope0"
+	var/sealed = FALSE
+	var/seal_stamp = ""
+
+/obj/item/folder/envelope/preset
 	icon_state = "envelope_sealed"
-	var/sealed = 1
+	sealed = TRUE
+	seal_stamp = "\improper SCG Expeditionary Command rubber stamp"
 
 /obj/item/folder/envelope/on_update_icon()
 	if(sealed)
@@ -126,15 +132,18 @@
 
 /obj/item/folder/envelope/examine(mob/user)
 	. = ..()
-	to_chat(user, "The seal is [sealed ? "intact" : "broken"].")
+	if (sealed || seal_stamp)
+		to_chat(user, "It [sealed ? "is" : "was"] sealed with \the [seal_stamp]. The seal is [sealed ? "intact" : "broken"].")
+	else
+		to_chat(user, "It is not sealed.")
 
 /obj/item/folder/envelope/proc/sealcheck(user)
 	var/ripperoni = alert("Are you sure you want to break the seal on \the [src]?", "Confirmation","Yes", "No")
 	if(ripperoni == "Yes")
 		visible_message("[user] breaks the seal on \the [src], and opens it.")
-		sealed = 0
+		sealed = FALSE
 		update_icon()
-		return 1
+		return TRUE
 
 /obj/item/folder/envelope/attack_self(mob/user as mob)
 	if(sealed)
@@ -146,6 +155,13 @@
 /obj/item/folder/envelope/use_tool(obj/item/item, mob/living/user, list/click_params)
 	if(sealed)
 		sealcheck(user)
+		return TRUE
+	else if (istype(item, /obj/item/stamp) && !sealed)
+		seal_stamp = item.name
+		visible_message("[user] seals \the [src] with [item].")
+		sealed = TRUE
+		playsound(src, 'sound/effects/stamp.ogg', 50, 1)
+		update_icon()
 		return TRUE
 	else
 		return ..()

--- a/maps/torch/items/manuals.dm
+++ b/maps/torch/items/manuals.dm
@@ -67,14 +67,14 @@
 
 /obj/item/folder/nt/rd
 
-/obj/item/folder/envelope/captain
+/obj/item/folder/envelope/preset/captain
 	desc = "A thick envelope. The SCG crest is stamped in the corner, along with 'TOP SECRET - TORCH UMBRA'."
 
-/obj/item/folder/envelope/captain/Initialize()
+/obj/item/folder/envelope/preset/captain/Initialize()
 	..()
 	return INITIALIZE_HINT_LATELOAD
 
-/obj/item/folder/envelope/captain/LateInitialize(mapload)
+/obj/item/folder/envelope/preset/captain/LateInitialize(mapload)
 	var/obj/overmap/visitable/torch = map_sectors["[z]"]
 	var/memo = {"
 	<tt><center><b>[SPAN_COLOR("red", "SECRET - CODE WORDS: TORCH")]</b>
@@ -110,10 +110,11 @@
 	new/obj/item/paper(src, memo, "Standing Orders")
 	new/obj/item/paper/umbra(src)
 
-/obj/item/folder/envelope/rep
+/obj/item/folder/envelope/preset/rep
 	desc = "A thick envelope. The SCG crest is stamped in the corner, along with 'TOP SECRET - TORCH UMBRA'."
+	seal_stamp = "General Secretary rubber stamp"
 
-/obj/item/folder/envelope/rep/Initialize()
+/obj/item/folder/envelope/preset/rep/Initialize()
 	. = ..()
 	new/obj/item/paper/umbra(src)
 

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -12683,7 +12683,7 @@
 /area/crew_quarters/lounge)
 "Qu" = (
 /obj/structure/table/standard,
-/obj/item/folder/envelope/dcorder,
+/obj/item/folder/envelope/preset/dcorder,
 /turf/simulated/floor/tiled,
 /area/quartermaster/deckchief)
 "Qy" = (
@@ -12744,7 +12744,7 @@
 /obj/random_multi/single_item/memo_research,
 /obj/random_multi/single_item/memo_exploration,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/item/folder/envelope/exploorder,
+/obj/item/folder/envelope/preset/exploorder,
 /turf/simulated/floor/tiled,
 /area/command/pathfinder)
 "QI" = (

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -3912,7 +3912,7 @@
 	pixel_x = 2;
 	pixel_y = 6
 	},
-/obj/item/folder/envelope/csorder,
+/obj/item/folder/envelope/preset/csorder,
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/chief_steward)
 "iO" = (

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -1758,8 +1758,8 @@
 /obj/structure/table/woodentable_reinforced/walnut,
 /obj/random_multi/single_item/memo_command,
 /obj/random_multi/single_item/memo_supply,
-/obj/item/folder/envelope/dcorder,
-/obj/item/folder/envelope/csorder,
+/obj/item/folder/envelope/preset/dcorder,
+/obj/item/folder/envelope/preset/csorder,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/xo)
 "de" = (
@@ -4197,7 +4197,7 @@
 	dir = 6
 	},
 /obj/random_multi/single_item/memo_engineering,
-/obj/item/folder/envelope/ceorder,
+/obj/item/folder/envelope/preset/ceorder,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/ce)
 "iU" = (
@@ -4899,7 +4899,7 @@
 /obj/random_multi/single_item/memo_command,
 /obj/random_multi/single_item/memo_supply,
 /obj/random_multi/single_item/memo_medical,
-/obj/item/folder/envelope/ndaorder,
+/obj/item/folder/envelope/preset/ndaorder,
 /obj/item/paper/immediateorder,
 /turf/simulated/floor/tiled/dark,
 /area/bridge)
@@ -5392,7 +5392,7 @@
 /area/hallway/primary/bridge/aft)
 "mT" = (
 /obj/structure/table/woodentable/walnut,
-/obj/item/folder/envelope/cmdorder,
+/obj/item/folder/envelope/preset/cmdorder,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
 "mV" = (
@@ -7711,7 +7711,7 @@
 /obj/structure/noticeboard{
 	pixel_x = 32
 	},
-/obj/item/folder/envelope/cmdorder,
+/obj/item/folder/envelope/preset/cmdorder,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
 "tC" = (
@@ -7970,7 +7970,7 @@
 /obj/item/storage/secure/safe{
 	pixel_x = 36
 	},
-/obj/item/folder/envelope/rep,
+/obj/item/folder/envelope/preset/rep,
 /obj/item/documents/scgr,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
@@ -8928,7 +8928,7 @@
 	},
 /obj/item/stamp/cos,
 /obj/random_multi/single_item/memo_security,
-/obj/item/folder/envelope/cosorder,
+/obj/item/folder/envelope/preset/cosorder,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "wD" = (
@@ -11116,7 +11116,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/obj/item/folder/envelope/lauletter1,
+/obj/item/folder/envelope/preset/lauletter1,
 /turf/simulated/floor/carpet/blue,
 /area/crew_quarters/heads/office/co)
 "Fn" = (
@@ -12328,7 +12328,7 @@
 /obj/floor_decal/corner/paleblue/diagonal,
 /obj/structure/table/glass,
 /obj/random_multi/single_item/memo_medical,
-/obj/item/folder/envelope/cmoorder,
+/obj/item/folder/envelope/preset/cmoorder,
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "Kh" = (
@@ -12634,7 +12634,7 @@
 /obj/floor_decal/corner/research{
 	dir = 5
 	},
-/obj/item/folder/envelope/exploorder,
+/obj/item/folder/envelope/preset/exploorder,
 /turf/simulated/floor/tiled,
 /area/crew_quarters/heads/office/rd)
 "Lw" = (
@@ -12764,7 +12764,7 @@
 /area/aquila/airlock)
 "Mf" = (
 /obj/structure/table/woodentable_reinforced/walnut/maple,
-/obj/item/folder/envelope/captain,
+/obj/item/folder/envelope/preset/captain,
 /obj/random_multi/single_item/runtime,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/co)
@@ -13289,7 +13289,7 @@
 	pixel_y = -4
 	},
 /obj/item/hand_labeler,
-/obj/item/folder/envelope/clorder,
+/obj/item/folder/envelope/preset/clorder,
 /turf/simulated/floor/carpet/green,
 /area/crew_quarters/heads/office/cl/backroom)
 "Ox" = (

--- a/packs/event_2022jul30/documents.dm
+++ b/packs/event_2022jul30/documents.dm
@@ -19,11 +19,11 @@
 "}
 
 
-/obj/item/folder/envelope/lauletter1
+/obj/item/folder/envelope/preset/lauletter1
 	desc = "A thick envelope. The Expeditionary Corps crest is stamped in the corner, along with 'DO NOT DISSEMINATE.'"
 
 
-/obj/item/folder/envelope/lauletter1/Initialize()
+/obj/item/folder/envelope/preset/lauletter1/Initialize()
 	. = ..()
 	new /obj/item/paper/lauletter1 (src)
 

--- a/packs/event_2024jul20/documents.dm
+++ b/packs/event_2024jul20/documents.dm
@@ -19,11 +19,11 @@
 "}
 
 
-/obj/item/folder/envelope/ndaorder
+/obj/item/folder/envelope/preset/ndaorder
 	desc = "A thick envelope. The Expeditionary Corps crest is stamped in the corner, along with 'DO NOT DISSEMINATE. FOR BRIDGE EYES ONLY.'"
 
 
-/obj/item/folder/envelope/ndaorder/Initialize()
+/obj/item/folder/envelope/preset/ndaorder/Initialize()
 	. = ..()
 	new /obj/item/paper/ndaorder (src)
 
@@ -53,11 +53,11 @@
 "}
 
 
-/obj/item/folder/envelope/cmoorder
+/obj/item/folder/envelope/preset/cmoorder
 	desc = "A thick envelope. The Expeditionary Corps crest is stamped in the corner, along with 'DISSEMINATE AS NECESSARY. FOR CMO EYES.'"
 
 
-/obj/item/folder/envelope/cmoorder/Initialize()
+/obj/item/folder/envelope/preset/cmoorder/Initialize()
 	. = ..()
 	new /obj/item/paper/cmoorder (src)
 
@@ -87,11 +87,11 @@
 "}
 
 
-/obj/item/folder/envelope/cosorder
+/obj/item/folder/envelope/preset/cosorder
 	desc = "A thick envelope. The Expeditionary Corps crest is stamped in the corner, along with 'DISSEMINATE AS NECESSARY. FOR COS EYES.'"
 
 
-/obj/item/folder/envelope/cosorder/Initialize()
+/obj/item/folder/envelope/preset/cosorder/Initialize()
 	. = ..()
 	new /obj/item/paper/cosorder (src)
 
@@ -119,11 +119,11 @@
 "}
 
 
-/obj/item/folder/envelope/ceorder
+/obj/item/folder/envelope/preset/ceorder
 	desc = "A thick envelope. The Expeditionary Corps crest is stamped in the corner, along with 'DISSEMINATE AS NECESSARY. FOR CE EYES.'"
 
 
-/obj/item/folder/envelope/ceorder/Initialize()
+/obj/item/folder/envelope/preset/ceorder/Initialize()
 	. = ..()
 	new /obj/item/paper/ceorder (src)
 
@@ -151,11 +151,11 @@
 "}
 
 
-/obj/item/folder/envelope/exploorder
+/obj/item/folder/envelope/preset/exploorder
 	desc = "A thick envelope. The Expeditionary Corps crest is stamped in the corner, along with 'DISSEMINATE AS NECESSARY. FOR CSO/PATHFINDER EYES.'"
 
 
-/obj/item/folder/envelope/exploorder/Initialize()
+/obj/item/folder/envelope/preset/exploorder/Initialize()
 	. = ..()
 	new /obj/item/paper/exploorder (src)
 
@@ -183,11 +183,11 @@
 "}
 
 
-/obj/item/folder/envelope/dcorder
+/obj/item/folder/envelope/preset/dcorder
 	desc = "A thick envelope. The Expeditionary Corps crest is stamped in the corner, along with 'DISSEMINATE AS NECESSARY. FOR DC/XO EYES.'"
 
 
-/obj/item/folder/envelope/dcorder/Initialize()
+/obj/item/folder/envelope/preset/dcorder/Initialize()
 	. = ..()
 	new /obj/item/paper/dcorder (src)
 
@@ -214,11 +214,11 @@
 "}
 
 
-/obj/item/folder/envelope/csorder
+/obj/item/folder/envelope/preset/csorder
 	desc = "A thick envelope. The Expeditionary Corps crest is stamped in the corner, along with 'DISSEMINATE AS NECESSARY. FOR CS/XO EYES.'"
 
 
-/obj/item/folder/envelope/csorder/Initialize()
+/obj/item/folder/envelope/preset/csorder/Initialize()
 	. = ..()
 	new /obj/item/paper/csorder (src)
 
@@ -243,11 +243,12 @@
 "}
 
 
-/obj/item/folder/envelope/clorder
+/obj/item/folder/envelope/preset/clorder
 	desc = "A thick envelope. The Expeditionary Corps Organisation crest is stamped in the corner, along with 'DO NOT DISSEMINATE. FOR CL EYES ONLY.'"
+	seal_stamp = "\improper Expeditionary Corps Organisation rubber stamp"
 
 
-/obj/item/folder/envelope/clorder/Initialize()
+/obj/item/folder/envelope/preset/clorder/Initialize()
 	. = ..()
 	new /obj/item/paper/clorder (src)
 
@@ -274,11 +275,12 @@
 "}
 
 
-/obj/item/folder/envelope/cmdorder
+/obj/item/folder/envelope/preset/cmdorder
 	desc = "A thick envelope. The Sol Central Government crest is stamped in the corner, along with 'DO NOT DISSEMINATE. FOR SCGR/CO EYES ONLY.'"
+	seal_stamp = "\improper Bureau of Emergency Operations rubber stamp"
 
 
-/obj/item/folder/envelope/cmdorder/Initialize()
+/obj/item/folder/envelope/preset/cmdorder/Initialize()
 	. = ..()
 	new /obj/item/paper/cmdorder (src)
 


### PR DESCRIPTION
Packing confidential documents in boxes is no more!
All existing envelopes are moved to a new preset subclass.
All preset envelopes are stamped with the ECO stamp by default.

:cl:
rscadd: Envelopes are craftable from cardboard.
rscadd: Envelopes can be sealed and resealed with rubber stamps. Open envelope will show the last stamp it was sealed with.
/:cl:
