### PR TITLE
Fixes the emergency shield generator

### DIFF
--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -9,6 +9,7 @@
 	unacidable = TRUE
 	health_max = 200
 	damage_hitsound = 'sound/effects/EMPulse.ogg'
+	atmos_canpass = CANPASS_NEVER
 	var/shield_generate_power = 7500	//how much power we use when regenerating
 	var/shield_idle_power = 1500		//how much power we use when just being sustained.
 


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Fixes the emergency shield generator not blocking air.
/:cl:

I'll note that during the seven years this generator was probably broken, a change has been PRd to increase its effective square from 5x5 to a wopping 17x17 that also covers one z-layer above. Personally, this feels far too powerful, but I haven't touched the value to see what other people think.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->