### PR TITLE
Fixes floor changes causing darkness

### DIFF
--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -105,7 +105,7 @@
 		recalc_atom_opacity()
 		lighting_overlay = old_lighting_overlay
 		affecting_lights = old_affecting_lights
-		if (old_opacity != opacity || dynamic_lighting != old_dynamic_lighting || force_lighting_update)
+		if (old_opacity != opacity || dynamic_lighting != old_dynamic_lighting || z_flags != old_zflags || force_lighting_update)
 			reconsider_lights()
 			updateVisibility(src)
 


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Fixes the removal or placing of floor causing dark areas.
/:cl:

When removing the floor, the room below must be taken into account for lighting calculations. Vice versa for when floor is put back in place. In these two cases, light must be recalculated.

![grafik](https://github.com/user-attachments/assets/ba96b150-b5e7-437d-a385-b1fd18adc183)

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->