### PR TITLE
Bumps AO layer down

### DIFF
--- a/code/__defines/__renderer.dm
+++ b/code/__defines/__renderer.dm
@@ -62,29 +62,29 @@
 	#define TURF_SHADOW_LAYER           2.02
 	//ABOVE TURF
 	#define DECAL_LAYER                 2.03
-	#define RUNE_LAYER                  2.04
-	#define ABOVE_TILE_LAYER            2.05
-	#define EXPOSED_PIPE_LAYER          2.06
-	#define EXPOSED_WIRE_LAYER          2.07
-	#define ABOVE_EXPOSED_WIRE_LAYER    2.08
-	#define CATWALK_LAYER               2.09
-	#define ABOVE_CATWALK_LAYER         2.10
-	#define BLOOD_LAYER                 2.11
-	#define MOUSETRAP_LAYER             2.12
-	#define PLANT_LAYER                 2.13
-	#define AO_LAYER                    2.14
-	#define ABOVE_AO_LAYER              2.141
+	#define AO_LAYER                    2.04
+	#define ABOVE_AO_LAYER              2.05
+	#define RUNE_LAYER                  2.06
+	#define ABOVE_TILE_LAYER            2.07
+	#define EXPOSED_PIPE_LAYER          2.08
+	#define EXPOSED_WIRE_LAYER          2.09
+	#define ABOVE_EXPOSED_WIRE_LAYER    2.10
+	#define CATWALK_LAYER               2.11
+	#define ABOVE_CATWALK_LAYER         2.12
+	#define BLOOD_LAYER                 2.13
+	#define MOUSETRAP_LAYER             2.14
+	#define PLANT_LAYER                 2.15
 	//HIDING MOB
-	#define HIDING_MOB_LAYER            2.15
-	#define SHALLOW_FLUID_LAYER         2.16
-	#define MOB_SHADOW_LAYER            2.17
+	#define HIDING_MOB_LAYER            2.16
+	#define SHALLOW_FLUID_LAYER         2.17
+	#define MOB_SHADOW_LAYER            2.18
 	//OBJ
-	#define BELOW_DOOR_LAYER            2.18
-	#define OPEN_DOOR_LAYER             2.19
-	#define BELOW_TABLE_LAYER           2.20
-	#define TABLE_LAYER                 2.21
-	#define BELOW_OBJ_LAYER             2.22
-	#define STRUCTURE_LAYER             2.23
+	#define BELOW_DOOR_LAYER            2.19
+	#define OPEN_DOOR_LAYER             2.20
+	#define BELOW_TABLE_LAYER           2.21
+	#define TABLE_LAYER                 2.22
+	#define BELOW_OBJ_LAYER             2.23
+	#define STRUCTURE_LAYER             2.24
 	// OBJ_LAYER                        3
 	#define ABOVE_OBJ_LAYER             3.01
 	#define CLOSED_DOOR_LAYER           3.02


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Fixes pipes, wires, atmos machinery and other specific object types adjacent to walls being hard to click.
/:cl:

Ambient Occlusion is a mouse-opaque overlay applied to turfs and will prevent people from clicking anything rendering below it.
As such, AO has been moved down to above the decal layer.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->