### PR TITLE
Allow toolbelts to hold RCDs

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -136,7 +136,8 @@
 		/obj/item/swapper,
 		/obj/item/device/drone_designator,
 		/obj/item/modular_computer/tablet,
-		/obj/item/modular_computer/pda
+		/obj/item/modular_computer/pda,
+		/obj/item/rcd
 		)
 
 


### PR DESCRIPTION
:cl: SierraKomodo
tweak: Toolbelts can now hold Rapid Construction Devices
/:cl: