### PR TITLE
Fixes pixel offset when taping things to walls

### DIFF
--- a/code/game/objects/items/weapons/tape.dm
+++ b/code/game/objects/items/weapons/tape.dm
@@ -143,16 +143,23 @@
 	anchored = TRUE
 
 	if(click_parameters)
+		var/offset_x = 16
+		var/offset_y = 16
+		if (stuck.center_of_mass)
+			var/list/center = cached_key_number_decode(stuck.center_of_mass)
+			offset_x = center["x"]
+			offset_y = center["y"]
 		if(click_parameters["icon-x"])
-			pixel_x = text2num(click_parameters["icon-x"]) - 16
+			pixel_x = text2num(click_parameters["icon-x"]) - offset_x
 			if(dir_offset & EAST)
 				pixel_x += 32
 			else if(dir_offset & WEST)
 				pixel_x -= 32
 		if(click_parameters["icon-y"])
-			pixel_y = text2num(click_parameters["icon-y"]) - 16
+			pixel_y = text2num(click_parameters["icon-y"]) - offset_y
 			if(dir_offset & NORTH)
 				pixel_y += 32
 			else if(dir_offset & SOUTH)
 				pixel_y -= 32
+		pixel_z = 0
 	return TRUE


### PR DESCRIPTION
:cl: Hubblenaut
bugfix: Fixes taped paper not correctly being placed under the cursor.
/:cl:

`pixel_z` was not reset when taping paper to walls.
Furthermore, now uses the placement offset `center_of_mass` to determine the correct offset.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->