### PR TITLE
RIG verbs and skills

### DIFF
--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -55,12 +55,12 @@
 	var/obj/item/tank/air_type =   /obj/item/tank/oxygen
 
 	//Component/device holders.
-	var/obj/item/tank/air_supply                       // Air tank, if any.
+	var/obj/item/tank/air_supply                              // Air tank, if any.
 	var/obj/item/clothing/shoes/boots = null                  // Deployable boots, if any.
 	var/obj/item/clothing/suit/space/rig/chest                // Deployable chestpiece, if any.
 	var/obj/item/clothing/head/helmet/space/rig/helmet = null // Deployable helmet, if any.
 	var/obj/item/clothing/gloves/rig/gloves = null            // Deployable gauntlets, if any.
-	var/obj/item/cell/cell                             // Power supply, if any.
+	var/obj/item/cell/cell                                    // Power supply, if any.
 	var/obj/item/rig_module/selected_module = null            // Primary system (used with middle-click)
 	var/obj/item/rig_module/vision/visor                      // Kinda shitty to have a var for a module, but saves time.
 	var/obj/item/rig_module/voice/speech                      // As above.
@@ -203,15 +203,18 @@
 		air_supply = new air_type(src)
 	if(glove_type)
 		gloves = new glove_type(src)
+		verbs |= /obj/item/rig/proc/toggle_gauntlets
 	if(helm_type)
 		helmet = new helm_type(src)
 		verbs |= /obj/item/rig/proc/toggle_helmet
 	if(boot_type)
 		boots = new boot_type(src)
+		verbs |= /obj/item/rig/proc/toggle_boots
 	if(chest_type)
 		chest = new chest_type(src)
 		if(allowed)
 			chest.allowed = allowed
+		verbs |= /obj/item/rig/proc/toggle_chest
 
 	for(var/obj/item/piece in list(gloves,helmet,boots,chest))
 		if(!istype(piece))
@@ -319,7 +322,7 @@
 			SPAN_INFO("[wearer]'s suit emits a quiet hum as it begins to adjust its seals."), \
 			SPAN_INFO("With a quiet hum, the suit begins running checks and adjusting components."))
 
-			if(seal_delay && !instant && !do_after(wearer,seal_delay, src))
+			if(seal_delay && !instant && !wearer.do_skilled(seal_delay, SKILL_EVA, src))
 				failed_to_seal = 1
 
 		if(!wearer)
@@ -342,7 +345,7 @@
 
 				if(!failed_to_seal && wearer.back == src && piece == compare_piece)
 
-					if(seal_delay && !instant && !do_after(wearer, seal_delay, src, do_flags = DO_DEFAULT & ~DO_USER_SAME_HAND))
+					if(seal_delay && !instant && !wearer.do_skilled(seal_delay, SKILL_EVA, src, do_flags = DO_DEFAULT & ~DO_USER_SAME_HAND))
 						failed_to_seal = 1
 
 					piece.icon_state = "[initial(icon_state)][!seal_target ? "_sealed" : ""]"
@@ -783,6 +786,9 @@
 
 			var/mob/living/carbon/human/holder
 
+			if(piece != "helmet" && (!offline || sealing))
+				FEEDBACK_FAILURE(initiator, SPAN_WARNING("The hardsuit needs to be deactivated before you can do that."))
+				return
 			if(use_obj)
 				holder = use_obj.loc
 				if(istype(holder))
@@ -842,6 +848,18 @@
 
 	for(var/piece in list("helmet","gauntlets","chest","boots"))
 		toggle_piece(piece, H, ONLY_DEPLOY)
+
+/obj/item/rig/proc/retract(mob/M)
+
+	var/mob/living/carbon/human/H = M
+
+	if(!H || !istype(H)) return
+
+	if(H.back != src)
+		return
+
+	for(var/piece in list("helmet","gauntlets","chest","boots"))
+		toggle_piece(piece, H, ONLY_RETRACT)
 
 /obj/item/rig/dropped(mob/user)
 	..()

--- a/code/modules/clothing/spacesuits/rig/rig_verbs.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_verbs.dm
@@ -55,10 +55,10 @@
 
 	toggle_piece("helmet",wearer)
 
-/obj/item/rig/verb/deploy_suit()
+/obj/item/rig/proc/toggle_chest()
 
-	set name = "Deploy Hardsuit"
-	set desc = "Deploys helmet, gloves and boots."
+	set name = "Toggle Chestpiece"
+	set desc = "Deploys or retracts your chestpiece."
 	set category = "Hardsuit"
 	set src = usr.contents
 
@@ -69,14 +69,62 @@
 	if(!check_suit_access(usr))
 		return
 
-	if(!check_power_cost(usr))
+	toggle_piece("chest",wearer)
+
+/obj/item/rig/proc/toggle_gauntlets()
+
+	set name = "Toggle Gauntlets"
+	set desc = "Deploys or retracts your gauntlets."
+	set category = "Hardsuit"
+	set src = usr.contents
+
+	if(!istype(wearer) || !wearer.back == src)
+		to_chat(usr, SPAN_WARNING("The hardsuit is not being worn."))
 		return
 
-	deploy(wearer)
+	if(!check_suit_access(usr))
+		return
+
+	toggle_piece("gauntlets",wearer)
+
+/obj/item/rig/proc/toggle_boots()
+
+	set name = "Toggle Boots"
+	set desc = "Deploys or retracts your boots."
+	set category = "Hardsuit"
+	set src = usr.contents
+
+	if(!istype(wearer) || !wearer.back == src)
+		to_chat(usr, SPAN_WARNING("The hardsuit is not being worn."))
+		return
+
+	if(!check_suit_access(usr))
+		return
+
+	toggle_piece("boots",wearer)
+
+/obj/item/rig/verb/toggle_all_pieces()
+
+	set name = "Toggle All Pieces"
+	set desc = "Retracts your hardsuit if it is completely deployed, or activates all currently stowed pieces."
+	set category = "Hardsuit"
+	set src = usr.contents
+
+	if(!istype(wearer) || !wearer.back == src)
+		to_chat(usr, SPAN_WARNING("The hardsuit is not being worn."))
+		return
+
+	if(!check_suit_access(usr))
+		return
+
+	if(!suit_is_deployed())
+		deploy(wearer)
+	else
+		retract(wearer)
 
 /obj/item/rig/verb/toggle_seals_verb()
 
-	set name = "Toggle Hardsuit"
+	set name = "Cycle Hardsuit"
 	set desc = "Activates or deactivates your rig."
 	set category = "Hardsuit"
 	set src = usr.contents

--- a/nano/templates/hardsuit.tmpl
+++ b/nano/templates/hardsuit.tmpl
@@ -1,11 +1,11 @@
-<!-- 
+<!--
 Title: Integrated Hardsuit Controller
 Used In File(s): /code/modules/clothing/spacesuits/rig/rig.dm
  -->
 
 <style type="text/css">
 	.inlineBlock {
-		padding: 2px; 
+		padding: 2px;
 		display: inline-block;
 	}
 	.extraTopPadding {
@@ -16,7 +16,7 @@ Used In File(s): /code/modules/clothing/spacesuits/rig/rig.dm
 		margin-left: 5px;
 	}
 	.paddedBorderBlue {
-		border: 1px solid #517087; 
+		border: 1px solid #517087;
 		padding: 2px;
 	}
 	.redText {
@@ -136,6 +136,11 @@ Used In File(s): /code/modules/clothing/spacesuits/rig/rig.dm
 				<div class='fixedLeftWider'>
 					{{:helper.capitalizeFirstLetter(data.gauntlets)}}
 				</div>
+				{{if data.sealing != 1}}
+					<div class='fixedLeft'>
+						{{:helper.link('Toggle', 'circle-arrow-s', {'toggle_piece' : 'gauntlets'}, null)}}
+					</div>
+				{{/if}}
 			</div>
 			<div class='inlineBlock'>
 				<div class='fixedLeft boldText'>
@@ -144,6 +149,11 @@ Used In File(s): /code/modules/clothing/spacesuits/rig/rig.dm
 				<div class='fixedLeftWider'>
 					{{:helper.capitalizeFirstLetter(data.boots)}}
 				</div>
+				{{if data.sealing != 1}}
+					<div class='fixedLeft'>
+						{{:helper.link('Toggle', 'circle-arrow-s', {'toggle_piece' : 'boots'}, null)}}
+					</div>
+				{{/if}}
 			</div>
 			<div class='inlineBlock'>
 				<div class='fixedLeft boldText'>
@@ -152,6 +162,11 @@ Used In File(s): /code/modules/clothing/spacesuits/rig/rig.dm
 				<div class='fixedLeftWider'>
 					{{:helper.capitalizeFirstLetter(data.chest)}}
 				</div>
+				{{if data.sealing != 1}}
+					<div class='fixedLeft'>
+						{{:helper.link('Toggle', 'circle-arrow-s', {'toggle_piece' : 'chest'}, null)}}
+					</div>
+				{{/if}}
 			</div>
 		</div>
 
@@ -200,7 +215,7 @@ Used In File(s): /code/modules/clothing/spacesuits/rig/rig.dm
 		{{if data.seals == 1 || data.sealing == 1}}
 			<h3><div class = 'bad'>HARDSUIT SYSTEMS OFFLINE</div></h3>
 		{{else}}
-			<h3>Selected primary system: 
+			<h3>Selected primary system:
 				{{if data.primarysystem}}
 					{{:helper.capitalizeFirstLetter(data.primarysystem)}}
 				{{else}}
@@ -225,9 +240,9 @@ Used In File(s): /code/modules/clothing/spacesuits/rig/rig.dm
 									{{/if}}
 									<div class='floatLeft' style='width: 100%; clear: left'>
 										<div class='caption floatLeft average' style='width: 20%; margin: 0'>
-												Engage: {{:value.engagecost}} 
-												Activate: {{:value.activecost}} 
-												Passive: {{:value.passivecost}} 
+												Engage: {{:value.engagecost}}
+												Activate: {{:value.activecost}}
+												Passive: {{:value.passivecost}}
 										</div>
 										<div class='caption floatLeft' style='width: 25%; margin: 0'>
 												{{:value.desc}}


### PR DESCRIPTION
🆑PurplePineapple
bugfix: Adds missing toggle verbs to take off the suit when the RIG is offline and only when offline.
tweak: "Cycle Hardsuit" is now the verb to seal a hardsuit. "Toggle All Pieces" deploys or stows the suit if able.
tweak: The speed at which you can activate your RIG is dependent on your EVA skill. Trained is the same as previous normal.
/🆑 


Currently seems like an oversight, as the suits can do this and have been able to do this for over a year but only through unequipping the module.

Also makes RIG interactions SKILL_EVA dependent. Functions as fast as before if you have Trained EVA, and is faster/slower for higher/lower skill levels.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->