### PR TITLE
transfer vote defaults to end the round if there are no voters

### DIFF
--- a/code/datums/vote/transfer.dm
+++ b/code/datums/vote/transfer.dm
@@ -48,9 +48,7 @@
 	to_world(SPAN_COLOR("purple", "Bluespace Jump Factor: [factor]"))
 
 /datum/vote/transfer/report_result()
-	if(..())
-		return 1
-	if(result[1] == CHOICE_TRANSFER)
+	if(..() || result[1] == CHOICE_TRANSFER)
 		init_autotransfer()
 	else if(result[1] == CHOICE_ADD_ANTAG)
 		SSvote.queued_auto_vote = /datum/vote/add_antagonist


### PR DESCRIPTION
:cl: Mucker
tweak: The Transfer vote will now default to the transfer option if there are no voters.
/:cl: