### PR TITLE
Revert "transfer vote defaults to end the round if there are no voters"

### DIFF
--- a/code/datums/vote/transfer.dm
+++ b/code/datums/vote/transfer.dm
@@ -48,7 +48,9 @@
 	to_world(SPAN_COLOR("purple", "Bluespace Jump Factor: [factor]"))
 
 /datum/vote/transfer/report_result()
-	if(..() || result[1] == CHOICE_TRANSFER)
+	if(..())
+		return 1
+	if(result[1] == CHOICE_TRANSFER)
 		init_autotransfer()
 	else if(result[1] == CHOICE_ADD_ANTAG)
 		SSvote.queued_auto_vote = /datum/vote/add_antagonist


### PR DESCRIPTION
:cl:
tweak: The Transfer vote will now default to the continue option if there are no voters.
/:cl:

This could go either way on "I forgot to vote", but favoring continues is preferable to me and behavior made intentional in the past.

Reverts Baystation12/Baystation12#34861