### PR TITLE
Add allergy autoinjectors to medical vendors

### DIFF
--- a/code/game/machinery/vending/medical.dm
+++ b/code/game/machinery/vending/medical.dm
@@ -34,7 +34,8 @@
 		/obj/item/stack/medical/advanced/bruise_pack = 3,
 		/obj/item/stack/medical/advanced/ointment = 3,
 		/obj/item/stack/medical/splint = 2,
-		/obj/item/reagent_containers/hypospray/autoinjector/pain = 4
+		/obj/item/reagent_containers/hypospray/autoinjector/pain = 4,
+		/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/allergy = 12
 	)
 	rare_products = list(
 		/obj/item/device/cosmetic_surgery_kit = 75,

--- a/code/game/machinery/vending/wallmed1.dm
+++ b/code/game/machinery/vending/wallmed1.dm
@@ -23,6 +23,7 @@
 		/obj/item/stack/medical/bruise_pack = 3,
 		/obj/item/stack/medical/ointment = 3,
 		/obj/item/reagent_containers/pill/paracetamol = 4,
+		/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/allergy = 3,
 		/obj/item/storage/med_pouch/trauma,
 		/obj/item/storage/med_pouch/burn,
 		/obj/item/storage/med_pouch/oxyloss,

--- a/code/game/machinery/vending/wallmed2.dm
+++ b/code/game/machinery/vending/wallmed2.dm
@@ -21,6 +21,7 @@
 	"}
 	products = list(
 		/obj/item/reagent_containers/hypospray/autoinjector/inaprovaline = 5,
+		/obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/allergy = 4,
 		/obj/item/stack/medical/bruise_pack = 4,
 		/obj/item/stack/medical/ointment = 4,
 		/obj/item/storage/med_pouch/trauma,


### PR DESCRIPTION
:cl: SierraKomodo
rscadd: NanoMed, NanoMed Mini, and NanoMed Plus vendors now carry allergy autoinjectors.
/:cl: