### PR TITLE
Th'oom Juice source rectification

### DIFF
--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drinks.dm
@@ -239,7 +239,7 @@
 
 /datum/reagent/drink/thoom
 	name = "Th'oom Juice"
-	description = "A thick off-white fluid expressed from the juice glands of the Skrellian Th'oom."
+	description = "A thick, off-white drink themed around the elusive skrellian Th'oom. Despite the name, no one is really sure what's in this."
 	taste_description = "thick, sweet, and savory ... milk?"
 	color = "#baeece"
 	glass_name = "th'oom juice"


### PR DESCRIPTION
🆑 TheStripes
spellcheck: Tweaked the th'oom reagent description to make its delectable origins unclear.
/:cl:

Originally, this was _intended_ to make it so Th'oom source their juice, rather than EZ Nutrient, which makes less sense. However, upon touching base, it was found out that Th'oom Juice is only named that with no real connection at all, as per Eckles:
![juice mystery](https://github.com/user-attachments/assets/9e987458-a609-419e-92ce-7e264dd6d0e5)
which, of course, means I ought to rectify the fraudulent juice itself. Where is it from, now? Who knows! ~~Skrell still love it, though.~~