### PR TITLE
Droppers can be used on help intent

### DIFF
--- a/code/modules/reagents/reagent_containers/dropper.dm
+++ b/code/modules/reagents/reagent_containers/dropper.dm
@@ -27,9 +27,6 @@
 		var/trans = 0
 
 		if(ismob(target))
-			if(user.a_intent == I_HELP)
-				return TRUE
-
 			var/time = 20 //2/3rds the time of a syringe
 			user.visible_message(SPAN_WARNING("[user] is trying to squirt something into [target]'s eyes!"))
 


### PR DESCRIPTION
:cl: SierraKomodo
bugfix: Droppers can now be used on mobs on help intent again.
/:cl: