### PR TITLE
Rework fortune cookies

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3003,6 +3003,7 @@
 #include "code\modules\reagents\reagent_containers\food\snacks\bugmeat.dm"
 #include "code\modules\reagents\reagent_containers\food\snacks\cheese.dm"
 #include "code\modules\reagents\reagent_containers\food\snacks\donkpocket.dm"
+#include "code\modules\reagents\reagent_containers\food\snacks\fortunecookie.dm"
 #include "code\modules\reagents\reagent_containers\food\snacks\meat.dm"
 #include "code\modules\reagents\reagent_containers\food\snacks\shellfish.dm"
 #include "code\modules\reagents\reagent_containers\glass\bottle.dm"

--- a/code/datums/recipe.dm
+++ b/code/datums/recipe.dm
@@ -28,8 +28,11 @@
 	var/antag_text
 
 
-/datum/microwave_recipe/proc/CreateResult(obj/machinery/microwave/microwave)
-	var/atom/movable/result = new result_path (microwave)
+/datum/microwave_recipe/proc/CreateResult(obj/machinery/microwave/microwave, ...)
+	var/list/result_args = list(microwave)
+	if (length(args) > 1)
+		result_args += args.Copy(2)
+	var/atom/movable/result = new result_path (arglist(result_args))
 	microwave.reagents.clear_reagents()
 	if (!length(microwave.ingredients))
 		return result

--- a/code/datums/trading/food.dm
+++ b/code/datums/trading/food.dm
@@ -81,8 +81,8 @@
 /datum/trader/ship/chinese/trade_quantity(quantity, list/offers, num, turf/location)
 	. = ..()
 	quantity = 1
-	if(.)
-		new/obj/item/reagent_containers/food/snacks/fortunecookie(location)
+	if (.)
+		new /obj/item/reagent_containers/food/snacks/fortunecookie (location)
 
 /datum/trader/grocery
 	name = "Grocer"

--- a/code/datums/trading/food.dm
+++ b/code/datums/trading/food.dm
@@ -82,11 +82,7 @@
 	. = ..()
 	quantity = 1
 	if(.)
-		var/obj/item/reagent_containers/food/snacks/fortunecookie/cookie = new(location)
-		var/obj/item/paper/paper = new(cookie)
-		cookie.trash = paper
-		paper.SetName("Fortune")
-		paper.info = pick(fortunes)
+		new/obj/item/reagent_containers/food/snacks/fortunecookie(location)
 
 /datum/trader/grocery
 	name = "Grocer"

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -211,7 +211,7 @@
 	result_path = /obj/item/reagent_containers/food/snacks/donkpocket
 
 
-/datum/microwave_recipe/hot_donkpocket/CreateResult(obj/machinery/microwave/microwave)
+/datum/microwave_recipe/hot_donkpocket/CreateResult(obj/machinery/microwave/microwave, ...)
 	var/obj/item/reagent_containers/food/snacks/donkpocket/donk = locate() in microwave
 	donk?.SetHot()
 	return donk
@@ -469,20 +469,12 @@
 	result_path = /obj/item/reagent_containers/food/snacks/fortunecookie
 
 
-/datum/microwave_recipe/fortunecookie/CreateResult(obj/machinery/microwave/microwave)
-	var/obj/item/reagent_containers/food/snacks/fortunecookie/cookie = ..()
+/datum/microwave_recipe/fortunecookie/CreateResult(obj/machinery/microwave/microwave, ...)
 	var/obj/item/paper/paper = locate() in microwave
-	if (paper)
-		cookie.set_fortune(paper)
-	return cookie
-
-
-/datum/microwave_recipe/fortunecookie/CheckItems(obj/machinery/microwave/microwave)
-	. = ..()
-	if (.)
-		var/obj/item/paper/paper = locate() in microwave
-		if (!paper?.info)
-			return FALSE
+	if (paper.info)
+		microwave.ingredients -= paper
+		return ..(microwave, paper)
+	return ..(microwave)
 
 
 /datum/microwave_recipe/plainsteak
@@ -614,7 +606,7 @@
 	result_path = /obj/item/reagent_containers/food/snacks/amanitajelly
 
 
-/datum/microwave_recipe/amanitajelly/CreateResult(obj/machinery/microwave/microwave)
+/datum/microwave_recipe/amanitajelly/CreateResult(obj/machinery/microwave/microwave, ...)
 		var/obj/item/reagent_containers/food/snacks/amanitajelly/jelly = ..()
 		jelly.reagents.del_reagent(/datum/reagent/toxin/amatoxin)
 		return jelly
@@ -1347,7 +1339,7 @@
 	result_path = /obj/item/reagent_containers/food/snacks/validsalad
 
 
-/datum/microwave_recipe/validsalad/CreateResult(obj/machinery/microwave/microwave)
+/datum/microwave_recipe/validsalad/CreateResult(obj/machinery/microwave/microwave, ...)
 	var/obj/item/reagent_containers/food/snacks/validsalad/salad = ..()
 	salad.reagents.del_reagent(/datum/reagent/toxin)
 	return salad

--- a/code/modules/food/recipes_microwave.dm
+++ b/code/modules/food/recipes_microwave.dm
@@ -473,9 +473,7 @@
 	var/obj/item/reagent_containers/food/snacks/fortunecookie/cookie = ..()
 	var/obj/item/paper/paper = locate() in microwave
 	if (paper)
-		paper.forceMove(cookie)
-		cookie.trash = paper
-		paper.loc = null
+		cookie.set_fortune(paper)
 	return cookie
 
 

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -1035,16 +1035,6 @@
 	.=..()
 	reagents.add_reagent(/datum/reagent/nutriment/protein, 2)
 
-/obj/item/reagent_containers/food/snacks/fortunecookie
-	name = "fortune cookie"
-	desc = "A true prophecy in each cookie!"
-	icon_state = "fortune_cookie"
-	filling_color = "#e8e79e"
-	center_of_mass = "x=15;y=14"
-	nutriment_desc = list("fortune cookie" = 2)
-	nutriment_amt = 3
-	bitesize = 2
-
 /obj/item/reagent_containers/food/snacks/badrecipe
 	name = "burned mess"
 	desc = "Someone should be demoted from chef for this."

--- a/code/modules/reagents/reagent_containers/food/snacks/fortunecookie.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/fortunecookie.dm
@@ -1,0 +1,80 @@
+GLOBAL_LIST_INIT(fortune_cookie_default_fortunes, list(\
+	"Today it's up to you to create the peacefulness you long for.",\
+	"If you refuse to accept anything but the best, you very often get it.",\
+	"A smile is your passport into the hearts of others.",\
+	"Hard work pays off in the future, laziness pays off now.",\
+	"Change can hurt, but it leads a path to something better.",\
+	"Hidden in a valley beside an open stream- This will be the type of place where you will find your dream.",\
+	"Never give up. You're not a failure if you don't give up.",\
+	"Love can last a lifetime, if you want it to.",\
+	"The love of your life is stepping into your planet this summer.",\
+	"Your ability for accomplishment will follow with success.",\
+	"Please help me, I'm trapped in a fortune cookie factory!"\
+))
+
+
+/obj/item/reagent_containers/food/snacks/fortunecookie
+	name = "fortune cookie"
+	desc = "A true prophecy in each cookie!"
+	icon_state = "fortune_cookie"
+	filling_color = "#e8e79e"
+	center_of_mass = "x=15;y=14"
+	nutriment_desc = list("fortune cookie" = 2)
+	nutriment_amt = 3
+	bitesize = 2
+	/// The paper fortune contained inside the cookie. Set during `Initialize()`.
+	var/obj/item/paper/fortune
+	/// Boolean. Whether or not the cookie has already been broken open,
+	var/opened = FALSE
+
+
+/obj/item/reagent_containers/food/snacks/fortunecookie/Initialize(mapload)
+	. = ..()
+	if (. == INITIALIZE_HINT_QDEL)
+		return
+
+	fortune = new(src)
+	fortune.set_content(pick(GLOB.fortune_cookie_default_fortunes), "fortune", FALSE)
+
+
+/obj/item/reagent_containers/food/snacks/fortunecookie/Destroy()
+	QDEL_NULL(fortune)
+
+	return ..()
+
+
+/obj/item/reagent_containers/food/snacks/fortunecookie/examine(mob/user, distance)
+	. = ..()
+	if (opened)
+		to_chat(user, SPAN_WARNING("It's been broken open and no longer holds a fortune."))
+
+
+/obj/item/reagent_containers/food/snacks/fortunecookie/attack_self(mob/user)
+	if (opened)
+		USE_FEEDBACK_FAILURE("\The [src] has already been broken open.")
+		return TRUE
+
+	var/message = "but it was empty"
+	if (fortune)
+		message = "revealing \a [fortune]"
+		fortune.forceMove(user.loc)
+		user.put_in_hands(fortune)
+		fortune = null
+
+	user.visible_message(
+		SPAN_NOTICE("\The [user] cracks open \a [src], [message]."),
+		SPAN_NOTICE("You crack open \the [src], [message].")
+	)
+	SetName("open [name]")
+	opened = TRUE
+
+
+/obj/item/reagent_containers/food/snacks/fortunecookie/proc/set_fortune(obj/item/paper/new_fortune)
+	if (new_fortune == fortune)
+		return
+
+	if (fortune)
+		QDEL_NULL(fortune)
+
+	new_fortune.forceMove(src)
+	fortune = new_fortune

--- a/code/modules/reagents/reagent_containers/food/snacks/fortunecookie.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/fortunecookie.dm
@@ -1,15 +1,15 @@
-GLOBAL_LIST_INIT(fortune_cookie_default_fortunes, list(\
-	"Today it's up to you to create the peacefulness you long for.",\
-	"If you refuse to accept anything but the best, you very often get it.",\
-	"A smile is your passport into the hearts of others.",\
-	"Hard work pays off in the future, laziness pays off now.",\
-	"Change can hurt, but it leads a path to something better.",\
-	"Hidden in a valley beside an open stream- This will be the type of place where you will find your dream.",\
-	"Never give up. You're not a failure if you don't give up.",\
-	"Love can last a lifetime, if you want it to.",\
-	"The love of your life is stepping into your planet this summer.",\
-	"Your ability for accomplishment will follow with success.",\
-	"Please help me, I'm trapped in a fortune cookie factory!"\
+GLOBAL_LIST_INIT(fortune_cookie_default_fortunes, list(
+	"Today it's up to you to create the peacefulness you long for.",
+	"If you refuse to accept anything but the best, you very often get it.",
+	"A smile is your passport into the hearts of others.",
+	"Hard work pays off in the future, laziness pays off now.",
+	"Change can hurt, but it leads a path to something better.",
+	"Hidden in a valley beside an open stream- This will be the type of place where you will find your dream.",
+	"Never give up. You're not a failure if you don't give up.",
+	"Love can last a lifetime, if you want it to.",
+	"The love of your life is stepping into your planet this summer.",
+	"Your ability for accomplishment will follow with success.",
+	"Please help me, I'm trapped in a fortune cookie factory!"
 ))
 
 
@@ -22,24 +22,26 @@ GLOBAL_LIST_INIT(fortune_cookie_default_fortunes, list(\
 	nutriment_desc = list("fortune cookie" = 2)
 	nutriment_amt = 3
 	bitesize = 2
+
 	/// The paper fortune contained inside the cookie. Set during `Initialize()`.
 	var/obj/item/paper/fortune
+
 	/// Boolean. Whether or not the cookie has already been broken open,
 	var/opened = FALSE
 
 
-/obj/item/reagent_containers/food/snacks/fortunecookie/Initialize(mapload)
+/obj/item/reagent_containers/food/snacks/fortunecookie/Initialize(mapload, obj/item/paper/fortune)
 	. = ..()
 	if (. == INITIALIZE_HINT_QDEL)
 		return
-
-	fortune = new(src)
-	fortune.set_content(pick(GLOB.fortune_cookie_default_fortunes), "fortune", FALSE)
+	if (!fortune)
+		fortune = new (src)
+		fortune.set_content(pick(GLOB.fortune_cookie_default_fortunes), "fortune", FALSE)
+	set_fortune(fortune)
 
 
 /obj/item/reagent_containers/food/snacks/fortunecookie/Destroy()
 	QDEL_NULL(fortune)
-
 	return ..()
 
 
@@ -53,14 +55,12 @@ GLOBAL_LIST_INIT(fortune_cookie_default_fortunes, list(\
 	if (opened)
 		USE_FEEDBACK_FAILURE("\The [src] has already been broken open.")
 		return TRUE
-
 	var/message = "but it was empty"
 	if (fortune)
 		message = "revealing \a [fortune]"
 		fortune.forceMove(user.loc)
 		user.put_in_hands(fortune)
 		fortune = null
-
 	user.visible_message(
 		SPAN_NOTICE("\The [user] cracks open \a [src], [message]."),
 		SPAN_NOTICE("You crack open \the [src], [message].")
@@ -72,9 +72,8 @@ GLOBAL_LIST_INIT(fortune_cookie_default_fortunes, list(\
 /obj/item/reagent_containers/food/snacks/fortunecookie/proc/set_fortune(obj/item/paper/new_fortune)
 	if (new_fortune == fortune)
 		return
-
 	if (fortune)
-		QDEL_NULL(fortune)
-
-	new_fortune.forceMove(src)
+		fortune.dropInto(loc)
+	if (new_fortune)
+		new_fortune.forceMove(src)
 	fortune = new_fortune


### PR DESCRIPTION
This could probably use a separate sprite for the broken open state but I'm not a spriter.

## Changelog
:cl: SierraKomodo
refactor: Reworked how fortune cookies work. Now you use them in your active hand to "break" them open and reveal the fortune (If one is present). If you eat the cookie without breaking it open first, you also eat the fortune.
tweak: Using blank paper with the fortune cookie recipe generates a random fortune for you. How convenient!
/:cl:

## Bug Fixes
- Fixes #34898