### PR TITLE
Support Lattice Construction Fixes

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -308,6 +308,7 @@
 #include "code\datums\extensions\local_network.dm"
 #include "code\datums\extensions\penetration.dm"
 #include "code\datums\extensions\state_machine.dm"
+#include "code\datums\extensions\support_lattice.dm"
 #include "code\datums\extensions\appearance\appearance.dm"
 #include "code\datums\extensions\appearance\base_icon_state.dm"
 #include "code\datums\extensions\appearance\cardborg.dm"

--- a/code/datums/extensions/support_lattice.dm
+++ b/code/datums/extensions/support_lattice.dm
@@ -1,0 +1,48 @@
+/datum/extension/support_lattice
+	base_type = /datum/extension/support_lattice
+	expected_type = /atom
+
+/datum/extension/support_lattice/proc/try_construct(obj/item/C, mob/living/user)
+	var/turf/T = get_turf(holder)
+	if (istype(C, /obj/item/stack/material/rods))
+		var/obj/structure/lattice/L = locate(/obj/structure/lattice, T)
+		if(L)
+			return L.use_tool(C, user)
+		var/obj/item/stack/material/rods/R = C
+		if (!R.can_use(1))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(R, 1, "to lay down support lattice.")
+			return TRUE
+
+		to_chat(user, SPAN_NOTICE("You lay down the support lattice."))
+		playsound(T, 'sound/weapons/Genhit.ogg', 50, 1)
+		T.ReplaceWithLattice(R.material.name)
+		R.use(1)
+		return TRUE
+
+	if (istype(C, /obj/item/stack/tile))
+		var/obj/structure/lattice/L = locate(/obj/structure/lattice, T)
+		if(!L)
+			to_chat(user, SPAN_WARNING("The plating is going to need some support."))
+			return TRUE
+		var/obj/item/stack/tile/floor/S = C
+		if (!S.can_use(1))
+			USE_FEEDBACK_STACK_NOT_ENOUGH(S, 1, "to place the plating.")
+			return TRUE
+
+		qdel(L)
+		playsound(T, 'sound/weapons/Genhit.ogg', 50, 1)
+		T.ChangeTurf(/turf/simulated/floor/plating, keep_air = TRUE)
+		S.use(1)
+		return TRUE
+
+	if(isCoil(C))
+		var/obj/item/stack/cable_coil/coil = C
+		var/obj/structure/lattice/L = locate(/obj/structure/lattice, T)
+		if(L)
+			coil.PlaceCableOnTurf(T, user)
+			return TRUE
+		else
+			to_chat(user, SPAN_WARNING("The cable needs something to be secured to."))
+			return TRUE
+
+	return FALSE

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -17,6 +17,8 @@
 	. = ..()
 	update_starlight()
 
+	set_extension(src, /datum/extension/support_lattice)
+
 	appearance = SSskybox.space_appearance_cache[(((x + y) ^ ~(x * y) + z) % 25) + 1]
 
 	if(!HasBelow(z))
@@ -77,47 +79,9 @@
 		remove_starlight()
 
 /turf/space/use_tool(obj/item/C, mob/living/user, list/click_params)
-	if (istype(C, /obj/item/stack/material/rods))
-		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
-		if(L)
-			return L.use_tool(C, user)
-		var/obj/item/stack/material/rods/R = C
-		if (!R.can_use(1))
-			USE_FEEDBACK_STACK_NOT_ENOUGH(R, 1, "to lay down support lattice.")
-			return TRUE
-
-		to_chat(user, SPAN_NOTICE("You lay down the support lattice."))
-		playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
-		ReplaceWithLattice(R.material.name)
-		R.use(1)
+	var/datum/extension/support_lattice/sl = get_extension(src, /datum/extension/support_lattice)
+	if (sl.try_construct(C, user))
 		return TRUE
-
-	if (istype(C, /obj/item/stack/tile))
-		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
-		if(!L)
-			to_chat(user, SPAN_WARNING("The plating is going to need some support."))
-			return TRUE
-		var/obj/item/stack/tile/floor/S = C
-		if (!S.can_use(1))
-			USE_FEEDBACK_STACK_NOT_ENOUGH(S, 1, "to place the plating.")
-			return TRUE
-
-		qdel(L)
-		playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
-		ChangeTurf(/turf/simulated/floor/plating, keep_air = TRUE)
-		S.use(1)
-		return TRUE
-
-	//Checking if the user attacked with a cable coil
-	if(isCoil(C))
-		var/obj/item/stack/cable_coil/coil = C
-		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
-		if(L)
-			coil.PlaceCableOnTurf(src, user)
-			return TRUE
-		else
-			to_chat(user, SPAN_WARNING("The cable needs something to be secured to."))
-			return TRUE
 
 	return ..()
 

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -34,6 +34,10 @@
 
 	z_flags = ZM_MIMIC_DEFAULTS | ZM_MIMIC_OVERWRITE | ZM_MIMIC_NO_AO | ZM_ALLOW_ATMOS
 
+/turf/simulated/open/Initialize()
+	. = ..()
+	set_extension(src, /datum/extension/support_lattice)
+
 /turf/simulated/open/update_dirt()
 	return 0
 
@@ -64,44 +68,9 @@
 	return TRUE
 
 /turf/simulated/open/use_tool(obj/item/C, mob/living/user, list/click_params)
-	if (istype(C, /obj/item/stack/material/rods))
-		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
-		if(L)
-			return L.use_tool(C, user)
-		var/obj/item/stack/material/rods/R = C
-		if (!R.can_use(1))
-			USE_FEEDBACK_STACK_NOT_ENOUGH(R, 1, "to lay down support lattice.")
-			return TRUE
-		to_chat(user, SPAN_NOTICE("You lay down the support lattice."))
-		playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
-		new /obj/structure/lattice(locate(src.x, src.y, src.z), R.material.name)
+	var/datum/extension/support_lattice/sl = get_extension(src, /datum/extension/support_lattice)
+	if (sl.try_construct(C, user))
 		return TRUE
-
-	if (istype(C, /obj/item/stack/tile))
-		var/obj/structure/lattice/L = locate(/obj/structure/lattice, src)
-		if(!L)
-			to_chat(user, SPAN_WARNING("The plating is going to need some support."))
-			return TRUE
-
-		var/obj/item/stack/tile/floor/S = C
-		if (!S.can_use(1))
-			USE_FEEDBACK_STACK_NOT_ENOUGH(S, 1, "to plate the lattice.")
-			return TRUE
-
-		qdel(L)
-		playsound(src, 'sound/weapons/Genhit.ogg', 50, 1)
-		ChangeTurf(/turf/simulated/floor/plating, keep_air = TRUE)
-		return TRUE
-
-	//To lay cable.
-	if(isCoil(C))
-		var/obj/item/stack/cable_coil/coil = C
-		coil.PlaceCableOnTurf(src, user)
-		return TRUE
-
-	for(var/atom/movable/M in below)
-		if(M.movable_flags & MOVABLE_FLAG_Z_INTERACT)
-			return C.resolve_attackby(M, user)
 
 	return ..()
 

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -163,9 +163,9 @@
 
 	return ..()
 
-/atom/movable/openspace/mimic/can_use_item(obj/item/tool, mob/user, click_params)
-	USE_FEEDBACK_FAILURE("\The [src] is too far away.")
-	return FALSE
+/atom/movable/openspace/mimic/use_tool(obj/item/tool, mob/user, list/click_params)
+	SHOULD_CALL_PARENT(FALSE)
+	return tool.resolve_attackby(loc, user, click_params)
 
 /atom/movable/openspace/mimic/attack_hand(mob/user)
 	to_chat(user, SPAN_NOTICE("You cannot reach \the [src] from here."))


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: The construction of support lattices is no longer blocked by objects on lower z-levels.
bugfix: Construction of lattices and floors on holes is no longer free.
/:cl:

- Adds an extension for building support lattices to eliminate copy-paste code from `/turf/space` and `/turf/simulated/open`. Coincidentally fixes rods and tiles not being used up when placing support lattices on `/turf/simulated/open`.
- Can use tools on `/atom/movable/openspace/mimic`, which defers it to `/turf/simulated/open`. This allows the construction of support lattices without a z-level mimic blocking the click.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->