### PR TITLE
Medical mechs from round start

### DIFF
--- a/code/modules/mechs/components/software.dm
+++ b/code/modules/mechs/components/software.dm
@@ -8,7 +8,7 @@
 /obj/item/circuitboard/exosystem/engineering
 	name = "exosuit software (engineering systems)"
 	contains_software = list(MECH_SOFTWARE_ENGINEERING)
-	origin_tech = list(TECH_DATA = 1)
+	origin_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
 
 /obj/item/circuitboard/exosystem/utility
 	name = "exosuit software (utility systems)"
@@ -20,10 +20,10 @@
 	name = "exosuit software (medical systems)"
 	contains_software = list(MECH_SOFTWARE_MEDICAL)
 	icon_state = "mcontroller"
-	origin_tech = list(TECH_DATA = 3,TECH_BIO = 2)
+	origin_tech = list(TECH_DATA = 1,TECH_BIO = 1)
 
 /obj/item/circuitboard/exosystem/weapons
 	name = "exosuit software (basic weapon systems)"
 	contains_software = list(MECH_SOFTWARE_WEAPONS)
 	icon_state = "mainboard"
-	origin_tech = list(TECH_DATA = 4, TECH_COMBAT = 3)
+	origin_tech = list(TECH_DATA = 1, TECH_COMBAT = 3)

--- a/code/modules/research/designs/designs_exosuits.dm
+++ b/code/modules/research/designs/designs_exosuits.dm
@@ -6,7 +6,7 @@
 /datum/design/circuit/exosuit/engineering
 	name = "engineering system control"
 	id = "mech_software_engineering"
-	req_tech = list(TECH_DATA = 1)
+	req_tech = list(TECH_DATA = 1, TECH_ENGINEERING = 1)
 	build_path = /obj/item/circuitboard/exosystem/engineering
 	sort_string = "NAAAA"
 
@@ -20,13 +20,13 @@
 /datum/design/circuit/exosuit/medical
 	name = "medical system control"
 	id = "mech_software_medical"
-	req_tech = list(TECH_DATA = 3,TECH_BIO = 2)
+	req_tech = list(TECH_DATA = 1,TECH_BIO = 1)
 	build_path = /obj/item/circuitboard/exosystem/medical
 	sort_string = "NAABA"
 
 /datum/design/circuit/exosuit/weapons
 	name = "basic weapon control"
 	id = "mech_software_weapons"
-	req_tech = list(TECH_DATA = 4)
+	req_tech = list(TECH_DATA = 1, TECH_COMBAT = 3)
 	build_path = /obj/item/circuitboard/exosystem/weapons
 	sort_string = "NAACA"


### PR DESCRIPTION
Makes the medical software control printable from the round start. Also changes tech costs to make more sense, accordingly.

The purpose of this change is to make roboticists' lives less dependant on science, allowing them to build at least one useful mech. Right now they are pretty much limited to maintenance and it's miserable.

:cl:
tweak: Medical system control for mechs is available for printing from round start.
tweak: All system controls require Data 1 and yield the appropriate origin tech upon destruction.
/:cl: