### PR TITLE
Fixes paint sprayer for borgs

### DIFF
--- a/code/game/objects/items/devices/paint_sprayer.dm
+++ b/code/game/objects/items/devices/paint_sprayer.dm
@@ -273,6 +273,8 @@
 /obj/item/device/paint_sprayer/proc/calc_paint_dir(mob/user, placement_mode, click_parameters, inversed)
 	if (!placement_mode)
 		return user.dir
+	if (istext(click_parameters)) // Borgs pass down click parameters in a string format
+		click_parameters = params2list(click_parameters)
 	var/mouse_x = text2num(click_parameters["icon-x"])
 	var/mouse_y = text2num(click_parameters["icon-y"])
 	switch (placement_mode)


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Fixes the paint sprayer for borgs.
/:cl:

Borgs are still passing down click parameters in string format. This will now be correctly recognized and unpacked.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->