### PR TITLE
Various map changes

### DIFF
--- a/code/game/objects/structures/crates_lockers/med_crate.dm
+++ b/code/game/objects/structures/crates_lockers/med_crate.dm
@@ -44,7 +44,6 @@
 
 /obj/structure/closet/crate/med_crate/toxin/WillContain()
 	return list(
-		/obj/item/storage/firstaid/surgery,
 		/obj/item/storage/pill_bottle/dylovene = 2,
 		/obj/item/storage/pill_bottle/hyronalin = 1
 			)

--- a/maps/torch/structures/closets/medical.dm
+++ b/maps/torch/structures/closets/medical.dm
@@ -53,6 +53,7 @@
 		/obj/item/storage/box/armband/med,
 		/obj/item/material/knife/folding/swiss/officer,
 		/obj/item/storage/backpack/dufflebag/med,
+		/obj/item/storage/belt/medical,
 		RANDOM_SCRUBS
 	)
 

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -10781,6 +10781,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
+/obj/machinery/hologram/holopad,
 /turf/simulated/floor/tiled,
 /area/quartermaster/deckchief)
 "Lb" = (

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -3612,7 +3612,6 @@
 	pixel_y = 24
 	},
 /obj/item/autopsy_scanner,
-/obj/item/scalpel/basic,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -6688,11 +6687,6 @@
 	pixel_x = -22;
 	pixel_y = 24
 	},
-/obj/machinery/button/windowtint{
-	id = "exam_windows";
-	pixel_x = -30;
-	pixel_y = 24
-	},
 /obj/floor_decal/corner/paleblue{
 	dir = 5
 	},
@@ -7456,10 +7450,6 @@
 	pixel_y = -6
 	},
 /obj/structure/table/steel,
-/obj/item/stamp/denied{
-	pixel_x = 5
-	},
-/obj/item/stamp,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -9430,9 +9420,6 @@
 /obj/structure/table/steel,
 /obj/item/device/multitool,
 /obj/item/stamp/brig,
-/obj/item/stamp/denied{
-	pixel_x = 5
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
@@ -10402,8 +10389,8 @@
 	dir = 8;
 	pixel_x = 21
 	},
-/obj/structure/table/steel,
 /obj/floor_decal/industrial/outline/grey,
+/obj/structure/table/steel,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "aKA" = (
@@ -10577,6 +10564,11 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "aLz" = (
+/obj/item/storage/firstaid/regular,
+/obj/item/storage/firstaid/fire{
+	pixel_x = -4;
+	pixel_y = -4
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "aLA" = (
@@ -14273,10 +14265,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/closet/secure_closet{
-	name = "Secure Evidence Locker";
-	req_access = list("ACCESS_SECURITY")
-	},
 /turf/simulated/floor/plating,
 /area/security/wing)
 "bpA" = (
@@ -15702,6 +15690,7 @@
 /obj/structure/sign/warning/nosmoking_1{
 	pixel_y = 24
 	},
+/obj/item/storage/firstaid/surgery,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/medical/morgue/autopsy)
 "daB" = (
@@ -16537,12 +16526,13 @@
 /area/medical/washroom)
 "elT" = (
 /obj/floor_decal/industrial/outline/grey,
-/obj/structure/closet/crate/medical,
-/obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/fire{
-	pixel_x = -4;
-	pixel_y = -4
+/obj/structure/table/rack{
+	dir = 4
 	},
+/obj/item/storage/box/smokes,
+/obj/item/storage/box/smokes,
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/handcuffs,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
 "emb" = (
@@ -18384,16 +18374,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/rnd/entry)
 "huf" = (
-/obj/structure/table/rack{
-	dir = 4
-	},
 /obj/floor_decal/industrial/outline/grey,
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/smokes,
-/obj/item/storage/box/smokes,
 /obj/machinery/rotating_alarm/security_alarm{
 	dir = 1
+	},
+/obj/structure/table/rack{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/security/storage)
@@ -25006,6 +24992,12 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
 	},
+/obj/structure/closet/crate/secure{
+	name = "Secure Evidence Storage";
+	req_access = list("ACCESS_SEC_DOORS");
+	dir = 8
+	},
+/obj/floor_decal/industrial/outline/yellow,
 /turf/simulated/floor/tiled,
 /area/security/processing)
 "pVv" = (
@@ -25279,7 +25271,6 @@
 /obj/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -25291,6 +25282,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery2)
 "qkb" = (
@@ -25340,7 +25332,6 @@
 /obj/floor_decal/corner/paleblue{
 	dir = 5
 	},
-/obj/machinery/light,
 /obj/structure/closet/crate/freezer,
 /obj/item/device/mmi,
 /obj/item/reagent_containers/ivbag/nanoblood,
@@ -25348,6 +25339,7 @@
 /obj/item/reagent_containers/ivbag/blood/human/oneg,
 /obj/item/reagent_containers/ivbag/blood/skrell/oneg,
 /obj/item/reagent_containers/ivbag/blood/unathi/oneg,
+/obj/machinery/light,
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "qqb" = (
@@ -29407,6 +29399,9 @@
 /area/medical/medicalhallway)
 "vIP" = (
 /obj/structure/filingcabinet/chestdrawer,
+/obj/machinery/light{
+	dir = 8
+	},
 /turf/simulated/floor/tiled,
 /area/security/detectives_office)
 "vJO" = (
@@ -29777,7 +29772,7 @@
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /obj/item/forensics/sample_kit/powder,
-/obj/item/forensics/swab,
+/obj/item/forensics/sample_kit,
 /turf/simulated/floor/tiled/white,
 /area/security/detectives_office)
 "wEb" = (

--- a/maps/torch/torch6_bridge.dmm
+++ b/maps/torch/torch6_bridge.dmm
@@ -797,6 +797,10 @@
 /obj/structure/hygiene/toilet{
 	dir = 4
 	},
+/obj/machinery/alarm{
+	dir = 1;
+	pixel_y = -28
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/heads/cobed)
 "bI" = (
@@ -1196,8 +1200,7 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -28;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	pixel_y = -28
 	},
 /obj/structure/disposalpipe/junction{
 	dir = 4;
@@ -2038,6 +2041,12 @@
 /turf/simulated/floor/tiled/monotile,
 /area/crew_quarters/heads/office/ce)
 "dG" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
 "dH" = (
@@ -3213,8 +3222,7 @@
 "fS" = (
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -28;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	pixel_y = -28
 	},
 /obj/floor_decal/corner/blue{
 	dir = 10
@@ -4298,6 +4306,12 @@
 /area/hallway/primary/bridge/aft)
 "jc" = (
 /obj/structure/hygiene/drain,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/heads/cobed)
 "je" = (
@@ -4909,6 +4923,9 @@
 	},
 /obj/structure/table/woodentable/walnut,
 /obj/item/device/flashlight/lamp/green,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
 "lx" = (
@@ -5133,6 +5150,9 @@
 /area/bridge/disciplinary_board_room)
 "lT" = (
 /obj/item/taperoll/bog,
+/obj/machinery/atmospherics/unary/vent_scrubber/on{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/heads/cobed)
 "lW" = (
@@ -7960,8 +7980,7 @@
 	},
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -28;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	pixel_y = -28
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/office/sgr)
@@ -10578,6 +10597,9 @@
 /obj/floor_decal/spline/fancy/wood/corner{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
 "Cs" = (
@@ -10612,6 +10634,15 @@
 "Cx" = (
 /obj/machinery/uniform_vendor{
 	dir = 1
+	},
+/turf/simulated/floor/wood/walnut,
+/area/crew_quarters/heads/cobed)
+"CA" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
@@ -10842,14 +10873,15 @@
 /turf/simulated/floor/tiled/dark,
 /area/bridge/disciplinary_board_room)
 "DY" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
 "DZ" = (
@@ -10973,6 +11005,9 @@
 /obj/floor_decal/spline/fancy/wood{
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 4
+	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
 "EM" = (
@@ -10989,7 +11024,6 @@
 "EP" = (
 /obj/floor_decal/corner/paleblue/diagonal,
 /obj/structure/closet/secure_closet/CMO_torch,
-/obj/item/storage/belt/medical,
 /obj/item/book/manual/sol_sop,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/firealarm{
@@ -11077,6 +11111,7 @@
 /obj/item/device/radio,
 /obj/item/crowbar/prybar,
 /obj/item/device/binoculars,
+/obj/item/clothing/mask/gas/half,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/crew_quarters/heads/office/cos)
 "Fg" = (
@@ -12095,10 +12130,10 @@
 	dir = 1;
 	icon_state = "pipe-c"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/wood/walnut,
 /area/crew_quarters/heads/cobed)
 "IJ" = (
@@ -12495,10 +12530,6 @@
 	department = "Torch - Chief Medical Officer"
 	},
 /obj/item/stamp/cmo,
-/obj/item/device/radio{
-	frequency = 1487;
-	name = "medbay emergency radio link"
-	},
 /turf/simulated/floor/tiled/white,
 /area/crew_quarters/heads/office/cmo)
 "KX" = (
@@ -13059,8 +13090,7 @@
 /obj/structure/table/woodentable/walnut,
 /obj/machinery/alarm{
 	dir = 1;
-	pixel_y = -28;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	pixel_y = -28
 	},
 /obj/item/storage/secure/briefcase/nukedisk,
 /turf/simulated/floor/wood/walnut,
@@ -13080,7 +13110,7 @@
 /area/security/bridgecheck)
 "NH" = (
 /obj/floor_decal/corner/blue/mono,
-/obj/structure/bed/chair/comfy/beige{
+/obj/structure/bed/chair/comfy/blue{
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark/monotile,
@@ -13389,8 +13419,7 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/alarm{
-	pixel_y = 23;
-	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	pixel_y = 23
 	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/aquila/air)
@@ -13981,6 +14010,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/machinery/atmospherics/unary/vent_pump/on,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/heads/cobed)
 "Rp" = (
@@ -14340,6 +14370,12 @@
 	name = "Head"
 	},
 /obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/heads/cobed)
 "SX" = (
@@ -24406,7 +24442,7 @@ uy
 IB
 To
 KC
-dG
+CA
 Cx
 uy
 tg


### PR DESCRIPTION
Random bullshit go! Won't add everything to the changelog to not clog it, only the most important stuff that might change roundflow.

Things that aren't in the changelog:
- Made the FT office brighter.
- Cleared the rack in the brig equipment room, freeing it up for equipment distribution (works nicely with guns).
- Added atmos equipment to the CO's bathroom, to prevent the dear Captain from suffocating while sitting on the toilet.
- Hardcoded CMO's belt to the crate, instead of it being mapped. Removed food from the CMO's office, also freeing it.
- Added a half-mask to the COS to keep them on par with their subordinates.
- Added a holopad to the DC office.
- Removed the lone locker infront of cells in the Brig. I assume it was added by mistake.
- Removed duplicate tinting button from the exam room.
- Replaced the swab kit in the forensics lab with a fiber kit, as requested.
- Removed unnecessary DENIED stamps from the BC office (not needed, there's nothing for BC to deny) and the e-arm desk (why are there stamps at all, it's an _emergency_ armory, nobody does paperwork there).

I also wanted to give CMO a custom apple, similar to what Ryan did in the COS armory, but the fruit code is a disaster and it's close to impossible to spawn. I'll appreciate it if anyone gives me an idea how to do it.

:cl:
maptweak: The brig equipment room table is is cleared, with its contents moved to the other corner of the room.
maptweak: Security gets a new crate in processing to help with confiscations.
maptweak: The extra surgery kit is moved to the autopsy area, replacing the scalpel.
/:cl: