### PR TITLE
IV Bag Drip Rate Tweaks

### DIFF
--- a/code/modules/reagents/reagent_containers/ivbag.dm
+++ b/code/modules/reagents/reagent_containers/ivbag.dm
@@ -227,9 +227,20 @@
 	var/title = "[origin]"
 	if (origin != src)
 		title = "[title] - [src]"
-	var/response = input(user, "Set Drip Rate:", title) as null | anything in allowed_transfer_amounts
-	if (isnull(response) || !(response in allowed_transfer_amounts))
+	var/list/options = allowed_transfer_amounts.Copy()
+	if (user.skill_check(SKILL_MEDICAL, SKILL_EXPERIENCED))
+		options += "Custom"
+	var/response = input(user, "Set Drip Rate:", title) as null | anything in options
+	if (isnull(response))
 		return
+	if (response == "Custom")
+		response = input(user, "Set Drip Rate (Custom):", title, transfer_amount) as null | num
+		if (isnull(response))
+			return
+		response = round(response, 0.1)
+		if (response < 0 || response > 2)
+			to_chat(user, SPAN_WARNING("Selected number is out of bounds. Drip rate must be between 0 and 2, inclusive."))
+			return
 	if (!origin.Adjacent(user) || user.incapacitated())
 		to_chat(user, SPAN_WARNING("You're in no condition to do that."))
 		return

--- a/code/modules/reagents/reagent_containers/ivbag.dm
+++ b/code/modules/reagents/reagent_containers/ivbag.dm
@@ -9,7 +9,7 @@
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 
 	/// The set of options for the amount of reagents the bag will try to transfer per process.
-	var/static/list/allowed_transfer_amounts = list(2, 1, 0)
+	var/static/list/allowed_transfer_amounts = list(2, 1, 0.5, 0)
 
 	/// The configured amount of reagents the IV bag will try to transfer per process.
 	var/transfer_amount = 2


### PR DESCRIPTION
Now you can have a medicine bag set to a flow rate matching the metabolism rate for full medical min maxing.

## Changelog
:cl: SierraKomodo
tweak: IV bag drip rate options now includes 0.5.
rscadd: Characters with Experienced or higher in the Medicine skill can now select an exact flow rate for IV bags by choosing "Custom" then typing in a number from 0.0 to 2.0. Numbers are rounded to the nearest multiple of 0.1.
/:cl: