### PR TITLE
Fix Eyeglow Layering

### DIFF
--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -25,10 +25,14 @@
 	var/graffiti_style
 
 /obj/item/organ/external/head/proc/get_eye_overlay()
-	if(glowing_eyes && owner)
-		var/obj/item/organ/internal/eyes/eyes = owner.internal_organs_by_name[owner.species.vision_organ ? owner.species.vision_organ : BP_EYES]
-		if(eyes)
-			return eyes.get_special_overlay()
+	if (!glowing_eyes || !owner)
+		return
+
+	var/obj/item/organ/internal/eyes/eyes = owner.internal_organs_by_name[owner.species.vision_organ ? owner.species.vision_organ : BP_EYES]
+	if (!eyes)
+		return
+
+	return eyes.get_special_overlay()
 
 /obj/item/organ/external/head/proc/get_eyes()
 	var/obj/item/organ/internal/eyes/eyes = owner.internal_organs_by_name[owner.species.vision_organ ? owner.species.vision_organ : BP_EYES]

--- a/code/modules/organs/external/head.dm
+++ b/code/modules/organs/external/head.dm
@@ -32,6 +32,10 @@
 	if (!eyes)
 		return
 
+	for (var/obj/item/equipped as anything in owner.get_equipped_items())
+		if (HAS_FLAGS(equipped.body_parts_covered, EYES))
+			return
+
 	return eyes.get_special_overlay()
 
 /obj/item/organ/external/head/proc/get_eyes()

--- a/code/modules/organs/external/species/diona.dm
+++ b/code/modules/organs/external/species/diona.dm
@@ -127,13 +127,15 @@
 	var/eye_icon_location = 'icons/mob/human_races/species/diona/eyes.dmi'
 
 /obj/item/organ/external/head/diona/get_eye_overlay()
+	if (!glowing_eyes)
+		return
+
 	var/icon/I = get_eyes()
-	if(glowing_eyes)
-		var/image/eye_glow = image(I)
-		eye_glow.AddOverlays(emissive_appearance(eye_icon_location, ""))
-		eye_glow.layer = FLOAT_LAYER
-		//eye_glow.plane = EFFECTS_ABOVE_LIGHTING_PLANE
-		return eye_glow
+	var/image/eye_glow = image(I)
+	eye_glow.AddOverlays(emissive_appearance(eye_icon_location, ""))
+	eye_glow.layer = FLOAT_LAYER
+	//eye_glow.plane = EFFECTS_ABOVE_LIGHTING_PLANE
+	return eye_glow
 
 /obj/item/organ/external/head/diona/get_eyes()
 	return icon(icon = eye_icon_location, icon_state = "")

--- a/code/modules/organs/external/species/diona.dm
+++ b/code/modules/organs/external/species/diona.dm
@@ -130,6 +130,10 @@
 	if (!glowing_eyes)
 		return
 
+	for (var/obj/item/equipped as anything in owner.get_equipped_items())
+		if (HAS_FLAGS(equipped.body_parts_covered, EYES))
+			return
+
 	var/icon/I = get_eyes()
 	var/image/eye_glow = image(I)
 	eye_glow.AddOverlays(emissive_appearance(eye_icon_location, ""))

--- a/code/modules/organs/external/species/nabber_stance.dm
+++ b/code/modules/organs/external/species/nabber_stance.dm
@@ -6,8 +6,9 @@
 
 /obj/item/organ/external/head/insectoid/nabber/get_eye_overlay()
 	var/obj/item/organ/internal/eyes/eyes = owner.internal_organs_by_name[owner.species.vision_organ ? owner.species.vision_organ : BP_EYES]
-	if(eyes)
-		return eyes.get_special_overlay()
+	if (!eyes)
+		return
+	return eyes.get_special_overlay()
 
 /obj/item/organ/external/head/insectoid/nabber/refresh_action_button()
 	. = ..()

--- a/code/modules/organs/external/species/nabber_stance.dm
+++ b/code/modules/organs/external/species/nabber_stance.dm
@@ -8,6 +8,11 @@
 	var/obj/item/organ/internal/eyes/eyes = owner.internal_organs_by_name[owner.species.vision_organ ? owner.species.vision_organ : BP_EYES]
 	if (!eyes)
 		return
+
+	for (var/obj/item/equipped as anything in owner.get_equipped_items())
+		if (HAS_FLAGS(equipped.body_parts_covered, EYES))
+			return
+
 	return eyes.get_special_overlay()
 
 /obj/item/organ/external/head/insectoid/nabber/refresh_action_button()

--- a/code/modules/organs/internal/eyes.dm
+++ b/code/modules/organs/internal/eyes.dm
@@ -38,10 +38,7 @@
 	if(I)
 		var/cache_key = "[last_eye_cache_key]-glow"
 		if(!human_icon_cache[cache_key])
-			var/image/eye_glow = image(I)
-			eye_glow.layer = EYE_GLOW_LAYER
-			eye_glow.plane = EFFECTS_ABOVE_LIGHTING_PLANE
-			human_icon_cache[cache_key] = eye_glow
+			human_icon_cache[cache_key] = emissive_appearance(I)
 		return human_icon_cache[cache_key]
 
 /obj/item/organ/internal/eyes/proc/change_eye_color()


### PR DESCRIPTION
There's probably a better way to do this but icon manipulation is not my strong suit.

## Changelog
:cl: SierraKomodo
bugfix: Glowing eyes should no longer glow through clothing.
/:cl:

## Bug Fixes
- Fixes the clothing part of #34907 but not the z-mimic part.