### PR TITLE
Rebalances Voidsuit Welding Protections

### DIFF
--- a/code/game/gamemodes/cult/cult_items.dm
+++ b/code/game/gamemodes/cult/cult_items.dm
@@ -121,6 +121,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR
 	) //Real tanky shit.
+	flash_protection = FLASH_PROTECTION_MAJOR
 	siemens_coefficient = 0.3 //Bone is not very conducive to electricity.
 
 /obj/item/clothing/suit/space/cult

--- a/code/modules/clothing/spacesuits/alien.dm
+++ b/code/modules/clothing/spacesuits/alien.dm
@@ -34,6 +34,7 @@
 		bio = ARMOR_BIO_SMALL,
 		rad = ARMOR_RAD_MINOR
 		)
+	flash_protection = FLASH_PROTECTION_MAJOR
 	siemens_coefficient = 0.6
 	item_flags = 0
 	flags_inv = 0

--- a/code/modules/clothing/spacesuits/rig/rig_pieces.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_pieces.dm
@@ -14,6 +14,7 @@
 		SPECIES_SKRELL = 'icons/mob/species/skrell/onmob_head_skrell.dmi',
 		SPECIES_UNATHI = 'icons/mob/species/unathi/onmob_head_unathi.dmi',
 		)
+	flash_protection = FLASH_PROTECTION_MAJOR
 	species_restricted = null
 
 /obj/item/clothing/gloves/rig

--- a/code/modules/clothing/spacesuits/spacesuits.dm
+++ b/code/modules/clothing/spacesuits/spacesuits.dm
@@ -27,7 +27,7 @@
 	siemens_coefficient = 0.9
 	randpixel = 0
 	species_restricted = list("exclude", SPECIES_NABBER, SPECIES_DIONA)
-	flash_protection = FLASH_PROTECTION_MAJOR
+	flash_protection = FLASH_PROTECTION_NONE
 
 	var/obj/machinery/camera/camera
 

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -13,6 +13,7 @@
 		bio = ARMOR_BIO_SMALL,
 		rad = ARMOR_RAD_MINOR
 		)
+	flash_protection = FLASH_PROTECTION_MODERATE
 	siemens_coefficient = 0.3
 
 /obj/item/clothing/suit/space/syndicate

--- a/code/modules/clothing/spacesuits/void/merc.dm
+++ b/code/modules/clothing/spacesuits/void/merc.dm
@@ -13,6 +13,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SMALL
 		)
+	flash_protection = FLASH_PROTECTION_MAJOR
 	siemens_coefficient = 0.3
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_IPC, SPECIES_VOX)
 	sprite_sheets = list(

--- a/code/modules/clothing/spacesuits/void/misc.dm
+++ b/code/modules/clothing/spacesuits/void/misc.dm
@@ -30,6 +30,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SHIELDED
 		)
+	flash_protection = FLASH_PROTECTION_MAJOR
 	max_heat_protection_temperature = SPACE_SUIT_MAX_HEAT_PROTECTION_TEMPERATURE
 	valid_accessory_slots = null
 	restricted_accessory_slots = null

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -18,6 +18,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_RESISTANT
 		)
+	flash_protection = FLASH_PROTECTION_MAJOR
 	max_pressure_protection = ENG_VOIDSUIT_MAX_PRESSURE
 	siemens_coefficient = 0.3
 
@@ -66,6 +67,7 @@
 		)
 	light_overlay = "helmet_light_dual_alt"
 	max_pressure_protection = ENG_VOIDSUIT_MAX_PRESSURE
+	flash_protection = FLASH_PROTECTION_MAJOR
 
 /obj/item/clothing/suit/space/void/mining
 	icon_state = "rig-mining"
@@ -148,6 +150,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_MINOR
 		)
+	flash_protection = FLASH_PROTECTION_MINOR
 	siemens_coefficient = 0.3
 	light_overlay = "helmet_light_dual"
 
@@ -193,6 +196,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SMALL
 		)
+	flash_protection = FLASH_PROTECTION_MAJOR
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	light_overlay = "helmet_light_dual"
 	max_pressure_protection = FIRESUIT_MAX_PRESSURE

--- a/code/modules/clothing/spacesuits/void/wizard.dm
+++ b/code/modules/clothing/spacesuits/void/wizard.dm
@@ -17,6 +17,7 @@
 		bio = ARMOR_BIO_SHIELDED,
 		rad = ARMOR_RAD_SMALL
 		)
+	flash_protection = FLASH_PROTECTION_MAJOR
 	siemens_coefficient = 0.7
 	sprite_sheets_obj = null
 	wizard_garb = TRUE

--- a/code/modules/psionics/equipment/cerebro_enhancers.dm
+++ b/code/modules/psionics/equipment/cerebro_enhancers.dm
@@ -9,6 +9,7 @@
 		slot_l_hand_str = "helmet",
 		slot_r_hand_str = "helmet"
 		)
+	flash_protection = FLASH_PROTECTION_MAJOR
 
 	var/operating = FALSE
 	var/list/boosted_faculties


### PR DESCRIPTION

:cl: JuneauQT
tweak: Most voidsuits have lost all welding protection. Engineering, Mining, offship, and all antag voidsuits still have full welding protection, as well as all RIGs. Riot Voidsuits have minor flash protection, and Exploration Voidsuits maintain their unique helmet tint behavior
/:cl:

Right now, full welding and flash protection with no visual impairment is available to any crewmember with access to EVA storage for a zero telecrystal cost. Additionally, the Exploration Voidsuit's helmet tint mechanic makes it flat out worse than every other voidsuit in the game. This PR seeks to rebalance this.

Antag voidsuits have maintained their flash and welding protection, as they require a telecrystal investment and are considered contraband under IC law. Offships have maintained their welding protection for a variety of reasons, but typically because they have no other sources of welding protection or need to weld in an environment where they also need a voidsuit. Engineering and Atmos voidsuits maintain their protections for the later reason. The riot voidsuits maintain minor flash protection for obvious gameplay reasons (this could be bumped to moderate, if necessary). All RIGs maintain full protection, since they're considered more sophisticated than voidsuits.

Alternative development plans were considered, namely a welding goggles attachment for helmets that could be mapped into the engineering bay and the offships that needed it (considered to be more effort than it was worth, as it would need both spriting and mapping, but might be considered preferable from some perspectives), and simply adding a permanent tint comparable with welding helmets or the exploration voidsuit helmet to all (non-antagonist, non-alien offship, non-exploration, non-hardsuit) voidsuits, which was considered to be more annoying for long-term usage (Although an argument could be made for this being the point)
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->