### PR TITLE
Adds Additional Transfer Amounts to Bluespace Syringe

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -415,6 +415,7 @@
 	name = "bluespace syringe"
 	desc = "An advanced syringe that can hold 60 units of chemicals."
 	amount_per_transfer_from_this = 20
+	possible_transfer_amounts = "1;2;5;10;15;20"
 	volume = 60
 	icon_state = "bs"
 


### PR DESCRIPTION
🆑 JebediahTechnic
tweak: Adds 10u, 15u, and 20u transfer amounts to bluespace syringes. Fixes issue of not being able to transfer in 20u amounts after switching to 1u, 2u, or 5u.
/:cl: