### PR TITLE
allows for single-step crafting recipes to actually make their product

### DIFF
--- a/code/controllers/subsystems/initialization/fabrication.dm
+++ b/code/controllers/subsystems/initialization/fabrication.dm
@@ -135,5 +135,7 @@ SUBSYSTEM_DEF(fabrication)
 		if (stage.can_begin_with(target) && stage.is_appropriate_tool(tool))
 			var/obj/item/crafting_holder/crafting = new (turf, stage, target, tool, user)
 			if (stage.progress_to(tool, user, crafting))
+				if (!length(stage.next_stages))
+					crafting.advance_to(stage, user, tool)
 				return crafting
 			qdel(crafting)


### PR DESCRIPTION
:cl:
bugfix: Makeshift splints are now fixed and can be made again by applying tape to a rod
/:cl:

fixes #34721 
As far as I can tell, the issue came from the fact that crafting code only had the advance part that made the product on the crafting holder, meaning it could only make it if it was able to progress a step after the crafting holder was made. The only crafting recipe that started and ended on the same step was the splint, so thats the only recipe that broke.

As a side note, there *is* another issue with the splint recipe, mainly that it will use the entire stack of rods to make one splint, so if you dont want to waste a bunch of rods you have to split a rod off the stack. The tricky part about fixing this is that the crafting datums only have variables to control how much is consumed on one side, and its already being used to stop the tape from being consumed, so you cant quite just swap the sides around. Aka, it would need a refactor to stop it from happening, which I would've done if executive dysfunction didnt hit me.