### PR TITLE
Fax languages fix

### DIFF
--- a/code/modules/paperwork/adminpaper.dm
+++ b/code/modules/paperwork/adminpaper.dm
@@ -164,5 +164,6 @@
 
 	if (href_list["changelanguage"])
 		choose_language(usr, TRUE)
+		generateInteractions()
 		updateDisplay()
 		return

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -158,7 +158,7 @@
 	if (istype(copy, /obj/item/paper/admin) && !copy_admin) // Edge case for admin faxes so that they don't show the editing form
 		copy_type = /obj/item/paper
 
-	var/obj/item/paper/c = new copy_type(loc, copy.text, copy.name, copy.metadata )
+	var/obj/item/paper/c = new copy_type(loc, copy.text, copy.name, copy.metadata, copy.language)
 
 	c.color = COLOR_WHITE
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
There are two issues:

**1. Send fax verb (adminpaper):** you can change language for the paper, and it actually works, but language is still displayed as Zurich in the adminpaper menu, since HTML for interactions isn't updated. (adminpaper.dm)

**2. Faxes and photocopier:** no matter what paper you are using, their copy will always have Zurich, because of the paper initialization. Example: use Send-Fax verb, change language to anything, send it -> result: Zurich language. (photocopier.dm)

:cl: Builder13
bugfix: Fixed languages for papers printed from faxes and photocopiers.
/:cl: