### PR TITLE
Randomises the ruin count on sensor scans

### DIFF
--- a/code/modules/overmap/exoplanets/_exoplanet.dm
+++ b/code/modules/overmap/exoplanets/_exoplanet.dm
@@ -353,11 +353,12 @@ GLOBAL_VAR(planet_repopulation_disabled)
 
 	if (LAZYLEN(spawned_features) && user.skill_check(SKILL_SCIENCE, SKILL_TRAINED))
 		var/ruin_num = 0
+		var/inaccuracy = rand(-2,2)
 		for (var/datum/map_template/ruin/exoplanet/R in spawned_features)
 			if (!(R.ruin_tags & RUIN_NATURAL))
 				ruin_num++
 		if (ruin_num)
-			extra_data += "<br>[ruin_num] possible artificial structure\s detected."
+			extra_data += "<br>Approximately [max(1, ruin_num+inaccuracy)] possible artificial structure\s detected."
 
 	for (var/datum/exoplanet_theme/T in themes)
 		if (T.get_sensor_data())


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

:cl: JuneauQT
tweak: Added a slight margin of error to the number of ruins shown by an exoplanet scan
/:cl:

I remember people talking about how being able to have a perfect shopping list for ruin count in explo made it feel kind of bad a few months back, so I figured I'd try to change this. Implementation could probably stand to be more complex but it gets the job done.