### PR TITLE
RPD pipe placement based on cursor position

### DIFF
--- a/code/__defines/atmospherics.dm
+++ b/code/__defines/atmospherics.dm
@@ -3,6 +3,10 @@
 #define PIPE_ROTATE_TWODIR   1 // Sanitizes cardinal directions to just two, leaves corner directions alone
 #define PIPE_ROTATE_ONEDIR   2 // Only has one dir, south
 
+#define PIPE_PLACEMENT_SIMPLE     1
+#define PIPE_PLACEMENT_ORTHOGONAL 2
+#define PIPE_PLACEMENT_DIAGONAL   3
+
 //Connection Type Definitions
 #define CONNECT_TYPE_REGULAR        1
 #define CONNECT_TYPE_SUPPLY         2

--- a/code/game/machinery/pipe/pipe_datums/pipe_datum_base.dm
+++ b/code/game/machinery/pipe/pipe_datums/pipe_datum_base.dm
@@ -38,6 +38,7 @@ GLOBAL_LIST_EMPTY(all_disposal_pipe_datums_by_category)
 	var/constructed_path = /obj/machinery/atmospherics/pipe/simple/hidden	//What's the final form of this item?
 	var/pipe_class = PIPE_CLASS_BINARY										//The node classification for this item.
 	var/rotate_class = PIPE_ROTATE_STANDARD                                 //How it behaves when rotated
+	var/placement_mode = PIPE_PLACEMENT_SIMPLE
 
 //==========
 //Procedures
@@ -79,6 +80,7 @@ GLOBAL_LIST_EMPTY(all_disposal_pipe_datums_by_category)
 		new_item.set_dir(D.dir)
 		new_item.icon = D.build_icon
 		new_item.icon_state = D.build_icon_state
+		return new_item
 
 /datum/pipe/disposal_dispenser/Build(datum/pipe/disposal_dispenser/D, loc, pipe_color = PIPE_COLOR_GREY)
 	if(D.build_path)
@@ -92,3 +94,4 @@ GLOBAL_LIST_EMPTY(all_disposal_pipe_datums_by_category)
 		new_item.turn = D.turn
 		new_item.constructed_path = D.constructed_path
 		new_item.update_icon()
+		return new_item

--- a/code/game/machinery/pipe/pipe_datums/pipe_datums.dm
+++ b/code/game/machinery/pipe/pipe_datums/pipe_datums.dm
@@ -1,5 +1,6 @@
-#define PIPE_STRAIGHT 2
-#define PIPE_BENT     5
+#define PIPE_STRAIGHT 1
+#define PIPE_BENT     9
+#define PIPE_CAP      1
 
 /datum/pipe/pipe_dispenser/simple
 	category = "Regular Pipes"
@@ -9,11 +10,13 @@
 	constructed_path = /obj/machinery/atmospherics/pipe/simple/hidden
 	pipe_class = PIPE_CLASS_BINARY
 
+
 /datum/pipe/pipe_dispenser/simple/straight
 	name = "a pipe fitting"
 	desc = "a straight pipe segment."
 	build_path = /obj/item/pipe
 	rotate_class = PIPE_ROTATE_TWODIR
+	placement_mode = PIPE_PLACEMENT_ORTHOGONAL
 
 /datum/pipe/pipe_dispenser/simple/bent
 	name = "bent pipe fitting"
@@ -21,6 +24,7 @@
 	build_path = /obj/item/pipe
 	dir = PIPE_BENT
 	rotate_class = PIPE_ROTATE_TWODIR
+	placement_mode = PIPE_PLACEMENT_DIAGONAL
 
 /datum/pipe/pipe_dispenser/simple/manifold
 	name = "pipe manifold fitting"
@@ -29,6 +33,7 @@
 	build_icon_state = "manifold"
 	constructed_path = /obj/machinery/atmospherics/pipe/manifold/hidden
 	pipe_class = PIPE_CLASS_TRINARY
+	placement_mode = PIPE_PLACEMENT_ORTHOGONAL
 
 /datum/pipe/pipe_dispenser/simple/manifold4w
 	name = "four-way pipe manifold fitting"
@@ -43,9 +48,11 @@
 	name = "pipe cap fitting"
 	desc = "a pipe cap for a regular pipe."
 	build_path = /obj/item/pipe
+	dir = PIPE_CAP
 	build_icon_state = "cap"
 	constructed_path = /obj/machinery/atmospherics/pipe/cap/hidden
 	pipe_class = PIPE_CLASS_UNARY
+	placement_mode = PIPE_PLACEMENT_ORTHOGONAL
 
 /datum/pipe/pipe_dispenser/simple/up
 	name = "upward pipe fitting"
@@ -53,7 +60,9 @@
 	build_path = /obj/item/pipe
 	build_icon = 'icons/obj/structures/structures.dmi'
 	build_icon_state = "up"
+	dir = PIPE_CAP
 	constructed_path = /obj/machinery/atmospherics/pipe/zpipe/up
+	placement_mode = PIPE_PLACEMENT_ORTHOGONAL
 
 /datum/pipe/pipe_dispenser/simple/down
 	name = "downward pipe fitting"
@@ -61,7 +70,9 @@
 	build_path = /obj/item/pipe
 	build_icon = 'icons/obj/structures/structures.dmi'
 	build_icon_state = "down"
+	dir = PIPE_CAP
 	constructed_path = /obj/machinery/atmospherics/pipe/zpipe/down
+	placement_mode = PIPE_PLACEMENT_ORTHOGONAL
 
 /datum/pipe/pipe_dispenser/simple/autoshutoff
 	name = "automatic shutoff valve"
@@ -87,6 +98,7 @@
 	desc = "a straight supply pipe segment."
 	build_path = /obj/item/pipe
 	rotate_class = PIPE_ROTATE_TWODIR
+	placement_mode = PIPE_PLACEMENT_ORTHOGONAL
 
 /datum/pipe/pipe_dispenser/supply/bent
 	name = "bent supply pipe fitting"
@@ -94,6 +106,7 @@
 	build_path = /obj/item/pipe
 	dir = PIPE_BENT
 	rotate_class = PIPE_ROTATE_TWODIR
+	placement_mode = PIPE_PLACEMENT_DIAGONAL
 
 /datum/pipe/pipe_dispenser/supply/manifold
 	name = "supply pipe manifold fitting"
@@ -102,6 +115,7 @@
 	build_icon_state = "manifold"
 	constructed_path = /obj/machinery/atmospherics/pipe/manifold/hidden/supply
 	pipe_class = PIPE_CLASS_TRINARY
+	placement_mode = PIPE_PLACEMENT_ORTHOGONAL
 
 /datum/pipe/pipe_dispenser/supply/manifold4w
 	name = "four-way supply pipe manifold fitting"
@@ -116,6 +130,7 @@
 	name = "supply pipe cap fitting"
 	desc = "a pipe cap for a regular pipe."
 	build_path = /obj/item/pipe
+	dir = PIPE_CAP
 	build_icon_state = "cap"
 	constructed_path = /obj/machinery/atmospherics/pipe/cap/hidden/supply
 	pipe_class = PIPE_CLASS_UNARY
@@ -126,6 +141,7 @@
 	build_path = /obj/item/pipe
 	build_icon = 'icons/obj/structures/structures.dmi'
 	build_icon_state = "up"
+	dir = PIPE_CAP
 	constructed_path = /obj/machinery/atmospherics/pipe/zpipe/up/supply
 
 /datum/pipe/pipe_dispenser/supply/down
@@ -134,6 +150,7 @@
 	build_path = /obj/item/pipe
 	build_icon = 'icons/obj/structures/structures.dmi'
 	build_icon_state = "down"
+	dir = PIPE_CAP
 	constructed_path = /obj/machinery/atmospherics/pipe/zpipe/down/supply
 
 /datum/pipe/pipe_dispenser/supply/autoshutoff
@@ -160,6 +177,7 @@
 	desc = "a straight scrubber pipe segment"
 	build_path = /obj/item/pipe
 	rotate_class = PIPE_ROTATE_TWODIR
+	placement_mode = PIPE_PLACEMENT_ORTHOGONAL
 
 /datum/pipe/pipe_dispenser/scrubber/bent
 	name = "bent scrubber pipe fitting"
@@ -167,6 +185,7 @@
 	build_path = /obj/item/pipe
 	rotate_class = PIPE_ROTATE_TWODIR
 	dir = PIPE_BENT
+	placement_mode = PIPE_PLACEMENT_DIAGONAL
 
 /datum/pipe/pipe_dispenser/scrubber/manifold
 	name = "scrubber pipe manifold fitting"
@@ -175,6 +194,7 @@
 	build_icon_state = "manifold"
 	constructed_path = /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers
 	pipe_class = PIPE_CLASS_TRINARY
+	placement_mode = PIPE_PLACEMENT_ORTHOGONAL
 
 /datum/pipe/pipe_dispenser/scrubber/manifold4w
 	name = "four-way scrubber pipe manifold fitting"
@@ -189,6 +209,7 @@
 	name = "scrubber pipe cap fitting"
 	desc = "a pipe cap for a scrubber pipe."
 	build_path = /obj/item/pipe
+	dir = PIPE_CAP
 	build_icon_state = "cap"
 	constructed_path = /obj/machinery/atmospherics/pipe/cap/hidden/scrubbers
 
@@ -198,6 +219,7 @@
 	build_path = /obj/item/pipe
 	build_icon = 'icons/obj/structures/structures.dmi'
 	build_icon_state = "up"
+	dir = PIPE_CAP
 	constructed_path = /obj/machinery/atmospherics/pipe/zpipe/up/scrubbers
 
 /datum/pipe/pipe_dispenser/scrubber/down
@@ -206,6 +228,7 @@
 	build_path = /obj/item/pipe
 	build_icon = 'icons/obj/structures/structures.dmi'
 	build_icon_state = "down"
+	dir = PIPE_CAP
 	constructed_path = /obj/machinery/atmospherics/pipe/zpipe/down/scrubbers
 
 /datum/pipe/pipe_dispenser/scrubber/autoshutoff
@@ -232,6 +255,7 @@
 	desc = "a striaght fuel pipe segment"
 	build_path = /obj/item/pipe
 	rotate_class = PIPE_ROTATE_TWODIR
+	placement_mode = PIPE_PLACEMENT_ORTHOGONAL
 
 /datum/pipe/pipe_dispenser/fuel/bent
 	name = "bent fuel pipe fitting"
@@ -239,6 +263,7 @@
 	build_path = /obj/item/pipe
 	rotate_class = PIPE_ROTATE_TWODIR
 	dir = PIPE_BENT
+	placement_mode = PIPE_PLACEMENT_DIAGONAL
 
 /datum/pipe/pipe_dispenser/fuel/manifold
 	name = "fuel pipe manifold fitting"
@@ -247,6 +272,7 @@
 	build_icon_state = "manifold"
 	constructed_path = /obj/machinery/atmospherics/pipe/manifold/hidden/fuel
 	pipe_class = PIPE_CLASS_TRINARY
+	placement_mode = PIPE_PLACEMENT_ORTHOGONAL
 
 /datum/pipe/pipe_dispenser/fuel/manifold4w
 	name = "four-way supply pipe manifold fitting"
@@ -261,6 +287,7 @@
 	name = "fuel pipe cap fitting"
 	desc = "a pipe cap for a fuel pipe."
 	build_path = /obj/item/pipe
+	dir = PIPE_CAP
 	build_icon_state = "cap"
 	constructed_path = /obj/machinery/atmospherics/pipe/cap/hidden/fuel
 	pipe_class = PIPE_CLASS_UNARY
@@ -271,6 +298,7 @@
 	build_path = /obj/item/pipe
 	build_icon = 'icons/obj/structures/structures.dmi'
 	build_icon_state = "up"
+	dir = PIPE_CAP
 	constructed_path = /obj/machinery/atmospherics/pipe/zpipe/up/fuel
 
 /datum/pipe/pipe_dispenser/fuel/down
@@ -279,6 +307,7 @@
 	build_path = /obj/item/pipe
 	build_icon = 'icons/obj/structures/structures.dmi'
 	build_icon_state = "down"
+	dir = PIPE_CAP
 	constructed_path = /obj/machinery/atmospherics/pipe/zpipe/down/fuel
 
 /datum/pipe/pipe_dispenser/fuel/autoshutoff
@@ -314,6 +343,7 @@
 	rotate_class = PIPE_ROTATE_TWODIR
 	build_icon_state = "he"
 	dir = PIPE_BENT
+	placement_mode = PIPE_PLACEMENT_DIAGONAL
 
 /datum/pipe/pipe_dispenser/he/junction
 	name = "heat exchanger junction"

--- a/code/game/objects/items/weapons/RPD.dm
+++ b/code/game/objects/items/weapons/RPD.dm
@@ -150,10 +150,55 @@ GLOBAL_LIST_INIT(rpd_pipe_selection_skilled, list(
 				return TRUE
 			playsound (get_turf(user), 'sound/items/Deconstruct.ogg', 50, 1)
 
-		P.Build(P, T, pipe_colors[pipe_color])
+		var/obj/item/pipe/pipe = P.Build(P, T, pipe_colors[pipe_color])
+		var/num_rotations
+		if (user.skill_check(SKILL_ATMOS, SKILL_EXPERIENCED))
+			num_rotations = get_placement_rotation(user, P.placement_mode, click_parameters)
+		else
+			num_rotations = rand(3)
+		for (var/i = 0, i < num_rotations, i++)
+			pipe.dir = GLOB.cw_dir[pipe.dir]
 		if (prob(20))
 			spark_system.start()
 		return TRUE
+
+/obj/item/rpd/proc/get_placement_rotation(mob/user, placement_mode, click_parameters)
+	var/mouse_x = text2num(click_parameters["icon-x"])
+	var/mouse_y = text2num(click_parameters["icon-y"])
+	switch (placement_mode)
+		if (PIPE_PLACEMENT_SIMPLE)
+			// Zero rotations as we use the default direction of the pipe
+			return 0
+		if (PIPE_PLACEMENT_DIAGONAL)
+			// One case for each of the four quarters of a square
+			//  0 │ 1
+			// ───┼───
+			//  3 │ 2
+			if (mouse_x <= 16)
+				if (mouse_y <= 16)
+					. = 3
+				else
+					. = 0
+			else
+				if (mouse_y <= 16)
+					. = 2
+				else
+					. = 1
+		if (PIPE_PLACEMENT_ORTHOGONAL)
+			// One case for each of the four triangles of a square
+			//  ⟍ 0 ⟋
+			//  3 ⤫ 1
+			//  ⟋ 2 ⟍
+			if (mouse_y > mouse_x)
+				if (mouse_y > 32-mouse_x)
+					. = 0
+				else
+					. = 3
+			else
+				if (mouse_y > 32-mouse_x)
+					. = 1
+				else
+					. = 2
 
 /obj/item/rpd/examine(mob/user, distance)
 	. = ..()


### PR DESCRIPTION
🆑 Hubblenaut
rscadd: Characters that are at least 'experienced' in atmospherics will find that the rapid piping device will place pipes intuitively based on mouse position.
/:cl:

Will use mouse position to determine the direction of the placed pipe if user has a skill level of at least `SKILL_EXPERIENCED` in `SKILL_ATMOS`. Will use a random direction otherwise.

![RPD](https://github.com/user-attachments/assets/91f8fb04-b6cb-460f-bb51-0ec63b95f485)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->