### PR TITLE
tweak shuttle fuel supply pack name for clarity

### DIFF
--- a/code/datums/supplypacks/atmospherics.dm
+++ b/code/datums/supplypacks/atmospherics.dm
@@ -109,7 +109,7 @@
 	access = access_atmospherics
 
 /singleton/hierarchy/supply_pack/atmospherics/fuel
-	name = "Liquid - Fuel tanks"
+	name = "Gas - Hydrogen tanks"
 	contains = list(/obj/item/tank/hydrogen = 4)
 	cost = 15
 	containername = "fuel tank crate"


### PR DESCRIPTION
:cl:
tweak: Hydrogen tanks' supply order name better reflects its contents.
/:cl:
