### PR TITLE
Changes to Laser DMR Damage, Accuracy, and ROF

### DIFF
--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -137,14 +137,14 @@
 	item_state = "laser"
 	origin_tech = list(TECH_COMBAT = 6, TECH_MATERIAL = 5, TECH_POWER = 4)
 	projectile_type = /obj/item/projectile/beam/sniper
-	one_hand_penalty = 5 // The weapon itself is heavy, and the long barrel makes it hard to hold steady with just one hand.
+	one_hand_penalty = 8 // The weapon itself is heavy, and the long barrel makes it hard to hold steady with just one hand.
 	slot_flags = SLOT_BACK
 	charge_cost = 40
 	max_shots = 8
-	fire_delay = 35
+	fire_delay = 30
 	force = 10
 	w_class = ITEM_SIZE_HUGE
-	accuracy = -2 //shooting at the hip
+	accuracy = -4 //shooting at the hip
 	scoped_accuracy = 9
 	scope_zoom = 2
 	wielded_item_state = "gun_wielded"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -223,8 +223,9 @@
 	name = "sniper beam"
 	icon_state = "xray"
 	fire_sound = 'sound/weapons/marauder.ogg'
-	damage = 35
+	damage = 60
 	armor_penetration = 10
+	distance_falloff = 0.5
 	damage_falloff_list = null
 
 	muzzle_type = /obj/projectile/laser/xray/muzzle


### PR DESCRIPTION
Accuracy falloff was changed so that laser DMR can hit targets at range much more reliably. One-handed accuracy and un-scoped accuracy negatives increased to more accurately fit the role of a sniper rifle.  

Below are the results of the testing before and after the changes made in this PR. All tests (except for 18-tiles master WE) was done on experienced WE, all tests were targeting the upper body while standing still. For magdump tests, it was done three tiles away in which the gun was fired as fast as possible onto the target, hitting all shots. 

![image](https://github.com/user-attachments/assets/0656d425-36a9-4e02-b43d-c37024287808)

:cl: JebediahTechnic
balance: Laser DMR's damage increased dramatically, long-range accuracy buffed, one-handed and un-scoped accuracy negatives increased, rate of fire slightly increased.
/:cl: