### PR TITLE
Readds the airlock controller for the engine room

### DIFF
--- a/code/game/machinery/embedded_controller/airlock_program.dm
+++ b/code/game/machinery/embedded_controller/airlock_program.dm
@@ -142,10 +142,17 @@
 				begin_cycle_in()
 
 		if("cycle_ext_door")
-			cycleDoors(TARGET_OUTOPEN)
+			// Close the door if it's open, otherwise cycle
+			if(memory["exterior_status"]["state"] == "open")
+				toggleDoor(memory["exterior_status"], tag_exterior_door, memory["secure"], "toggle")
+			else
+				cycleDoors(TARGET_OUTOPEN)
 
 		if("cycle_int_door")
-			cycleDoors(TARGET_INOPEN)
+			if(memory["interior_status"]["state"] == "open")
+				toggleDoor(memory["interior_status"], tag_interior_door, memory["secure"], "toggle")
+			else
+				cycleDoors(TARGET_INOPEN)
 
 		if("abort")
 			stop_cycling()

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -3446,12 +3446,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/hatch/maintenance/bolted{
 	frequency = 1379;
-	id_tag = "";
+	id_tag = "engine_exterior";
 	name = "Engine Airlock Exterior"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "gX" = (
@@ -4980,6 +4980,10 @@
 	dir = 8
 	},
 /obj/floor_decal/industrial/outline/yellow,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_monitoring)
 "kY" = (
@@ -4992,10 +4996,6 @@
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
 /obj/floor_decal/industrial/outline/yellow,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_monitoring)
 "la" = (
@@ -5009,8 +5009,7 @@
 	},
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+	pixel_y = 21
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
@@ -5020,6 +5019,11 @@
 	dir = 5
 	},
 /obj/floor_decal/industrial/outline/yellow,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "le" = (
@@ -5315,12 +5319,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/hatch{
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/hatch/maintenance/bolted{
 	frequency = 1379;
-	id_tag = "";
+	id_tag = "engine_interior";
 	name = "Engine Airlock Interior"
 	},
-/obj/machinery/door/firedoor,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "lQ" = (
@@ -5332,7 +5336,20 @@
 /obj/floor_decal/industrial/warning{
 	dir = 10
 	},
-/obj/machinery/light/small,
+/obj/machinery/embedded_controller/radio/airlock/access_controller{
+	dir = 1;
+	id_tag = "engine_controller";
+	name = "Engine Room Access Controller";
+	pixel_y = -21;
+	req_access = list("ACCESS_ENGINE_EQUIP");
+	tag_exterior_door = "engine_exterior";
+	tag_interior_door = "engine_interior"
+	},
+/obj/machinery/access_button/airlock_interior{
+	master_tag = "engine_controller";
+	pixel_x = -23;
+	pixel_y = 23
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "lR" = (
@@ -5344,6 +5361,11 @@
 /obj/floor_decal/industrial/warning{
 	dir = 6
 	},
+/obj/machinery/access_button/airlock_exterior{
+	master_tag = "engine_controller";
+	pixel_x = 23;
+	pixel_y = 23
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "lT" = (
@@ -5352,6 +5374,11 @@
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
+	},
+/obj/machinery/access_button/airlock_exterior{
+	master_tag = "engine_controller";
+	pixel_x = -23;
+	pixel_y = 23
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
@@ -5902,6 +5929,11 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/access_button/airlock_interior{
+	master_tag = "engine_controller";
+	pixel_x = 23;
+	pixel_y = 23
+	},
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/engine_monitoring)
 "nw" = (
@@ -5914,7 +5946,8 @@
 /area/engineering/engine_monitoring)
 "nx" = (
 /obj/structure/sign/warning/internals_required{
-	name = "\improper RADIATION GEAR REQUIRED"
+	name = "\improper RADIATION GEAR REQUIRED";
+	pixel_y = 4
 	},
 /turf/simulated/wall/r_wall/prepainted,
 /area/engineering/engine_room)


### PR DESCRIPTION
🆑 Hubblenaut
rscadd: Adds an airlock controller to the engine room
/:cl:

Also:
- Tweaks simple airlocks (xenobiology, BSD, engine room) so that they can be closed by pressing the button outside (as is already possible with cycling airlocks).
- Adds meson goggles to the other radiation suit closet.

![grafik](https://github.com/user-attachments/assets/1700a987-9dd8-42e8-a25a-4e0b422974a1)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->