### PR TITLE
Fix newscaster images not appearing if channel contains symbols

### DIFF
--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -18,6 +18,7 @@
 
 /datum/feed_channel
 	var/channel_name=""
+	var/channel_id=0
 	var/list/datum/feed_message/messages = list()
 	var/locked=0
 	var/author=""
@@ -67,6 +68,7 @@
 /datum/feed_network/proc/CreateFeedChannel(channel_name, author, locked, adminChannel = 0, announcement_message)
 	var/datum/feed_channel/newChannel = new /datum/feed_channel
 	newChannel.channel_name = channel_name
+	newChannel.channel_id = length(network_channels)
 	newChannel.author = author
 	newChannel.locked = locked
 	newChannel.is_admin_channel = adminChannel
@@ -95,7 +97,7 @@
 /datum/feed_network/proc/insert_message_in_channel(datum/feed_channel/FC, datum/feed_message/newMsg)
 	FC.messages += newMsg
 	if(newMsg.img)
-		register_asset("newscaster_photo_[sanitize(FC.channel_name)]_[length(FC.messages)].png", newMsg.img)
+		register_asset("newscaster_photo_[FC.channel_id]_[length(FC.messages)].png", newMsg.img)
 	newMsg.parent_channel = FC
 	FC.update()
 	alert_readers(FC.announcement)
@@ -354,7 +356,7 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 							++i
 							dat+="-[MESSAGE.body] <BR>"
 							if(MESSAGE.img)
-								var/resourc_name = "newscaster_photo_[sanitize(viewing_channel.channel_name)]_[i].png"
+								var/resourc_name = "newscaster_photo_[viewing_channel.channel_id]_[i].png"
 								send_asset(usr.client, resourc_name)
 								dat+="<img src='[resourc_name]' width = '180'><BR>"
 								if(MESSAGE.caption)
@@ -841,7 +843,7 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 							++i
 							dat+="-[MESSAGE.body] <BR>"
 							if(MESSAGE.img)
-								var/resourc_name = "newscaster_photo_[sanitize(C.channel_name)]_[i].png"
+								var/resourc_name = "newscaster_photo_[C.channel_id]_[i].png"
 								send_asset(user.client, resourc_name)
 								dat+="<img src='[resourc_name]' width = '180'><BR>"
 							dat+="[FONT_SMALL("\[[MESSAGE.message_type] by [SPAN_COLOR("maroon", MESSAGE.author)]\]")]<BR><BR>"

--- a/html/changelogs/HeyBanditoz-fix-newscaster-images.yml
+++ b/html/changelogs/HeyBanditoz-fix-newscaster-images.yml
@@ -1,0 +1,4 @@
+author: Banditoz
+delete-after: True
+changes:
+  - bugfix: "Fixed images in newscaster articles not showing up if the channel has special symbols in its title."


### PR DESCRIPTION
Each feed channel has its own ID, image resources will use that ID instead.

Fixes #30058
![dreamseeker_vJVELpfpNg](https://github.com/user-attachments/assets/f058c9ef-65a1-4a16-a221-c2515ad4121f)
![dreamseeker_qou2IGfPZ3](https://github.com/user-attachments/assets/200022ff-7f3f-4e11-b332-c56b6889d057)

