### PR TITLE
Fixes the light replacer not being stowable

### DIFF
--- a/code/game/objects/items/devices/lightreplacer.dm
+++ b/code/game/objects/items/devices/lightreplacer.dm
@@ -67,27 +67,6 @@
 
 
 /obj/item/device/lightreplacer/use_before(atom/target, mob/living/user, click_parameters)
-	// Check for lights in a container, refilling our charges.
-	if (istype(target, /obj/item/storage))
-		var/obj/item/storage/storage = target
-		var/amt_inserted = 0
-		var/turf/turf = get_turf(src)
-		for (var/obj/item/light/light in storage.contents)
-			if (uses < max_uses && light.status == LIGHT_OK)
-				AddUses(1)
-				amt_inserted++
-				storage.remove_from_storage(light, turf, TRUE)
-				qdel(light)
-		if (!amt_inserted)
-			USE_FEEDBACK_FAILURE("\The [target] has no lights to add to \the [src].")
-			return TRUE
-		storage.finish_bulk_removal()
-		user.visible_message(
-			SPAN_NOTICE("\The [user] transfers some lights from \a [target] to \a [src]."),
-			SPAN_NOTICE("You insert [amt_inserted] light\s from \the [target] to \the [src]. It now has [uses] light\s remaining.")
-		)
-		return TRUE
-
 	// Replace light bulbs
 	if (istype(target, /obj/machinery/light))
 		var/obj/machinery/light/fixture = target
@@ -116,6 +95,29 @@
 			SPAN_NOTICE("You add \the [tool] to \the [src]. It now has [uses] light\s remaining.")
 		)
 		qdel(tool)
+		return TRUE
+
+	// Container - Add lights
+	if (istype(tool, /obj/item/storage))
+		if (uses >= max_uses)
+			USE_FEEDBACK_FAILURE("\The [src] is full.")
+			return TRUE
+		var/obj/item/storage/storage = tool
+		var/amt_inserted = 0
+		for (var/obj/item/light/light in storage.contents)
+			if (uses < max_uses && light.status == LIGHT_OK)
+				AddUses(1)
+				amt_inserted++
+				storage.remove_from_storage(light, src, TRUE)
+				qdel(light)
+		if (!amt_inserted)
+			USE_FEEDBACK_FAILURE("\The [tool] has no lights to add to \the [src].")
+			return TRUE
+		storage.finish_bulk_removal()
+		user.visible_message(
+			SPAN_NOTICE("\The [user] transfers some lights from \a [tool] to \a [src]."),
+			SPAN_NOTICE("You insert [amt_inserted] light\s from \the [tool] to \the [src]. It now has [uses] light\s remaining.")
+		)
 		return TRUE
 
 	// Material Stack - Add lights


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Fixes not being able to put the light replacer into a container.
/:cl:

Containers like replacement light boxes now have to be used on the light replacer instead of the other way around in order to fill it up. This is in line with using other items such as glass or lights on the replacer and should've been the more intuitive process all along.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->