### PR TITLE
Manually spawned legion now use the warp effect

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -3380,5 +3380,6 @@
 #include "maps\_map_include.dm"
 #include "maps\_maps.dm"
 #include "packs\legion\_pack.dm"
+#include "packs\legion\legion_warp_effect.dm"
 #include "~code\global_init.dm"
 // END_INCLUDE

--- a/packs/legion/legion_beacon.dm
+++ b/packs/legion/legion_beacon.dm
@@ -59,7 +59,7 @@
 	. = ..()
 
 	if (!mapload)
-		effect_warp()
+		legion_warp_effect()
 		visible_message(SPAN_WARNING("\A [src] warps in!"))
 
 	if (!length(spawn_types))
@@ -163,7 +163,7 @@
 	))
 
 	if (target_turf)
-		effect_warp(target_turf)
+		legion_warp_effect(target_turf)
 		var/mob/living/simple_animal/hostile/legion/legion = new spawntype(target_turf, src)
 		linked_mobs += legion
 		last_spawn_time = world.time
@@ -209,10 +209,10 @@
 			continue
 		unlink_mob(child)
 
-	effect_warp()
+	legion_warp_effect(get_turf(src))
 	visible_message(SPAN_DANGER("\The [src] lets out a horrifying screech, then warps away!"))
 	forceMove(target_turf)
-	effect_warp()
+	legion_warp_effect(get_turf(src))
 	visible_message(SPAN_DANGER("\The [src] warps in!"))
 	log_and_message_admins("\The [src] has teleported to a new location at [get_area(target_turf)]", null, location = target_turf)
 
@@ -222,9 +222,9 @@
 		if (!length(child_target_turfs))
 			unlink_mob(child)
 			continue
-		effect_warp(get_turf(child))
+		legion_warp_effect(get_turf(child))
 		child.forceMove(pick_n_take(child_target_turfs))
-		effect_warp(get_turf(child))
+		legion_warp_effect(get_turf(child))
 
 
 /obj/structure/legion/beacon/proc/unlink_mob(mob/living/child)
@@ -232,17 +232,6 @@
 		var/mob/living/simple_animal/hostile/legion/legion = child
 		legion.linked_beacon = null
 	linked_mobs -= child
-
-
-
-/**
- * Creates a warp effect on the beacon's current turf.
- */
-/obj/structure/legion/beacon/proc/effect_warp(turf/target)
-	if (!target)
-		target = get_turf(src)
-	new /obj/explosion(target)
-	playsound(src, GLOB.legion_warp_sound, 25, TRUE)
 
 
 /* Hivebot Variant */

--- a/packs/legion/legion_hivebot.dm
+++ b/packs/legion/legion_hivebot.dm
@@ -58,8 +58,10 @@
 
 /obj/spawner/legion/hivebot/Initialize(mapload, ...)
 	. = ..()
+	legion_warp_effect(get_turf(src))
 	base_hivebot = new base_hivebot(loc)
 	base_hivebot.legionify()
+	base_hivebot.visible_message(SPAN_DANGER("\A [base_hivebot] warps in!"))
 	return INITIALIZE_HINT_QDEL
 
 

--- a/packs/legion/legion_mob.dm
+++ b/packs/legion/legion_mob.dm
@@ -17,14 +17,6 @@
 	if (spawner)
 		linked_beacon = spawner
 
-	if (!mapload)
-		new /obj/explosion(loc)
-		playsound(src, GLOB.legion_warp_sound, 25, TRUE)
-		if (linked_beacon)
-			visible_message(SPAN_WARNING("\The [linked_beacon] warps \a [src] in!"))
-		else
-			visible_message(SPAN_WARNING("\A [src] warps in!"))
-
 
 /mob/living/simple_animal/hostile/legion/Destroy()
 	if (linked_beacon)

--- a/packs/legion/legion_warp_effect.dm
+++ b/packs/legion/legion_warp_effect.dm
@@ -1,0 +1,8 @@
+/**
+ * Creates a warp effect on the given target turf.
+ */
+/proc/legion_warp_effect(turf/target)
+	if (!target)
+		return
+	new /obj/explosion(target)
+	playsound(target, GLOB.legion_warp_sound, 25, TRUE)


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
admin: Individual legion can now be spawned in with the warp effect manually.
/:cl:

## Other Changes
- Legion warp effect logic moved to a global proc, away from a proc under the beacon.