### PR TITLE
Legion hivebots are space movable and airflow immune

### DIFF
--- a/packs/legion/legion_hivebot.dm
+++ b/packs/legion/legion_hivebot.dm
@@ -49,6 +49,18 @@
 	..()
 
 
+/mob/living/simple_animal/hostile/hivebot/Process_Spacemove(allow_movement)
+	if (is_legion)
+		return !is_physically_disabled()
+	return ..()
+
+
+/mob/living/simple_animal/hostile/hivebot/AirflowCanMove(n)
+	if (is_legion)
+		return FALSE
+	return ..()
+
+
 // Legion hivebot spawners
 /obj/spawner/legion/hivebot
 	abstract_type = /obj/spawner/legion/hivebot


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
balance: Legionified hivebots are now able to move in space and are immune to airflow knockdown. These aren't your average hivebots, but you already knew that. Hopefully.
/:cl: