### PR TITLE
Layer changes to atmos machines and telebeacon

### DIFF
--- a/code/__defines/__renderer.dm
+++ b/code/__defines/__renderer.dm
@@ -66,7 +66,7 @@
 	#define ABOVE_TILE_LAYER            2.05
 	#define EXPOSED_PIPE_LAYER          2.06
 	#define EXPOSED_WIRE_LAYER          2.07
-	#define EXPOSED_WIRE_TERMINAL_LAYER 2.08
+	#define ABOVE_EXPOSED_WIRE_LAYER    2.08
 	#define CATWALK_LAYER               2.09
 	#define ABOVE_CATWALK_LAYER         2.10
 	#define BLOOD_LAYER                 2.11

--- a/code/game/machinery/teleporter/beacon.dm
+++ b/code/game/machinery/teleporter/beacon.dm
@@ -13,6 +13,7 @@ var/global/const/TELEBEACON_WIRE_SIGNALLER = 4
 	active_power_usage = 50
 	anchored = TRUE
 	level = ATOM_LEVEL_UNDER_TILE
+	layer = ABOVE_EXPOSED_WIRE_LAYER
 	obj_flags = OBJ_FLAG_ANCHORABLE
 
 	machine_name = "teleporter beacon"

--- a/code/modules/atmospherics/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/components/binary_devices/circulator.dm
@@ -7,7 +7,7 @@
 	icon = 'icons/obj/machines/power/teg.dmi'
 	icon_state = "circ-unassembled"
 	anchored = FALSE
-	layer = ABOVE_CATWALK_LAYER
+	layer = STRUCTURE_LAYER
 
 	var/kinetic_efficiency = 0.04 //combined kinetic and kinetic-to-electric efficiency
 	var/volume_ratio = 0.2

--- a/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
+++ b/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
@@ -12,7 +12,7 @@
 	construct_state = /singleton/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
-	layer = ABOVE_CATWALK_LAYER
+	layer = STRUCTURE_LAYER
 
 	machine_name = "oxygen regenerator"
 	machine_desc = "Catalyzes gaseous CO2 to convert it into gaseous oxygen. The excess carbon is condensed and ejected as graphite sheets."

--- a/code/modules/atmospherics/components/unary/cold_sink.dm
+++ b/code/modules/atmospherics/components/unary/cold_sink.dm
@@ -14,6 +14,7 @@
 	construct_state = /singleton/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
+	layer = STRUCTURE_LAYER
 
 	machine_name = "gas cooling system"
 	machine_desc = "While active, this machine cools the gas in a connected pipeline to lower temperatures. Gas pressure decreases with chilling, allowing it to be compressed more easily."

--- a/code/modules/atmospherics/components/unary/heat_source.dm
+++ b/code/modules/atmospherics/components/unary/heat_source.dm
@@ -14,6 +14,7 @@
 	construct_state = /singleton/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
+	layer = STRUCTURE_LAYER
 
 	machine_name = "gas heating system"
 	machine_desc = "While active, this machine increases the temperature of a connected gas line to the configured amount. Gas pressure increases with heat."

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -9,7 +9,7 @@
 	icon_state = "term"
 	desc = "It's an underfloor wiring terminal for power equipment."
 	level = ATOM_LEVEL_UNDER_TILE
-	layer = EXPOSED_WIRE_TERMINAL_LAYER
+	layer = ABOVE_EXPOSED_WIRE_LAYER
 	var/obj/item/stock_parts/power/terminal/master
 	anchored = TRUE
 


### PR DESCRIPTION
- Lifts gas cooler, gas heater, circulator and regenerator to `STRUCTURE_LAYER` to render them above pipes and catwalks like other machines.
- Renames `EXPOSED_WIRE_TERMINAL_LAYER` to `ABOVE_EXPOSED_WIRE_LAYER` and applies it to the teleport beacon to render it below the catwalk.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->