### PR TITLE
`/atom/movable` documentation, cleanup, and standardization

### DIFF
--- a/code/__defines/ZAS.dm
+++ b/code/__defines/ZAS.dm
@@ -7,9 +7,14 @@
 
 #define ZONE_MIN_SIZE 14 //zones with less than this many turfs will always merge, even if the connection is not direct
 
+// Options for `/atom/movable/var/atmos_canpass`.
+/// Air can always pass through this atom.
 #define CANPASS_ALWAYS 1
+/// Air can only pass through this atom if `density` is `FALSE`.
 #define CANPASS_DENSITY 2
+/// Air passability is checked through this atom's `c_airblock()` override.
 #define CANPASS_PROC 3
+/// Air can never pass through this atom.
 #define CANPASS_NEVER 4
 
 #define NORTHUP (NORTH|UP)

--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -23,9 +23,12 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define ATOM_FLAG_NO_TOOLS               FLAG(9)  // Blocks tool interactions.
 #define ATOM_AWAITING_OVERLAY_UPDATE     FLAG(10)
 
-#define MOVABLE_FLAG_PROXMOVE       FLAG(0)  // Does this object require proximity checking in Enter()?
-#define MOVABLE_FLAG_Z_INTERACT     FLAG(1)  // Should use_tool and attack_hand be relayed through ladders and open spaces?
-#define MOVABLE_FLAG_EFFECTMOVE     FLAG(2)  // Is this an effect that should move?
+/// This atom requires proximity checking in `Enter()`.
+#define MOVABLE_FLAG_PROXMOVE         FLAG(0)
+/// `use_tool()` and `attack_hand()` should be relayed through ladders and open spaces.
+#define MOVABLE_FLAG_Z_INTERACT       FLAG(1)
+/// This atom is effect that should move.
+#define MOVABLE_FLAG_EFFECTMOVE       FLAG(2)
 
 #define OBJ_FLAG_ANCHORABLE     FLAG(0)  // This object can be stuck in place with a tool
 #define OBJ_FLAG_CONDUCTIBLE    FLAG(1)  // Conducts electricity. (metal etc.)

--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -180,7 +180,7 @@
 			O.forceMove(new_turf)
 		else if(istype(O,/obj/effect))
 			var/obj/E = O
-			if(E.movable_flags & MOVABLE_FLAG_EFFECTMOVE)
+			if (HAS_FLAGS(E.movable_flags, MOVABLE_FLAG_EFFECTMOVE))
 				E.forceMove(new_turf)
 
 	for(var/mob/M in source)

--- a/code/controllers/subsystems/spacedrift.dm
+++ b/code/controllers/subsystems/spacedrift.dm
@@ -35,7 +35,7 @@ SUBSYSTEM_DEF(spacedrift)
 				return
 			continue
 
-		if (!AM.loc || AM.loc != AM.inertia_last_loc || AM.Process_Spacemove(0))
+		if (!AM.loc || AM.loc != AM.inertia_last_loc || AM.Process_Spacemove())
 			AM.inertia_dir = 0
 
 		AM.inertia_ignore = null

--- a/code/datums/movement/mob.dm
+++ b/code/datums/movement/mob.dm
@@ -94,7 +94,7 @@
 		return MOVEMENT_PROCEED
 
 	if(!mob.has_gravity())
-		allow_move = mob.Process_Spacemove(1)
+		allow_move = mob.Process_Spacemove(TRUE)
 		if(!allow_move)
 			return MOVEMENT_STOP
 

--- a/code/datums/movement/movement.dm
+++ b/code/datums/movement/movement.dm
@@ -17,8 +17,7 @@ if(LAZYLEN(movement_handlers) && ispath(movement_handlers[1])) { \
 
 #define REMOVE_AND_QDEL(X) LAZYREMOVE(movement_handlers, X); qdel(X);
 
-/atom/movable
-	var/list/movement_handlers
+/atom/movable/var/list/movement_handlers
 
 // We don't want to check for subtypes, hence why we don't call is_path_in_list(), etc.
 /atom/movable/proc/HasMovementHandler(handler_path)

--- a/code/datums/movement/movement.dm
+++ b/code/datums/movement/movement.dm
@@ -15,11 +15,26 @@ if(LAZYLEN(movement_handlers) && ispath(movement_handlers[1])) { \
 	movement_handlers= new_handlers; \
 }
 
+/// Removes `X` from `movement_handlers` then qdel's it.
 #define REMOVE_AND_QDEL(X) LAZYREMOVE(movement_handlers, X); qdel(X);
 
+
+/**
+ * List (Instances of `/datum/movement`) - List of movement handlers attached to this atom.
+ *
+ * Do not modify or reference directly. See the various procs defined in `code\datums\movement\movement.dm`.
+ */
 /atom/movable/var/list/movement_handlers
 
-// We don't want to check for subtypes, hence why we don't call is_path_in_list(), etc.
+
+/**
+ * Checks if the provided movement handler path exists in this atom's `movement_handlers` list. Ignores subtypes, must be an exact match.
+ *
+ * **Parameters**:
+ * - `handler_path` (Path, type of `/datum/movement_handler`) - The movement handler path to search for.
+ *
+ * Returns boolean.
+ */
 /atom/movable/proc/HasMovementHandler(handler_path)
 	if(!LAZYLEN(movement_handlers))
 		return FALSE
@@ -32,6 +47,16 @@ if(LAZYLEN(movement_handlers) && ispath(movement_handlers[1])) { \
 				return TRUE
 	return FALSE
 
+
+/**
+ * Creates a new movement handler instance and attaches it to this atom's `movement_handlers` list.
+ *
+ * **Parameters**:
+ * - `handler_path` (Path, type of `/datum/movement_handler`) - The movement handler to create.
+ * - `handler_path_to_add_before` (Path, type of `/datum/movement_handler`) - If defined, and this path already exists in the atom's movement handlers, the new handler will be added before this. Otherwise, the new handler is added to the beginning of the list.
+ *
+ * Returns instance of `/datum/movement_handler` - The created movement handler.
+ */
 /atom/movable/proc/AddMovementHandler(handler_path, handler_path_to_add_before)
 	INIT_MOVEMENT_HANDLERS
 
@@ -49,6 +74,7 @@ if(LAZYLEN(movement_handlers) && ispath(movement_handlers[1])) { \
 
 	// If no handler_path_to_add_after was given or found, add first
 	LAZYINSERT(movement_handlers, ., 1)
+
 
 /atom/movable/proc/RemoveMovementHandler(handler_path)
 	INIT_MOVEMENT_HANDLERS

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -13,7 +13,6 @@
 	// var/elevation = 2    - not used anywhere
 	var/move_speed = 10
 	var/l_move_time = 1
-	var/m_flag = 1
 	var/datum/thrownthing/throwing
 	var/throw_speed = 2
 	var/throw_range = 7

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -59,7 +59,7 @@
 
 //call this proc to start space drifting
 /atom/movable/proc/space_drift(direction)//move this down
-	if(!loc || direction & (UP|DOWN) || Process_Spacemove(0))
+	if(!loc || direction & (UP|DOWN) || Process_Spacemove())
 		inertia_dir = 0
 		inertia_ignore = null
 		return 0
@@ -71,8 +71,15 @@
 	SSspacedrift.processing[src] = src
 	return 1
 
-//return 0 to space drift, 1 to stop, -1 for mobs to handle space slips
-/atom/movable/proc/Process_Spacemove(allow_movement)
+/**
+ * Whether or not the atom is able to start drifting. Includes various relevant checks such as gravity, anchored, whether the atom's movement is already being controlled by something else, etc.
+ *
+ * **Parameters**:
+ * - `allow_movement` (Boolean) - Whether or not this check should allow for manual mob movement.
+ *
+ * Returns `-1`, `1` to block/halt drifting, or `0` to start/continue drifting. TODO: Make these defines instead.
+ */
+/atom/movable/proc/Process_Spacemove(allow_movement = FALSE)
 	if(!simulated)
 		return 1
 

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -5,38 +5,56 @@
 
 	animate_movement = SLIDE_STEPS
 
+	/// Boolean. Whether or not the atom is affected by being submerged in water. If set to `FALSE`, `water_act()` is called when in contact with fluids.
 	var/waterproof = TRUE
-	var/movable_flags
+	/// Bitflag (Any of `MOVABLE_FLAG_*`). Bitflags for movable atoms. See `code\__defines\flags.dm`.
+	var/movable_flags = EMPTY_BITFIELD
 
-	var/last_move = null
+	/// Bitflag (Directionals). Direction of the last movement. Generally passed to `step()` as the `dir` parameter. Set during `Move()`.
+	var/last_move = EMPTY_BITFIELD
+	/// Boolean. Whether or not the atom is considered anchored.
 	var/anchored = FALSE
-	// var/elevation = 2    - not used anywhere
+	/// Integer. The atom's current movement speed, calculated as the difference between `world.time` and `l_move_time`. Set during `Move()`.
 	var/move_speed = 10
+	/// Integer. The `world.time` of the last movement. Set during `Move()`.
 	var/l_move_time = 1
+	/// Instance. Current thrown thing datum linked to this atom. Set during `throw_at()`.
 	var/datum/thrownthing/throwing
+	/// Integer. The speed at which the atom moves when thrown. Used when calling `throw_at()`, and in `momentum_power()` and `momentum_do()`.
 	var/throw_speed = 2
+	/// Integer. Maximum range, in tiles, this atom can be thrown.
 	var/throw_range = 7
-	var/moved_recently = 0
+	/// Boolean. Whether or not this atom has recently (Within the past 50 ticks) been force moved by `/obj/item/device/radio/electropack/receive_signal()`.
+	var/moved_recently = FALSE
+	/// Instance. The mob currently pulling the atom.
 	var/mob/pulledby = null
-	var/item_state = null // Used to specify the item state for the on-mob overlays.
-	var/does_spin = TRUE // Does the atom spin when thrown (of course it does :P)
+	/// String (Icon state). Used to specify the item state for the on-mob overlays. Primarily only used in `/obj/item/get_icon_state()`. Generally, you should only be updating this in `on_update_icon()`.
+	var/item_state = null // TODO: Move this to `/obj/item`?
+	/// Boolean. Does the atom spin when thrown (of course it does :P)
+	var/does_spin = TRUE
 
-	/// The icon width this movable expects to have by default.
+	/// Integer. The icon width this movable expects to have by default.
 	var/icon_width = 32
 
-	/// The icon height this movable expects to have by default.
+	/// Integer. The icon height this movable expects to have by default.
 	var/icon_height = 32
 
-	/// Either [EMISSIVE_BLOCK_NONE], [EMISSIVE_BLOCK_GENERIC], or [EMISSIVE_BLOCK_UNIQUE]
+	/// Integer (One of `EMISSIVE_BLOCK_*`). Whether this atom blocks emissive overlays, and what method is used for blocking. See `code\__defines\emissives.dm`.
 	var/blocks_emissive = EMISSIVE_BLOCK_NONE
-	///Internal holder for emissive blocker object, DO NOT USE DIRECTLY. Use blocks_emissive
+	/// Instance. Internal holder for emissive blocker object, DO NOT USE DIRECTLY. Use blocks_emissive
 	var/mutable_appearance/em_block
 
-	var/inertia_dir = 0
+	/// Bitflag (Directional). Direction the atom is currently travelling for space drift. Set by `space_drift()` and `Bump()`. Used by `momentum_do()` and the `spacedrift` subsystem.
+	var/inertia_dir = EMPTY_BITFIELD
+	/// Instance. The atoms `loc` value during the last space movement. Set by `space_drift()` and the `spacedrift` subsystem.
 	var/atom/inertia_last_loc
-	var/inertia_moving = 0
+	/// Boolean. Whether or not the atom is currently being moved by space drift inertia. Set by the `spacedrift` subsystem and checked during `Move()`.
+	var/inertia_moving = FALSE
+	/// Integer. `world.time` that the next space drift movement should occur. Set by `Move()` and the `spacedrift` subsystem. Used by the `spacedrift` subsystem.
 	var/inertia_next_move = 0
+	/// Integer. Number of ticks to add to the current `world.time` when updating `inertia_next_move`. Used by `Move()` and the `spacedrift` subsystem.
 	var/inertia_move_delay = 5
+	/// Instance. Atom that should be ignored by `/mob/get_spacemove_backup()`. Updated and used by various movement related procs.
 	var/atom/movable/inertia_ignore
 
 //call this proc to start space drifting

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -77,31 +77,31 @@
  * **Parameters**:
  * - `allow_movement` (Boolean) - Whether or not this check should allow for manual mob movement.
  *
- * Returns `-1`, `1` to block/halt drifting, or `0` to start/continue drifting. TODO: Make these defines instead.
+ * Returns boolean. Whether or not space drifting should be blocked/stopped.
  */
 /atom/movable/proc/Process_Spacemove(allow_movement = FALSE)
 	if(!simulated)
-		return 1
+		return TRUE
 
 	if(has_gravity())
-		return 1
+		return TRUE
 
 	if(pulledby)
-		return 1
+		return TRUE
 
 	if(throwing)
-		return 1
+		return TRUE
 
 	if(anchored)
-		return 1
+		return TRUE
 
 	if(!isturf(loc))
-		return 1
+		return TRUE
 
 	if(locate(/obj/structure/lattice) in range(1, get_turf(src))) //Not realistic but makes pushing things in space easier
-		return -1
+		return TRUE
 
-	return 0
+	return FALSE
 
 /atom/movable/hitby(atom/movable/AM, datum/thrownthing/TT)
 	. = ..()

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -57,7 +57,15 @@
 	/// Instance. Atom that should be ignored by `/mob/get_spacemove_backup()`. Updated and used by various movement related procs.
 	var/atom/movable/inertia_ignore
 
-//call this proc to start space drifting
+
+/**
+ * Initializes space drifting for the atom and adds it to the `spacedrift` subsystem.
+ *
+ * **Parameters**:
+ * - `direction` (Bitflag - Directional) - The direction to start drifting.
+ *
+ * Returns boolean. If `TRUE`, the atom is now drifting. If `FALSE`, the atom was blocked from drifting.
+ */
 /atom/movable/proc/space_drift(direction)//move this down
 	if(!loc || direction & (UP|DOWN) || Process_Spacemove())
 		inertia_dir = 0
@@ -107,12 +115,28 @@
 	. = ..()
 	process_momentum(AM,TT)
 
+
+/**
+ *
+ */
 /atom/movable/proc/process_momentum(atom/movable/AM, datum/thrownthing/TT)//physic isn't an exact science
 	. = momentum_power(AM,TT)
 
 	if(.)
 		momentum_do(.,TT,AM)
 
+
+/**
+ * Calculates the amount of momentum force this atom receives when impacted by another atom.
+ *
+ * Called by `process_momentum` as part of the `hitby` chain.
+ *
+ * **Parameters**:
+ * - `AM` - The atom colliding with `src`.
+ * - `TT` - The `/datum/thrownthing` instance handling `AM`.
+ *
+ * Returns float.
+ */
 /atom/movable/proc/momentum_power(atom/movable/AM, datum/thrownthing/TT)
 	if(anchored)
 		return 0
@@ -121,6 +145,18 @@
 	if(has_gravity())
 		. *= 0.5
 
+
+/**
+ * Handled momentum logic when impacted by another atom. Typically this means sending this atom flying.
+ *
+ * Called by `process_momentum` as part of the `hitby` chain.
+ *
+ * **Parameters**:
+ * - `power` (Positive float) - The amount of momentum force as calculated by `/atom/movable/proc/momentum_power()`.
+ * - `TT` - The `/datum/thrownthing` instance handling the atom that hit `src`.
+ *
+ * Has no return value.
+ */
 /atom/movable/proc/momentum_do(power, datum/thrownthing/TT)
 	var/direction = TT.init_dir
 	switch(power)
@@ -148,6 +184,13 @@
 				drift_dir |= inertia_dir & (EAST|WEST)
 			space_drift(drift_dir)
 
+/**
+ * The effective mass of this atom.
+ *
+ * Called by `/atom/movable/proc/momentum_power()` as part of the `hitby()` chain.
+ *
+ * Returns positive float.
+ */
 /atom/movable/proc/get_mass()
 	return 1.5
 
@@ -196,6 +239,20 @@
 	..()
 
 
+/**
+ * Attempts to move the atom to the destination's contents.
+ *
+ * Calls `Entered()` and `Exited()` on the destination and origin, respectively.
+ *
+ * Calls `Entered()` and `Exited()` on the destination and origin's areas, respectively, if the areas are different.
+ *
+ * Calls `Crossed()` and `Uncrossed()` on atoms that are in the destination and origin, respectively, if `destination` is a turf.
+ *
+ * **Paratemers**:
+ * - `destination` - The atom to move `src` into.
+ *
+ * Returns boolean.
+ */
 /atom/movable/proc/forceMove(atom/destination)
 	if((gc_destroyed && gc_destroyed != GC_CURRENTLY_BEING_QDELETED) && !isnull(destination))
 		CRASH("Attempted to forceMove a QDELETED [src] out of nullspace!!!")
@@ -272,7 +329,17 @@
 				L = thing
 				L.source_atom.update_light()
 
-//called when src is thrown into hit_atom
+/**
+ * Handles impacting an atom.
+ *
+ * Called by `/datum/thrownthing/proc/finalize()`.
+ *
+ * **Parameters**:
+ * - `hit_atom` - The atom being impacted. `hitby()` is typically called on this by this proc.
+ * - `TT` - The `/datum/thrownthing` instance calling this proc.
+ *
+ * Has no return value.
+ */
 /atom/movable/proc/throw_impact(atom/hit_atom, datum/thrownthing/TT)
 	if(istype(hit_atom,/mob/living))
 		var/mob/living/M = hit_atom
@@ -288,7 +355,22 @@
 		var/turf/T = hit_atom
 		T.hitby(src,TT)
 
-/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, datum/callback/callback) //If this returns FALSE then callback will not be called.
+/**
+ * Throws the atom at a given target.
+ *
+ * Initializes a `/datum/thrownthing` handling this atom and adds it to `SSthrowing`.
+ *
+ * **Parameters**:
+ * - `target` - The atom to throw this at.
+ * - `range` (Positive integer) - How far this atom is allowed to go before stopping, in tiles.
+ * - `speed` (Positive integer) - How fast the atom should move.
+ * - `thrower` - The mob throwing this atom, if any.
+ * - `spin` (Boolean, default `TRUE`) - If set, the atom spins while flying through the air.
+ * - `callback` - A callback to be invoked once the atom has finished its flight. Not called if this proc returns `FALSE`.
+ *
+ * Returns boolean.
+ */
+/atom/movable/proc/throw_at(atom/target, range, speed, mob/thrower, spin = TRUE, datum/callback/callback)
 	. = TRUE
 	if (!target || speed <= 0 || QDELETED(src) || (target.z != src.z))
 		return FALSE
@@ -306,6 +388,13 @@
 	SSthrowing.processing[src] = TT
 
 
+/**
+ * Updates the atom's emissive blocker image and assigns it to `em_block`. If no image is generated, `em_block` is left as it was.
+ *
+ * What this does exactly depends on the value of `blocks_emissive`.
+ *
+ * Returns `/mutable_appearance`. The value of `em_block`.
+ */
 /atom/movable/proc/update_emissive_blocker()
 	switch (blocks_emissive)
 		if (EMISSIVE_BLOCK_GENERIC)
@@ -392,6 +481,13 @@
 	if (master)
 		return master.attack_hand(user)
 
+/**
+ * Handler for when this atom touches the edge of a map or z-level.
+ *
+ * Generally, this handles transitioning to a new z-level if there's a valid connection.
+ *
+ * Has no return value.
+ */
 /atom/movable/proc/touch_map_edge()
 	if(!simulated)
 		return
@@ -430,9 +526,25 @@
 		if(T)
 			forceMove(T)
 
-/atom/movable/proc/get_bullet_impact_effect_type()
+/**
+ * Determines the type of bullet impact effect this atom should use when hit.
+ *
+ * **Parameters**:
+ * - `def_zone` - The body zone the impact effect should be based on. Only used for `/mob` overrides.
+ *
+ * Returns string (One of `BULLET_IMPACT_*`).
+ */
+/atom/movable/proc/get_bullet_impact_effect_type(def_zone)
 	return BULLET_IMPACT_NONE
 
 
+/**
+ * Whether or not user is capable of using this atom based on dexterity. Usually this equates to "Are you a human or silicon mob?"
+ *
+ * **Parameters**:
+ * - `user` - The mob attempting to use the atom.
+ *
+ * Returns boolean.
+ */
 /atom/movable/proc/CheckDexterity(mob/living/user)
 	return TRUE

--- a/code/game/machinery/cracker.dm
+++ b/code/game/machinery/cracker.dm
@@ -6,7 +6,6 @@
 	construct_state = /singleton/machine_construction/default/panel_closed
 	density = TRUE
 	anchored = TRUE
-	waterproof = TRUE
 	volume = 5000
 	use_power = POWER_USE_IDLE
 	idle_power_usage = 100

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -202,14 +202,14 @@ var/global/const/enterloopsanity = 100
 		M.make_floating(0) //we know we're not on solid ground so skip the checks to save a bit of processing
 
 	var/objects = 0
-	if(A && (A.movable_flags & MOVABLE_FLAG_PROXMOVE))
+	if (A && HAS_FLAGS(A.movable_flags, MOVABLE_FLAG_PROXMOVE))
 		for(var/atom/movable/thing in range(1))
 			if(objects > enterloopsanity) break
 			objects++
 			spawn(0)
 				if(A)
 					A.HasProximity(thing)
-					if ((thing && A) && (thing.movable_flags & MOVABLE_FLAG_PROXMOVE))
+					if ((thing && A) && HAS_FLAGS(thing.movable_flags, MOVABLE_FLAG_PROXMOVE))
 						thing.HasProximity(A)
 	return
 

--- a/code/modules/ZAS/Atom.dm
+++ b/code/modules/ZAS/Atom.dm
@@ -69,4 +69,5 @@
 	. = 0
 	ATMOS_CANPASS_TURF(., src, other)
 
+/// Integer (One of `CANPASS_*`). Whether air can pass through this atom, and on what conditions. See `code\__defines\ZAS.dm`.
 /atom/movable/var/atmos_canpass = CANPASS_ALWAYS

--- a/code/modules/ZAS/Atom.dm
+++ b/code/modules/ZAS/Atom.dm
@@ -69,5 +69,4 @@
 	. = 0
 	ATMOS_CANPASS_TURF(., src, other)
 
-/atom/movable
-	var/atmos_canpass = CANPASS_ALWAYS
+/atom/movable/var/atmos_canpass = CANPASS_ALWAYS

--- a/code/modules/mechs/mech_movement.dm
+++ b/code/modules/mechs/mech_movement.dm
@@ -118,7 +118,7 @@
 		return MOVEMENT_PROCEED
 
 	if(!mob.has_gravity())
-		allow_move = mob.Process_Spacemove(1)
+		allow_move = mob.Process_Spacemove(TRUE)
 		if(!allow_move)
 			return MOVEMENT_STOP
 

--- a/code/modules/mob/floating_message.dm
+++ b/code/modules/mob/floating_message.dm
@@ -12,8 +12,8 @@ var/global/list/floating_chat_colors = list()
 /// Max width of chat message in pixels
 #define CHAT_MESSAGE_HEIGHT 64
 
-/atom/movable
-	var/list/stored_chat_text
+/// LAZYLIST of `/image`. Floating text message images being processed by this atom.
+/atom/movable/var/list/stored_chat_text
 
 /atom/movable/proc/animate_chat(message, datum/language/language, small, list/show_to, duration = CHAT_MESSAGE_LIFESPAN)
 	set waitfor = FALSE

--- a/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/code/modules/mob/living/carbon/human/human_movement.dm
@@ -85,7 +85,7 @@
 			implant_jet = TRUE
 
 	if(implant_jet || (thrust && thrust.on && (allow_movement || thrust.stabilization_on) && thrust.allow_thrust(0.01, src)))
-		return 1
+		return TRUE
 
 	. = ..()
 

--- a/code/modules/mob/living/silicon/robot/flying/flying.dm
+++ b/code/modules/mob/living/silicon/robot/flying/flying.dm
@@ -43,7 +43,7 @@
 		stop_flying()
 
 /mob/living/silicon/robot/flying/Process_Spacemove()
-	return (pass_flags & PASS_FLAG_TABLE) || ..()
+	return HAS_FLAGS(pass_flags, PASS_FLAG_TABLE) || ..()
 
 /mob/living/silicon/robot/flying/can_fall(anchor_bypass = FALSE, turf/location_override = loc)
 	return !Process_Spacemove()

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -8,12 +8,15 @@
 		return 1
 	return 0
 
-/mob/living/silicon/robot/Process_Spacemove()
-	if(module)
-		for(var/obj/item/tank/jetpack/J in module.equipment)
-			if(J && J.allow_thrust(0.01))
-				return 1
-	. = ..()
+/mob/living/silicon/robot/Process_Spacemove(allow_movement)
+	if (!module)
+		return ..()
+
+	for (var/obj/item/tank/jetpack/jetpack in module.equipment)
+		if (jetpack?.allow_thrust(0.01))
+			return TRUE
+
+	return ..()
 
 
 /mob/living/silicon/robot/movement_delay(singleton/move_intent/using_intent = move_intent)

--- a/code/modules/mob/living/simple_animal/familiars/familiars.dm
+++ b/code/modules/mob/living/simple_animal/familiars/familiars.dm
@@ -69,8 +69,8 @@
 
 	wizardy_spells = list(/spell/aoe_turf/conjure/forcewall)
 
-/mob/living/simple_animal/familiar/pike/Process_Spacemove()
-	return 1	//No drifting in space for space carp!	//original comments do not steal
+/mob/living/simple_animal/familiar/pike/Process_Spacemove(allow_movement)
+	return TRUE
 
 /mob/living/simple_animal/familiar/horror
 	name = "horror"

--- a/code/modules/mob/living/simple_animal/friendly/juvenile_space_whale.dm
+++ b/code/modules/mob/living/simple_animal/friendly/juvenile_space_whale.dm
@@ -71,7 +71,7 @@
 			bound_height = 32
 			bound_width = 64
 
-/mob/living/simple_animal/passive/juvenile_space_whale/Process_Spacemove()
+/mob/living/simple_animal/passive/juvenile_space_whale/Process_Spacemove(allow_movement)
 	return TRUE
 
 /datum/say_list/juvenile_space_whale

--- a/code/modules/mob/living/simple_animal/hostile/bluespace.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bluespace.dm
@@ -20,8 +20,8 @@
 	light_power = 1
 	bleed_colour = "#0000ff"
 
-/mob/living/simple_animal/hostile/bluespace/Process_Spacemove()
-	return 1
+/mob/living/simple_animal/hostile/bluespace/Process_Spacemove(allow_movement)
+	return TRUE
 
 /obj/item/natural_weapon/bluespace
 	name = "fractal touch"

--- a/code/modules/mob/living/simple_animal/hostile/faithless.dm
+++ b/code/modules/mob/living/simple_animal/hostile/faithless.dm
@@ -34,8 +34,8 @@
 	damtype = DAMAGE_BURN
 	force = 15
 
-/mob/living/simple_animal/hostile/faithless/Process_Spacemove()
-	return 1
+/mob/living/simple_animal/hostile/faithless/Process_Spacemove(allow_movement)
+	return TRUE
 
 /mob/living/simple_animal/hostile/faithless/apply_melee_effects(atom/A)
 	if(isliving(A))

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/drone.dm
@@ -58,7 +58,7 @@
 		trail.start()
 
 
-/mob/living/simple_animal/hostile/retaliate/malf_drone/Process_Spacemove()
+/mob/living/simple_animal/hostile/retaliate/malf_drone/Process_Spacemove(allow_movement)
 	return TRUE
 
 

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/king_of_goats.dm
@@ -256,8 +256,8 @@
 	QDEL_NULL(boss_theme)
 	. = ..()
 
-/mob/living/simple_animal/hostile/retaliate/goat/king/Process_Spacemove()
-	return 1
+/mob/living/simple_animal/hostile/retaliate/goat/king/Process_Spacemove(allow_movement)
+	return TRUE
 
 /datum/say_list/goat/king
 	emote_hear = list("brays in a booming voice")

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/space_whale.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/space_whale.dm
@@ -74,7 +74,7 @@
 // 	if(istype(M, /mob/living/simple_animal/passive/juvenile_space_whale))
 // 		return FALSE
 
-/mob/living/simple_animal/hostile/retaliate/space_whale/Process_Spacemove()
+/mob/living/simple_animal/hostile/retaliate/space_whale/Process_Spacemove(allow_movement)
 	return TRUE
 
 /datum/say_list/space_whale

--- a/code/modules/mob/living/simple_animal/hostile/robotic/bad_drone.dm
+++ b/code/modules/mob/living/simple_animal/hostile/robotic/bad_drone.dm
@@ -28,8 +28,8 @@
 		new corpse (loc)
 	qdel(src)
 
-/mob/living/simple_animal/hostile/rogue_drone/Process_Spacemove()
-	return 1
+/mob/living/simple_animal/hostile/rogue_drone/Process_Spacemove(allow_movement)
+	return TRUE
 
 /datum/ai_holder/simple_animal/rogue_drone
 	speak_chance = 1

--- a/code/modules/mob/living/simple_animal/hostile/robotic/robots.dm
+++ b/code/modules/mob/living/simple_animal/hostile/robotic/robots.dm
@@ -37,8 +37,8 @@
 	maxHealth = 100
 	health = 100
 
-/mob/living/simple_animal/hostile/hivebot/ranged_damage/fleet_robot/Process_Spacemove()
-	return 1
+/mob/living/simple_animal/hostile/hivebot/ranged_damage/fleet_robot/Process_Spacemove(allow_movement)
+	return TRUE
 
 /datum/ai_holder/simple_animal/ranged/kiting/threatening/deimos
 	speak_chance = 0
@@ -270,7 +270,7 @@
 		explosion(loc, explosion_radius, explosion_max_power)
 		qdel(src)
 
-/mob/living/simple_animal/hostile/fleet_heavy/Process_Spacemove()
+/mob/living/simple_animal/hostile/fleet_heavy/Process_Spacemove(allow_movement)
 	return TRUE
 
 /obj/aura/mobshield

--- a/code/modules/mob/living/simple_animal/hostile/space_carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/space_carp.dm
@@ -62,5 +62,5 @@
 	icon_dead = "[carp_color]_dead"
 
 
-/mob/living/simple_animal/hostile/carp/Process_Spacemove()
+/mob/living/simple_animal/hostile/carp/Process_Spacemove(allow_movement)
 	return TRUE

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -102,8 +102,8 @@
 	corpse = /obj/landmark/corpse/syndicate
 	speed = 0
 
-/mob/living/simple_animal/hostile/human/syndicate/melee/space/Process_Spacemove()
-	return 1
+/mob/living/simple_animal/hostile/human/syndicate/melee/space/Process_Spacemove(allow_movement)
+	return TRUE
 
 /mob/living/simple_animal/hostile/human/syndicate/ranged
 	ranged = 1
@@ -126,8 +126,8 @@
 	corpse = /obj/landmark/corpse/syndicate/commando
 	speed = 0
 
-/mob/living/simple_animal/hostile/human/syndicate/ranged/space/Process_Spacemove()
-	return 1
+/mob/living/simple_animal/hostile/human/syndicate/ranged/space/Process_Spacemove(allow_movement)
+	return TRUE
 
 /mob/living/simple_animal/hostile/viscerator
 	name = "viscerator"

--- a/code/modules/mob/living/simple_animal/hostile/vagrant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/vagrant.dm
@@ -54,8 +54,8 @@
 			H.visible_message(SPAN_DANGER("\the [holder] latches onto \the [H], pulsating!"))
 			V.forceMove(V.gripping.loc)
 
-/mob/living/simple_animal/hostile/vagrant/Process_Spacemove()
-	return 1
+/mob/living/simple_animal/hostile/vagrant/Process_Spacemove(allow_movement)
+	return TRUE
 
 /mob/living/simple_animal/hostile/vagrant/bullet_act(obj/item/projectile/Proj)
 	if (status_flags & GODMODE)

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -158,7 +158,6 @@
 
 		src.move_speed = world.time - src.l_move_time
 		src.l_move_time = world.time
-		src.m_flag = 1
 		if ((A != src.loc && A && A.z == src.z))
 			src.last_move = get_dir(A, src.loc)
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -175,14 +175,14 @@
 
 /mob/Process_Spacemove(allow_movement)
 	. = ..()
-	if(.)
+	if (.)
 		return
 
 	var/atom/movable/backup = get_spacemove_backup()
-	if(backup)
-		if(istype(backup) && allow_movement)
+	if (backup)
+		if (istype(backup) && allow_movement)
 			return backup
-		return -1
+		return TRUE
 
 /mob/proc/space_do_move(allow_move, direction)
 	if(ismovable(allow_move))//push off things in space

--- a/code/modules/mob/observer/virtual/base.dm
+++ b/code/modules/mob/observer/virtual/base.dm
@@ -52,8 +52,7 @@ var/global/list/all_virtual_listeners = list()
 /***********************
 * Virtual Mob Creation *
 ***********************/
-/atom/movable
-	var/mob/observer/virtual/virtual_mob
+/atom/movable/var/mob/observer/virtual/virtual_mob
 
 /atom/movable/Initialize()
 	. = ..()

--- a/code/modules/multiz/structures.dm
+++ b/code/modules/multiz/structures.dm
@@ -201,7 +201,7 @@
 
 			//We cannot use the ladder, but we probably can remove the obstruction
 			var/atom/movable/M = A
-			if(istype(M) && M.movable_flags & MOVABLE_FLAG_Z_INTERACT)
+			if (istype(M) && HAS_FLAGS(M.movable_flags, MOVABLE_FLAG_Z_INTERACT))
 				if(isnull(I))
 					M.attack_hand(user)
 				else

--- a/code/modules/multiz/turf.dm
+++ b/code/modules/multiz/turf.dm
@@ -76,7 +76,7 @@
 
 /turf/simulated/open/attack_hand(mob/user)
 	for(var/atom/movable/M in below)
-		if(M.movable_flags & MOVABLE_FLAG_Z_INTERACT)
+		if (HAS_FLAGS(M.movable_flags, MOVABLE_FLAG_Z_INTERACT))
 			return M.attack_hand(user)
 
 //Most things use is_plating to test if there is a cover tile on top (like regular floors)

--- a/code/modules/multiz/zmimic/mimic_movable.dm
+++ b/code/modules/multiz/zmimic/mimic_movable.dm
@@ -1,8 +1,7 @@
-/atom/movable
-	/// The mimic (if any) that's *directly* copying us.
-	var/atom/movable/openspace/mimic/bound_overlay
-	/// If TRUE, this atom is ignored by Z-Mimic.
-	var/z_flags
+/// The mimic (if any) that's *directly* copying us.
+/atom/movable/var/atom/movable/openspace/mimic/bound_overlay
+/// If TRUE, this atom is ignored by Z-Mimic.
+/atom/movable/var/z_flags
 
 /atom/movable/forceMove(atom/dest)
 	. = ..(dest)

--- a/code/modules/projectiles/guns/launcher/slugsling.dm
+++ b/code/modules/projectiles/guns/launcher/slugsling.dm
@@ -12,7 +12,7 @@
 	if(break_on_impact)
 		squish()
 	else
-		movable_flags |= MOVABLE_FLAG_PROXMOVE //Dont want it active during the throw... loooots of unneeded checking.
+		SET_FLAGS(movable_flags, MOVABLE_FLAG_PROXMOVE) //Dont want it active during the throw... loooots of unneeded checking.
 	return ..()
 
 /obj/item/slugegg/attack_self(mob/living/user)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -541,5 +541,5 @@
 		SP.desc += " It looks like it was fired from [shot_from]."
 		return SP
 
-/obj/item/projectile/Process_Spacemove()
-	return TRUE	//Bullets don't drift in space
+/obj/item/projectile/Process_Spacemove(allow_movement)
+	return TRUE

--- a/maps/torch/torch_simplemobs.dm
+++ b/maps/torch/torch_simplemobs.dm
@@ -181,8 +181,8 @@
 	say_list_type = /datum/say_list/fleet/friendly
 	faction = MOB_FACTION_CREW
 
-/mob/living/simple_animal/hostile/human/fleet/space/Process_Spacemove()
-	return 1
+/mob/living/simple_animal/hostile/human/fleet/space/Process_Spacemove(allow_movement)
+	return TRUE
 
 //////////////Rigsuit - Bullpup////////////////
 


### PR DESCRIPTION
NUFC (Hopefully).

Adds docblocks to all properties and procs under `/atom/movable`, and cleans things up a bit to follow current formatting and style standards.