### PR TITLE
Fix coffee cup recipe typo

### DIFF
--- a/code/modules/fabrication/designs/micro/designs_glasses.dm
+++ b/code/modules/fabrication/designs/micro/designs_glasses.dm
@@ -30,7 +30,7 @@
 /datum/fabricator_recipe/drinkingglass/flute
 	path = /obj/item/reagent_containers/food/drinks/glass2/flute
 
-/datum/fabricator_recipe/drinkingglass/coffecup
+/datum/fabricator_recipe/drinkingglass/coffeecup
 	path = /obj/item/reagent_containers/food/drinks/glass2/coffeecup
 
 /datum/fabricator_recipe/drinkingglass/cognac


### PR DESCRIPTION
Go figure a simple path typo made DM decide to include an otherwise undefined path and assume it inherited _everything_ from its parent, instead of crashing because, you know. Undefined.

## Changelog
:cl: SierraKomodo
bugfix: Half-pint glass no longer appears twice in the microlathe.
/:cl:

## Bug Fixes
- Fixes #32977