### PR TITLE
Legion beacon spawn spam buffer

### DIFF
--- a/packs/legion/legion_beacon.dm
+++ b/packs/legion/legion_beacon.dm
@@ -24,7 +24,7 @@
 	var/sensor_range = 8
 
 	/// Integer. Time between mob spawns.
-	var/spawn_rate = 5 SECONDS
+	var/spawn_rate = 10 SECONDS
 
 	/// Integer. `world.time` of the last mob spawn.
 	var/last_spawn_time = 0

--- a/packs/legion/legion_beacon.dm
+++ b/packs/legion/legion_beacon.dm
@@ -88,6 +88,7 @@
 
 		if (BEACON_STATE_ON)
 			if (world.time < last_spawn_time + spawn_rate)
+				last_spawn_time = world.time
 				return
 			if (length(linked_mobs) >= max_active_bots)
 				return


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
tweak: There is now a delay between a legion dying and the legion beacon summoning a replacement.
tweak: The delay between legion beacons summoning reinforcements has been increased from 5 seconds to 10.
/:cl: