### PR TITLE
GAS no longer lose their voice from allergies

### DIFF
--- a/code/modules/mob/living/carbon/allergy.dm
+++ b/code/modules/mob/living/carbon/allergy.dm
@@ -99,7 +99,7 @@ Also checks if medications that stop allergies from triggering are in system. Th
 	if (trait_flags & SEVERE_ALLERGY)
 		add_chemical_effect(CE_BREATHLOSS, 2)
 		add_chemical_effect(CE_PULSE, 2)
-		if (prob(50))
+		if (prob(50) && active_breathing())
 			add_chemical_effect(CE_VOICELOSS, 1)
 
 	if (!can_feel_pain() || world.time < next_allergy_time || chem_effects[CE_STABLE])

--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -96,3 +96,9 @@
 /mob/living/carbon/proc/handle_post_breath(datum/gas_mixture/breath)
 	if(breath)
 		loc.assume_air(breath) //by default, exhale
+
+
+/// Whether or not the mob has lungs that use active breathing. Used for various effects that shouldn't occur on mobs that just don't breathe.
+/mob/living/carbon/proc/active_breathing()
+	var/obj/item/organ/internal/lungs/lungs = internal_organs_by_name[species.breathing_organ]
+	return lungs?.active_breathing


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
tweak: GAS and other mobs that don't use actively breathing lungs no longer lose their voice from allergies.
/:cl: