### PR TITLE
Add single stack practice pistol magazines

### DIFF
--- a/code/modules/projectiles/ammunition/boxes.dm
+++ b/code/modules/projectiles/ammunition/boxes.dm
@@ -187,6 +187,10 @@
 	labels = list("rubber")
 	ammo_type = /obj/item/ammo_casing/pistol/rubber
 
+/obj/item/ammo_magazine/pistol/practice
+	labels = list("practice")
+	ammo_type = /obj/item/ammo_casing/pistol/practice
+
 /obj/item/ammo_magazine/pistol/double
 	name = "doublestack pistol magazine"
 	icon_state = "pistol_mag"

--- a/maps/torch/datums/supplypacks/security.dm
+++ b/maps/torch/datums/supplypacks/security.dm
@@ -130,7 +130,10 @@
 
 /singleton/hierarchy/supply_pack/security/pistolammopractice
 	name = "Ammunition - pistol practice ammo"
-	contains = list(/obj/item/ammo_magazine/pistol/double/practice = 8)
+	contains = list(
+		/obj/item/ammo_magazine/pistol/double/practice = 4,
+		/obj/item/ammo_magazine/pistol/practice = 4
+	)
 	cost = 20
 	containertype = /obj/structure/closet/crate/secure/weapon
 	containername = "pistol practice ammunition crate"


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
rscadd: Added single-stack pistol practice magazines. The practice magazine crate now contains 4 single stack and 4 double stack mags.
/:cl: