### PR TITLE
Mule psi latency fix

### DIFF
--- a/code/modules/psionics/mob/mob.dm
+++ b/code/modules/psionics/mob/mob.dm
@@ -13,10 +13,10 @@
 	. = ..()
 
 /mob/living/proc/set_psi_rank(faculty, rank, take_larger, defer_update, temporary)
-	if(!src.zone_sel)
-		to_chat(src, SPAN_NOTICE("You feel something strange brush against your mind... but your brain is not able to grasp it."))
-		return
 	if(!psi)
+		if(!zone_sel)
+			to_chat(src, SPAN_NOTICE("You feel something strange brush against your mind... but your brain is not able to grasp it."))
+			return
 		psi = new(src)
 	var/current_rank = psi.get_rank(faculty)
 	if(current_rank != rank && (!take_larger || current_rank < rank))


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Mules can't get their guaranteed psi latency on spawn, because of the check at set_psi_rank for simple mobs.
https://github.com/Baystation12/Baystation12/blob/49d9ddb5a76bdef548ee3d27e4c90ecf9d2ff082/code/modules/species/station/human_subspecies.dm#L167-L172

:cl: Builder13
bugfix: Fixed a bug where Mules were not getting guaranteed psi latency
/:cl: