### PR TITLE
Research borgs get RPED

### DIFF
--- a/code/modules/mob/living/silicon/robot/modules/module_research.dm
+++ b/code/modules/mob/living/silicon/robot/modules/module_research.dm
@@ -26,7 +26,8 @@
 		/obj/item/extinguisher/mini,
 		/obj/item/reagent_containers/syringe,
 		/obj/item/gripper/chemistry,
-		/obj/item/stack/nanopaste
+		/obj/item/stack/nanopaste,
+		/obj/item/storage/part_replacer
 	)
 	synths = list(
 		/datum/matter_synth/nanite = 10000


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
tweak: Research borg modules now come with rapid part exchange devices.
/:cl: