### PR TITLE
Tweak injury examination colors

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -174,14 +174,14 @@
 	if (src.stat)
 		msg += "[SPAN_WARNING("[P.He] [P.is]n't responding to anything around [P.him] and seems to be unconscious.")]\n"
 		if((stat == DEAD || is_asystole() || losebreath || status_flags & FAKEDEATH) && distance <= 3)
-			msg += "[SPAN_WARNING("[P.He] [P.does] not appear to be breathing.")]\n"
+			msg += "[SPAN_DANGER("[P.He] [P.does] not appear to be breathing.")]\n"
 
 	if (fire_stacks > 0)
 		msg += "[P.He] looks flammable.\n"
 	else if (fire_stacks < 0)
 		msg += "[P.He] looks wet.\n"
 	if(on_fire)
-		msg += "[SPAN_WARNING("[P.He] [P.is] on fire!.")]\n"
+		msg += "[SPAN_DANGER("[P.He] [P.is] on fire!.")]\n"
 
 	var/ssd_msg = species.get_ssd(src)
 	if(ssd_msg && (!should_have_organ(BP_BRAIN) || has_brain()) && stat != DEAD)
@@ -223,7 +223,7 @@
 		var/obj/item/organ/external/E = organs_by_name[organ_tag]
 
 		if(!E)
-			wound_flavor_text[organ_descriptor] = "<b>[P.He] [P.is] missing [P.his] [organ_descriptor].</b>\n"
+			wound_flavor_text[organ_descriptor] = SPAN_WARNING("<b>[P.He] [P.is] missing [P.his] [organ_descriptor].</b>\n")
 			continue
 
 		wound_flavor_text[E.name] = ""
@@ -245,20 +245,20 @@
 				hidden_bleeders[hidden] += E.name
 		else
 			if(E.is_stump())
-				wound_flavor_text[E.name] += "<b>[P.He] [P.has] a stump where [P.his] [organ_descriptor] should be.</b>\n"
+				wound_flavor_text[E.name] += SPAN_DANGER("<b>[P.He] [P.has] a stump where [P.his] [organ_descriptor] should be.</b>\n")
 				if(LAZYLEN(E.wounds) && E.parent)
-					wound_flavor_text[E.name] += "[P.He] [P.has] [E.get_wounds_desc()] on [P.his] [E.parent.name].<br>"
+					wound_flavor_text[E.name] += SPAN_DANGER("[P.He] [P.has] [E.get_wounds_desc()] on [P.his] [E.parent.name].<br>")
 			else
 				if(!is_synth && BP_IS_ROBOTIC(E) && (E.parent && !BP_IS_ROBOTIC(E.parent) && !BP_IS_ASSISTED(E.parent)))
-					wound_flavor_text[E.name] = "[P.He] [P.has] a [E.name].\n"
+					wound_flavor_text[E.name] = SPAN_INFO("[P.He] [P.has] a [E.name].\n")
 				var/wounddesc = E.get_wounds_desc()
 				if(wounddesc != "nothing")
-					wound_flavor_text[E.name] += "[P.He] [P.has] [wounddesc] on [P.his] [E.name].<br>"
+					wound_flavor_text[E.name] += SPAN_DANGER("[P.He] [P.has] [wounddesc] on [P.his] [E.name].<br>")
 		if(!hidden || distance <=1)
 			if(E.dislocated > 0)
-				wound_flavor_text[E.name] += "[P.His] [E.joint] is dislocated!<br>"
+				wound_flavor_text[E.name] += SPAN_WARNING("[P.His] [E.joint] is dislocated!<br>")
 			if(((E.status & ORGAN_BROKEN) && E.brute_dam > E.min_broken_damage) || (E.status & ORGAN_MUTATED))
-				wound_flavor_text[E.name] += "[P.His] [E.name] is dented and swollen!<br>"
+				wound_flavor_text[E.name] += SPAN_DANGER("[P.His] [E.name] is dented and swollen!<br>")
 
 		for(var/datum/wound/wound in E.wounds)
 			var/list/embedlist = wound.embedded_objects
@@ -271,14 +271,12 @@
 					else if(!parsedembed.Find("multiple [embedded.name]"))
 						parsedembed.Remove(embedded.name)
 						parsedembed.Add("multiple "+embedded.name)
-				wound_flavor_text["[E.name]"] += "The [wound.desc] on [P.his] [E.name] has \a [english_list(parsedembed, and_text = " and a ", comma_text = ", a ")] sticking out of it!<br>"
+				wound_flavor_text["[E.name]"] += SPAN_DANGER("The [wound.desc] on [P.his] [E.name] has \a [english_list(parsedembed, and_text = " and a ", comma_text = ", a ")] sticking out of it!<br>")
 	for(var/hidden in hidden_bleeders)
-		wound_flavor_text[hidden] = "[P.He] [P.has] blood soaking through [hidden] around [P.his] [english_list(hidden_bleeders[hidden])]!<br>"
+		wound_flavor_text[hidden] = SPAN_DANGER("[P.He] [P.has] blood soaking through [hidden] around [P.his] [english_list(hidden_bleeders[hidden])]!<br>")
 
-	var/wound_msg = ""
 	for(var/limb in wound_flavor_text)
-		wound_msg += wound_flavor_text[limb]
-	msg += SPAN_WARNING(wound_msg)
+		msg += wound_flavor_text[limb]
 
 	for(var/obj/implant in get_visible_implants(0))
 		if(implant in shown_objects)


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Colors and styles used for various injury states when examining carbon mobs have been individually tweaked. Injuries are now red again.
/:cl: