### PR TITLE
Organ Surgery Restyling & Documentation

### DIFF
--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -142,29 +142,31 @@
 		// place the item in the usr's hand if possible
 		usr.put_in_hands(P)
 
-/obj/item/autopsy_scanner/do_surgery(mob/living/carbon/human/M, mob/living/user)
-	if(!istype(M))
-		return 0
+/obj/item/autopsy_scanner/do_surgery(mob/living/carbon/human/target, mob/living/user)
+	if (!istype(target))
+		return FALSE
 
-	set_target(M, user)
+	set_target(target, user)
 
-	timeofdeath = M.timeofdeath
+	timeofdeath = target.timeofdeath
 
-	var/obj/item/organ/external/S = M.get_organ(user.zone_sel.selecting)
-	if(!S)
-		to_chat(usr, SPAN_WARNING("You can't scan this body part."))
-		return
-	if(!S.how_open())
-		to_chat(usr, SPAN_WARNING("You have to cut [S] open first!"))
-		return
-	M.visible_message(SPAN_NOTICE("\The [user] scans the wounds on [M]'s [S.name] with [src]"))
+	var/obj/item/organ/external/organ = target.get_organ(user.zone_sel.selecting)
+	if (!organ)
+		to_chat(usr, SPAN_WARNING("\The [src] can't scan \the [target]'s [organ.name]."))
+		return TRUE
+	if (!organ.how_open())
+		to_chat(usr, SPAN_WARNING("You have to cut \the [organ] open before you scan scan it with \the [src]."))
+		return TRUE
+	user.visible_message(
+		SPAN_NOTICE("\The [user] scans the wounds on [target]'s [organ.name] with \a [src]."),
+		SPAN_NOTICE("You scan the wounds on \the [target]'s [organ.name] with \the [src].")
+	)
 
-	add_data(S)
-	for(var/T in M.chem_doses)
-		var/datum/reagent/R = T
-		chemtraces |= initial(R.name)
+	add_data(organ)
+	for(var/datum/reagent/reagent as anything in target.chem_doses)
+		chemtraces |= initial(reagent.name)
 
-	return 1
+	return TRUE
 
 /obj/item/autopsy_scanner/proc/set_target(atom/new_target, user)
 	if(target_name != new_target.name)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -195,8 +195,8 @@
 	to_chat(user, SPAN_NOTICE("You transfer [trans] unit\s of the solution to \the [target].  \The [src] now contains [src.reagents.total_volume] units."))
 	return 1
 
-/obj/item/reagent_containers/do_surgery(mob/living/carbon/M, mob/living/user)
-	if(user.zone_sel.selecting != BP_MOUTH) //in case it is ever used as a surgery tool
+/obj/item/reagent_containers/do_surgery(mob/living/carbon/target, mob/living/user)
+	if (user.zone_sel.selecting != BP_MOUTH) //in case it is ever used as a surgery tool
 		return ..()
 
 /obj/item/reagent_containers/AltClick(mob/user)

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -32,10 +32,13 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/bone = affected.encased ? "\the [target]'s [affected.encased]" : "bones in \the [target]'s [affected.name]"
 	if (affected.stage == 0)
-		user.visible_message("\The [user] starts applying \the [tool] to [bone]." , \
-		"You start applying \the [tool] to [bone].")
-	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!",50, affecting = affected)
-	playsound(target.loc, 'sound/items/bonegel.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts applying \a [tool] to [bone]."),
+			SPAN_NOTICE("You start applying \the [tool] to [bone].")
+		)
+	target.custom_pain("Something in your [affected.name] is causing you a lot of pain!", 50, affecting = affected)
+	playsound(target, 'sound/items/bonegel.ogg', 50, TRUE)
+
 	..()
 
 /singleton/surgery_step/bone/glue/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -73,14 +76,19 @@
 /singleton/surgery_step/bone/set_bone/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/bone = affected.encased ? "\the [target]'s [affected.encased]" : "bones in \the [target]'s [affected.name]"
-	if(affected.encased == "skull")
-		user.visible_message("[user] is beginning to piece [bone] back together with \the [tool]." , \
-			"You are beginning to piece [bone] back together with \the [tool].")
+	if (affected.encased == "skull")
+		user.visible_message(
+			SPAN_NOTICE("\The [user] begins to piece [bone] back together with \a [tool]."),
+			SPAN_NOTICE("You begin to piece [bone] back together with \the [tool].")
+		)
 	else
-		user.visible_message("[user] is beginning to set [bone] in place with \the [tool]." , \
-			"You are beginning to set [bone] in place with \the [tool].")
-	target.custom_pain("The pain in your [affected.name] is going to make you pass out!",50, affecting = affected)
-	playsound(target.loc, 'sound/items/bonesetter.ogg', 50, TRUE)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] begins to set [bone] in place with \a [tool]."),
+			SPAN_NOTICE("You begin to set [bone] in place with \the [tool].")
+		)
+	target.custom_pain("The pain in your [affected.name] is going to make you pass out!", 50, affecting = affected)
+	playsound(target, 'sound/items/bonesetter.ogg', 50, TRUE)
+
 	..()
 
 /singleton/surgery_step/bone/set_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -125,9 +133,12 @@
 /singleton/surgery_step/bone/finish/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/bone = affected.encased ? "\the [target]'s damaged [affected.encased]" : "damaged bones in \the [target]'s [affected.name]"
-	user.visible_message("[user] starts to finish mending [bone] with \the [tool].", \
-	"You start to finish mending [bone] with \the [tool].")
-	playsound(target.loc, 'sound/items/bonegel.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts to finish mending [bone] with \a [tool]."),
+		SPAN_NOTICE("You start to finish mending [bone] with \the [tool].")
+	)
+	playsound(target, 'sound/items/bonegel.ogg', 50, TRUE)
+
 	..()
 
 /singleton/surgery_step/bone/finish/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -9,8 +9,9 @@
 
 /singleton/surgery_step/bone/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected && (affected.status & ORGAN_BROKEN) && affected.stage == required_stage)
-		return affected
+	if (!affected || !HAS_FLAGS(affected.status, ORGAN_BROKEN) || affected.stage != required_stage)
+		return FALSE
+	return affected
 
 //////////////////////////////////////////////////////////////////
 //	bone gelling surgery step

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -44,11 +44,13 @@
 /singleton/surgery_step/bone/glue/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/bone = affected.encased ? "\the [target]'s [affected.encased]" : "bones in \the [target]'s [affected.name]"
-	user.visible_message(SPAN_NOTICE("[user] applies some [tool.name] to [bone]"), \
-		SPAN_NOTICE("You apply some [tool.name] to [bone]."))
-	if(affected.stage == 0)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] applies some [tool.name] to [bone]"),
+		SPAN_NOTICE("You apply some [tool.name] to [bone].")
+	)
+	if (affected.stage == 0)
 		affected.stage = 1
-	affected.status &= ~ORGAN_BRITTLE
+	CLEAR_FLAGS(affected.status, ORGAN_BRITTLE)
 
 /singleton/surgery_step/bone/glue/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -94,18 +96,20 @@
 /singleton/surgery_step/bone/set_bone/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/bone = affected.encased ? "\the [target]'s [affected.encased]" : "bones in \the [target]'s [affected.name]"
-	if (affected.status & ORGAN_BROKEN)
-		if(affected.encased == "skull")
-			user.visible_message(SPAN_NOTICE("\The [user] pieces [bone] back together with \the [tool]."), \
-				SPAN_NOTICE("You piece [bone] back together with \the [tool]."))
-		else
-			user.visible_message(SPAN_NOTICE("\The [user] sets [bone] in place with \the [tool]."), \
-				SPAN_NOTICE("You set [bone] in place with \the [tool]."))
+	if (HAS_FLAGS(affected.status, ORGAN_BROKEN))
+		var/verb = affected.encased == "skull" ? "piece" : "set"
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [verb]s [bone] back together with \a [tool]."),
+			SPAN_NOTICE("You [verb] [bone] back together with \the [tool].")
+		)
 		affected.stage = 2
-	else
-		user.visible_message("[SPAN_NOTICE("\The [user] sets [bone]")] [SPAN_WARNING("in the WRONG place with \the [tool].")]", \
-			"[SPAN_NOTICE("You set [bone]")] [SPAN_WARNING("in the WRONG place with \the [tool].")]")
-		affected.fracture()
+		return
+
+	user.visible_message(
+		"[SPAN_NOTICE("\The [user] sets [bone]")] [SPAN_WARNING("in the WRONG place with \a [tool].")]",
+		"[SPAN_NOTICE("You set [bone]")] [SPAN_WARNING("in the WRONG place with \the [tool].")]"
+	)
+	affected.fracture()
 
 /singleton/surgery_step/bone/set_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -143,10 +147,12 @@
 
 /singleton/surgery_step/bone/finish/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	var/bone = affected.encased ? "\the [target]'s damaged [affected.encased]" : "damaged bones in [target]'s [affected.name]"
-	user.visible_message(SPAN_NOTICE("[user] has mended [bone] with \the [tool].")  , \
-		SPAN_NOTICE("You have mended [bone] with \the [tool].") )
-	affected.status &= ~ORGAN_BROKEN
+	var/bone = affected.encased ? "\the [target]'s damaged [affected.encased]" : "damaged bones in \the [target]'s [affected.name]"
+	user.visible_message(
+		SPAN_NOTICE("\The [user] has mended [bone] with \a [tool]."),
+		SPAN_NOTICE("You have mended [bone] with \the [tool].")
+	)
+	CLEAR_FLAGS(affected.status, ORGAN_BROKEN)
 	affected.stage = 0
 	affected.update_wounds()
 

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -54,8 +54,10 @@
 
 /singleton/surgery_step/bone/glue/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!") , \
-	SPAN_WARNING("Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!"))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, smearing \the [tool] in the incision in \the [target]'s [affected.name]!"),
+		SPAN_WARNING("Your hand slips, smearing \the [tool] in the incision in \the [target]'s [affected.name]!")
+	)
 
 
 //////////////////////////////////////////////////////////////////
@@ -113,8 +115,10 @@
 
 /singleton/surgery_step/bone/set_bone/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("\The [user]'s hand slips, damaging the [affected.encased ? affected.encased : "bones"] in \the [target]'s [affected.name] with \the [tool]!") , \
-		SPAN_WARNING("Your hand slips, damaging the [affected.encased ? affected.encased : "bones"] in \the [target]'s [affected.name] with \the [tool]!"))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, damaging the [affected.encased ? affected.encased : "bones"] in \the [target]'s [affected.name] with \the [tool]!") , \
+		SPAN_WARNING("Your hand slips, damaging the [affected.encased ? affected.encased : "bones"] in \the [target]'s [affected.name] with \the [tool]!")
+	)
 	affected.fracture()
 	affected.take_external_damage(5, used_weapon = tool)
 
@@ -158,5 +162,7 @@
 
 /singleton/surgery_step/bone/finish/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!") , \
-	SPAN_WARNING("Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!"))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, smearing \the [tool] in the incision in \the [target]'s [affected.name]!"),
+		SPAN_WARNING("Your hand slips, smearing \the [tool] in the incision in \the [target]'s [affected.name]!")
+	)

--- a/code/modules/surgery/bones.dm
+++ b/code/modules/surgery/bones.dm
@@ -21,10 +21,10 @@
 		/obj/item/bonegel = 100,
 		/obj/item/tape_roll = 75
 	)
-	can_infect = 1
-	blood_level = 1
-	min_duration = 50
-	max_duration = 60
+	can_infect = TRUE
+	blood_level = BLOOD_LEVEL_HANDS
+	min_duration = 5 SECONDS
+	max_duration = 6 SECONDS
 	shock_level = 20
 
 /singleton/surgery_step/bone/glue/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -62,10 +62,10 @@
 		/obj/item/swapper/power_drill = 100,
 		/obj/item/wrench = 75
 	)
-	min_duration = 60
-	max_duration = 70
+	min_duration = 6 SECONDS
+	max_duration = 7 SECONDS
 	shock_level = 40
-	delicate = 1
+	delicate = TRUE
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NEEDS_ENCASEMENT
 	required_stage = 1
 
@@ -114,10 +114,10 @@
 		/obj/item/bonegel = 100,
 		/obj/item/tape_roll = 75
 	)
-	can_infect = 1
-	blood_level = 1
-	min_duration = 50
-	max_duration = 60
+	can_infect = TRUE
+	blood_level = BLOOD_LEVEL_HANDS
+	min_duration = 5 SECONDS
+	max_duration = 6 SECONDS
 	shock_level = 20
 	required_stage = 2
 

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -23,8 +23,9 @@
 
 /singleton/surgery_step/open_encased/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected && affected.encased)
-		return affected
+	if (!affected?.encased)
+		return FALSE
+	return affected
 
 /singleton/surgery_step/open_encased/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -29,10 +29,12 @@
 
 /singleton/surgery_step/open_encased/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] begins to cut through [target]'s [affected.encased] with \the [tool].", \
-	"You begin to cut through [target]'s [affected.encased] with \the [tool].")
-	target.custom_pain("Something hurts horribly in your [affected.name]!",60, affecting = affected)
-	playsound(target.loc, 'sound/items/circularsaw.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] begins to cut through [target]'s [affected.encased] with \a [tool]."),
+		SPAN_NOTICE("You begin to cut through [target]'s [affected.encased] with \the [tool].")
+	)
+	target.custom_pain("Something hurts horribly in your [affected.name]!", 60, affecting = affected)
+	playsound(target, 'sound/items/circularsaw.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/open_encased/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -39,8 +39,10 @@
 
 /singleton/surgery_step/open_encased/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] has cut [target]'s [affected.encased] open with \the [tool]."),		\
-	SPAN_NOTICE("You have cut [target]'s [affected.encased] open with \the [tool]."))
+	user.visible_message(
+		SPAN_NOTICE("\The [user] has cut \the [target]'s [affected.encased] open with \a [tool]."),
+		SPAN_NOTICE("You have cut \the [target]'s [affected.encased] open with \the [tool].")
+	)
 	affected.fracture()
 
 /singleton/surgery_step/open_encased/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -47,7 +47,9 @@
 
 /singleton/surgery_step/open_encased/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, cracking [target]'s [affected.encased] with \the [tool]!") , \
-	SPAN_WARNING("Your hand slips, cracking [target]'s [affected.encased] with \the [tool]!") )
-	affected.take_external_damage(15, 0, (DAMAGE_FLAG_SHARP|DAMAGE_FLAG_EDGE), used_weapon = tool)
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, cracking \the [target]'s [affected.encased] with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, cracking \the [target]'s [affected.encased] with \the [tool]!")
+	)
+	affected.take_external_damage(15, 0, DAMAGE_FLAG_SHARP | DAMAGE_FLAG_EDGE, tool)
 	affected.fracture()

--- a/code/modules/surgery/encased.dm
+++ b/code/modules/surgery/encased.dm
@@ -13,14 +13,13 @@
 		/obj/item/material/knife = 50,
 		/obj/item/material/hatchet = 75
 	)
-	can_infect = 1
-	blood_level = 1
-	min_duration = 50
-	max_duration = 70
+	can_infect = TRUE
+	blood_level = BLOOD_LEVEL_HANDS
+	min_duration = 5 SECONDS
+	max_duration = 7 SECONDS
 	shock_level = 60
-	delicate = 1
+	delicate = TRUE
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_CRYSTAL | SURGERY_NO_STUMP | SURGERY_NEEDS_RETRACTED
-	strict_access_requirement = TRUE
 
 /singleton/surgery_step/open_encased/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -32,11 +32,14 @@
 	..()
 
 /singleton/surgery_step/fix_face/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message(SPAN_NOTICE("[user] repairs \the [target]'s face with \the [tool]."),	\
-	SPAN_NOTICE("You repair \the [target]'s face with \the [tool]."))
-	var/obj/item/organ/external/head/h = target.get_organ(target_zone)
-	if(h)
-		h.status &= ~ORGAN_DISFIGURED
+	user.visible_message(
+		SPAN_NOTICE("\The [user] repairs \the [target]'s face with \a [tool]."),
+		SPAN_NOTICE("You repair \the [target]'s face with \the [tool].")
+	)
+	var/obj/item/organ/external/head/head = target.get_organ(target_zone)
+	if (!head)
+		return
+	CLEAR_FLAGS(head.status, ORGAN_DISFIGURED)
 
 /singleton/surgery_step/fix_face/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -86,7 +89,7 @@
 
 /singleton/surgery_step/plastic_surgery/prepare_face/end_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message(
-		SPAN_NOTICE("\The [user] finishes peeling back the skin around \the [target]'s face with \the [tool]."),
+		SPAN_NOTICE("\The [user] finishes peeling back the skin around \the [target]'s face with \a [tool]."),
 		SPAN_NOTICE("You finish peeling back the skin around \the [target]'s face with \the [tool].")
 	)
 
@@ -122,27 +125,27 @@
 
 /singleton/surgery_step/plastic_surgery/reform_face/end_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message(
-		SPAN_NOTICE("\The [user] finishes molding \the [target]'s face with \the [tool]."),
+		SPAN_NOTICE("\The [user] finishes molding \the [target]'s face with \a [tool]."),
 		SPAN_NOTICE("You finish molding \the [target]'s face with \the [tool].")
 	)
-	if(!target.fake_name)
+	if (!target.fake_name)
 		var/new_name = sanitizeSafe(input(user, "Select a new name for \the [target].") as text|null, MAX_NAME_LEN)
-		if(new_name && user.Adjacent(target))
-			user.visible_message(
-				SPAN_NOTICE("\The [user] molds \the [target]'s face into the spitting image of [new_name]!"),
-				SPAN_NOTICE("You mold \the [target]'s face into the spitting image of [new_name]!")
-			)
-			target.fake_name=new_name
-			target.name=new_name
-
-	else
-		target.fake_name=null
+		if (!new_name || !user.use_sanity_check(target, tool))
+			return
 		user.visible_message(
-			SPAN_NOTICE("\The [user] returns \the [target]'s face back to normal!"),
-			SPAN_NOTICE("You return \the [target]'s face back to normal!")
+			SPAN_NOTICE("\The [user] molds \the [target]'s face into the spitting image of [new_name] with \a [tool]!"),
+			SPAN_NOTICE("You mold \the [target]'s face into the spitting image of [new_name] with \the [tool]!")
+		)
+		target.fake_name = new_name
+		target.name = new_name
+	else
+		target.fake_name = null
+		user.visible_message(
+			SPAN_NOTICE("\The [user] returns \the [target]'s face back to normal with \a [tool]!"),
+			SPAN_NOTICE("You return \the [target]'s face back to normal with \the [tool]!")
 		)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	affected.stage=0
+	affected.stage = 0
 
 /singleton/surgery_step/plastic_surgery/reform_face/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -43,9 +43,11 @@
 
 /singleton/surgery_step/fix_face/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, tearing skin on [target]'s face with \the [tool]!"), \
-	SPAN_WARNING("Your hand slips, tearing skin on [target]'s face with \the [tool]!"))
-	affected.take_external_damage(10, 0, (DAMAGE_FLAG_SHARP|DAMAGE_FLAG_EDGE), used_weapon = tool)
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, tearing skin on \the [target]'s face with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, tearing skin on \the [target]'s face with \the [tool]!")
+	)
+	affected.take_external_damage(10, 0, DAMAGE_FLAG_SHARP | DAMAGE_FLAG_EDGE, tool)
 
 //////////////////////////////////////////////////////////////////
 //	Plastic Surgery
@@ -99,7 +101,7 @@
 		SPAN_WARNING("\The [user]'s hand slips, tearing skin on \the [target]'s face with \the [tool]!"),
 		SPAN_WARNING("Your hand slips, tearing skin on \the [target]'s face with \the [tool]!")
 	)
-	affected.take_external_damage(10, 0, (DAMAGE_FLAG_SHARP|DAMAGE_FLAG_EDGE), used_weapon = tool)
+	affected.take_external_damage(10, 0, DAMAGE_FLAG_SHARP | DAMAGE_FLAG_EDGE, tool)
 
 /singleton/surgery_step/plastic_surgery/reform_face
 	name = "Reform Face"
@@ -153,7 +155,7 @@
 		SPAN_WARNING("\The [user]'s hand slips, tearing skin on \the [target]'s face with \the [tool]!"),
 		SPAN_WARNING("Your hand slips, tearing skin on \the [target]'s face with \the [tool]!")
 	)
-	var/obj/item/organ/external/head/h = target.get_organ(target_zone)
-	affected.take_external_damage(10, 0, (DAMAGE_FLAG_SHARP|DAMAGE_FLAG_EDGE), used_weapon = tool)
-	if(h)
-		h.status &= ~ORGAN_DISFIGURED
+	var/obj/item/organ/external/head/head = target.get_organ(target_zone)
+	affected.take_external_damage(10, 0, DAMAGE_FLAG_SHARP | DAMAGE_FLAG_EDGE, tool)
+	if (head)
+		CLEAR_FLAGS(head.status, ORGAN_DISFIGURED)

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -9,10 +9,9 @@
 		/obj/item/device/assembly/mousetrap = 10,
 		/obj/item/material/utensil/fork = 75
 	)
-	min_duration = 100
-	max_duration = 120
+	min_duration = 10 SECONDS
+	max_duration = 12 SECONDS
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_CRYSTAL | SURGERY_NEEDS_RETRACTED
-	strict_access_requirement = TRUE
 
 /singleton/surgery_step/fix_face/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(target_zone == BP_HEAD)
@@ -45,7 +44,6 @@
 
 /singleton/surgery_step/plastic_surgery
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_CRYSTAL | SURGERY_NEEDS_RETRACTED
-	strict_access_requirement = TRUE
 	var/required_stage = 0
 
 /singleton/surgery_step/plastic_surgery/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -60,9 +58,9 @@
 		/obj/item/scalpel = 100,
 		/obj/item/material/shard = 50
 	)
-	min_duration = 100
-	max_duration = 120
-	can_infect = 1
+	min_duration = 10 SECONDS
+	max_duration = 12 SECONDS
+	can_infect = TRUE
 	shock_level = 20
 
 /singleton/surgery_step/plastic_surgery/prepare_face/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -98,9 +96,9 @@
 		/obj/item/device/assembly/mousetrap = 10,
 		/obj/item/material/utensil/fork = 75
 	)
-	min_duration = 100
-	max_duration = 120
-	can_infect = 1
+	min_duration = 10 SECONDS
+	max_duration = 12 SECONDS
+	can_infect = TRUE
 	shock_level = 20
 	required_stage = 1
 

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -14,10 +14,14 @@
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_CRYSTAL | SURGERY_NEEDS_RETRACTED
 
 /singleton/surgery_step/fix_face/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if(target_zone == BP_HEAD)
-		var/obj/item/organ/external/affected = ..()
-		if(affected && (affected.status & ORGAN_DISFIGURED))
-			return affected
+	if (target_zone != BP_HEAD)
+		return FALSE
+	var/obj/item/organ/external/affected = ..()
+	if (!affected)
+		return FALSE
+	if (!HAS_FLAGS(affected.status, ORGAN_DISFIGURED))
+		return FALSE
+	return affected
 
 /singleton/surgery_step/fix_face/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message("[user] starts repairing damage to \the [target]'s face with \the [tool].", \
@@ -47,10 +51,14 @@
 	var/required_stage = 0
 
 /singleton/surgery_step/plastic_surgery/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if(target_zone == BP_HEAD)
-		var/obj/item/organ/external/affected = ..()
-		if(affected && affected.stage == required_stage)
-			return affected
+	if (target_zone != BP_HEAD)
+		return FALSE
+	var/obj/item/organ/external/affected = ..()
+	if (!affected)
+		return FALSE
+	if (affected.stage != required_stage)
+		return FALSE
+	return affected
 
 /singleton/surgery_step/plastic_surgery/prepare_face
 	name = "Prepare Face"

--- a/code/modules/surgery/face.dm
+++ b/code/modules/surgery/face.dm
@@ -24,9 +24,11 @@
 	return affected
 
 /singleton/surgery_step/fix_face/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message("[user] starts repairing damage to \the [target]'s face with \the [tool].", \
-	"You start repairing damage to \the [target]'s face with \the [tool].")
-	playsound(target.loc, 'sound/items/hemostat.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts repairing damage to \the [target]'s face with \a [tool]."),
+		SPAN_NOTICE("You start repairing damage to \the [target]'s face with \the [tool].")
+	)
+	playsound(target, 'sound/items/hemostat.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/fix_face/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -73,13 +75,13 @@
 
 /singleton/surgery_step/plastic_surgery/prepare_face/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message(
-		SPAN_NOTICE("\The [user] starts peeling back the skin around \the [target]'s face with \the [tool]."),
+		SPAN_NOTICE("\The [user] starts peeling back the skin around \the [target]'s face with \a [tool]."),
 		SPAN_NOTICE("You start peeling back the skin around \the [target]'s face with \the [tool].")
 	)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(affected.stage == 0)
+	if (affected.stage == 0)
 		affected.stage = 1
-	playsound(target.loc, 'sound/items/scalpel.ogg', 50, TRUE)
+	playsound(target, 'sound/items/scalpel.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/plastic_surgery/prepare_face/end_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -112,10 +114,10 @@
 
 /singleton/surgery_step/plastic_surgery/reform_face/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message(
-		SPAN_NOTICE("\The [user] starts molding \the [target]'s face with \the [tool]."),
+		SPAN_NOTICE("\The [user] starts molding \the [target]'s face with \a [tool]."),
 		SPAN_NOTICE("You start molding \the [target]'s face with \the [tool].")
 	)
-	playsound(target.loc, 'sound/items/hemostat.ogg', 50, TRUE)
+	playsound(target, 'sound/items/hemostat.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/plastic_surgery/reform_face/end_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -60,9 +60,11 @@
 
 /singleton/surgery_step/generic/cut_with_laser/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips as the blade sputters, searing a long gash in [target]'s [affected.name] with \the [tool]!"), \
-	SPAN_WARNING("Your hand slips as the blade sputters, searing a long gash in [target]'s [affected.name] with \the [tool]!"))
-	affected.take_external_damage(15, 5, (DAMAGE_FLAG_SHARP|DAMAGE_FLAG_EDGE), used_weapon = tool)
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips as the blade sputters, searing a long gash in \the [target]'s [affected.name] with \the [tool]!"),
+		SPAN_WARNING("Your hand slips as the blade sputters, searing a long gash in \the [target]'s [affected.name] with \the [tool]!")
+	)
+	affected.take_external_damage(15, 5, DAMAGE_FLAG_SHARP | DAMAGE_FLAG_EDGE, tool)
 
 //////////////////////////////////////////////////////////////////
 //	laser scalpel surgery step
@@ -106,9 +108,11 @@
 
 /singleton/surgery_step/generic/managed/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand jolts as the system sparks, ripping a gruesome hole in [target]'s [affected.name] with \the [tool]!"), \
-	SPAN_WARNING("Your hand jolts as the system sparks, ripping a gruesome hole in [target]'s [affected.name] with \the [tool]!"))
-	affected.take_external_damage(20, 15, (DAMAGE_FLAG_SHARP|DAMAGE_FLAG_EDGE), used_weapon = tool)
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand jolts as the system sparks, ripping a gruesome hole in \the [target]'s [affected.name] with \the [tool]!"), \
+		SPAN_WARNING("Your hand jolts as the system sparks, ripping a gruesome hole in \the [target]'s [affected.name] with \the [tool]!")
+	)
+	affected.take_external_damage(20, 15, DAMAGE_FLAG_SHARP | DAMAGE_FLAG_EDGE, tool)
 
 //////////////////////////////////////////////////////////////////
 //	 scalpel surgery step
@@ -155,9 +159,11 @@
 
 /singleton/surgery_step/generic/cut_open/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, [fail_string] \the [target]'s [affected.name] in the wrong place with \the [tool]!"), \
-	SPAN_WARNING("Your hand slips, [fail_string] \the [target]'s [affected.name] in the wrong place with \the [tool]!"))
-	affected.take_external_damage(10, 0, (DAMAGE_FLAG_SHARP|DAMAGE_FLAG_EDGE), used_weapon = tool)
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, [fail_string] \the [target]'s [affected.name] in the wrong place with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, [fail_string] \the [target]'s [affected.name] in the wrong place with \the [tool]!")
+	)
+	affected.take_external_damage(10, 0, DAMAGE_FLAG_SHARP | DAMAGE_FLAG_EDGE, tool)
 
 /singleton/surgery_step/generic/cut_open/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	. = ..()
@@ -207,9 +213,11 @@
 
 /singleton/surgery_step/generic/clamp_bleeders/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, tearing blood vessals and causing massive bleeding in [target]'s [affected.name] with \the [tool]!"),	\
-	SPAN_WARNING("Your hand slips, tearing blood vessels and causing massive bleeding in [target]'s [affected.name] with \the [tool]!"),)
-	affected.take_external_damage(10, 0, (DAMAGE_FLAG_SHARP|DAMAGE_FLAG_EDGE), used_weapon = tool)
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, tearing blood vessals and causing massive bleeding in \the [target]'s [affected.name] with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, tearing blood vessels and causing massive bleeding in \the [target]'s [affected.name] with \the [tool]!")
+	)
+	affected.take_external_damage(10, 0, DAMAGE_FLAG_SHARP | DAMAGE_FLAG_EDGE, tool)
 
 //////////////////////////////////////////////////////////////////
 //	 retractor surgery step
@@ -261,9 +269,11 @@
 
 /singleton/surgery_step/generic/retract_skin/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, tearing the edges of the incision on [target]'s [affected.name] with \the [tool]!"),	\
-	SPAN_WARNING("Your hand slips, tearing the edges of the incision on [target]'s [affected.name] with \the [tool]!"))
-	affected.take_external_damage(12, 0, (DAMAGE_FLAG_SHARP|DAMAGE_FLAG_EDGE), used_weapon = tool)
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, tearing the edges of the incision on \the [target]'s [affected.name] with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, tearing the edges of the incision on \the [target]'s [affected.name] with \the [tool]!")
+	)
+	affected.take_external_damage(12, 0, DAMAGE_FLAG_SHARP | DAMAGE_FLAG_EDGE, tool)
 
 //////////////////////////////////////////////////////////////////
 //	 skin cauterization surgery step
@@ -344,8 +354,10 @@
 
 /singleton/surgery_step/generic/cauterize/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, damaging [target]'s [affected.name] with \the [tool]!"), \
-	SPAN_WARNING("Your hand slips, damaging [target]'s [affected.name] with \the [tool]!"))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, damaging \the [target]'s [affected.name] with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, damaging \the [target]'s [affected.name] with \the [tool]!")
+	)
 	affected.take_external_damage(0, 3, used_weapon = tool)
 
 //////////////////////////////////////////////////////////////////
@@ -396,7 +408,9 @@
 
 /singleton/surgery_step/generic/amputate/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, sawing through the bone in [target]'s [affected.name] with \the [tool]!"), \
-	SPAN_WARNING("Your hand slips, sawwing through the bone in [target]'s [affected.name] with \the [tool]!"))
-	affected.take_external_damage(30, 0, (DAMAGE_FLAG_SHARP|DAMAGE_FLAG_EDGE), used_weapon = tool)
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, sawing through the bone in \the [target]'s [affected.name] with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, sawwing through the bone in \the [target]'s [affected.name] with \the [tool]!")
+	)
+	affected.take_external_damage(30, 0, DAMAGE_FLAG_SHARP | DAMAGE_FLAG_EDGE, tool)
 	affected.fracture()

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -50,9 +50,11 @@
 
 /singleton/surgery_step/generic/cut_with_laser/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] has made a bloodless incision on [target]'s [affected.name] with \the [tool]."), \
-	SPAN_NOTICE("You have made a bloodless incision on [target]'s [affected.name] with \the [tool]."),)
-	affected.createwound(INJURY_TYPE_CUT, affected.min_broken_damage/2, 1)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] has made a bloodless incision on \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You have made a bloodless incision on \the [target]'s [affected.name] with \the [tool].")
+	)
+	affected.createwound(INJURY_TYPE_CUT, affected.min_broken_damage / 2, 1)
 	affected.clamp_organ()
 	spread_germs_to_organ(affected, user)
 
@@ -94,8 +96,10 @@
 
 /singleton/surgery_step/generic/managed/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] has constructed a prepared incision on and within [target]'s [affected.name] with \the [tool]."), \
-	SPAN_NOTICE("You have constructed a prepared incision on and within [target]'s [affected.name] with \the [tool]."),)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] has constructed a prepared incision on and within \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You have constructed a prepared incision on and within \the [target]'s [affected.name] with \the [tool].")
+	)
 	affected.createwound(INJURY_TYPE_CUT, affected.min_broken_damage/2, 1) // incision
 	affected.clamp_organ() // clamp
 	affected.open_incision() // retract
@@ -142,10 +146,12 @@
 
 /singleton/surgery_step/generic/cut_open/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] has made [access_string] on [target]'s [affected.name] with \the [tool]."), \
-	SPAN_NOTICE("You have made [access_string] on [target]'s [affected.name] with \the [tool]."),)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] has made [access_string] on \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You have made [access_string] on \the [target]'s [affected.name] with \the [tool].")
+	)
 	affected.createwound(INJURY_TYPE_CUT, affected.min_broken_damage/2, 1)
-	playsound(target.loc, 'sound/weapons/bladeslice.ogg', 15, 1)
+	playsound(target, 'sound/weapons/bladeslice.ogg', 15, TRUE)
 
 /singleton/surgery_step/generic/cut_open/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -191,11 +197,13 @@
 
 /singleton/surgery_step/generic/clamp_bleeders/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] clamps bleeders in [target]'s [affected.name] with \the [tool]."),	\
-	SPAN_NOTICE("You clamp bleeders in [target]'s [affected.name] with \the [tool]."))
+	user.visible_message(
+		SPAN_NOTICE("\The [user] clamps bleeders in \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You clamp bleeders in \the [target]'s [affected.name] with \the [tool].")
+	)
 	affected.clamp_organ()
 	spread_germs_to_organ(affected, user)
-	playsound(target.loc, 'sound/items/Welder.ogg', 15, 1)
+	playsound(target, 'sound/items/Welder.ogg', 15, TRUE)
 
 /singleton/surgery_step/generic/clamp_bleeders/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -245,8 +253,10 @@
 
 /singleton/surgery_step/generic/retract_skin/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] keeps the incision open on [target]'s [affected.name] with \the [tool]."),	\
-	SPAN_NOTICE("You keep the incision open on [target]'s [affected.name] with \the [tool]."))
+	user.visible_message(
+		SPAN_NOTICE("\The [user] keeps the incision open on \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You keep the incision open on \the [target]'s [affected.name] with \the [tool].")
+	)
 	affected.open_incision()
 
 /singleton/surgery_step/generic/retract_skin/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -319,15 +329,17 @@
 
 /singleton/surgery_step/generic/cauterize/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	var/datum/wound/W = affected.get_incision()
-	user.visible_message(SPAN_NOTICE("[user] [post_cauterize_term][W ? " \a [W.desc] on" : ""] \the [target]'s [affected.name] with \the [tool]."), \
-	SPAN_NOTICE("You [cauterize_term][W ? " \a [W.desc] on" : ""] \the [target]'s [affected.name] with \the [tool]."))
-	if(istype(W))
-		W.close()
+	var/datum/wound/wound = affected.get_incision()
+	user.visible_message(
+		SPAN_NOTICE("\The [user] [post_cauterize_term][wound ? " \a [wound.desc] on" : ""] \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You [cauterize_term][wound ? " \a [wound.desc] on" : ""] \the [target]'s [affected.name] with \the [tool].")
+	)
+	if (istype(wound))
+		wound.close()
 		affected.update_wounds()
-	if(affected.is_stump())
-		affected.status &= ~ORGAN_ARTERY_CUT
-	if(affected.clamped())
+	if (affected.is_stump())
+		CLEAR_FLAGS(affected.status, ORGAN_ARTERY_CUT)
+	if (affected.clamped())
 		affected.remove_clamps()
 
 /singleton/surgery_step/generic/cauterize/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -376,9 +388,11 @@
 
 /singleton/surgery_step/generic/amputate/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] amputates [target]'s [affected.name] at the [affected.amputation_point] with \the [tool]."), \
-	SPAN_NOTICE("You amputate [target]'s [affected.name] with \the [tool]."))
-	affected.droplimb(1,DROPLIMB_EDGE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] amputates \the [target]'s [affected.name] at the [affected.amputation_point] with \a [tool]."),
+		SPAN_NOTICE("You amputate \the [target]'s [affected.name] with \the [tool].")
+	)
+	affected.droplimb(1, DROPLIMB_EDGE)
 
 /singleton/surgery_step/generic/amputate/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -235,10 +235,12 @@
 
 /singleton/surgery_step/generic/retract_skin/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] starts to pry open the incision on [target]'s [affected.name] with \the [tool].",	\
-	"You start to pry open the incision on [target]'s [affected.name] with \the [tool].")
-	target.custom_pain("It feels like the skin on your [affected.name] is on fire!",40,affecting = affected)
-	playsound(target.loc, 'sound/items/retractor.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts to pry open the incision on \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You start to pry open the incision on \the [target]'s [affected.name] with \the [tool].")
+	)
+	target.custom_pain("It feels like the skin on your [affected.name] is on fire!", 40, affecting = affected)
+	playsound(target, 'sound/items/retractor.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/generic/retract_skin/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -307,10 +309,12 @@
 /singleton/surgery_step/generic/cauterize/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/datum/wound/W = affected.get_incision()
-	user.visible_message("[user] is beginning to [cauterize_term][W ? " \a [W.desc] on" : ""] \the [target]'s [affected.name] with \the [tool]." , \
-	"You are beginning to [cauterize_term][W ? " \a [W.desc] on" : ""] \the [target]'s [affected.name] with \the [tool].")
-	target.custom_pain("Your [affected.name] is being burned!",40,affecting = affected)
-	playsound(target.loc, 'sound/items/cautery.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts to [cauterize_term][W ? " \a [W.desc] on" : ""] \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You start to [cauterize_term][W ? " \a [W.desc] on" : ""] \the [target]'s [affected.name] with \the [tool].")
+	)
+	target.custom_pain("Your [affected.name] is being burned!", 40, affecting = affected)
+	playsound(target, 'sound/items/cautery.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/generic/cauterize/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -362,10 +366,12 @@
 
 /singleton/surgery_step/generic/amputate/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] is beginning to amputate [target]'s [affected.name] with \the [tool]." , \
-	FONT_LARGE("You are beginning to cut through [target]'s [affected.amputation_point] with \the [tool]."))
-	target.custom_pain("Your [affected.amputation_point] is being ripped apart!",100,affecting = affected)
-	playsound(target.loc, 'sound/items/amputation.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_DANGER("\The [user] starts to amputate \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_DANGER(FONT_LARGE("You start to cut through \the [target]'s [affected.amputation_point] with \the [tool]."))
+	)
+	target.custom_pain("Your [affected.amputation_point] is being ripped apart!", 100, affecting = affected)
+	playsound(target, 'sound/items/amputation.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/generic/amputate/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -339,13 +339,13 @@
 	if(affected && (affected.limb_flags & ORGAN_FLAG_CAN_AMPUTATE) && !affected.how_open())
 		return affected
 
-/singleton/surgery_step/generic/amputate/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
-	var/target_zone = user.zone_sel.selecting
+
+/singleton/surgery_step/generic/amputate/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(BP_IS_ROBOTIC(affected))
+	if (BP_IS_ROBOTIC(affected))
 		return SURGERY_SKILLS_ROBOTIC
-	else
-		return ..()
+	return ..()
+
 
 /singleton/surgery_step/generic/amputate/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/generic.dm
+++ b/code/modules/surgery/generic.dm
@@ -8,7 +8,7 @@
 //	generic surgery step datum
 //////////////////////////////////////////////////////////////////
 /singleton/surgery_step/generic
-	can_infect = 1
+	can_infect = TRUE
 	shock_level = 10
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_CRYSTAL | SURGERY_NO_STUMP
 
@@ -26,8 +26,8 @@
 		/obj/item/scalpel/laser = 100,
 		/obj/item/melee/energy/sword = 5
 	)
-	min_duration = 90
-	max_duration = 110
+	min_duration = 9 SECONDS
+	max_duration = 11 SECONDS
 
 /singleton/surgery_step/generic/cut_with_laser/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	. = ..()
@@ -69,8 +69,8 @@
 	allowed_tools = list(
 		/obj/item/scalpel/ims = 100
 	)
-	min_duration = 80
-	max_duration = 120
+	min_duration = 8 SECONDS
+	max_duration = 12 SECONDS
 
 /singleton/surgery_step/generic/managed/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	. = ..()
@@ -114,8 +114,8 @@
 		/obj/item/broken_bottle = 50,
 		/obj/item/material/shard = 50
 	)
-	min_duration = 90
-	max_duration = 110
+	min_duration = 9 SECONDS
+	max_duration = 11 SECONDS
 	var/fail_string = "slicing open"
 	var/access_string = "an incision"
 
@@ -166,8 +166,8 @@
 		/obj/item/stack/cable_coil = 75,
 		/obj/item/device/assembly/mousetrap = 20
 	)
-	min_duration = 40
-	max_duration = 60
+	min_duration = 4 SECONDS
+	max_duration = 6 SECONDS
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_CRYSTAL | SURGERY_NO_STUMP | SURGERY_NEEDS_INCISION
 	strict_access_requirement = FALSE
 
@@ -210,10 +210,9 @@
 		/obj/item/material/knife = 50,
 		/obj/item/material/utensil/fork = 50
 	)
-	min_duration = 30
-	max_duration = 40
+	min_duration = 3 SECONDS
+	max_duration = 4 SECONDS
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_CRYSTAL | SURGERY_NO_STUMP | SURGERY_NEEDS_INCISION
-	strict_access_requirement = TRUE
 
 /singleton/surgery_step/generic/retract_skin/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	. = FALSE
@@ -256,8 +255,8 @@
 		/obj/item/flame/lighter = 50,
 		/obj/item/weldingtool = 25
 	)
-	min_duration = 70
-	max_duration = 100
+	min_duration = 7 SECONDS
+	max_duration = 10 SECONDS
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_CRYSTAL
 	var/cauterize_term = "cauterize"
 	var/post_cauterize_term = "cauterized"
@@ -322,9 +321,9 @@
 		/obj/item/circular_saw = 100,
 		/obj/item/material/hatchet = 75
 	)
-	min_duration = 110
-	max_duration = 160
-	surgery_candidate_flags = 0
+	min_duration = 11 SECONDS
+	max_duration = 16 SECONDS
+	surgery_candidate_flags = EMPTY_BITFIELD
 
 /singleton/surgery_step/generic/amputate/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -14,9 +14,11 @@
 
 /singleton/surgery_step/cavity/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, scraping around inside [target]'s [affected.name] with \the [tool]!"), \
-	SPAN_WARNING("Your hand slips, scraping around inside [target]'s [affected.name] with \the [tool]!"))
-	affected.take_external_damage(20, 0, (DAMAGE_FLAG_SHARP|DAMAGE_FLAG_EDGE), used_weapon = tool)
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, scraping around inside \the [target]'s [affected.name] with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, scraping around inside \the [target]'s [affected.name] with \the [tool]!")
+	)
+	affected.take_external_damage(20, 0, DAMAGE_FLAG_SHARP | DAMAGE_FLAG_EDGE, tool)
 
 //////////////////////////////////////////////////////////////////
 //	 create implant space surgery step
@@ -243,11 +245,14 @@
 /singleton/surgery_step/cavity/implant_removal/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	..()
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	for(var/obj/item/implant/imp in affected.implants)
+	for (var/obj/item/implant/implant in affected.implants)
 		var/fail_prob = 10
 		fail_prob += 100 - tool_quality(tool)
-		if (prob(fail_prob))
-			user.visible_message(SPAN_WARNING("Something beeps inside [target]'s [affected.name]!"))
-			playsound(imp.loc, 'sound/items/countdown.ogg', 75, 1, -3)
-			spawn(25)
-				imp.activate()
+		if (!prob(fail_prob))
+			continue
+		target.visible_message(
+			SPAN_DANGER("Something beeps inside \the [target]'s [affected.name]!"),
+			SPAN_DANGER("Something beeps inside your [affected.name]!")
+		)
+		playsound(target, 'sound/items/countdown.ogg', 75, TRUE, -3)
+		addtimer(new Callback(implant, /obj/item/implant/proc/activate), 2.5 SECONDS, TIMER_UNIQUE)

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -104,9 +104,10 @@
 	max_duration = 10 SECONDS
 
 /singleton/surgery_step/cavity/place_item/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if(istype(user,/mob/living/silicon/robot))
+	if (istype(user, /mob/living/silicon/robot))
 		return FALSE
-	. = ..()
+
+	return ..()
 
 /singleton/surgery_step/cavity/place_item/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -103,22 +103,28 @@
 	if(affected && affected.cavity)
 		return affected
 
+
 /singleton/surgery_step/cavity/place_item/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(affected && affected.cavity)
-		var/max_volume = BASE_STORAGE_CAPACITY(affected.cavity_max_w_class)
-		if(tool.w_class > affected.cavity_max_w_class)
-			to_chat(user, SPAN_WARNING("\The [tool] is too big for [affected.cavity_name] cavity."))
-			return FALSE
-		var/total_volume = tool.get_storage_cost()
-		for(var/obj/item/I in affected.implants)
-			if(istype(I,/obj/item/implant))
-				continue
-			total_volume += I.get_storage_cost()
-		if(total_volume > max_volume)
-			to_chat(user, SPAN_WARNING("There isn't enough space left in [affected.cavity_name] cavity for [tool]."))
-			return FALSE
-		return TRUE
+	if (!affected?.cavity)
+		return FALSE
+
+	var/max_volume = BASE_STORAGE_CAPACITY(affected.cavity_max_w_class)
+	if (tool.w_class > affected.cavity_max_w_class)
+		USE_FEEDBACK_FAILURE("\The [tool] is too big for \the [target]'s [affected.cavity_name] cavity.")
+		return FALSE
+
+	var/total_volume = tool.get_storage_cost()
+	for (var/obj/item/item as anything in affected.implants)
+		if (istype(item, /obj/item/implant))
+			continue
+		total_volume += item.get_storage_cost()
+	if (total_volume > max_volume)
+		USE_FEEDBACK_FAILURE("There isn't enough space left in \the [target]'s [affected.cavity_name] cavity for \the [tool].")
+		return FALSE
+
+	return TRUE
+
 
 /singleton/surgery_step/cavity/place_item/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -40,11 +40,13 @@
 
 /singleton/surgery_step/cavity/make_space/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] starts making some space inside [target]'s [affected.cavity_name] cavity with \the [tool].", \
-	"You start making some space inside [target]'s [affected.cavity_name] cavity with \the [tool]." )
-	target.custom_pain("The pain in your chest is living hell!",1,affecting = affected)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts making some space inside \the [target]'s [affected.cavity_name] cavity with \a [tool]."),
+		SPAN_NOTICE("You start making some space inside \the [target]'s [affected.cavity_name] cavity with \the [tool].")
+	)
+	target.custom_pain("The pain in your chest is living hell!", 1, affecting = affected)
 	affected.cavity = TRUE
-	playsound(target.loc, 'sound/items/surgicaldrill.ogg', 50, TRUE)
+	playsound(target, 'sound/items/surgicaldrill.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/cavity/make_space/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -74,10 +76,12 @@
 
 /singleton/surgery_step/cavity/close_space/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] starts mending [target]'s [affected.cavity_name] cavity wall with \the [tool].", \
-	"You start mending [target]'s [affected.cavity_name] cavity wall with \the [tool]." )
-	target.custom_pain("The pain in your chest is living hell!",1,affecting = affected)
-	playsound(target.loc, 'sound/items/cautery.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts mending \the [target]'s [affected.cavity_name] cavity wall with \a [tool]."),
+		SPAN_NOTICE("You start mending \the [target]'s [affected.cavity_name] cavity wall with \the [tool].")
+	)
+	target.custom_pain("The pain in your chest is living hell!", 1, affecting = affected)
+	playsound(target, 'sound/items/cautery.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/cavity/close_space/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -131,10 +135,12 @@
 
 /singleton/surgery_step/cavity/place_item/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] starts putting \the [tool] inside [target]'s [affected.cavity_name] cavity.", \
-	"You start putting \the [tool] inside [target]'s [affected.cavity_name] cavity." )
-	target.custom_pain("The pain in your chest is living hell!",1,affecting = affected)
-	playsound(target.loc, 'sound/effects/squelch1.ogg', 25, 1)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts putting \a [tool] inside \the [target]'s [affected.cavity_name] cavity."),
+		SPAN_NOTICE("You start putting \the [tool] inside \the [target]'s [affected.cavity_name] cavity.")
+	)
+	target.custom_pain("The pain in your chest is living hell!", 1, affecting = affected)
+	playsound(target, 'sound/effects/squelch1.ogg', 25, TRUE)
 	..()
 
 /singleton/surgery_step/cavity/place_item/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -173,10 +179,12 @@
 
 /singleton/surgery_step/cavity/implant_removal/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] starts poking around inside [target]'s [affected.name] with \the [tool].", \
-	"You start poking around inside [target]'s [affected.name] with \the [tool]." )
-	target.custom_pain("The pain in your [affected.name] is living hell!",1,affecting = affected)
-	playsound(target.loc, 'sound/items/hemostat.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts poking around inside \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You start poking around inside \the [target]'s [affected.name] with \the [tool].")
+	)
+	target.custom_pain("The pain in your [affected.name] is living hell!", 1, affecting = affected)
+	playsound(target, 'sound/items/hemostat.ogg', 50, TRUE)
 	..()
 
 

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -34,8 +34,9 @@
 
 /singleton/surgery_step/cavity/make_space/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected && affected.cavity_name && !affected.cavity)
-		return affected
+	if (!affected || !affected.cavity_name || affected.cavity)
+		return FALSE
+	return affected
 
 /singleton/surgery_step/cavity/make_space/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -67,8 +68,9 @@
 
 /singleton/surgery_step/cavity/close_space/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected && affected.cavity)
-		return affected
+	if (!affected?.cavity)
+		return FALSE
+	return affected
 
 /singleton/surgery_step/cavity/close_space/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -100,8 +102,9 @@
 
 /singleton/surgery_step/cavity/place_item/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected && affected.cavity)
-		return affected
+	if (!affected?.cavity)
+		return FALSE
+	return affected
 
 
 /singleton/surgery_step/cavity/place_item/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -161,10 +164,11 @@
 
 /singleton/surgery_step/cavity/implant_removal/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected)
-		for(var/obj/O in affected.implants)
-			if(!istype(O, /obj/item/organ/internal))
-				return affected
+	if (!affected)
+		return FALSE
+	for (var/obj/O in affected.implants)
+		if (!istype(O, /obj/item/organ/internal))
+			return affected
 	return FALSE
 
 /singleton/surgery_step/cavity/implant_removal/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -9,7 +9,7 @@
 //////////////////////////////////////////////////////////////////
 /singleton/surgery_step/cavity
 	shock_level = 40
-	delicate = 1
+	delicate = TRUE
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_STUMP | SURGERY_NEEDS_ENCASEMENT | SURGERY_NO_ROBOTIC
 
 /singleton/surgery_step/cavity/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -29,8 +29,8 @@
 		/obj/item/pen = 75,
 		/obj/item/stack/material/rods = 50
 	)
-	min_duration = 60
-	max_duration = 80
+	min_duration = 6 SECONDS
+	max_duration = 8 SECONDS
 
 /singleton/surgery_step/cavity/make_space/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
@@ -62,8 +62,8 @@
 		/obj/item/flame/lighter = 50,
 		/obj/item/weldingtool = 25
 	)
-	min_duration = 60
-	max_duration = 80
+	min_duration = 6 SECONDS
+	max_duration = 8 SECONDS
 
 /singleton/surgery_step/cavity/close_space/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
@@ -90,8 +90,8 @@
 /singleton/surgery_step/cavity/place_item
 	name = "Place item in cavity"
 	allowed_tools = list(/obj/item = 100)
-	min_duration = 80
-	max_duration = 100
+	min_duration = 8 SECONDS
+	max_duration = 10 SECONDS
 
 /singleton/surgery_step/cavity/place_item/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(istype(user,/mob/living/silicon/robot))
@@ -150,8 +150,8 @@
 		/obj/item/wirecutters = 75,
 		/obj/item/material/utensil/fork = 20
 	)
-	min_duration = 120
-	max_duration = 150
+	min_duration = 12 SECONDS
+	max_duration = 15 SECONDS
 
 /singleton/surgery_step/cavity/implant_removal/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -51,8 +51,10 @@
 
 /singleton/surgery_step/cavity/make_space/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] makes some space inside [target]'s [affected.cavity_name] cavity with \the [tool]."), \
-	SPAN_NOTICE("You make some space inside [target]'s [affected.cavity_name] cavity with \the [tool].") )
+	user.visible_message(
+		SPAN_NOTICE("\The [user] makes some space inside \the [target]'s [affected.cavity_name] cavity with \a [tool]."),
+		SPAN_NOTICE("You make some space inside \the [target]'s [affected.cavity_name] cavity with \the [tool].")
+	)
 
 //////////////////////////////////////////////////////////////////
 //	 implant cavity sealing surgery step
@@ -86,8 +88,10 @@
 
 /singleton/surgery_step/cavity/close_space/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] mends [target]'s [affected.cavity_name] cavity walls with \the [tool]."), \
-	SPAN_NOTICE("You mend [target]'s [affected.cavity_name] cavity walls with \the [tool].") )
+	user.visible_message(
+		SPAN_NOTICE("\The [user] mends \the [target]'s [affected.cavity_name] cavity walls with \a [tool]."),
+		SPAN_NOTICE("You mend \the [target]'s [affected.cavity_name] cavity walls with \the [tool].")
+	)
 	affected.cavity = FALSE
 
 //////////////////////////////////////////////////////////////////
@@ -145,15 +149,18 @@
 
 /singleton/surgery_step/cavity/place_item/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
-	if(!user.unEquip(tool, affected))
+	if (!user.unEquip(tool, affected))
+		FEEDBACK_UNEQUIP_FAILURE(user, tool)
 		return
-	user.visible_message(SPAN_NOTICE("[user] puts \the [tool] inside [target]'s [affected.cavity_name] cavity."), \
-	SPAN_NOTICE("You put \the [tool] inside [target]'s [affected.cavity_name] cavity.") )
-	if (tool.w_class > affected.cavity_max_w_class/2 && prob(50) && !BP_IS_ROBOTIC(affected) && affected.sever_artery())
+	user.visible_message(
+		SPAN_NOTICE("\The [user] puts \a [tool] inside \the [target]'s [affected.cavity_name] cavity."),
+		SPAN_NOTICE("You put \the [tool] inside \the [target]'s [affected.cavity_name] cavity.")
+	)
+	if (tool.w_class > affected.cavity_max_w_class / 2 && prob(50) && !BP_IS_ROBOTIC(affected) && affected.sever_artery())
 		to_chat(user, SPAN_WARNING("You tear some blood vessels trying to fit such a big object in this cavity."))
-		affected.owner.custom_pain("You feel something rip in your [affected.name]!", 1,affecting = affected)
+		affected.owner.custom_pain("You feel something rip in your [affected.name]!", 1, affecting = affected)
 	affected.implants += tool
-	affected.cavity = 0
+	affected.cavity = FALSE
 
 //////////////////////////////////////////////////////////////////
 //	 implant removal surgery step
@@ -190,11 +197,13 @@
 
 /singleton/surgery_step/cavity/implant_removal/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/chest/affected = target.get_organ(target_zone)
+
 	var/exposed
-	if(affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED))
+	if (affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED))
 		exposed = TRUE
-	if(BP_IS_ROBOTIC(affected) && affected.hatch_state == HATCH_OPENED)
+	if (BP_IS_ROBOTIC(affected) && affected.hatch_state == HATCH_OPENED)
 		exposed = TRUE
+
 	var/list/loot = list()
 	if (exposed)
 		loot = affected.implants
@@ -202,12 +211,14 @@
 		for (var/datum/wound/wound in affected.wounds)
 			if (length(wound.embedded_objects))
 				loot |= wound.embedded_objects
+
 	if (!length(loot))
 		user.visible_message(
-			SPAN_NOTICE("\The [user] could not find anything inside \the [target]'s [affected.name], and pulls their [tool] out."),
-			SPAN_NOTICE("You could not find anything inside \the [target]'s [affected.name].")
+			SPAN_NOTICE("\The [user] could not find anything inside \the [target]'s [affected.name], and pulls their [tool.name] out."),
+			SPAN_NOTICE("You could not find anything inside \the [target]'s [affected.name] anmd pull your [tool.name] out..")
 		)
 		return
+
 	shuffle(loot, TRUE)
 	for (var/i = length(loot) to 1 step -1)
 		var/obj/item/obj = loot[i]
@@ -223,7 +234,7 @@
 				target.release_control()
 			worm.detatch()
 			worm.leave_host()
-		playsound(target.loc, 'sound/effects/squelch1.ogg', 15, TRUE)
+		playsound(target, 'sound/effects/squelch1.ogg', 15, TRUE)
 		if (i == 1 || !user.do_skilled(3 SECONDS, SKILL_ANATOMY, target, 0.3, DO_SURGERY) || !user.use_sanity_check(target, tool))
 			break
 

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -73,10 +73,13 @@
 
 
 /singleton/surgery_step/limb/attach/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if(..())
-		var/obj/item/organ/external/E = tool
-		var/obj/item/organ/external/P = target.organs_by_name[E.parent_organ]
-		. = (P && !P.is_stump() && !(BP_IS_ROBOTIC(P) && !BP_IS_ROBOTIC(E)))
+	. = ..()
+	if (!.)
+		return
+
+	var/obj/item/organ/external/external_tool = tool
+	var/obj/item/organ/external/attach_point = target.organs_by_name[external_tool.parent_organ]
+	return (attach_point && !attach_point.is_stump() && !(BP_IS_ROBOTIC(attach_point) && !BP_IS_ROBOTIC(external_tool)))
 
 /singleton/surgery_step/limb/attach/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = tool
@@ -132,9 +135,12 @@
 
 
 /singleton/surgery_step/limb/connect/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if(..())
-		var/obj/item/organ/external/E = target.get_organ(target_zone)
-		return E && !E.is_stump() && (E.status & ORGAN_CUT_AWAY)
+	. = ..()
+	if (!.)
+		return
+
+	var/obj/item/organ/external/external = target.get_organ(target_zone)
+	return external && !external.is_stump() && HAS_FLAGS(external.status, ORGAN_CUT_AWAY)
 
 /singleton/surgery_step/limb/connect/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -182,12 +188,16 @@
 
 
 /singleton/surgery_step/limb/mechanize/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if(..())
-		var/obj/item/robot_parts/p = tool
-		if (p.part)
-			if (!(target_zone in p.part))
-				return 0
-		return isnull(target.get_organ(target_zone))
+	. = ..()
+	if (!.)
+		return
+
+	var/obj/item/robot_parts/robot_parts = tool
+	if (robot_parts.part)
+		if (!(target_zone in robot_parts.part))
+			return FALSE
+
+	return isnull(target.get_organ(target_zone))
 
 /singleton/surgery_step/limb/mechanize/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message(

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -13,11 +13,10 @@
 
 /singleton/surgery_step/limb/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(affected)
+	if (affected)
 		return affected
-	else
-		var/list/organ_data = target.species.has_limbs["[target_zone]"]
-		return !isnull(organ_data)
+	var/list/organ_data = target.species.has_limbs["[target_zone]"]
+	return !isnull(organ_data)
 
 //////////////////////////////////////////////////////////////////
 //	 limb attachment surgery step

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -64,13 +64,14 @@
 	return TRUE
 
 
-/singleton/surgery_step/limb/attach/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/organ/external/tool)
-	if(istype(tool) && BP_IS_ROBOTIC(tool))
-		if(target.isSynthetic())
-			return SURGERY_SKILLS_ROBOTIC
-		else
-			return SURGERY_SKILLS_ROBOTIC_ON_MEAT
-	return ..()
+/singleton/surgery_step/limb/attach/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
+	var/obj/item/organ/external/external_organ = tool
+	if (!istype(external_organ) || !BP_IS_ROBOTIC(external_organ))
+		return ..()
+	if (target.isSynthetic())
+		return SURGERY_SKILLS_ROBOTIC
+	return SURGERY_SKILLS_ROBOTIC_ON_MEAT
+
 
 /singleton/surgery_step/limb/attach/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
@@ -115,14 +116,15 @@
 	min_duration = 10 SECONDS
 	max_duration = 12 SECONDS
 
+
 /singleton/surgery_step/limb/connect/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
-	var/obj/item/organ/external/E = target && target.get_organ(target_zone)
-	if(istype(E) && BP_IS_ROBOTIC(E))
-		if(target.isSynthetic())
-			return SURGERY_SKILLS_ROBOTIC
-		else
-			return SURGERY_SKILLS_ROBOTIC_ON_MEAT
-	return ..()
+	var/obj/item/organ/external/external_organ = target && target.get_organ(target_zone)
+	if (!istype(external_organ) || !BP_IS_ROBOTIC(external_organ))
+		return ..()
+	if (target.isSynthetic())
+		return SURGERY_SKILLS_ROBOTIC
+	return SURGERY_SKILLS_ROBOTIC_ON_MEAT
+
 
 /singleton/surgery_step/limb/connect/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())
@@ -163,11 +165,12 @@
 	min_duration = 8 SECONDS
 	max_duration = 10 SECONDS
 
+
 /singleton/surgery_step/limb/mechanize/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
-	if(target.isSynthetic())
+	if (target.isSynthetic())
 		return SURGERY_SKILLS_ROBOTIC
-	else
-		return SURGERY_SKILLS_ROBOTIC_ON_MEAT
+	return SURGERY_SKILLS_ROBOTIC_ON_MEAT
+
 
 /singleton/surgery_step/limb/mechanize/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(..())

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -8,9 +8,8 @@
 //	 generic limb surgery step datum
 //////////////////////////////////////////////////////////////////
 /singleton/surgery_step/limb
-	can_infect = 0
 	shock_level = 40
-	delicate = 1
+	delicate = TRUE
 
 /singleton/surgery_step/limb/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -26,8 +25,8 @@
 /singleton/surgery_step/limb/attach
 	name = "Replace limb"
 	allowed_tools = list(/obj/item/organ/external = 100)
-	min_duration = 50
-	max_duration = 70
+	min_duration = 5 SECONDS
+	max_duration = 7 SECONDS
 
 /singleton/surgery_step/limb/attach/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	. = FALSE
@@ -100,9 +99,9 @@
 		/obj/item/stack/cable_coil = 75,
 		/obj/item/device/assembly/mousetrap = 20
 	)
-	can_infect = 1
-	min_duration = 100
-	max_duration = 120
+	can_infect = TRUE
+	min_duration = 10 SECONDS
+	max_duration = 12 SECONDS
 
 /singleton/surgery_step/limb/connect/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
 	var/obj/item/organ/external/E = target && target.get_organ(target_zone)
@@ -149,8 +148,8 @@
 	name = "Attach prosthetic limb"
 	allowed_tools = list(/obj/item/robot_parts = 100)
 
-	min_duration = 80
-	max_duration = 100
+	min_duration = 8 SECONDS
+	max_duration = 10 SECONDS
 
 /singleton/surgery_step/limb/mechanize/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	if(target.isSynthetic())

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -87,12 +87,16 @@
 	playsound(target, 'sound/items/bonesetter.ogg', 50, TRUE)
 
 /singleton/surgery_step/limb/attach/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if(!user.unEquip(tool))
+	if (!user.unEquip(tool))
+		FEEDBACK_UNEQUIP_FAILURE(user, tool)
 		return
-	var/obj/item/organ/external/E = tool
-	user.visible_message(SPAN_NOTICE("[user] has attached [target]'s [E.name] to the [E.amputation_point]."),	\
-	SPAN_NOTICE("You have attached [target]'s [E.name] to the [E.amputation_point]."))
-	E.replaced(target)
+	var/obj/item/organ/external/external = tool
+	var/datum/pronouns/pronouns = target.choose_from_pronouns()
+	user.visible_message(
+		SPAN_NOTICE("\The [user] has attached \the [target]'s [external.name] to [pronouns.his] [external.amputation_point]."),
+		SPAN_NOTICE("You have attached \the [target]'s [external.name] to [pronouns.his] [external.amputation_point].")
+	)
+	external.replaced(target)
 	target.update_body()
 	target.updatehealth()
 	target.UpdateDamageIcon()
@@ -141,13 +145,15 @@
 	playsound(target, 'sound/items/fixovein.ogg', 50, TRUE)
 
 /singleton/surgery_step/limb/connect/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/obj/item/organ/external/E = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] has connected tendons and muscles in [target]'s [E.amputation_point] with [tool]."),	\
-	SPAN_NOTICE("You have connected tendons and muscles in [target]'s [E.amputation_point] with [tool]."))
-	E.status &= ~ORGAN_CUT_AWAY
-	if(E.children)
-		for(var/obj/item/organ/external/C in E.children)
-			C.status &= ~ORGAN_CUT_AWAY
+	var/obj/item/organ/external/external = target.get_organ(target_zone)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] has connected tendons and muscles in \the [target]'s [external.amputation_point] with \a [tool]."),
+		SPAN_NOTICE("You have connected tendons and muscles in \the [target]'s [external.amputation_point] with \the [tool].")
+	)
+	CLEAR_FLAGS(external.status, ORGAN_CUT_AWAY)
+	if (external.children)
+		for (var/obj/item/organ/external/child in external.children)
+			CLEAR_FLAGS(child.status, ORGAN_CUT_AWAY)
 	target.update_body()
 	target.updatehealth()
 	target.UpdateDamageIcon()
@@ -191,22 +197,24 @@
 	playsound(target, 'sound/items/bonesetter.ogg', 50, TRUE)
 
 /singleton/surgery_step/limb/mechanize/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/obj/item/robot_parts/L = tool
-	user.visible_message(SPAN_NOTICE("[user] has attached \the [tool] to [target]."),	\
-	SPAN_NOTICE("You have attached \the [tool] to [target]."))
+	var/obj/item/robot_parts/robot_parts = tool
+	user.visible_message(
+		SPAN_NOTICE("\The [user] has attached \a [tool] to \the [target]."),
+		SPAN_NOTICE("You have attached \the [tool] to \the [target].")
+	)
 
-	if(L.part)
-		for(var/part_name in L.part)
-			if(!isnull(target.get_organ(part_name)))
+	if (robot_parts.part)
+		for (var/part_name in robot_parts.part)
+			if (!isnull(target.get_organ(part_name)))
 				continue
 			var/list/organ_data = target.species.has_limbs["[part_name]"]
-			if(!organ_data)
+			if (!organ_data)
 				continue
 			var/new_limb_type = organ_data["path"]
 			var/obj/item/organ/external/new_limb = new new_limb_type(target)
-			new_limb.robotize(L.model_info)
-			if(L.sabotaged)
-				new_limb.status |= ORGAN_SABOTAGED
+			new_limb.robotize(robot_parts.model_info)
+			if (robot_parts.sabotaged)
+				SET_FLAGS(new_limb.status, ORGAN_SABOTAGED)
 
 	target.update_body()
 	target.updatehealth()

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -105,10 +105,12 @@
 	target.UpdateDamageIcon()
 
 /singleton/surgery_step/limb/attach/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/obj/item/organ/external/E = tool
-	user.visible_message(SPAN_WARNING(" [user]'s hand slips, damaging [target]'s [E.amputation_point]!"), \
-	SPAN_WARNING(" Your hand slips, damaging [target]'s [E.amputation_point]!"))
-	target.apply_damage(10, DAMAGE_BRUTE, null, damage_flags=DAMAGE_FLAG_SHARP)
+	var/obj/item/organ/external/external = tool
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, damaging \the [target]'s [external.amputation_point]!"),
+		SPAN_WARNING("Your hand slips, damaging \the [target]'s [external.amputation_point]!")
+	)
+	target.apply_damage(10, DAMAGE_BRUTE, damage_flags = DAMAGE_FLAG_SHARP)
 
 //////////////////////////////////////////////////////////////////
 //	 limb connecting surgery step
@@ -165,10 +167,12 @@
 	target.UpdateDamageIcon()
 
 /singleton/surgery_step/limb/connect/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/obj/item/organ/external/E = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING(" [user]'s hand slips, damaging [target]'s [E.amputation_point]!"), \
-	SPAN_WARNING(" Your hand slips, damaging [target]'s [E.amputation_point]!"))
-	target.apply_damage(10, DAMAGE_BRUTE, null, damage_flags=DAMAGE_FLAG_SHARP)
+	var/obj/item/organ/external/external = target.get_organ(target_zone)
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, damaging \the [target]'s [external.amputation_point]!"),
+		SPAN_WARNING("Your hand slips, damaging \the [target]'s [external.amputation_point]!")
+	)
+	target.apply_damage(10, DAMAGE_BRUTE, damage_flags = DAMAGE_FLAG_SHARP)
 
 //////////////////////////////////////////////////////////////////
 //	 robotic limb attachment surgery step
@@ -233,6 +237,8 @@
 	qdel(tool)
 
 /singleton/surgery_step/limb/mechanize/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-		user.visible_message(SPAN_WARNING(" [user]'s hand slips, damaging [target]'s flesh!"), \
-		SPAN_WARNING(" Your hand slips, damaging [target]'s flesh!"))
-		target.apply_damage(10, DAMAGE_BRUTE, null, damage_flags=DAMAGE_FLAG_SHARP)
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, damaging \the [target]'s flesh with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, damaging \the [target]'s flesh with \the [tool]!")
+	)
+	target.apply_damage(10, DAMAGE_BRUTE, damage_flags = DAMAGE_FLAG_SHARP)

--- a/code/modules/surgery/limb_reattach.dm
+++ b/code/modules/surgery/limb_reattach.dm
@@ -79,10 +79,12 @@
 		. = (P && !P.is_stump() && !(BP_IS_ROBOTIC(P) && !BP_IS_ROBOTIC(E)))
 
 /singleton/surgery_step/limb/attach/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/obj/item/organ/external/E = tool
-	user.visible_message("[user] starts attaching [E.name] to [target]'s [E.amputation_point].", \
-	"You start attaching [E.name] to [target]'s [E.amputation_point].")
-	playsound(target.loc, 'sound/items/bonesetter.ogg', 50, TRUE)
+	var/obj/item/organ/external/affected = tool
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts attaching \a [affected] to \the [target]'s [affected.amputation_point]."),
+		SPAN_NOTICE("You start attaching \the [affected] to \the [target]'s [affected.amputation_point].")
+	)
+	playsound(target, 'sound/items/bonesetter.ogg', 50, TRUE)
 
 /singleton/surgery_step/limb/attach/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!user.unEquip(tool))
@@ -131,10 +133,12 @@
 		return E && !E.is_stump() && (E.status & ORGAN_CUT_AWAY)
 
 /singleton/surgery_step/limb/connect/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/obj/item/organ/external/E = target.get_organ(target_zone)
-	user.visible_message("[user] starts connecting tendons and muscles in [target]'s [E.amputation_point] with [tool].", \
-	"You start connecting tendons and muscle in [target]'s [E.amputation_point].")
-	playsound(target.loc, 'sound/items/fixovein.ogg', 50, TRUE)
+	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts connecting tendons and muscles in \the [target]'s [affected.amputation_point] with \a [tool]."),
+		SPAN_NOTICE("You start connecting tendons and muscle in \the [target]'s [affected.amputation_point] with \the [tool].")
+	)
+	playsound(target, 'sound/items/fixovein.ogg', 50, TRUE)
 
 /singleton/surgery_step/limb/connect/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/E = target.get_organ(target_zone)
@@ -180,9 +184,11 @@
 		return isnull(target.get_organ(target_zone))
 
 /singleton/surgery_step/limb/mechanize/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message("[user] starts attaching \the [tool] to [target].", \
-	"You start attaching \the [tool] to [target].")
-	playsound(target.loc, 'sound/items/bonesetter.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts attaching \a [tool] to \the [target]."),
+		SPAN_NOTICE("You start attaching \the [tool] to \the [target].")
+	)
+	playsound(target, 'sound/items/bonesetter.ogg', 50, TRUE)
 
 /singleton/surgery_step/limb/mechanize/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/robot_parts/L = tool

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -207,17 +207,15 @@
 	return choice
 
 
-/singleton/surgery_step/internal/remove_organ/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
-	var/target_zone = user.zone_sel.selecting
-	var/obj/item/organ/internal/O = LAZYACCESS(target.surgeries_in_progress, target_zone)
+/singleton/surgery_step/internal/remove_organ/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
+	var/obj/item/organ/internal/organ_to_remove = LAZYACCESS(target.surgeries_in_progress, target_zone)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(BP_IS_ROBOTIC(O))
-		if(BP_IS_ROBOTIC(affected))
-			return SURGERY_SKILLS_ROBOTIC
-		else
-			return SURGERY_SKILLS_ROBOTIC_ON_MEAT
-	else
+	if (!BP_IS_ROBOTIC(organ_to_remove))
 		return ..()
+	if (BP_IS_ROBOTIC(affected))
+		return SURGERY_SKILLS_ROBOTIC
+	return SURGERY_SKILLS_ROBOTIC_ON_MEAT
+
 
 /singleton/surgery_step/internal/remove_organ/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/removing = LAZYACCESS(target.surgeries_in_progress, target_zone)
@@ -269,16 +267,15 @@
 	max_duration = 8 SECONDS
 	var/robotic_surgery = FALSE
 
-/singleton/surgery_step/internal/replace_organ/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
-	var/obj/item/organ/internal/O = tool
+
+/singleton/surgery_step/internal/replace_organ/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
+	var/obj/item/organ/internal/organ_to_attach = tool
 	var/obj/item/organ/external/affected = target.get_organ(user.zone_sel.selecting)
-	if(BP_IS_ROBOTIC(O) || istype(O, /obj/item/organ/internal/augment))
-		if(BP_IS_ROBOTIC(affected))
-			return SURGERY_SKILLS_ROBOTIC
-		else
-			return SURGERY_SKILLS_ROBOTIC_ON_MEAT
-	else
+	if (!BP_IS_ROBOTIC(organ_to_attach) && !istype(organ_to_attach, /obj/item/organ/internal/augment))
 		return ..()
+	if (BP_IS_ROBOTIC(affected))
+		return SURGERY_SKILLS_ROBOTIC
+	return SURGERY_SKILLS_ROBOTIC_ON_MEAT
 
 
 /singleton/surgery_step/internal/replace_organ/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -363,17 +360,15 @@
 	max_duration = 12 SECONDS
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_ENCASEMENT
 
-/singleton/surgery_step/internal/attach_organ/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
-	var/target_zone = user.zone_sel.selecting
-	var/obj/item/organ/internal/O = LAZYACCESS(target.surgeries_in_progress, target_zone)
+
+/singleton/surgery_step/internal/attach_organ/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
+	var/obj/item/organ/internal/organ_to_attach = LAZYACCESS(target.surgeries_in_progress, target_zone)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(BP_IS_ROBOTIC(O))
-		if(BP_IS_ROBOTIC(affected))
-			return SURGERY_SKILLS_ROBOTIC
-		else
-			return SURGERY_SKILLS_ROBOTIC_ON_MEAT
-	else
+	if (!BP_IS_ROBOTIC(organ_to_attach))
 		return ..()
+	if (BP_IS_ROBOTIC(affected))
+		return SURGERY_SKILLS_ROBOTIC
+	return SURGERY_SKILLS_ROBOTIC_ON_MEAT
 
 
 /singleton/surgery_step/internal/attach_organ/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -3,10 +3,10 @@
 //						INTERNAL ORGANS							//
 //////////////////////////////////////////////////////////////////
 /singleton/surgery_step/internal
-	can_infect = 1
-	blood_level = 1
+	can_infect = TRUE
+	blood_level = BLOOD_LEVEL_HANDS
 	shock_level = 40
-	delicate = 1
+	delicate = TRUE
 	surgery_candidate_flags = SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_ENCASEMENT
 
 //////////////////////////////////////////////////////////////////
@@ -19,8 +19,8 @@
 		/obj/item/stack/medical/bruise_pack = 40,
 		/obj/item/tape_roll = 20
 	)
-	min_duration = 70
-	max_duration = 90
+	min_duration = 7 SECONDS
+	max_duration = 9 SECONDS
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP
 
 /singleton/surgery_step/internal/fix_organ/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -96,8 +96,8 @@
 		/obj/item/scalpel = 100,
 		/obj/item/material/shard = 50
 	)
-	min_duration = 90
-	max_duration = 110
+	min_duration = 9 SECONDS
+	max_duration = 11 SECONDS
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_ENCASEMENT
 
 /singleton/surgery_step/internal/detatch_organ/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -151,8 +151,8 @@
 		/obj/item/swapper/jaws_of_life = 50,
 		/obj/item/material/utensil/fork = 20
 	)
-	min_duration = 60
-	max_duration = 80
+	min_duration = 6 SECONDS
+	max_duration = 8 SECONDS
 
 /singleton/surgery_step/internal/remove_organ/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -233,8 +233,8 @@
 	allowed_tools = list(
 		/obj/item/organ/internal = 100
 	)
-	min_duration = 60
-	max_duration = 80
+	min_duration = 6 SECONDS
+	max_duration = 8 SECONDS
 	var/robotic_surgery = FALSE
 
 /singleton/surgery_step/internal/replace_organ/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
@@ -319,8 +319,8 @@
 		/obj/item/stack/cable_coil = 75,
 		/obj/item/tape_roll = 50
 	)
-	min_duration = 100
-	max_duration = 120
+	min_duration = 10 SECONDS
+	max_duration = 12 SECONDS
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_ENCASEMENT
 
 /singleton/surgery_step/internal/attach_organ/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
@@ -425,11 +425,11 @@
 		/obj/item/reagent_containers/glass/bucket = 50,
 	)
 
-	can_infect = 0
-	blood_level = 0
+	can_infect = FALSE
+	blood_level = BLOOD_LEVEL_NONE
 
-	min_duration = 50
-	max_duration = 60
+	min_duration = 5 SECONDS
+	max_duration = 6 SECONDS
 
 /singleton/surgery_step/internal/treat_necrosis/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/reagent_containers/container = tool

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -100,18 +100,20 @@
 
 /singleton/surgery_step/internal/fix_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, getting mess and tearing the inside of [target]'s [affected.name] with \the [tool]!"), \
-	SPAN_WARNING("Your hand slips, getting mess and tearing the inside of [target]'s [affected.name] with \the [tool]!"))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, making a mess and tearing the inside of \the [target]'s [affected.name] with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, making a mess and tearing the inside of \the [target]'s [affected.name] with \the [tool]!")
+	)
 	var/dam_amt = 2
-	if(istype(tool, /obj/item/stack/medical/advanced/bruise_pack))
+	if (istype(tool, /obj/item/stack/medical/advanced/bruise_pack))
 		target.adjustToxLoss(5)
 	else
 		dam_amt = 5
 		target.adjustToxLoss(10)
-		affected.take_external_damage(dam_amt, 0, (DAMAGE_FLAG_SHARP|DAMAGE_FLAG_EDGE), used_weapon = tool)
-	for(var/obj/item/organ/internal/I in affected.internal_organs)
-		if(I && I.damage > 0 && !BP_IS_ROBOTIC(I) && (I.surface_accessible || affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED)))
-			I.take_internal_damage(dam_amt)
+		affected.take_external_damage(dam_amt, 0, DAMAGE_FLAG_SHARP | DAMAGE_FLAG_EDGE, tool)
+	for (var/obj/item/organ/internal/internal in affected.internal_organs)
+		if (internal.damage > 0 && !BP_IS_ROBOTIC(internal) && (internal.surface_accessible || affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED)))
+			internal.take_internal_damage(dam_amt)
 
 //////////////////////////////////////////////////////////////////
 //	 Organ detatchment surgery step
@@ -182,9 +184,11 @@
 
 /singleton/surgery_step/internal/detatch_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, slicing an artery inside [target]'s [affected.name] with \the [tool]!"), \
-	SPAN_WARNING("Your hand slips, slicing an artery inside [target]'s [affected.name] with \the [tool]!"))
-	affected.take_external_damage(rand(30,50), 0, (DAMAGE_FLAG_SHARP|DAMAGE_FLAG_EDGE), used_weapon = tool)
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, slicing an artery inside \the [target]'s [affected.name] with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, slicing an artery inside \the [target]'s [affected.name] with \the [tool]!")
+	)
+	affected.take_external_damage(rand(30, 50), 0, DAMAGE_FLAG_SHARP | DAMAGE_FLAG_EDGE, tool)
 
 //////////////////////////////////////////////////////////////////
 //	 Organ removal surgery step
@@ -286,8 +290,10 @@
 
 /singleton/surgery_step/internal/remove_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, damaging [target]'s [affected.name] with \the [tool]!"), \
-	SPAN_WARNING("Your hand slips, damaging [target]'s [affected.name] with \the [tool]!"))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, damaging \the [target]'s [affected.name] with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, damaging \the [target]'s [affected.name] with \the [tool]!")
+	)
 	affected.take_external_damage(20, used_weapon = tool)
 
 //////////////////////////////////////////////////////////////////
@@ -384,11 +390,14 @@
 	playsound(target.loc, 'sound/effects/squelch1.ogg', 15, 1)
 
 /singleton/surgery_step/internal/replace_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, damaging \the [tool]!"), \
-	SPAN_WARNING("Your hand slips, damaging \the [tool]!"))
-	var/obj/item/organ/internal/I = tool
-	if(istype(I))
-		I.take_internal_damage(rand(3,5))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, damaging \the [tool]!"),
+		SPAN_WARNING("Your hand slips, damaging \the [tool]!")
+	)
+
+	var/obj/item/organ/internal/internal = tool
+	if (istype(internal))
+		internal.take_internal_damage(rand(3, 5))
 
 //////////////////////////////////////////////////////////////////
 //	 Organ attachment surgery step
@@ -507,8 +516,10 @@
 
 /singleton/surgery_step/internal/attach_organ/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, damaging the flesh in [target]'s [affected.name] with \the [tool]!"), \
-	SPAN_WARNING("Your hand slips, damaging the flesh in [target]'s [affected.name] with \the [tool]!"))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, damaging the flesh in \the [target]'s [affected.name] with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, damaging the flesh in \the [target]'s [affected.name] with \the [tool]!")
+	)
 	affected.take_external_damage(20, used_weapon = tool)
 
 //////////////////////////////////////////////////////////////////
@@ -629,7 +640,9 @@
 
 	var/trans = container.reagents.trans_to_mob(target, container.amount_per_transfer_from_this, CHEM_BLOOD)
 
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, applying [trans] units of the solution to the wrong place in [target]'s [affected.name] with the [tool]!") , \
-	SPAN_WARNING("Your hand slips, applying [trans] units of the solution to the wrong place in [target]'s [affected.name] with the [tool]!"))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, applying some of \the [tool]'s solution to the wrong place in \the [target]'s [affected.name]!"),
+		SPAN_WARNING("Your hand slips, applying [trans] units of \the [tool]'s solution to the wrong place in [target]'s [affected.name]!")
+	)
 
 	//no damage or anything, just wastes medicine

--- a/code/modules/surgery/organs_internal.dm
+++ b/code/modules/surgery/organs_internal.dm
@@ -25,11 +25,14 @@
 
 /singleton/surgery_step/internal/fix_organ/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected)
-		for(var/obj/item/organ/internal/I in affected.internal_organs)
-			if(I.damage > 0)
-				if(I.surface_accessible || (affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED)))
-					return affected
+	if (!affected)
+		return FALSE
+	for (var/obj/item/organ/internal/organ in affected.internal_organs)
+		if (organ.damage <= 0)
+			return FALSE
+		if (!organ.surface_accessible && (affected.how_open() < (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED)))
+			return FALSE
+	return affected
 
 /singleton/surgery_step/internal/fix_organ/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/tool_name = "\the [tool]"

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -29,10 +29,12 @@
 
 /singleton/surgery_step/fix_tendon/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] starts reattaching the damaged [affected.tendon_name] in [target]'s [affected.name] with \the [tool]." , \
-	"You start reattaching the damaged [affected.tendon_name] in [target]'s [affected.name] with \the [tool].")
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts reattaching the damaged [affected.tendon_name] in [target]'s [affected.name] with \the [tool]."),
+		SPAN_NOTICE("You start reattaching the damaged [affected.tendon_name] in [target]'s [affected.name] with \the [tool].")
+	)
 	target.custom_pain("The pain in your [affected.name] is unbearable!",100,affecting = affected)
-	playsound(target.loc, 'sound/items/fixovein.ogg', 50, TRUE)
+	playsound(target, 'sound/items/fixovein.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/fix_tendon/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -75,10 +77,12 @@
 
 /singleton/surgery_step/fix_vein/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] starts patching the damaged [affected.artery_name] in [target]'s [affected.name] with \the [tool]." , \
-	"You start patching the damaged [affected.artery_name] in [target]'s [affected.name] with \the [tool].")
-	target.custom_pain("The pain in your [affected.name] is unbearable!",100,affecting = affected)
-	playsound(target.loc, 'sound/items/fixovein.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts patching the damaged [affected.artery_name] in \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You start patching the damaged [affected.artery_name] in \the [target]'s [affected.name] with \the [tool].")
+	)
+	target.custom_pain("The pain in your [affected.name] is unbearable!", 100, affecting = affected)
+	playsound(target, 'sound/items/fixovein.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/fix_vein/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -128,9 +132,11 @@
 	return (target_zone == BP_CHEST) && istype(target.back, /obj/item/rig) && !(target.back.canremove)
 
 /singleton/surgery_step/hardsuit/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message("[user] starts cutting through the support systems of [target]'s [target.back] with \the [tool]." , \
-	"You start cutting through the support systems of [target]'s [target.back] with \the [tool].")
-	playsound(target.loc, 'sound/items/circularsaw.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts cutting through the support systems of \the [target]'s [target.back] with \a [tool]."),
+		SPAN_NOTICE("You start cutting through the support systems of \the [target]'s [target.back] with \the [tool].")
+	)
+	playsound(target, 'sound/items/circularsaw.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/hardsuit/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -178,10 +184,12 @@
 
 /singleton/surgery_step/sterilize/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] starts pouring [tool]'s contents on \the [target]'s [affected.name]." , \
-	"You start pouring [tool]'s contents on \the [target]'s [affected.name].")
-	target.custom_pain("Your [affected.name] is on fire!",50,affecting = affected)
-	playsound(target.loc, 'sound/items/spray_1.ogg', 15, 1)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts pouring \a [tool]'s contents on \the [target]'s [affected.name]."),
+		SPAN_NOTICE("You start pouring \the [tool]'s contents on \the [target]'s [affected.name].")
+	)
+	target.custom_pain("Your [affected.name] is on fire!", 50, affecting = affected)
+	playsound(target, 'sound/items/spray_1.ogg', 15, TRUE)
 	..()
 
 /singleton/surgery_step/sterilize/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -39,9 +39,11 @@
 
 /singleton/surgery_step/fix_tendon/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] has reattached the [affected.tendon_name] in [target]'s [affected.name] with \the [tool]."), \
-		SPAN_NOTICE("You have reattached the [affected.tendon_name] in [target]'s [affected.name] with \the [tool]."))
-	affected.status &= ~ORGAN_TENDON_CUT
+	user.visible_message(
+		SPAN_NOTICE("\The [user] has reattached the [affected.tendon_name] in \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You have reattached the [affected.tendon_name] in \the [target]'s [affected.name] with \the [tool].")
+	)
+	CLEAR_FLAGS(affected.status, ORGAN_TENDON_CUT)
 	affected.update_damages()
 
 /singleton/surgery_step/fix_tendon/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -87,9 +89,11 @@
 
 /singleton/surgery_step/fix_vein/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] has patched the [affected.artery_name] in [target]'s [affected.name] with \the [tool]."), \
-		SPAN_NOTICE("You have patched the [affected.artery_name] in [target]'s [affected.name] with \the [tool]."))
-	affected.status &= ~ORGAN_ARTERY_CUT
+	user.visible_message(
+		SPAN_NOTICE("\The [user] has patched the [affected.artery_name] in \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You have patched the [affected.artery_name] in \the [target]'s [affected.name] with \the [tool].")
+	)
+	CLEAR_FLAGS(affected.status, ORGAN_ARTERY_CUT)
 	affected.update_damages()
 
 /singleton/surgery_step/fix_vein/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -140,13 +144,14 @@
 	..()
 
 /singleton/surgery_step/hardsuit/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-
 	var/obj/item/rig/rig = target.back
-	if(!istype(rig))
+	if (!istype(rig))
 		return
 	rig.reset()
-	user.visible_message(SPAN_NOTICE("[user] has cut through the support systems of [target]'s [rig] with \the [tool]."), \
-		SPAN_NOTICE("You have cut through the support systems of [target]'s [rig] with \the [tool]."))
+	user.visible_message(
+		SPAN_NOTICE("\The [user] has cut through the support systems of \the [target]'s [rig.name] with \a [tool]."),
+		SPAN_NOTICE("You have cut through the support systems of \the [target]'s [rig.name] with \the [tool].")
+	)
 
 /singleton/surgery_step/hardsuit/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message(SPAN_DANGER("[user]'s [tool] can't quite seem to get through the metal..."), \
@@ -207,8 +212,10 @@
 
 	var/trans = temp_reagents.trans_to_mob(target, temp_reagents.total_volume, CHEM_BLOOD) //technically it's contact, but the reagents are being applied to internal tissue
 	if (trans > 0)
-		user.visible_message("[SPAN_NOTICE("[user] rubs [target]'s [affected.name] down with \the [tool]'s contents")].", \
-			SPAN_NOTICE("You rub [target]'s [affected.name] down with \the [tool]'s contents."))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] rubs \the [target]'s [affected.name] down with \a [tool]'s contents"),
+			SPAN_NOTICE("You rub \the [target]'s [affected.name] down with \the [tool]'s contents.")
+		)
 	affected.disinfect()
 	qdel(temp_reagents)
 	qdel(temp_holder)

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -122,18 +122,23 @@
 	return TRUE
 
 
+/singleton/surgery_step/hardsuit/assess_surgery_candidate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
+	return ..() && target_zone == BP_CHEST && istype(target.back, /obj/item/rig) && !(target.back.canremove)
+
+
 /singleton/surgery_step/hardsuit/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	return list(SKILL_EVA = SKILL_BASIC)
 
 
 /singleton/surgery_step/hardsuit/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if(!istype(target))
-		return FALSE
-	if(isWelder(tool))
+	. = ..()
+	if (!.)
+		return
+
+	if (isWelder(tool))
 		var/obj/item/weldingtool/welder = tool
-		if(!welder.remove_fuel(1,user))
+		if (!welder.remove_fuel(1, user))
 			return FALSE
-	return (target_zone == BP_CHEST) && istype(target.back, /obj/item/rig) && !(target.back.canremove)
 
 /singleton/surgery_step/hardsuit/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message(

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -23,8 +23,9 @@
 
 /singleton/surgery_step/fix_tendon/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected && (affected.status & ORGAN_TENDON_CUT))
-		return affected
+	if (!affected || !HAS_FLAGS(affected.status, ORGAN_TENDON_CUT))
+		return FALSE
+	return affected
 
 /singleton/surgery_step/fix_tendon/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -68,8 +69,9 @@
 
 /singleton/surgery_step/fix_vein/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected && (affected.status & ORGAN_ARTERY_CUT))
-		return affected
+	if (!affected || !HAS_FLAGS(affected.status, ORGAN_ARTERY_CUT))
+		return FALSE
+	return affected
 
 /singleton/surgery_step/fix_vein/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -165,8 +167,9 @@
 
 /singleton/surgery_step/sterilize/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected && !affected.is_disinfected() && check_chemicals(tool))
-		return affected
+	if (!affected || affected.is_disinfected() || !check_chemicals(tool))
+		return FALSE
+	return affected
 
 
 /singleton/surgery_step/sterilize/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -13,12 +13,12 @@
 		/obj/item/stack/cable_coil = 75,
 		/obj/item/tape_roll = 50
 	)
-	can_infect = 1
-	blood_level = 1
-	min_duration = 70
-	max_duration = 90
+	can_infect = TRUE
+	blood_level = BLOOD_LEVEL_HANDS
+	min_duration = 7 SECONDS
+	max_duration = 9 SECONDS
 	shock_level = 40
-	delicate = 1
+	delicate = TRUE
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_RETRACTED
 
 /singleton/surgery_step/fix_tendon/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -57,12 +57,12 @@
 		/obj/item/stack/cable_coil = 75,
 		/obj/item/tape_roll = 50
 	)
-	can_infect = 1
-	blood_level = 1
-	min_duration = 70
-	max_duration = 90
+	can_infect = TRUE
+	blood_level = BLOOD_LEVEL_HANDS
+	min_duration = 7 SECONDS
+	max_duration = 9 SECONDS
 	shock_level = 40
-	delicate = 1
+	delicate = TRUE
 	strict_access_requirement = FALSE
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_ROBOTIC | SURGERY_NO_STUMP | SURGERY_NEEDS_RETRACTED
 
@@ -105,11 +105,8 @@
 		/obj/item/psychic_power/psiblade = 75,
 		/obj/item/gun/energy/plasmacutter = 30
 	)
-	can_infect = 0
-	blood_level = 0
-	min_duration = 120
-	max_duration = 180
-	surgery_candidate_flags = 0
+	min_duration = 12 SECONDS
+	max_duration = 18 SECONDS
 
 /singleton/surgery_step/hardsuit/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return TRUE
@@ -161,10 +158,8 @@
 		/obj/item/reagent_containers/food/drinks/glass2 = 75,
 		/obj/item/reagent_containers/glass/bucket = 50
 	)
-	can_infect = 0
-	blood_level = 0
-	min_duration = 50
-	max_duration = 60
+	min_duration = 5 SECONDS
+	max_duration = 6 SECONDS
 
 /singleton/surgery_step/sterilize/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -48,8 +48,10 @@
 
 /singleton/surgery_step/fix_tendon/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!") , \
-	SPAN_WARNING("Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!"))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, smearing \the [tool] in the incision in \the [target]'s [affected.name]!"),
+		SPAN_WARNING("Your hand slips, smearing \the [tool] in the incision in \the [target]'s [affected.name]!")
+	)
 	affected.take_external_damage(5, used_weapon = tool)
 
 //////////////////////////////////////////////////////////////////
@@ -98,8 +100,10 @@
 
 /singleton/surgery_step/fix_vein/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, smearing [tool] in the incision in [target]'s [affected.name]!") , \
-	SPAN_WARNING("Your hand slips, smearing [tool] in the incision in [target]'s [affected.name]!"))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, smearing \the [tool] in the incision in \the [target]'s [affected.name]!"),
+		SPAN_WARNING("Your hand slips, smearing \the [tool] in the incision in \the [target]'s [affected.name]!")
+	)
 	affected.take_external_damage(5, used_weapon = tool)
 
 
@@ -159,8 +163,10 @@
 	)
 
 /singleton/surgery_step/hardsuit/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message(SPAN_DANGER("[user]'s [tool] can't quite seem to get through the metal..."), \
-	SPAN_DANGER("Your [tool] can't quite seem to get through the metal. It's weakening, though - try again."))
+	user.visible_message(
+		SPAN_DANGER("\The [user]'s [tool.name] can't quite seem to get through the metal..."), \
+		SPAN_DANGER("Your [tool.name] can't quite seem to get through the metal. It's weakening, though - try again.")
+	)
 
 
 //////////////////////////////////////////////////////////////////
@@ -230,13 +236,14 @@
 
 	if (!istype(tool, /obj/item/reagent_containers))
 		return
-
 	var/obj/item/reagent_containers/container = tool
 
 	container.reagents.trans_to_mob(target, container.amount_per_transfer_from_this, CHEM_BLOOD)
 
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, spilling \the [tool]'s contents over the [target]'s [affected.name]!") , \
-	SPAN_WARNING("Your hand slips, spilling \the [tool]'s contents over the [target]'s [affected.name]!"))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, spilling \the [tool]'s contents over the \the [target]'s [affected.name]!"),
+		SPAN_WARNING("Your hand slips, spilling \the [tool]'s contents over the \the [target]'s [affected.name]!")
+	)
 	affected.disinfect()
 
 /singleton/surgery_step/sterilize/proc/check_chemicals(obj/item/reagent_containers/container)

--- a/code/modules/surgery/other.dm
+++ b/code/modules/surgery/other.dm
@@ -111,8 +111,10 @@
 /singleton/surgery_step/hardsuit/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return TRUE
 
+
 /singleton/surgery_step/hardsuit/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	return list(SKILL_EVA = SKILL_BASIC)
+
 
 /singleton/surgery_step/hardsuit/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	if(!istype(target))
@@ -166,8 +168,10 @@
 	if(affected && !affected.is_disinfected() && check_chemicals(tool))
 		return affected
 
+
 /singleton/surgery_step/sterilize/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	return list(SKILL_MEDICAL = SKILL_BASIC)
+
 
 /singleton/surgery_step/sterilize/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -16,8 +16,9 @@
 
 /singleton/surgery_step/robotics/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected && !(affected.status & ORGAN_CUT_AWAY))
-		return affected
+	if (!affected || HAS_FLAGS(affected.status, ORGAN_CUT_AWAY))
+		return FALSE
+	return affected
 
 /singleton/surgery_step/robotics/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	. = ..()
@@ -46,8 +47,9 @@
 
 /singleton/surgery_step/robotics/unscrew_hatch/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected && affected.hatch_state == HATCH_CLOSED)
-		return affected
+	if (!affected || affected.hatch_state != HATCH_CLOSED)
+		return FALSE
+	return affected
 
 /singleton/surgery_step/robotics/unscrew_hatch/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -83,8 +85,9 @@
 
 /singleton/surgery_step/robotics/screw_hatch/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected && affected.hatch_state == HATCH_UNSCREWED)
-		return affected
+	if (!affected || affected.hatch_state != HATCH_UNSCREWED)
+		return FALSE
+	return affected
 
 /singleton/surgery_step/robotics/screw_hatch/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -121,8 +124,9 @@
 
 /singleton/surgery_step/robotics/open_hatch/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected && affected.hatch_state == HATCH_UNSCREWED)
-		return affected
+	if (!affected || affected.hatch_state != HATCH_UNSCREWED)
+		return FALSE
+	return affected
 
 /singleton/surgery_step/robotics/open_hatch/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -159,8 +163,9 @@
 
 /singleton/surgery_step/robotics/close_hatch/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected && affected.hatch_state == HATCH_OPENED)
-		return affected
+	if (!affected || affected.hatch_state != HATCH_OPENED)
+		return FALSE
+	return affected
 
 /singleton/surgery_step/robotics/close_hatch/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -234,8 +239,9 @@
 
 /singleton/surgery_step/robotics/repair_brute/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected && affected.hatch_state == HATCH_OPENED && ((affected.status & ORGAN_DISFIGURED) || affected.brute_dam > 0))
-		return affected
+	if (!affected || affected.hatch_state != HATCH_OPENED || (!HAS_FLAGS(affected.status, ORGAN_DISFIGURED) && affected.brute_dam <= 0))
+		return FALSE
+	return affected
 
 /singleton/surgery_step/robotics/repair_brute/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -277,8 +283,9 @@
 
 /singleton/surgery_step/robotics/repair_brittle/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected && BP_IS_BRITTLE(affected) && affected.hatch_state == HATCH_OPENED)
-		return affected
+	if (!affected || !BP_IS_BRITTLE(affected) || affected.hatch_state != HATCH_OPENED)
+		return FALSE
+	return affected
 
 /singleton/surgery_step/robotics/repair_brittle/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -344,8 +351,9 @@
 
 /singleton/surgery_step/robotics/repair_burn/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected && affected.hatch_state == HATCH_OPENED && ((affected.status & ORGAN_DISFIGURED) || affected.burn_dam > 0))
-		return affected
+	if (!affected || affected.hatch_state != HATCH_OPENED || (!HAS_FLAGS(affected.status, ORGAN_DISFIGURED) && affected.burn_dam <= 0))
+		return FALSE
+	return affected
 
 /singleton/surgery_step/robotics/repair_burn/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -399,13 +407,16 @@
 
 /singleton/surgery_step/robotics/fix_organ_robotic/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected)
-		for(var/obj/item/organ/internal/I in affected.internal_organs)
-			if(BP_IS_ROBOTIC(I) && !BP_IS_CRYSTAL(I) && I.damage > 0)
-				if(I.surface_accessible)
-					return affected
-				if(affected.how_open() >= (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED) || affected.hatch_state == HATCH_OPENED)
-					return affected
+	if (!affected)
+		return FALSE
+	for (var/obj/item/organ/internal/organ in affected.internal_organs)
+		if (!BP_IS_ROBOTIC(organ) || BP_IS_CRYSTAL(organ) || organ.damage <= 0)
+			return FALSE
+		if (!organ.surface_accessible)
+			return FALSE
+	if (affected.how_open() < (affected.encased ? SURGERY_ENCASED : SURGERY_RETRACTED) && affected.hatch_state != HATCH_OPENED)
+		return FALSE
+	return affected
 
 /singleton/surgery_step/robotics/fix_organ_robotic/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -630,9 +641,9 @@
 
 
 /singleton/surgery_step/robotics/install_mmi/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	var/obj/item/organ/external/affected = ..()
-	if(affected && target_zone == BP_HEAD)
-		return affected
+	if (target_zone != BP_HEAD)
+		return FALSE
+	return ..()
 
 /singleton/surgery_step/robotics/install_mmi/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -691,8 +702,9 @@
 
 /singleton/surgery_step/remove_mmi/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected && (locate(/obj/item/device/mmi) in affected.implants))
-		return affected
+	if (!affected || !((locate(/obj/item/device/mmi) in affected.implants)))
+		return FALSE
+	return affected
 
 /singleton/surgery_step/remove_mmi/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -734,8 +746,9 @@
 
 /singleton/surgery_step/robotics/robone/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
-	if(affected && (affected.status & ORGAN_BROKEN) && affected.stage == required_stage)
-		return affected
+	if (!affected || !HAS_FLAGS(affected.status, ORGAN_BROKEN) || affected.stage != required_stage)
+		return FALSE
+	return affected
 
 
 /singleton/surgery_step/robotics/robone/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -9,8 +9,10 @@
 /singleton/surgery_step/robotics
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_FLESH | SURGERY_NO_STUMP
 
+
 /singleton/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	return SURGERY_SKILLS_ROBOTIC
+
 
 /singleton/surgery_step/robotics/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
@@ -380,11 +382,12 @@
 	max_duration = 11 SECONDS
 	surgery_candidate_flags = SURGERY_NO_STUMP
 
+
 /singleton/surgery_step/robotics/fix_organ_robotic/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
-	if(target.isSynthetic())
+	if (target.isSynthetic())
 		return SURGERY_SKILLS_ROBOTIC
-	else
-		return SURGERY_SKILLS_ROBOTIC_ON_MEAT
+	return SURGERY_SKILLS_ROBOTIC_ON_MEAT
+
 
 /singleton/surgery_step/robotics/fix_organ_robotic/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	. = ..()
@@ -681,8 +684,10 @@
 	)
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_FLESH | SURGERY_NO_STUMP | SURGERY_NEEDS_ENCASEMENT
 
+
 /singleton/surgery_step/remove_mmi/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	return SURGERY_SKILLS_ROBOTIC
+
 
 /singleton/surgery_step/remove_mmi/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
@@ -732,11 +737,12 @@
 	if(affected && (affected.status & ORGAN_BROKEN) && affected.stage == required_stage)
 		return affected
 
+
 /singleton/surgery_step/robotics/robone/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
-	if(target.isSynthetic())
+	if (target.isSynthetic())
 		return SURGERY_SKILLS_ROBOTIC
-	else
-		return SURGERY_SKILLS_ROBOTIC_ON_MEAT
+	return SURGERY_SKILLS_ROBOTIC_ON_MEAT
+
 
 //////////////////////////////////////////////////////////////////
 //	welding surgery step

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -7,7 +7,6 @@
 //	generic robotic surgery step datum
 //////////////////////////////////////////////////////////////////
 /singleton/surgery_step/robotics
-	can_infect = 0
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_FLESH | SURGERY_NO_STUMP
 
 /singleton/surgery_step/robotics/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
@@ -40,8 +39,8 @@
 		/obj/item/material/coin = 30,
 		/obj/item/material/knife = 40
 	)
-	min_duration = 50
-	max_duration = 90
+	min_duration = 5 SECONDS
+	max_duration = 9 SECONDS
 
 /singleton/surgery_step/robotics/unscrew_hatch/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
@@ -77,8 +76,8 @@
 		/obj/item/material/coin = 30,
 		/obj/item/material/knife = 40
 	)
-	min_duration = 50
-	max_duration = 90
+	min_duration = 5 SECONDS
+	max_duration = 9 SECONDS
 
 /singleton/surgery_step/robotics/screw_hatch/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
@@ -115,8 +114,8 @@
 		/obj/item/material/utensil = 30
 	)
 
-	min_duration = 30
-	max_duration = 40
+	min_duration = 3 SECONDS
+	max_duration = 4 SECONDS
 
 /singleton/surgery_step/robotics/open_hatch/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
@@ -153,8 +152,8 @@
 		/obj/item/material/utensil = 30
 	)
 
-	min_duration = 70
-	max_duration = 100
+	min_duration = 7 SECONDS
+	max_duration = 10 SECONDS
 
 /singleton/surgery_step/robotics/close_hatch/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
@@ -192,8 +191,8 @@
 		/obj/item/psychic_power/psiblade/master = 100
 	)
 
-	min_duration = 70
-	max_duration = 90
+	min_duration = 7 SECONDS
+	max_duration = 9 SECONDS
 
 /singleton/surgery_step/robotics/repair_brute/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	. = ..()
@@ -255,8 +254,8 @@
 /singleton/surgery_step/robotics/repair_brittle
 	name = "Reinforce prosthetic"
 	allowed_tools = list(/obj/item/stack/nanopaste = 50)
-	min_duration = 50
-	max_duration = 60
+	min_duration = 5 SECONDS
+	max_duration = 6 SECONDS
 
 /singleton/surgery_step/robotics/repair_brittle/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	. = ..()
@@ -299,8 +298,8 @@
 	allowed_tools = list(
 		/obj/item/stack/cable_coil = 50
 	)
-	min_duration = 70
-	max_duration = 90
+	min_duration = 7 SECONDS
+	max_duration = 9 SECONDS
 
 /singleton/surgery_step/robotics/repair_burn/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	. = ..()
@@ -365,8 +364,8 @@
 		/obj/item/screwdriver = 30,
 		/obj/item/swapper/power_drill = 50,
 	)
-	min_duration = 80
-	max_duration = 110
+	min_duration = 8 SECONDS
+	max_duration = 11 SECONDS
 	surgery_candidate_flags = SURGERY_NO_STUMP
 
 /singleton/surgery_step/robotics/fix_organ_robotic/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
@@ -431,8 +430,8 @@
 	allowed_tools = list(
 		/obj/item/device/multitool = 70
 	)
-	min_duration = 90
-	max_duration = 110
+	min_duration = 9 SECONDS
+	max_duration = 11 SECONDS
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_FLESH | SURGERY_NO_STUMP | SURGERY_NEEDS_ENCASEMENT
 
 /singleton/surgery_step/robotics/detatch_organ_robotic/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -484,8 +483,8 @@
 		/obj/item/screwdriver = 50,
 		/obj/item/swapper/power_drill = 70,
 	)
-	min_duration = 100
-	max_duration = 120
+	min_duration = 10 SECONDS
+	max_duration = 12 SECONDS
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_FLESH | SURGERY_NO_STUMP | SURGERY_NEEDS_ENCASEMENT
 
 
@@ -551,8 +550,8 @@
 	allowed_tools = list(
 		/obj/item/device/mmi = 100
 	)
-	min_duration = 60
-	max_duration = 80
+	min_duration = 6 SECONDS
+	max_duration = 8 SECONDS
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_FLESH | SURGERY_NO_STUMP | SURGERY_NEEDS_ENCASEMENT
 
 /singleton/surgery_step/robotics/install_mmi/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -608,25 +607,24 @@
 
 /singleton/surgery_step/internal/remove_organ/robotic
 	name = "Remove robotic component"
-	can_infect = 0
+	can_infect = FALSE
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_FLESH | SURGERY_NO_STUMP | SURGERY_NEEDS_ENCASEMENT
 
 /singleton/surgery_step/internal/replace_organ/robotic
 	name = "Replace robotic component"
-	can_infect = 0
+	can_infect = FALSE
 	robotic_surgery = TRUE
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_FLESH | SURGERY_NO_STUMP | SURGERY_NEEDS_ENCASEMENT
 
 /singleton/surgery_step/remove_mmi
 	name = "Remove MMI"
-	min_duration = 60
-	max_duration = 80
+	min_duration = 6 SECONDS
+	max_duration = 8 SECONDS
 	allowed_tools = list(
 		/obj/item/hemostat = 100,
 		/obj/item/wirecutters = 75,
 		/obj/item/material/utensil/fork = 20
 	)
-	can_infect = 0
 	surgery_candidate_flags = SURGERY_NO_CRYSTAL | SURGERY_NO_FLESH | SURGERY_NO_STUMP | SURGERY_NEEDS_ENCASEMENT
 
 /singleton/surgery_step/remove_mmi/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
@@ -696,8 +694,8 @@
 		/obj/item/tape_roll = 30,
 		/obj/item/bonegel = 30
 	)
-	min_duration = 50
-	max_duration = 60
+	min_duration = 5 SECONDS
+	max_duration = 6 SECONDS
 
 /singleton/surgery_step/robotics/robone/weld/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -739,10 +737,10 @@
 		/obj/item/wrench = 70,
 		/obj/item/bonesetter = 50
 	)
-	min_duration = 60
-	max_duration = 70
+	min_duration = 6 SECONDS
+	max_duration = 7 SECONDS
 	shock_level = 40
-	delicate = 1
+	delicate = TRUE
 	surgery_candidate_flags = SURGERY_NO_FLESH | SURGERY_NEEDS_ENCASEMENT
 	required_stage = 1
 
@@ -803,8 +801,8 @@
 		/obj/item/tape_roll = 30,
 		/obj/item/bonegel = 30
 	)
-	min_duration = 50
-	max_duration = 60
+	min_duration = 5 SECONDS
+	max_duration = 6 SECONDS
 	required_stage = 2
 
 /singleton/surgery_step/robotics/robone/finish/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -62,8 +62,10 @@
 
 /singleton/surgery_step/robotics/unscrew_hatch/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] has opened the maintenance hatch on [target]'s [affected.name] with \the [tool]."), \
-	SPAN_NOTICE("You have opened the maintenance hatch on [target]'s [affected.name] with \the [tool]."),)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] has opened the maintenance hatch on \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You have opened the maintenance hatch on \the [target]'s [affected.name] with \the [tool].")
+	)
 	affected.hatch_state = HATCH_UNSCREWED
 
 /singleton/surgery_step/robotics/unscrew_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -102,8 +104,10 @@
 
 /singleton/surgery_step/robotics/screw_hatch/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] has screwed down the maintenance hatch on [target]'s [affected.name] with \the [tool]."), \
-	SPAN_NOTICE("You have screwed down the maintenance hatch on [target]'s [affected.name] with \the [tool]."),)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] has screwed down the maintenance hatch on \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You have screwed down the maintenance hatch on \the [target]'s [affected.name] with \the [tool].")
+	)
 	affected.hatch_state = HATCH_CLOSED
 
 /singleton/surgery_step/robotics/screw_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -143,8 +147,10 @@
 
 /singleton/surgery_step/robotics/open_hatch/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] opens the maintenance hatch on [target]'s [affected.name] with \the [tool]."), \
-	SPAN_NOTICE("You open the maintenance hatch on [target]'s [affected.name] with \the [tool]."))
+	user.visible_message(
+		SPAN_NOTICE("\The [user] opens the maintenance hatch on \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You open the maintenance hatch on \the [target]'s [affected.name] with \the [tool].")
+	)
 	affected.hatch_state = HATCH_OPENED
 
 /singleton/surgery_step/robotics/open_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -184,8 +190,10 @@
 
 /singleton/surgery_step/robotics/close_hatch/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] closes the hatch on [target]'s [affected.name] with \the [tool]."), \
-	SPAN_NOTICE("You close the hatch on [target]'s [affected.name] with \the [tool]."))
+	user.visible_message(
+		SPAN_NOTICE("\The [user] closes the hatch on \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You close the hatch on \the [target]'s [affected.name] with \the [tool].")
+	)
 	affected.hatch_state = HATCH_UNSCREWED
 	affected.germ_level = 0
 
@@ -262,10 +270,12 @@
 
 /singleton/surgery_step/robotics/repair_brute/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] finishes patching damage to [target]'s [affected.name] with \the [tool]."), \
-	SPAN_NOTICE("You finish patching damage to [target]'s [affected.name] with \the [tool]."))
-	affected.heal_damage(rand(30,50),0,1,1)
-	affected.status &= ~ORGAN_DISFIGURED
+	user.visible_message(
+		SPAN_NOTICE("\The [user] finishes patching damage to \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You finish patching damage to \the [target]'s [affected.name] with \the [tool].")
+	)
+	affected.heal_damage(rand(30,50), 0, 1, 1)
+	CLEAR_FLAGS(affected.status, ORGAN_DISFIGURED)
 
 /singleton/surgery_step/robotics/repair_brute/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -308,9 +318,11 @@
 
 /singleton/surgery_step/robotics/repair_brittle/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] finishes repairing the brittle interior of \the [target]'s [affected.name]."), \
-	SPAN_NOTICE("You finish repairing the brittle interior of \the [target]'s [affected.name]."))
-	affected.status &= ~ORGAN_BRITTLE
+	user.visible_message(
+		SPAN_NOTICE("\The [user] finishes repairing the brittle interior of \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You finish repairing the brittle interior of \the [target]'s [affected.name] with \the [tool].")
+	)
+	CLEAR_FLAGS(affected.status, ORGAN_BRITTLE)
 
 /singleton/surgery_step/robotics/repair_brittle/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -378,10 +390,12 @@
 
 /singleton/surgery_step/robotics/repair_burn/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] finishes splicing cable into [target]'s [affected.name]."), \
-	SPAN_NOTICE("You finishes splicing new cable into [target]'s [affected.name]."))
-	affected.heal_damage(0,rand(30,50),1,1)
-	affected.status &= ~ORGAN_DISFIGURED
+	user.visible_message(
+		SPAN_NOTICE("\The [user] finishes splicing cable into \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You finishes splicing new cable into \the [target]'s [affected.name] with \the [tool].")
+	)
+	affected.heal_damage(0, rand(30, 50), 1, 1)
+	CLEAR_FLAGS(affected.status, ORGAN_DISFIGURED)
 
 /singleton/surgery_step/robotics/repair_burn/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -448,12 +462,16 @@
 
 /singleton/surgery_step/robotics/fix_organ_robotic/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	for(var/obj/item/organ/I in affected.internal_organs)
-		if(I && I.damage > 0)
-			if(BP_IS_ROBOTIC(I))
-				user.visible_message(SPAN_NOTICE("[user] repairs [target]'s [I.name] with [tool]."), \
-				SPAN_NOTICE("You repair [target]'s [I.name] with [tool].") )
-				I.damage = 0
+	for (var/obj/item/organ/internal in affected.internal_organs)
+		if (internal.damage <= 0)
+			continue
+		if (!BP_IS_ROBOTIC(internal))
+			continue
+		user.visible_message(
+			SPAN_NOTICE("\The [user] repairs \the [target]'s [internal.name] with \a [tool]."),
+			SPAN_NOTICE("You repair \the [target]'s [internal.name] with \the [tool].")
+		)
+		internal.damage = 0
 
 /singleton/surgery_step/robotics/fix_organ_robotic/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -527,12 +545,15 @@
 /singleton/surgery_step/robotics/detatch_organ_robotic/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/affected = target.get_organ(target_zone)
 	var/obj/removing = LAZYACCESS(target.surgeries_in_progress, target_zone)
-	user.visible_message(SPAN_NOTICE("[user] has decoupled \the [removing] from \the [target]'s [affected.name] with \the [tool].") , \
-	SPAN_NOTICE("You have decoupled \the [removing] from \the [target]'s [affected.name] with \the [tool]."))
+	user.visible_message(
+		SPAN_NOTICE("[user] has decoupled \a [removing] from \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You have decoupled \the [removing] from \the [target]'s [affected.name] with \the [tool].")
+	)
 
-	var/obj/item/organ/internal/I = target.internal_organs_by_name[LAZYACCESS(target.surgeries_in_progress, target_zone)]
-	if(I && istype(I))
-		I.cut_away(user)
+	var/obj/item/organ/internal/internal = target.internal_organs_by_name[LAZYACCESS(target.surgeries_in_progress, target_zone)]
+	if (!istype(internal))
+		return
+	internal.cut_away(user)
 
 /singleton/surgery_step/robotics/detatch_organ_robotic/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message(SPAN_WARNING("[user]'s hand slips, disconnecting \the [tool]."), \
@@ -604,10 +625,10 @@
 	var/obj/item/organ/attaching = target.surgeries_in_progress?[target_zone]
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	affected.implants -= attaching
-	attaching.status &= ~ORGAN_CUT_AWAY
+	CLEAR_FLAGS(attaching.status, ORGAN_CUT_AWAY)
 	attaching.replaced(target, affected)
 	user.visible_message(
-		SPAN_NOTICE("\The [user] has attached \the [target]'s [attaching.name] with \the [tool]."),
+		SPAN_NOTICE("\The [user] has attached \the [target]'s [attaching.name] with \a [tool]."),
 		SPAN_NOTICE("You have attached \the [target]'s [attaching.name] with \the [tool].")
 	)
 
@@ -677,21 +698,24 @@
 	..()
 
 /singleton/surgery_step/robotics/install_mmi/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	if(!user.unEquip(tool))
+	if (!user.unEquip(tool))
+		FEEDBACK_UNEQUIP_FAILURE(user, tool)
 		return
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_NOTICE("[user] has installed \the [tool] into [target]'s [affected.name]."), \
-	SPAN_NOTICE("You have installed \the [tool] into [target]'s [affected.name]."))
+	user.visible_message(
+		SPAN_NOTICE("\The [user] has installed \a [tool] into \the [target]'s [affected.name]."),
+		SPAN_NOTICE("You have installed \the [tool] into \the [target]'s [affected.name].")
+	)
 
-	var/obj/item/device/mmi/M = tool
+	var/obj/item/device/mmi/mmi = tool
 	var/obj/item/organ/internal/mmi_holder/holder = new(target, 1)
 	target.internal_organs_by_name[BP_BRAIN] = holder
 	tool.forceMove(holder)
 	holder.stored_mmi = tool
 	holder.update_from_mmi()
 
-	if(M.brainmob && M.brainmob.mind)
-		M.brainmob.mind.transfer_to(target)
+	if (mmi.brainmob?.mind)
+		mmi.brainmob.mind.transfer_to(target)
 
 /singleton/surgery_step/robotics/install_mmi/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	user.visible_message(SPAN_WARNING("[user]'s hand slips."), \
@@ -742,17 +766,20 @@
 
 /singleton/surgery_step/remove_mmi/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	if(affected)
-		var/obj/item/device/mmi/mmi = locate() in affected.implants
-		if(affected && mmi)
-			user.visible_message( \
-			SPAN_NOTICE("\The [user] removes \the [mmi] from \the [target]'s [affected.name] with \the [tool]."), \
-			SPAN_NOTICE("You  remove \the [mmi] from \the [target]'s [affected.name] with \the [tool]."))
-			target.remove_implant(mmi, TRUE, affected)
-		else
-			user.visible_message( \
-			SPAN_NOTICE("\The [user] could not find anything inside [target]'s [affected.name]."), \
-			SPAN_NOTICE("You could not find anything inside [target]'s [affected.name]."))
+	if (!affected)
+		return
+	var/obj/item/device/mmi/mmi = locate() in affected.implants
+	if (mmi)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] removes \a [mmi] from \the [target]'s [affected.name] with \a [tool]."),
+			SPAN_NOTICE("You  remove \the [mmi] from \the [target]'s [affected.name] with \the [tool].")
+		)
+		target.remove_implant(mmi, TRUE, affected)
+	else
+		user.visible_message(
+			SPAN_NOTICE("\The [user] could not find anything inside \the [target]'s [affected.name]."),
+			SPAN_NOTICE("You could not find anything inside \the [target]'s [affected.name].")
+		)
 
 /singleton/surgery_step/remove_mmi/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -810,12 +837,12 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/prosthetic = affected.encased ? "\the [target]'s [affected.encased]" : "structural support in \the [target]'s [affected.name]"
 	user.visible_message(
-		SPAN_INFO("\The [user] finishes mending \the [prosthetic] with \the [tool.name]"),
-		SPAN_INFO("You finish mending \the [prosthetic] with \the [tool.name].")
+		SPAN_INFO("\The [user] finishes mending \the [prosthetic] with \a [tool]"),
+		SPAN_INFO("You finish mending \the [prosthetic] with \the [tool].")
 	)
-	if(affected.stage == 0)
+	if (affected.stage == 0)
 		affected.stage = 1
-	affected.status &= ~ORGAN_BRITTLE
+	CLEAR_FLAGS(affected.status, ORGAN_BRITTLE)
 
 /singleton/surgery_step/robotics/robone/weld/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
@@ -861,21 +888,21 @@
 /singleton/surgery_step/robotics/robone/realign_support/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/prosthetic = affected.encased ? "\the [target]'s [affected.encased]" : "structural support in \the [target]'s [affected.name]"
-	if (affected.status & ORGAN_BROKEN)
-		if(affected.encased == "skull")
+	if (HAS_FLAGS(affected.status, ORGAN_BROKEN))
+		if (affected.encased == "skull")
 			user.visible_message(
-				SPAN_INFO("\The [user] pieces \the [prosthetic] back together with \the [tool]."),
+				SPAN_INFO("\The [user] pieces \the [prosthetic] back together with \a [tool]."),
 				SPAN_INFO("You piece \the [prosthetic] back together with \the [tool].")
 			)
 		else
 			user.visible_message(
-				SPAN_INFO("\The [user] twists \the [prosthetic] in place with \the [tool]."),
+				SPAN_INFO("\The [user] twists \the [prosthetic] in place with \a [tool]."),
 				SPAN_INFO("You twist \the [prosthetic] in place with \the [tool].")
 			)
 		affected.stage = 2
 	else
 		user.visible_message(
-			SPAN_WARNING("\The [user] twists \the [prosthetic] in the WRONG place with \the [tool]!."),
+			SPAN_WARNING("\The [user] twists \the [prosthetic] in the WRONG place with \a [tool]!."),
 			SPAN_WARNING("You twist \the [prosthetic] in the WRONG place with \the [tool]!.")
 		)
 		affected.fracture()
@@ -915,12 +942,12 @@
 
 /singleton/surgery_step/robotics/robone/finish/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	var/prosthetic = affected.encased ? "\the [target]'s damaged [affected.encased]" : "structural support in [target]'s [affected.name]"
+	var/prosthetic = affected.encased ? "\the [target]'s damaged [affected.encased]" : "structural support in \the [target]'s [affected.name]"
 	user.visible_message(
-		SPAN_INFO("\The [user] has finished mending [prosthetic] with \the [tool]."),
+		SPAN_INFO("\The [user] has finished mending [prosthetic] with \a [tool]."),
 		SPAN_INFO("You have finished mending [prosthetic] with \the [tool]." )
 	)
-	affected.status &= ~ORGAN_BROKEN
+	CLEAR_FLAGS(affected.status, ORGAN_BROKEN)
 	affected.stage = 0
 	affected.update_wounds()
 

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -53,9 +53,11 @@
 
 /singleton/surgery_step/robotics/unscrew_hatch/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] starts to unscrew the maintenance hatch on [target]'s [affected.name] with \the [tool].", \
-	"You start to unscrew the maintenance hatch on [target]'s [affected.name] with \the [tool].")
-	playsound(target.loc, 'sound/items/Screwdriver.ogg', 15, 1)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts to unscrew the maintenance hatch on \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You start to unscrew the maintenance hatch on \the [target]'s [affected.name] with \the [tool].")
+	)
+	playsound(target, 'sound/items/Screwdriver.ogg', 15, TRUE)
 	..()
 
 /singleton/surgery_step/robotics/unscrew_hatch/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -91,9 +93,11 @@
 
 /singleton/surgery_step/robotics/screw_hatch/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] starts to screw down the maintenance hatch on [target]'s [affected.name] with \the [tool].", \
-	"You start to screw down the maintenance hatch on [target]'s [affected.name] with \the [tool].")
-	playsound(target.loc, 'sound/items/Screwdriver.ogg', 15, 1)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts to screw down the maintenance hatch on \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You start to screw down the maintenance hatch on \the [target]'s [affected.name] with \the [tool].")
+	)
+	playsound(target, 'sound/items/Screwdriver.ogg', 15, TRUE)
 	..()
 
 /singleton/surgery_step/robotics/screw_hatch/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -130,9 +134,11 @@
 
 /singleton/surgery_step/robotics/open_hatch/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] starts to pry open the maintenance hatch on [target]'s [affected.name] with \the [tool].",
-	"You start to pry open the maintenance hatch on [target]'s [affected.name] with \the [tool].")
-	playsound(target.loc, 'sound/items/Crowbar.ogg', 15, 1)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts to pry open the maintenance hatch on \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You start to pry open the maintenance hatch on \the [target]'s [affected.name] with \the [tool].")
+	)
+	playsound(target, 'sound/items/Crowbar.ogg', 15, TRUE)
 	..()
 
 /singleton/surgery_step/robotics/open_hatch/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -169,9 +175,11 @@
 
 /singleton/surgery_step/robotics/close_hatch/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] begins to close the hatch on [target]'s [affected.name] with \the [tool]." , \
-	"You begin to close the hatch on [target]'s [affected.name] with \the [tool].")
-	playsound(target.loc, 'sound/items/Crowbar.ogg', 15, 1)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] begins to close the hatch on \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You begin to close the hatch on \the [target]'s [affected.name] with \the [tool].")
+	)
+	playsound(target, 'sound/items/Crowbar.ogg', 15, TRUE)
 	..()
 
 /singleton/surgery_step/robotics/close_hatch/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -245,9 +253,11 @@
 
 /singleton/surgery_step/robotics/repair_brute/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] begins to patch damage to [target]'s [affected.name]'s support structure with \the [tool]." , \
-	"You begin to patch damage to [target]'s [affected.name]'s support structure with \the [tool].")
-	playsound(target.loc, 'sound/items/Welder.ogg', 15, 1)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] begins to patch damage to \the [target]'s [affected.name]'s support structure with \a [tool]."),
+		SPAN_NOTICE("You begin to patch damage to \the [target]'s [affected.name]'s support structure with \the [tool].")
+	)
+	playsound(target, 'sound/items/Welder.ogg', 15, TRUE)
 	..()
 
 /singleton/surgery_step/robotics/repair_brute/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -289,9 +299,11 @@
 
 /singleton/surgery_step/robotics/repair_brittle/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] begins to repair the brittle metal inside \the [target]'s [affected.name]." , \
-	"You begin to repair the brittle metal inside \the [target]'s [affected.name].")
-	playsound(target.loc, 'sound/items/bonegel.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] begins to repair the brittle metal inside \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You begin to repair the brittle metal inside \the [target]'s [affected.name] with \the [tool].")
+	)
+	playsound(target, 'sound/items/bonegel.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/robotics/repair_brittle/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -357,9 +369,11 @@
 
 /singleton/surgery_step/robotics/repair_burn/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] begins to splice new cabling into [target]'s [affected.name]." , \
-	"You begin to splice new cabling into [target]'s [affected.name].")
-	playsound(target.loc, 'sound/items/Deconstruct.ogg', 15, 1)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] begins to splice new cabling into \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You begin to splice new cabling into \the [target]'s [affected.name] with \the [tool].")
+	)
+	playsound(target, 'sound/items/Deconstruct.ogg', 15, TRUE)
 	..()
 
 /singleton/surgery_step/robotics/repair_burn/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -420,12 +434,16 @@
 
 /singleton/surgery_step/robotics/fix_organ_robotic/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	for(var/obj/item/organ/I in affected.internal_organs)
-		if(I && I.damage > 0)
-			if(BP_IS_ROBOTIC(I))
-				user.visible_message("[user] starts mending the damage to [target]'s [I.name]'s mechanisms.", \
-				"You start mending the damage to [target]'s [I.name]'s mechanisms." )
-	playsound(target.loc, 'sound/items/bonegel.ogg', 50, TRUE)
+	for (var/obj/item/organ/internal in affected.internal_organs)
+		if (internal.damage <= 0)
+			continue
+		if (!BP_IS_ROBOTIC(internal))
+			continue
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts mending the damage to \the [target]'s [internal.name]'s mechanisms with \a [tool]."),
+			SPAN_NOTICE("You start mending the damage to \the [target]'s [internal.name]'s mechanisms with \the [tool].")
+		)
+	playsound(target, 'sound/items/bonegel.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/robotics/fix_organ_robotic/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -499,9 +517,11 @@
 /singleton/surgery_step/robotics/detatch_organ_robotic/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/affected = target.get_organ(target_zone)
 	var/obj/removing = target.internal_organs_by_name[LAZYACCESS(target.surgeries_in_progress, target_zone)]
-	user.visible_message("[user] starts to decouple \the [removing] from \the [target]'s [affected.name] with \the [tool].", \
-	"You start to decouple \the [removing] from \the [target]'s [affected.name] with \the [tool]." )
-	playsound(target.loc, 'sound/items/Deconstruct.ogg', 15, 1)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts to decouple \a [removing] from \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You start to decouple \the [removing] from \the [target]'s [affected.name] with \the [tool].")
+	)
+	playsound(target, 'sound/items/Deconstruct.ogg', 15, TRUE)
 	..()
 
 /singleton/surgery_step/robotics/detatch_organ_robotic/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -573,9 +593,11 @@
 /singleton/surgery_step/robotics/attach_organ_robotic/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/affected = target.get_organ(target_zone)
 	var/obj/attaching = LAZYACCESS(target.surgeries_in_progress, target_zone)
-	user.visible_message("[user] begins attaching \the [attaching] to \the [target]'s [affected.name] with \the [tool].", \
-	"You start attaching \the [attaching] to \the [target]'s [affected.name] with \the [tool].")
-	playsound(target.loc, 'sound/items/Screwdriver.ogg', 15, 1)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] begins attaching \a [attaching] to \the [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You start attaching \the [attaching] to \the [target]'s [affected.name] with \the [tool].")
+	)
+	playsound(target, 'sound/items/Screwdriver.ogg', 15, TRUE)
 	..()
 
 /singleton/surgery_step/robotics/attach_organ_robotic/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -647,9 +669,11 @@
 
 /singleton/surgery_step/robotics/install_mmi/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message("[user] starts installing \the [tool] into [target]'s [affected.name].", \
-	"You start installing \the [tool] into [target]'s [affected.name].")
-	playsound(target.loc, 'sound/items/bonesetter.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts installing \a [tool] into [target]'s [affected.name]."),
+		SPAN_NOTICE("You start installing \the [tool] into [target]'s [affected.name].")
+	)
+	playsound(target, 'sound/items/bonesetter.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/robotics/install_mmi/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -708,11 +732,12 @@
 
 /singleton/surgery_step/remove_mmi/begin_step(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message( \
-	"\The [user] starts poking around inside [target]'s [affected.name] with \the [tool].", \
-	"You start poking around inside [target]'s [affected.name] with \the [tool]." )
-	target.custom_pain("The pain in your [affected.name] is living hell!",1,affecting = affected)
-	playsound(target.loc, 'sound/items/bonesetter.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts poking around inside [target]'s [affected.name] with \a [tool]."),
+		SPAN_NOTICE("You start poking around inside [target]'s [affected.name] with \the [tool].")
+	)
+	target.custom_pain("The pain in your [affected.name] is living hell!", 1, affecting = affected)
+	playsound(target, 'sound/items/bonesetter.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/remove_mmi/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -775,10 +800,10 @@
 	var/prosthetic = affected.encased ? "\the [target]'s [affected.encased]" : "structural support in \the [target]'s [affected.name]"
 	if (affected.stage == 0)
 		user.visible_message(
-			SPAN_NOTICE("\The [user] starts mending \the [prosthetic] with \the [tool]."),
+			SPAN_NOTICE("\The [user] starts mending \the [prosthetic] with \a [tool]."),
 			SPAN_NOTICE("You start mending \the [prosthetic] with \the [tool].")
 		)
-	playsound(target.loc, 'sound/items/Welder.ogg', 15, 1)
+	playsound(target, 'sound/items/Welder.ogg', 15, TRUE)
 	..()
 
 /singleton/surgery_step/robotics/robone/weld/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -822,15 +847,15 @@
 	var/prosthetic = affected.encased ? "\the [target]'s [affected.encased]" : "structural support in \the [target]'s [affected.name]"
 	if(affected.encased == "skull")
 		user.visible_message(
-			SPAN_NOTICE("\The [user] begins to piece \the [prosthetic] back together with \the [tool]."),
+			SPAN_NOTICE("\The [user] begins to piece \the [prosthetic] back together with \a [tool]."),
 			SPAN_NOTICE("You begin to piece \the [prosthetic] back together with \the [tool].")
 		)
 	else
 		user.visible_message(
-			SPAN_NOTICE("\The [user] is beginning to twist \the [prosthetic] in place with \the [tool]."),
+			SPAN_NOTICE("\The [user] is beginning to twist \the [prosthetic] in place with \a [tool]."),
 			SPAN_NOTICE("You are beginning to twist \the [prosthetic] in place with \the [tool].")
 		)
-	playsound(target.loc, 'sound/items/bonesetter.ogg', 50, TRUE)
+	playsound(target, 'sound/items/bonesetter.ogg', 50, TRUE)
 	..()
 
 /singleton/surgery_step/robotics/robone/realign_support/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -882,10 +907,10 @@
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	var/prosthetic = affected.encased ? "\the [target]'s damaged [affected.encased]" : "structural support in \the [target]'s [affected.name]"
 	user.visible_message(
-		SPAN_NOTICE("\the [user] starts to finish mending [prosthetic] with \the [tool]."),
+		SPAN_NOTICE("\the [user] starts to finish mending [prosthetic] with \a [tool]."),
 		SPAN_NOTICE("You start to finish mending [prosthetic] with \the [tool].")
 	)
-	playsound(target.loc, 'sound/items/Welder.ogg', 15, 1)
+	playsound(target, 'sound/items/Welder.ogg', 15, TRUE)
 	..()
 
 /singleton/surgery_step/robotics/robone/finish/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/robotics.dm
+++ b/code/modules/surgery/robotics.dm
@@ -70,8 +70,10 @@
 
 /singleton/surgery_step/robotics/unscrew_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("\The [user]'s [tool.name] slips, failing to unscrew \the [target]'s [affected.name]."), \
-	SPAN_WARNING("Your [tool.name] slips, failing to unscrew [target]'s [affected.name]."))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s [tool.name] slips, failing to unscrew \the [target]'s [affected.name]."),
+		SPAN_WARNING("Your [tool.name] slips, failing to unscrew \the [target]'s [affected.name].")
+	)
 
 //////////////////////////////////////////////////////////////////
 //	 screw robotic limb hatch surgery step
@@ -112,8 +114,10 @@
 
 /singleton/surgery_step/robotics/screw_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s [tool.name] slips, failing to screw down [target]'s [affected.name]."), \
-	SPAN_WARNING("Your [tool] slips, failing to screw down [target]'s [affected.name]."))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s [tool.name] slips, failing to screw down \the [target]'s [affected.name]."),
+		SPAN_WARNING("Your [tool.name] slips, failing to screw down \the [target]'s [affected.name].")
+	)
 
 //////////////////////////////////////////////////////////////////
 //	open robotic limb surgery step
@@ -155,8 +159,10 @@
 
 /singleton/surgery_step/robotics/open_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s [tool.name] slips, failing to open the hatch on [target]'s [affected.name]."),
-	SPAN_WARNING("Your [tool] slips, failing to open the hatch on [target]'s [affected.name]."))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s [tool.name] slips, failing to open the hatch on \the [target]'s [affected.name]."),
+		SPAN_WARNING("Your [tool.name] slips, failing to open the hatch on \the [target]'s [affected.name].")
+	)
 
 //////////////////////////////////////////////////////////////////
 //	close robotic limb surgery step
@@ -199,8 +205,10 @@
 
 /singleton/surgery_step/robotics/close_hatch/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s [tool.name] slips, failing to close the hatch on [target]'s [affected.name]."),
-	SPAN_WARNING("Your [tool.name] slips, failing to close the hatch on [target]'s [affected.name]."))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s [tool.name] slips, failing to close the hatch on \the [target]'s [affected.name]."),
+		SPAN_WARNING("Your [tool.name] slips, failing to close the hatch on \the [target]'s [affected.name].")
+	)
 
 //////////////////////////////////////////////////////////////////
 //	robotic limb brute damage repair surgery step
@@ -279,9 +287,11 @@
 
 /singleton/surgery_step/robotics/repair_brute/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s [tool.name] slips, damaging the internal structure of [target]'s [affected.name]."),
-	SPAN_WARNING("Your [tool.name] slips, damaging the internal structure of [target]'s [affected.name]."))
-	target.apply_damage(rand(5,10), DAMAGE_BURN, affected)
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s [tool.name] slips, damaging the internal structure of \the [target]'s [affected.name]."),
+		SPAN_WARNING("Your [tool.name] slips, damaging the internal structure of \the [target]'s [affected.name].")
+	)
+	target.apply_damage(rand(5, 10), DAMAGE_BURN, affected)
 
 //////////////////////////////////////////////////////////////////
 //	robotic limb brittleness repair surgery step
@@ -326,9 +336,11 @@
 
 /singleton/surgery_step/robotics/repair_brittle/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user] causes some of \the [target]'s [affected.name] to crumble!"),
-	SPAN_WARNING("You cause some of \the [target]'s [affected.name] to crumble!"))
-	target.apply_damage(rand(5,10), DAMAGE_BRUTE, affected)
+	user.visible_message(
+		SPAN_WARNING("\The [user] causes some of \the [target]'s [affected.name] to crumble with \the [tool]!"),
+		SPAN_WARNING("You cause some of \the [target]'s [affected.name] to crumble with \the [tool]!")
+	)
+	target.apply_damage(rand(5, 10), DAMAGE_BRUTE, affected)
 
 //////////////////////////////////////////////////////////////////
 //	robotic limb burn damage repair surgery step
@@ -399,9 +411,11 @@
 
 /singleton/surgery_step/robotics/repair_burn/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user] causes a short circuit in [target]'s [affected.name]!"),
-	SPAN_WARNING("You cause a short circuit in [target]'s [affected.name]!"))
-	target.apply_damage(rand(5,10), DAMAGE_BURN, affected)
+	user.visible_message(
+		SPAN_WARNING("\The [user] causes a short circuit in \the [target]'s [affected.name] with \the [tool]!"),
+		SPAN_WARNING("You cause a short circuit in \the [target]'s [affected.name] with \the [tool]!")
+	)
+	target.apply_damage(rand(5, 10), DAMAGE_BURN, affected)
 
 //////////////////////////////////////////////////////////////////
 //	 artificial organ repair surgery step
@@ -475,14 +489,14 @@
 
 /singleton/surgery_step/robotics/fix_organ_robotic/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, gumming up the mechanisms inside of [target]'s [affected.name] with \the [tool]!"), \
-	SPAN_WARNING("Your hand slips, gumming up the mechanisms inside of [target]'s [affected.name] with \the [tool]!"))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, gumming up the mechanisms inside of \the [target]'s [affected.name] with \the [tool]!"),
+		SPAN_WARNING("Your hand slips, gumming up the mechanisms inside of \the [target]'s [affected.name] with \the [tool]!")
+	)
 	target.adjustToxLoss(5)
 	affected.createwound(INJURY_TYPE_CUT, 5)
-	for(var/internal in affected.internal_organs)
-		var/obj/item/organ/internal/I = internal
-		if(I)
-			I.take_internal_damage(rand(3,5))
+	for (var/obj/item/organ/internal/internal in affected.internal_organs)
+		internal.take_internal_damage(rand(3, 5))
 
 //////////////////////////////////////////////////////////////////
 //	robotic organ detachment surgery step
@@ -556,8 +570,10 @@
 	internal.cut_away(user)
 
 /singleton/surgery_step/robotics/detatch_organ_robotic/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, disconnecting \the [tool]."), \
-	SPAN_WARNING("Your hand slips, disconnecting \the [tool]."))
+	user.visible_message(
+		SPAN_WARNING("[user]'s hand slips, disconnecting \the [tool] from \the [target]."),
+		SPAN_WARNING("Your hand slips, disconnecting \the [tool] from \the [target].")
+	)
 
 //////////////////////////////////////////////////////////////////
 //	robotic organ transplant finalization surgery step
@@ -634,8 +650,10 @@
 
 
 /singleton/surgery_step/robotics/attach_organ_robotic/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, disconnecting \the [tool]."), \
-	SPAN_WARNING("Your hand slips, disconnecting \the [tool]."))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, disconnecting \the [tool] from \the [target]."),
+		SPAN_WARNING("Your hand slips, disconnecting \the [tool] from \the [target].")
+	)
 
 //////////////////////////////////////////////////////////////////
 //	mmi installation surgery step
@@ -718,8 +736,10 @@
 		mmi.brainmob.mind.transfer_to(target)
 
 /singleton/surgery_step/robotics/install_mmi/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips."), \
-	SPAN_WARNING("Your hand slips."))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips while trying to install \the [tool] in \the [target]."),
+		SPAN_WARNING("Your hand slips while trying to install \the [tool] in \the [target].")
+	)
 
 /singleton/surgery_step/internal/remove_organ/robotic
 	name = "Remove robotic component"
@@ -847,8 +867,8 @@
 /singleton/surgery_step/robotics/robone/weld/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message(
-		SPAN_WARNING("\The [user]'s hand slips, causing damage with \the [tool] in the open panel on [target]'s [affected.name]!"),
-		SPAN_WARNING("Your hand slips, causing damage with \the [tool] in the open panel on [target]'s [affected.name]!")
+		SPAN_WARNING("\The [user]'s hand slips, causing damage with \the [tool] in the open panel on \the [target]'s [affected.name]!"),
+		SPAN_WARNING("Your hand slips, causing damage with \the [tool] in the open panel on \the [target]'s [affected.name]!")
 	)
 	affected.take_external_damage(5, 0, used_weapon = tool)
 
@@ -954,7 +974,7 @@
 /singleton/surgery_step/robotics/robone/finish/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
 	user.visible_message(
-		SPAN_WARNING("\The [user]'s hand slips, causing damage with \the [tool] in the open panel in [target]'s [affected.name]!"),
-		SPAN_WARNING("Your hand slips, causing damage with \the [tool] in the open panel in [target]'s [affected.name]!")
+		SPAN_WARNING("\The [user]'s hand slips, causing damage with \the [tool] in the open panel in \the [target]'s [affected.name]!"),
+		SPAN_WARNING("Your hand slips, causing damage with \the [tool] in the open panel in \the [target]'s [affected.name]!")
 	)
 	affected.take_external_damage(5, 0, used_weapon = tool)

--- a/code/modules/surgery/slimes.dm
+++ b/code/modules/surgery/slimes.dm
@@ -22,6 +22,7 @@
 /singleton/surgery_step/slime/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	return list(SKILL_SCIENCE = SKILL_TRAINED)
 
+
 //////////////////////////////////////////////////////////////////
 //	slime flesh cutting surgery step
 //////////////////////////////////////////////////////////////////

--- a/code/modules/surgery/slimes.dm
+++ b/code/modules/surgery/slimes.dm
@@ -36,8 +36,8 @@
 	min_duration = 0.5 SECONDS
 	max_duration = 2 SECONDS
 
-/singleton/surgery_step/slime/cut_flesh/can_use(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
-	return ..() && istype(target) && target.core_removal_stage == 0
+/singleton/surgery_step/slime/cut_flesh/assess_surgery_candidate(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
+	return ..() && target.core_removal_stage == 0
 
 /singleton/surgery_step/slime/cut_flesh/begin_step(mob/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
 	user.visible_message(
@@ -70,8 +70,8 @@
 	min_duration = 0.5 SECONDS
 	max_duration = 2 SECONDS
 
-/singleton/surgery_step/slime/cut_innards/can_use(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
-	return ..() && istype(target) && target.core_removal_stage == 1
+/singleton/surgery_step/slime/cut_innards/assess_surgery_candidate(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
+	return ..() && target.core_removal_stage == 1
 
 /singleton/surgery_step/slime/cut_innards/begin_step(mob/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
 	user.visible_message(
@@ -103,8 +103,8 @@
 	min_duration = 1 SECOND
 	max_duration = 2 SECONDS
 
-/singleton/surgery_step/slime/cut_laser/can_use(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
-	return ..() && istype(target) && target.core_removal_stage < 2
+/singleton/surgery_step/slime/cut_laser/assess_surgery_candidate(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
+	return ..() && target.core_removal_stage < 2
 
 /singleton/surgery_step/slime/cut_laser/begin_step(mob/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
 	user.visible_message(
@@ -138,8 +138,8 @@
 	min_duration = 1 SECOND
 	max_duration = 3 SECONDS
 
-/singleton/surgery_step/slime/saw_core/can_use(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
-	return ..() && (istype(target) && target.core_removal_stage == 2 && target.cores > 0) //This is being passed a human as target, unsure why.
+/singleton/surgery_step/slime/saw_core/assess_surgery_candidate(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
+	return ..() && target.core_removal_stage == 2 && target.cores > 0
 
 /singleton/surgery_step/slime/saw_core/begin_step(mob/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
 	user.visible_message(

--- a/code/modules/surgery/slimes.dm
+++ b/code/modules/surgery/slimes.dm
@@ -54,8 +54,10 @@
 	target.core_removal_stage = 1
 
 /singleton/surgery_step/slime/cut_flesh/fail_step(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, tearing [target]'s flesh with \the [tool]!"), \
-	SPAN_WARNING("Your hand slips, tearing [target]'s flesh with \the [tool]!"))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, tearing \the [target]'s flesh with \a [tool]!"),
+		SPAN_WARNING("Your hand slips, tearing \the [target]'s flesh with \the [tool]!")
+	)
 
 //////////////////////////////////////////////////////////////////
 //	slime innards cutting surgery step
@@ -88,8 +90,10 @@
 	target.core_removal_stage = 2
 
 /singleton/surgery_step/slime/cut_innards/fail_step(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, tearing [target]'s innards with \the [tool]!"), \
-	SPAN_WARNING("Your hand slips, tearing [target]'s innards with \the [tool]!"))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, tearing \the [target]'s innards with \a [tool]!"),
+		SPAN_WARNING("Your hand slips, tearing \the [target]'s innards with \the [tool]!")
+	)
 
 //////////////////////////////////////////////////////////////////
 //	slime flesh & innards laser cutting surgery step
@@ -121,8 +125,10 @@
 	target.core_removal_stage = 2
 
 /singleton/surgery_step/slime/cut_laser/fail_step(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, tearing [target]'s innards with \the [tool]!"), \
-	SPAN_WARNING("Your hand slips, searing [target]'s innards with \the [tool]!"))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, tearing \the [target]'s innards with \a [tool]!"),
+		SPAN_WARNING("Your hand slips, searing \the [target]'s innards with \the [tool]!")
+	)
 
 //////////////////////////////////////////////////////////////////
 //	slime core removal surgery step
@@ -163,5 +169,7 @@
 
 /singleton/surgery_step/slime/saw_core/fail_step(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
 	var/datum/pronouns/pronouns = user.choose_from_pronouns()
-	user.visible_message(SPAN_WARNING("[user]'s hand slips, causing [pronouns.him] to miss the core!"), \
-	SPAN_WARNING("Your hand slips, causing you to miss the core!"))
+	user.visible_message(
+		SPAN_WARNING("\The [user]'s hand slips, causing [pronouns.him] to miss \the [src]'s core!"),
+		SPAN_WARNING("Your hand slips, causing you to miss \the [src]'s core!")
+	)

--- a/code/modules/surgery/slimes.dm
+++ b/code/modules/surgery/slimes.dm
@@ -14,8 +14,10 @@
 /singleton/surgery_step/slime/assess_bodypart(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
 	return TRUE
 
+
 /singleton/surgery_step/slime/assess_surgery_candidate(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
 	return isslime(target) && target.stat == DEAD
+
 
 /singleton/surgery_step/slime/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool)
 	return list(SKILL_SCIENCE = SKILL_TRAINED)

--- a/code/modules/surgery/slimes.dm
+++ b/code/modules/surgery/slimes.dm
@@ -47,8 +47,10 @@
 	playsound(target, 'sound/items/scalpel.ogg', 50, TRUE)
 
 /singleton/surgery_step/slime/cut_flesh/end_step(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
-	user.visible_message(SPAN_NOTICE("[user] cuts through [target]'s flesh with \the [tool]."),	\
-	SPAN_NOTICE("You cut through [target]'s flesh with \the [tool], revealing its silky innards."))
+	user.visible_message(
+		SPAN_NOTICE("\The [user] cuts through \the [target]'s flesh with \a [tool]."),
+		SPAN_NOTICE("You cut through \the [target]'s flesh with \the [tool], revealing its silky innards.")
+	)
 	target.core_removal_stage = 1
 
 /singleton/surgery_step/slime/cut_flesh/fail_step(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
@@ -79,8 +81,10 @@
 	playsound(target, 'sound/items/scalpel.ogg', 50, TRUE)
 
 /singleton/surgery_step/slime/cut_innards/end_step(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
-	user.visible_message(SPAN_NOTICE("[user] cuts [target]'s innards apart with \the [tool], exposing the cores."),	\
-	SPAN_NOTICE("You cut [target]'s innards apart with \the [tool], exposing the cores."))
+	user.visible_message(
+		SPAN_NOTICE("\The [user] cuts \the [target]'s innards apart with \a [tool], exposing the cores."),
+		SPAN_NOTICE("You cut \the [target]'s innards apart with \the [tool], exposing the cores.")
+	)
 	target.core_removal_stage = 2
 
 /singleton/surgery_step/slime/cut_innards/fail_step(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
@@ -110,8 +114,10 @@
 	playsound(target, 'sound/items/cautery.ogg', 50, TRUE)
 
 /singleton/surgery_step/slime/cut_laser/end_step(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
-	user.visible_message(SPAN_NOTICE("[user] slices [target]'s innards apart with \the [tool], exposing the cores."),	\
-	SPAN_NOTICE("You slice [target]'s innards apart with \the [tool], exposing the cores."))
+	user.visible_message(
+		SPAN_NOTICE("\The [user] slices \the [target]'s innards apart with \a [tool], exposing the cores."),
+		SPAN_NOTICE("You slice \the [target]'s innards apart with \the [tool], exposing the cores.")
+	)
 	target.core_removal_stage = 2
 
 /singleton/surgery_step/slime/cut_laser/fail_step(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
@@ -144,12 +150,15 @@
 
 /singleton/surgery_step/slime/saw_core/end_step(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
 	target.cores--
-	user.visible_message(SPAN_NOTICE("[user] cuts out one of [target]'s cores with \the [tool]."),,	\
-	SPAN_NOTICE("You cut out one of [target]'s cores with \the [tool]. [target.cores] cores left."))
-	if(target.cores >= 0)
+	var/datum/pronouns/pronouns = target.choose_from_pronouns()
+	user.visible_message(
+		SPAN_NOTICE("\The [user] cuts out one of \the [target]'s cores with \a [tool]."),
+		SPAN_NOTICE("You cut out one of \the [target]'s cores with \a [tool]. [pronouns.He] has [target.cores] cores left.")
+	)
+	if (target.cores >= 0)
 		var/coreType = target.GetCoreType()
 		new coreType(target.loc)
-	if(target.cores <= 0)
+	if (target.cores <= 0)
 		target.icon_state = "[target.colour] baby slime dead-nocore"
 
 /singleton/surgery_step/slime/saw_core/fail_step(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/slimes.dm
+++ b/code/modules/surgery/slimes.dm
@@ -30,7 +30,7 @@
 		/obj/item/material/knife = 75,
 		/obj/item/material/shard = 50
 	)
-	min_duration = 5
+	min_duration = 0.5 SECONDS
 	max_duration = 2 SECONDS
 
 /singleton/surgery_step/slime/cut_flesh/can_use(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
@@ -60,7 +60,7 @@
 		/obj/item/material/knife = 75,
 		/obj/item/material/shard = 50
 	)
-	min_duration = 5
+	min_duration = 0.5 SECONDS
 	max_duration = 2 SECONDS
 
 /singleton/surgery_step/slime/cut_innards/can_use(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/slimes.dm
+++ b/code/modules/surgery/slimes.dm
@@ -40,9 +40,11 @@
 	return ..() && istype(target) && target.core_removal_stage == 0
 
 /singleton/surgery_step/slime/cut_flesh/begin_step(mob/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
-	user.visible_message("[user] starts cutting through [target]'s flesh with \the [tool].", \
-	"You start cutting through [target]'s flesh with \the [tool].")
-	playsound(target.loc, 'sound/items/scalpel.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts cutting through \the [target]'s flesh with \a [tool]."),
+		SPAN_NOTICE("You start cutting through \the [target]'s flesh with \the [tool].")
+	)
+	playsound(target, 'sound/items/scalpel.ogg', 50, TRUE)
 
 /singleton/surgery_step/slime/cut_flesh/end_step(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
 	user.visible_message(SPAN_NOTICE("[user] cuts through [target]'s flesh with \the [tool]."),	\
@@ -70,9 +72,11 @@
 	return ..() && istype(target) && target.core_removal_stage == 1
 
 /singleton/surgery_step/slime/cut_innards/begin_step(mob/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
-	user.visible_message("[user] starts cutting [target]'s silky innards apart with \the [tool].", \
-	"You start cutting [target]'s silky innards apart with \the [tool].")
-	playsound(target.loc, 'sound/items/scalpel.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts cutting \the [target]'s silky innards apart with \a [tool]."),
+		SPAN_NOTICE("You start cutting \the [target]'s silky innards apart with \the [tool].")
+	)
+	playsound(target, 'sound/items/scalpel.ogg', 50, TRUE)
 
 /singleton/surgery_step/slime/cut_innards/end_step(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
 	user.visible_message(SPAN_NOTICE("[user] cuts [target]'s innards apart with \the [tool], exposing the cores."),	\
@@ -99,9 +103,11 @@
 	return ..() && istype(target) && target.core_removal_stage < 2
 
 /singleton/surgery_step/slime/cut_laser/begin_step(mob/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
-	user.visible_message("[user] starts slicing through to the [target]'s silky innards apart with \the [tool].", \
-	"You start slicing through to the [target]'s silky innards apart with \the [tool].")
-	playsound(target.loc, 'sound/items/cautery.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts slicing through to the \the [target]'s silky innards apart with \a [tool]."),
+		SPAN_NOTICE("You start slicing through to the \the [target]'s silky innards apart with \the [tool].")
+	)
+	playsound(target, 'sound/items/cautery.ogg', 50, TRUE)
 
 /singleton/surgery_step/slime/cut_laser/end_step(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
 	user.visible_message(SPAN_NOTICE("[user] slices [target]'s innards apart with \the [tool], exposing the cores."),	\
@@ -130,9 +136,11 @@
 	return ..() && (istype(target) && target.core_removal_stage == 2 && target.cores > 0) //This is being passed a human as target, unsure why.
 
 /singleton/surgery_step/slime/saw_core/begin_step(mob/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
-	user.visible_message("[user] starts cutting out one of [target]'s cores with \the [tool].", \
-	"You start cutting out one of [target]'s cores with \the [tool].")
-	playsound(target.loc, 'sound/items/circularsaw.ogg', 50, TRUE)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts cutting out one of \the [target]'s cores with \a [tool]."),
+		SPAN_NOTICE("You start cutting out one of \the [target]'s cores with \the [tool].")
+	)
+	playsound(target, 'sound/items/circularsaw.ogg', 50, TRUE)
 
 /singleton/surgery_step/slime/saw_core/end_step(mob/living/user, mob/living/carbon/slime/target, target_zone, obj/item/tool)
 	target.cores--

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -17,11 +17,11 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 /singleton/surgery_step
 	/// String. Name of the surgery step, i.e. `"Make incision"`. Used in feedback messages and surgery selection dialogues.
 	var/name
-	/// List (Subpaths of `/obj/item`). Map of type paths to percentages (`0` - `100`) indicating what tools can perform this surgery and their efficiency at it.
+	/// List (Subpaths of `/obj/item` => integer). Map of type paths to percentages (`0` - `100`) indicating what tools can perform this surgery and their efficiency at it.
 	var/list/allowed_tools = list()
-	/// LAZYLIST (String - Any of `SPECIES_*`). Type paths referencing races that this step applies to. Overrides `disallowed_species`.
+	/// LAZYLIST (String - Any of `SPECIES_*`). List of type paths referencing races that this step applies to. Overrides `disallowed_species`.
 	var/list/allowed_species
-	/// LAZYLIST (String - Any of `SPECIES_*`). Type paths referencing races that this step does not apply to. Overridden by `allowed_species`.
+	/// LAZYLIST (String - Any of `SPECIES_*`). List of type paths referencing races that this step does not apply to. Overridden by `allowed_species`.
 	var/list/disallowed_species
 	/// Integer. Minimum duration of the step in ticks. Used for randomizing `do_after()` times.
 	var/min_duration = 0
@@ -130,9 +130,9 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 		spread_germs_to_organ(affected, user)
 	if(ishuman(user) && prob(60))
 		var/mob/living/carbon/human/H = user
-		if (blood_level)
+		if (blood_level >= BLOOD_LEVEL_HANDS)
 			H.bloody_hands(target,0)
-		if (blood_level > 1)
+		if (blood_level >= BLOOD_LEVEL_FULLBODY)
 			H.bloody_body(target,0)
 	if(shock_level)
 		target.shock_stage = max(target.shock_stage, shock_level)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -106,11 +106,24 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 	return TRUE
 
 
+/**
+ * Determines the skill requirements to perform the surgery without potential failures.
+ *
+ * **Parameters**:
+ * - `user` - The mob performing the operation.
+ * - `target` - The mob the operation is being performed on.
+ * - `tool` - The item being used to perform the operation.
+ * - `target_zone` (string) - The targeted body doll zone the operation is being performed on. Valid for
+ *       `mob/get_organ(target_zone)`.
+ *
+ * Returns a list (Map of `SKILL_{CATEGORY} = SKILL_{LEVEL}`). Can also be one of the `SURGERY_SKILLS_*` presets defined
+ *     in `code\modules\surgery\__surgery_setup.dm`.
+ */
 /singleton/surgery_step/proc/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
-	if(delicate)
+	if (delicate)
 		return SURGERY_SKILLS_DELICATE
-	else
-		return SURGERY_SKILLS_GENERIC
+	return SURGERY_SKILLS_GENERIC
+
 
 // checks whether this step can be applied with the given user and target
 /singleton/surgery_step/proc/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
@@ -185,7 +198,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 	if(user == target)
 		. -= 10
 
-	var/skill_reqs = get_skill_reqs(user, target, tool, target_zone)
+	var/list/skill_reqs = get_skill_reqs(user, target, tool, target_zone)
 	for(var/skill in skill_reqs)
 		var/penalty = delicate ? 40 : 20
 		. -= max(0, penalty * (skill_reqs[skill] - user.get_skill_value(skill)))
@@ -286,7 +299,7 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 			if(operation_data)
 				LAZYSET(M.surgeries_in_progress, zone, operation_data)
 				S.begin_step(user, M, zone, src)
-				var/skill_reqs = S.get_skill_reqs(user, M, src, zone)
+				var/list/skill_reqs = S.get_skill_reqs(user, M, src, zone)
 				var/duration = user.skill_delay_mult(skill_reqs[1]) * rand(S.min_duration, S.max_duration)
 				if(prob(S.success_chance(user, M, src, zone)) && do_after(user, duration, M, DO_SURGERY))
 					if (S.can_use(user, M, zone, src))

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -63,8 +63,23 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 	return 0
 
 
+/**
+ * Actions and checks to be performed before starting the actual surgery.
+ *
+ * **Parameters**:
+ * - `user` - The mob performing the operation.
+ * - `target` - The mob the operation is being performed on.
+ * - `target_zone` (string) - The targeted body doll zone the operation is being performed on. Valid for
+ *       `mob/get_organ(target_zone)`.
+ * - `tool` - The item being used to perform the operation.
+ *
+ * Returns boolean or an instance of a selected organ for certain subtypes. If `FALSE`, the surgery cannot be performed
+ *     and the process is halted. A user feedback message may be sent when returning `FALSE`, though bear in mind this
+ *     proc may run for multiple surgery steps if those steps consider the used tool valid.
+ */
 /singleton/surgery_step/proc/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return TRUE
+
 
 // Checks if this step applies to the user mob at all
 /singleton/surgery_step/proc/is_valid_target(mob/living/carbon/human/target)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -229,7 +229,19 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 		to_chat(target, SPAN_NOTICE(SPAN_BOLD("... [pick("bright light", "faraway pain", "something moving in you", "soft beeping")] ...")))
 
 
-// does stuff to end the step, which is normally print a message + do whatever this step changes
+/**
+ * Does stuff to end the step, usually just printing messages and logic for whatever the step changes.
+ *
+ * This is generally things that occur before the `do_after()` timer.
+ *
+ * **Parameters**:
+ * - `user` - The mob performing the surgery.
+ * - `target` - The mob being operated on.
+ * - `target_zone` - `user`'s targeted body zone.
+ * - `tool` - The item being used to perform the surgery.
+ *
+ * Has no return value.
+ */
 /singleton/surgery_step/proc/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -322,14 +322,25 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 			. -= 10
 	. = max(., 0)
 
-/proc/spread_germs_to_organ(obj/item/organ/external/E, mob/living/carbon/human/user)
-	if(!istype(user) || !istype(E)) return
+
+/**
+ * Handles spreading `germ_level` from `user` to `organ`.
+ *
+ * **Parameters**:
+ * - `organ` - The organ germs are being spread to.
+ * - `user` - The mob germs are being spread from.
+ *
+ * Has no return value.
+ */
+/proc/spread_germs_to_organ(obj/item/organ/external/organ, mob/living/carbon/human/user)
+	if(!istype(user) || !istype(organ))
+		return
 
 	var/germ_level = user.germ_level
 	if(user.gloves)
 		germ_level = user.gloves.germ_level
 
-	E.germ_level = max(germ_level,E.germ_level) //as funny as scrubbing microbes out with clean gloves is - no.
+	organ.germ_level = max(germ_level, organ.germ_level)
 
 /obj/item/proc/do_surgery(mob/living/carbon/M, mob/living/user, fuckup_prob)
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -257,9 +257,21 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 /singleton/surgery_step/proc/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return
 
-// stuff that happens when the step fails
+
+/**
+ * Does stuff if the surgery step fails.
+ *
+ * **Parameters**:
+ * - `user` - The mob performing the surgery.
+ * - `target` - The ~~victim~~mob being operated on.
+ * - `target_zone` - `user`'s targeted body zone when the surgery started.
+ * - `tool` - The item being used to perform the surgery.
+ *
+ * Has no return value.
+ */
 /singleton/surgery_step/proc/fail_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return null
+
 
 /singleton/surgery_step/proc/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
 	. = tool_quality(tool)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -1,4 +1,4 @@
-// A list of types that will not attempt to perform surgery if the user is on help intent.
+/// A list of types that will not attempt to perform surgery if the user is on help intent.
 GLOBAL_LIST_INIT(surgery_tool_exceptions, list(
 	/obj/item/auto_cpr,
 	/obj/item/device/scanner/health,
@@ -8,22 +8,44 @@ GLOBAL_LIST_INIT(surgery_tool_exceptions, list(
 	/obj/item/reagent_containers/syringe,
 	/obj/item/reagent_containers/borghypo
 ))
+
+
+/// A cache of types that have already been checked against `GLOB.surgery_tool_exceptions`.
 GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 
-/* SURGERY STEPS */
+
 /singleton/surgery_step
+	/// String. Name of the surgery step, i.e. `"Make incision"`. Used in feedback messages and surgery selection dialogues.
 	var/name
-	var/list/allowed_tools               // type path referencing tools that can be used for this step, and how well are they suited for it
-	var/list/allowed_species             // type paths referencing races that this step applies to.
-	var/list/disallowed_species          // type paths referencing races that this step applies to.
-	var/min_duration = 0                 // duration of the step
-	var/max_duration = 0                 // duration of the step
-	var/can_infect = 0                   // evil infection stuff that will make everyone hate me
-	var/blood_level = 0                  // How much blood this step can get on surgeon. 1 - hands, 2 - full body.
-	var/shock_level = 0	                 // what shock level will this step put patient on
-	var/delicate = 0                     // if this step NEEDS stable optable or can be done on any valid surface with no penalty
-	var/surgery_candidate_flags = 0      // Various bitflags for requirements of the surgery.
-	var/strict_access_requirement = TRUE // Whether or not this surgery will be fuzzy on size requirements.
+	/// List (Subpaths of `/obj/item`). Map of type paths to percentages (`0` - `100`) indicating what tools can perform this surgery and their efficiency at it.
+	var/list/allowed_tools = list()
+	/// LAZYLIST (String - Any of `SPECIES_*`). Type paths referencing races that this step applies to. Overrides `disallowed_species`.
+	var/list/allowed_species
+	/// LAZYLIST (String - Any of `SPECIES_*`). Type paths referencing races that this step does not apply to. Overridden by `allowed_species`.
+	var/list/disallowed_species
+	/// Integer. Minimum duration of the step in ticks. Used for randomizing `do_after()` times.
+	var/min_duration = 0
+	/// Integer. Maximum duration of the step in ticks. Used for randomizing `do_after()` times.
+	var/max_duration = 0
+	/// Boolean. Whether or not this step can cause infection.
+	var/can_infect = FALSE
+	/// Integer (One of `src.BLOOD_LEVEL_*`). How much blood this step can get on the surgeon.
+	var/blood_level = BLOOD_LEVEL_NONE
+	/// Integer. The shock level this surgery will put the patient into.
+	var/shock_level = 0
+	/// Boolean. If this step NEEDS a stable operation table or can be done on any valid surface with no penalty.
+	var/delicate = FALSE
+	/// Bitflags (Any of `SURGERY_*`). Various surgery requirements. See `code\modules\surgery\__surgery_setup.dm` for valid options.
+	var/surgery_candidate_flags = EMPTY_BITFIELD
+	/// Boolean. Whether or not this surgery is strict or fuzzy on size requirements.
+	var/strict_access_requirement = TRUE
+
+	/// The surgery step does not cover the surgeon in blood.
+	var/const/BLOOD_LEVEL_NONE = 0
+	/// The surgery step only covers the surgeon's hands in blood.
+	var/const/BLOOD_LEVEL_HANDS = 1
+	/// The surgery step covers the surgeon's entire body in blood.
+	var/const/BLOOD_LEVEL_FULLBODY = 2
 
 //returns how well tool is suited for this step
 /singleton/surgery_step/proc/tool_quality(obj/item/tool)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -195,22 +195,39 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 /singleton/surgery_step/proc/assess_surgery_candidate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ishuman(target)
 
-// does stuff to begin the step, usually just printing messages. Moved germs transfering and bloodying here too
+
+/**
+ * Does stuff to begin the step, usually just printing messages. Moved germs transfering and bloodying here too.
+ *
+ * This is generally things that occur before the `do_after()` timer.
+ *
+ * **Parameters**:
+ * - `user` - The mob performing the surgery.
+ * - `target` - The mob being operated on.
+ * - `target_zone` - `user`'s targeted body zone.
+ * - `tool` - The item being used to perform the surgery.
+ *
+ * Has no return value.
+ */
 /singleton/surgery_step/proc/begin_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = target.get_organ(target_zone)
+
 	if (can_infect && affected)
 		spread_germs_to_organ(affected, user)
-	if(ishuman(user) && prob(60))
+
+	if (ishuman(user) && prob(60))
 		var/mob/living/carbon/human/H = user
 		if (blood_level >= BLOOD_LEVEL_HANDS)
 			H.bloody_hands(target,0)
 		if (blood_level >= BLOOD_LEVEL_FULLBODY)
 			H.bloody_body(target,0)
-	if(shock_level)
+
+	if (shock_level)
 		target.shock_stage = max(target.shock_stage, shock_level)
+
 	if (target.stat == UNCONSCIOUS && prob(20))
 		to_chat(target, SPAN_NOTICE(SPAN_BOLD("... [pick("bright light", "faraway pain", "something moving in you", "soft beeping")] ...")))
-	return
+
 
 // does stuff to end the step, which is normally print a message + do whatever this step changes
 /singleton/surgery_step/proc/end_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -47,12 +47,21 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 	/// The surgery step covers the surgeon's entire body in blood.
 	var/const/BLOOD_LEVEL_FULLBODY = 2
 
-//returns how well tool is suited for this step
+
+/**
+ * Determines whether a tool is suited for this surgery and how efficient it is. References the `allowed_tools` map.
+ *
+ * **Parameters**
+ * - `tool` - The tool to check.
+ *
+ * Returns a percentage as an integer from `0` to `100`. A value of `0` indicates the tool cannot be used for this surgery.
+ */
 /singleton/surgery_step/proc/tool_quality(obj/item/tool)
-	for (var/T in allowed_tools)
-		if (istype(tool,T))
-			return allowed_tools[T]
+	for (var/allowed_type in allowed_tools)
+		if (istype(tool, allowed_type))
+			return allowed_tools[allowed_type]
 	return 0
+
 
 /singleton/surgery_step/proc/pre_surgery_step(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return TRUE

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -125,7 +125,19 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 	return SURGERY_SKILLS_GENERIC
 
 
-// checks whether this step can be applied with the given user and target
+/**
+ * Whether this step can be applied with the given user and target.
+ *
+ * By default, checks both `assess_bodypart()` and `assess_surgery_candidate()`.
+ *
+ * **Parameters**:
+ * - `user` - The mob performing the operation.
+ * - `target` - The mob being operated on.
+ * - `target_zone` - The user's selected target zone.
+ * - `tool` - The item being used to perform the operation.
+ *
+ * Returns boolean.
+ */
 /singleton/surgery_step/proc/can_use(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return assess_bodypart(user, target, target_zone, tool) && assess_surgery_candidate(user, target, target_zone, tool)
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -439,6 +439,13 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 	return FALSE
 
 
+/**
+ * Handles any additional logic the item should perform after completing a surgery. I.e., resource usage.
+ *
+ * Called by `do_surgery()` after `/datum/surgery_step/proc/end_step()`
+ *
+ * Has no return value.
+ */
 /obj/item/proc/handle_post_surgery()
 	return
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -273,6 +273,17 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 	return null
 
 
+/**
+ * Determines the change the surgery can succeed as a percentile value from `0` to `100`.
+ *
+ * **Parameters**:
+ * - `user` - The mob attempting the surgery.
+ * - `target` - The mob being operated on.
+ * - `tool` - The item being used to perform the surgery.
+ * - `target_zone` - `user`'s targeted body zone when the surgery started.
+ *
+ * Returns integer value from `0` to `100`. Final value is based on `tool_quality(tool)` alongside several other generalized and surgery specific checks.
+ */
 /singleton/surgery_step/proc/success_chance(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
 	. = tool_quality(tool)
 	if(user == target)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -181,6 +181,17 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 
 	return affected
 
+/**
+ * Determines whether or not `target` is valid for this surgery.
+ *
+ * **Parameters**:
+ * - `user` - The mob performing the surgery.
+ * - `target` - The mob being operated on.
+ * - `target_zone` - `user`'s target body zone.
+ * - `tool` - The item being used to perform the surgery.
+ *
+ * Returns boolean.
+ */
 /singleton/surgery_step/proc/assess_surgery_candidate(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	return ishuman(target)
 

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -81,22 +81,30 @@ GLOBAL_LIST_INIT(surgery_tool_exception_cache, new)
 	return TRUE
 
 
-// Checks if this step applies to the user mob at all
+/**
+ * Determines whether the target mob is a valid target for this surgery step.
+ *
+ * **Parameters**:
+ * - `target` - The mob being targeted for the operation.
+ *
+ * Returns boolean.
+ */
 /singleton/surgery_step/proc/is_valid_target(mob/living/carbon/human/target)
-	if(!ishuman(target))
-		return 0
+	if (!ishuman(target))
+		return FALSE
 
-	if(allowed_species)
-		for(var/species in allowed_species)
-			if(target.species.get_bodytype(target) == species)
-				return 1
+	if (allowed_species)
+		for (var/species in allowed_species)
+			if (target.species.get_bodytype(target) == species)
+				return TRUE
 
-	if(disallowed_species)
-		for(var/species in disallowed_species)
-			if(target.species.get_bodytype(target) == species)
-				return 0
+	if (disallowed_species)
+		for (var/species in disallowed_species)
+			if (target.species.get_bodytype(target) == species)
+				return FALSE
 
-	return 1
+	return TRUE
+
 
 /singleton/surgery_step/proc/get_skill_reqs(mob/living/user, mob/living/carbon/human/target, obj/item/tool, target_zone)
 	if(delicate)

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -48,7 +48,7 @@ exactly 26 "text2path uses" 'text2path'
 exactly 5 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 4 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 329 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 328 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 0 "anchored = 0/1" 'anchored\s*=\s*\d' -P
 exactly 2 "density = 0/1" 'density\s*=\s*\d' -P


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
refactor: Surgery code has been cleaned up. Report any new surgery related bugs.
admin: The debug log for transplanted organs missing the cut away flag is now a runtime error for stacktracing.
/:cl:

## Other Changes
- Added docblocks to surgery step properties and procs.
- Updated surgery step properties and procs to match current coding styling standards.
- Updated procs defined in `surgery.dm` that weren't surgery_step methods.
- Moved some logic to more applicable proc calls.
- Removed `fuckup_prob` from `do_surgery()`. This parameter was never set nor used.
