### PR TITLE
Fix cancelled allergy inputs breaking allergies

### DIFF
--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -696,6 +696,8 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 			for (var/severity in possible_levels)
 				LAZYSET(letterized_levels, LetterizeSeverity(severity), severity)
 			var/letterized_input = input(user, "Select the trait's level to apply.", "Select Level") as null | anything in letterized_levels
+			if (!letterized_input)
+				return
 			selected_level = letterized_levels[letterized_input]
 		else
 			selected_level = possible_levels[1]


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Fixed a bug where cancelling the prompt to select an allergy in character setup would break your ability to see, modify, or spawn with any allergies at all.
/:cl: