### PR TITLE
changes allergy autoinjector description to standard

### DIFF
--- a/code/game/objects/items/weapons/storage/med_pouch.dm
+++ b/code/game/objects/items/weapons/storage/med_pouch.dm
@@ -218,5 +218,5 @@ Single Use Emergency Pouches
 
 /obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/allergy
 	name = "emergency allergy autoinjector"
-	desc = "The ingredient label reads 1.5 units of epinephrine and 3.5 units of inaprovaline."
+	desc = "The ingredient label reads 1.5 units of adrenaline and 3.5 units of inaprovaline."
 	starts_with = list(/datum/reagent/adrenaline = 1.5, /datum/reagent/inaprovaline = 3.5)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

Unfortunately, today, I'm a very busy man. I'm not here to litigate any arguments between North American/Japanese and European medical terminology, although I would love to because epinephrine is a better term. Regardless of the divigation, this is one of the very, very few places epinephrine is used, and it's not really acceptable because it's referring to a chemical that is named something else in the code and in the game (adrenaline). A person reading this would have to know that some NA/Japanese chemicals have different names than European ones and make the association, and I just don't see why this is necessary or makes any sense in 2312. 

I considered also changing the changeling references to epinephrine, but some of the paths are called epinephrine and I'm not sure what I'd break doing that, so I'll go back to it later once I stop being Busy. No changelog because I changed one word.