### PR TITLE
Fixes escape pods not repressurizing after launch

### DIFF
--- a/code/modules/shuttles/escape_pods.dm
+++ b/code/modules/shuttles/escape_pods.dm
@@ -177,8 +177,9 @@ var/global/list/escape_pods_by_name = list()
 	signal.data = list(
 		"tag" = tag_pump,
 		"sigtype" = "command",
-		"power" = 1,
-		"direction" = 1,
+		//"status" = TRUE,
+		"set_power" = 1,
+		"set_direction" = 1,
 		"set_external_pressure" = ONE_ATMOSPHERE
 	)
 	post_signal(signal)


### PR DESCRIPTION
🆑 Hubblenaut
bugfix: Fixes escape pods not repressurizing after launch.
/:cl:

Cause for this bug was the escape pod signal to the vent pumps not being updated after the change to atmospheric machine signals five years ago.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->