### PR TITLE
Ammo Boxes

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1199,6 +1199,7 @@
 #include "code\game\objects\items\weapons\material\urn.dm"
 #include "code\game\objects\items\weapons\melee\energy.dm"
 #include "code\game\objects\items\weapons\melee\misc.dm"
+#include "code\game\objects\items\weapons\storage\ammobox.dm"
 #include "code\game\objects\items\weapons\storage\backpack.dm"
 #include "code\game\objects\items\weapons\storage\bags.dm"
 #include "code\game\objects\items\weapons\storage\belt.dm"

--- a/code/game/objects/items/weapons/storage/ammobox.dm
+++ b/code/game/objects/items/weapons/storage/ammobox.dm
@@ -1,0 +1,403 @@
+/obj/item/ammobox
+	name = "ammo box"
+	icon = 'icons/obj/weapons/ammo_boxes.dmi'
+	icon_state = "ammo"
+	desc = "A sturdy metal box with several warning symbols on the front.<br>WARNING: Live ammunition. Misuse may result in serious injury or death."
+
+	/// Path (Subtypes of `/obj/item/ammo_casing`). The ammo type this ammo box holds. Generally, you should not modify directly. See `set_ammo_type()`
+	var/obj/item/ammo_casing/ammo_type
+
+	/// Positive Integer. The amount on ammunition currently in this box. Generally, you should not modify directly. See `insert_casing()` and `remove_casing()`.
+	var/ammo_count
+
+	/// Positive Integer. The maximum amount of ammunition this box can hold.
+	var/ammo_max = 100
+
+
+/obj/item/ammobox/pistol
+	ammo_type = /obj/item/ammo_casing/pistol
+	ammo_count = 100
+
+
+/obj/item/ammobox/Initialize(mapload)
+	. = ..()
+	if (. == INITIALIZE_HINT_QDEL || QDELETED(src))
+		return
+
+	if (!ammo_count)
+		ammo_type = null
+
+	update_name()
+
+
+/obj/item/ammobox/examine(mob/user, distance, is_adjacent)
+	. = ..()
+
+	if (!ammo_count)
+		to_chat(user, SPAN_NOTICE("It is empty."))
+	else
+		var/remaining_space = ammo_max - ammo_count
+		to_chat(user, SPAN_NOTICE("It is currently holding [ammo_count] [initial(ammo_type.name)]\s and has room for [remaining_space] more."))
+
+
+/obj/item/ammobox/attack_hand(mob/user)
+	if (user.get_inactive_hand() != src)
+		return ..()
+	if (!ammo_count)
+		USE_FEEDBACK_FAILURE("\The [src] is empty.")
+		return TRUE
+	if (!do_after(user, 0.25 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src))
+		return TRUE
+	var/obj/item/ammo_casing/casing = remove_casing(user, get_turf(user))
+	user.put_in_hands(casing)
+	user.visible_message(
+		SPAN_NOTICE("\The [user] removes \a [casing] from \a [src]."),
+		SPAN_NOTICE("You remove \a [casing] from \the [src]. [ammo_count ? "It now holds [ammo_count] more." : "It is not empty."]")
+	)
+	return TRUE
+
+
+
+/obj/item/ammobox/attack_self(mob/living/user)
+	if (!ammo_count)
+		USE_FEEDBACK_FAILURE("\The [src] is empty.")
+		return
+	var/confirm = alert(user, "Dump \the [src]'s contents on the floor?" , name, "Yes", "No")
+	if (confirm != "Yes" || !user.use_sanity_check(src))
+		return
+	var/turf/target = get_turf(user)
+	while (ammo_count)
+		var/obj/item/ammo_casing/ammo_casing = remove_casing(user, target)
+		ammo_casing.set_dir(pick(GLOB.alldirs))
+	user.visible_message(
+		SPAN_NOTICE("\The [user] dumps \a [src] all over the floor."),
+		SPAN_NOTICE("You dump \the [src] all over the floor.")
+	)
+
+
+/obj/item/ammobox/use_tool(obj/item/tool, mob/living/user, list/click_params)
+	// Ammo Box - Transfer contents
+	if (istype(tool, /obj/item/ammobox))
+		var/obj/item/ammobox/donor_box = tool
+		if (!donor_box.ammo_count)
+			USE_FEEDBACK_FAILURE("\The [donor_box] is empty.")
+			return TRUE
+
+		if (ammo_count >= ammo_max)
+			USE_FEEDBACK_FAILURE("\The [src] is full.")
+			return TRUE
+
+		if (ammo_count && donor_box.ammo_type != ammo_type)
+			USE_FEEDBACK_FAILURE("\The [donor_box]'s contents can't be mixed with \the [initial(ammo_type.name)] already in \the [src].")
+			return TRUE
+
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts dumping \a [tool] into \a [src]."),
+			SPAN_NOTICE("You start dumping \the [tool] into \the [src].")
+		)
+
+		var/partial = FALSE // Alters the visible message to say "partially" if there was a casing that halted the loop
+		while (donor_box.ammo_count > 0 && ammo_count < ammo_max)
+			if (!do_after(user, 0.5 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+				partial = TRUE
+				break
+			if (!insert_casing(new donor_box.ammo_type()))
+				partial = TRUE
+				break
+			donor_box.remove_casing()
+
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [partial ? "partially " : null]dumps \a [tool] into \a [src]."),
+			SPAN_NOTICE("You [partial ? "partially " : null]dump \the [tool] into \the [src]. The target box now holds [ammo_count] round\s. [partial ? "The donor box has [donor_box.ammo_count] round\s remaining." : null]")
+		)
+		return TRUE
+
+
+	// Ammo Casing - Attempt to add to the box.
+	if (istype(tool, /obj/item/ammo_casing))
+		if (!do_after(user, 0.5 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+			return TRUE
+		if (!insert_casing(tool, user))
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] adds \a [tool] to \a [src]."),
+			SPAN_NOTICE("You add \a [tool] to \the [src]. It now holds [ammo_count] round\s.")
+		)
+		return TRUE
+
+
+	// Ammo Magazine - Attempt to feed the rounds to the box.
+	if (istype(tool, /obj/item/ammo_magazine))
+		var/obj/item/ammo_magazine/magazine = tool
+		if (!length(magazine.stored_ammo))
+			USE_FEEDBACK_FAILURE("\The [tool] is empty.")
+			return TRUE
+
+		if (ammo_count >= ammo_max)
+			USE_FEEDBACK_FAILURE("\The [src] is full.")
+			return TRUE
+
+		var/obj/item/ammo_casing/first_casing = magazine.stored_ammo[1]
+		if (!can_insert_casing(first_casing, user))
+			return TRUE
+
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts emptying \a [tool] into \a [src]."),
+			SPAN_NOTICE("You start emptying \the [tool] into \the [src].")
+		)
+
+		var/partial = FALSE // Alters the visible message to say "partially" if there was a casing that halted the loop
+		for (var/obj/item/ammo_casing/casing in magazine.stored_ammo)
+			if (!do_after(user, 0.25 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+				partial = TRUE
+				break
+			if (!insert_casing(casing))
+				partial = TRUE
+				break
+			magazine.stored_ammo -= casing
+
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [partial ? "partially " : null]empties \a [tool] into \a [src]."),
+			SPAN_NOTICE("You [partial ? "partially " : null]empty \the [tool] into \the [src]. The box now holds [ammo_count] round\s. [partial ? "The magazine has [length(magazine.stored_ammo)] round\s remaining." : null]")
+		)
+		return TRUE
+
+
+	return ..()
+
+
+/obj/item/ammobox/use_after(atom/target, mob/living/user, click_parameters)
+	// Magazine - Load magazine
+	if (istype(target, /obj/item/ammo_magazine))
+		if (!ammo_count)
+			USE_FEEDBACK_FAILURE("\The [src] is empty.")
+			return TRUE
+		var/obj/item/ammo_magazine/magazine = target
+		if (magazine.caliber != initial(ammo_type.caliber))
+			USE_FEEDBACK_FAILURE("\The [src]'s ammunition does not fit into \the [target].")
+			return TRUE
+		if (length(magazine.stored_ammo) >= magazine.max_ammo)
+			USE_FEEDBACK_FAILURE("\The [target] is full.")
+			return TRUE
+
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts loading \a [target] from \a [src]."),
+			SPAN_NOTICE("You start loading \the [target] from \the [src].")
+		)
+		var/partial = FALSE
+		var/count = 0
+		while (ammo_count > 0 && length(magazine.stored_ammo) < magazine.max_ammo)
+			if (!do_after(user, 0.5 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(target, src))
+				partial = TRUE
+				break
+			if (length(magazine.stored_ammo) >= magazine.max_ammo)
+				partial = TRUE
+				break
+			var/casing = remove_casing(user, magazine)
+			if (!casing)
+				partial = TRUE
+				break
+			count++
+			magazine.stored_ammo += casing
+			magazine.update_icon()
+
+		if (!count)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] fails to load any rounds from \a [src] to \a [target]."),
+				SPAN_WARNING("You fail to load any rounds from \the [src] to \the [target].")
+			)
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [partial ? "partially " : null]loads \a [target] with \a [src]."),
+			SPAN_NOTICE("You [partial ? "partially " : null]load \the [target] with [count] round\s from \the [src].<br />\The [src] now has [ammo_count] round\s remaining.<br />\The [target] now has [length(magazine.stored_ammo)] round\s loaded.")
+		)
+		return TRUE
+
+
+	// Try to scoop bullets up
+	var/turf/target_turf
+	var/obj/item/ammo_casing/target_type
+	if (isturf(target))
+		target_turf = target
+	else if (istype(target, /obj/item/ammo_casing) && isturf(target.loc))
+		target_turf = target.loc
+		target_type = target.type
+	else
+		return ..()
+
+	if (ammo_count >= ammo_max)
+		USE_FEEDBACK_FAILURE("\The [src] is full.")
+		return TRUE
+
+	if (ammo_count && target_type && target_type != ammo_type)
+		var/obj/item/ammo_casing/clicked = target
+		USE_FEEDBACK_FAILURE("The [clicked.caliber] [clicked.name] can't be mixed with the [initial(ammo_type.caliber)] [initial(ammo_type.name)] already in \the [src].")
+		return TRUE
+
+	var/list/candidates = list()
+	for (var/obj/item/ammo_casing/ammo_casing in target_turf)
+		if (!ammo_count && !target_type)
+			target_type = ammo_casing.type
+		else if (ammo_count && ammo_casing.type != target_type)
+			continue
+		candidates += ammo_casing
+
+	if (!length(candidates))
+		USE_FEEDBACK_FAILURE("There are no bullets \the [src] can hold here.")
+		return TRUE
+
+	user.visible_message(
+		SPAN_NOTICE("\The [user] starts loading \a [src] with loose bullets."),
+		SPAN_NOTICE("You start loading \the [src] with loose bullets.")
+	)
+	var/count = 0
+	for (var/obj/item/ammo_casing/ammo_casing as anything in candidates)
+		if (ammo_count && ammo_casing.type != ammo_type)
+			continue
+		if (!do_after(user, 0.25 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, ammo_casing, SANITY_CHECK_DEFAULT & ~SANITY_CHECK_TOOL_IN_HAND))
+			break
+		if (!insert_casing(ammo_casing, user))
+			break
+		count++
+
+	if (!count)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] fails to load \a [src] with loose bullets."),
+			SPAN_WARNING("You fail to load \the [src] with loose bullets.")
+		)
+		return TRUE
+	user.visible_message(
+		SPAN_NOTICE("\The [user] loads \a [src] with loose bullets."),
+		SPAN_NOTICE("You load \the [src] with loose bullets.")
+	)
+	return TRUE
+
+
+/obj/item/ammobox/get_mechanics_info()
+	return "<p>A specialized box dedicated to holding loose ammunition. These boxes can only hold a single type of ammunition at a time.</p>"
+
+
+/obj/item/ammobox/get_interactions_info()
+	. = ..()
+	.["Ammo Box"] = "Transfers the contents of the held box to the clicked box, if the ammo types match."
+	.["Bullet Casing"] = "Adds the bullet casing to the box, if the ammo types match."
+	.["Magazine"] = "Transfers the contents of the magazine to the box, if the ammo types match."
+
+
+/**
+ * Sets the box's `ammo_type` to the given type, updating its name in the process.
+ *
+ * **Parameters**:
+ * - `new_ammo_type` (Path - Subtype of `obj/item/ammo_casing`).
+ *
+ * Has no return value.
+ */
+/obj/item/ammobox/proc/set_ammo_type(obj/item/ammo_casing/new_ammo_type)
+	if (isatom(new_ammo_type))
+		new_ammo_type = new_ammo_type.type
+
+	if (!ispath(new_ammo_type, /obj/item/ammo_casing))
+		return
+
+	if (ammo_type == new_ammo_type)
+		return
+
+	ammo_type = new_ammo_type
+	update_name()
+
+
+/**
+ * Checks if the casing can be added to the box.
+ *
+ * Provides user feedback messages on failure.
+ *
+ * **Parameters**:
+ * - `ammo_casing` (Object or path. Subtypes of `/obj/item/ammo_casing`) - The casing to insert. Has to be the same type as `ammo_type`, unless `ammo_count` is `0`.
+ * - `user` - The mob attempting to insert the casing. Used for feedback messages. If not set, no feedback messages are sent.
+ *
+ * Returns boolean. `TRUE` if the casing was successfully inserted, `FALSE` otherwise.
+ */
+/obj/item/ammobox/proc/can_insert_casing(obj/item/ammo_casing/ammo_casing, mob/user)
+	var/obj/item/ammo_casing/casing_type
+	var/casing_name
+	if (ispath(ammo_casing))
+		casing_type = ammo_casing
+		casing_name = initial(ammo_casing.name)
+	else
+		casing_type = ammo_casing.type
+		casing_name = ammo_casing.name
+
+	if (!ispath(casing_type, /obj/item/ammo_casing))
+		if (user)
+			USE_FEEDBACK_FAILURE("\The [src] isn't designed to hold \the [ammo_casing].")
+		return FALSE
+
+	if (ammo_count && ammo_type != casing_type)
+		if (user)
+			USE_FEEDBACK_FAILURE("\The [casing_name] can't be mixed with \the [initial(ammo_type.name)] already in \the [src].")
+		return FALSE
+
+	if (ammo_count >= ammo_max)
+		if (user)
+			USE_FEEDBACK_FAILURE("\The [src] is full.")
+		return FALSE
+
+	return TRUE
+
+
+
+/**
+ * Adds `ammo_casing` to the ammo box's inventory. Checks `can_insert_casing()`.
+ *
+ * **Parameters**:
+ * - `ammo_casing` - The casing to insert. Has to be the same type as `ammo_type`, unless `ammo_count` is `0`.
+ * - `user` - The mob attempting to insert the casing. Used for feedback messages. If not set, no feedback messages are sent.
+ * - `skip_check` (Boolean, default `FALSE`) - If set, skips `can_insert_casing()` checks. Useful if you're already checking outside this proc, or simply want to force a casing.
+ * 		**Be warned this will also force update the ammoboxe's ammo type to the new casing.**
+ *
+ * Returns boolean. `TRUE` if the casing was successfully inserted, `FALSE` otherwise.
+ */
+/obj/item/ammobox/proc/insert_casing(obj/item/ammo_casing/ammo_casing, mob/user, skip_check = FALSE)
+	if (!skip_check && !can_insert_casing(ammo_casing, user))
+		return FALSE
+	ammo_count++
+	if (ammo_type != ammo_casing.type)
+		set_ammo_type(ammo_casing.type)
+	qdel(ammo_casing)
+	return TRUE
+
+
+/**
+ * Removes a casing and places it in `target`.
+ *
+ * Provides user feedback messages on failure.
+ *
+ * **Parameters**:
+ * - `user` - The mob removing the casing. If not set, there will be no feedback messages.
+ * - `target` - The atom to place the casing in. If not set, the casing is not spawned and the round is simply removed.
+ *
+ * Returns the removed casing if one was created or `null`.
+ */
+/obj/item/ammobox/proc/remove_casing(mob/user, atom/target)
+	RETURN_TYPE(/obj/item/ammo_casing)
+	if (!ammo_count)
+		if (user)
+			USE_FEEDBACK_FAILURE("\The [src] is empty.")
+		return
+
+	ammo_count--
+	if (target)
+		var/obj/item/ammo_casing/casing = new ammo_type(target)
+		. = casing
+
+
+	if (!ammo_count)
+		ammo_type = null
+		update_name()
+
+
+/obj/item/ammobox/proc/update_name()
+	if (!ammo_count)
+		SetName("empty [initial(name)]")
+		return
+	SetName("[initial(name)] - [initial(ammo_type.caliber)] [initial(ammo_type.name)]")

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -171,7 +171,7 @@
 
 
 /obj/item/storage/box/ammo
-	name = "ammo box"
+	name = "magazine box"
 	icon = 'icons/obj/weapons/ammo_boxes.dmi'
 	icon_state = "ammo"
 	desc = "A sturdy metal box with several warning symbols on the front.<br>WARNING: Live ammunition. Misuse may result in serious injury or death."

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -14,17 +14,22 @@
 		return
 	var/name
 	var/caliber
+	var/label
 	if (ispath(ammo_casing))
 		name = initial(ammo_casing.name)
 		caliber = initial(ammo_casing.caliber)
+		label = initial(ammo_casing.label)
 	else
 		name = ammo_casing.name
 		caliber = ammo_casing.caliber
 		spent = !ammo_casing.BB
+		label = ammo_casing.label
 
 	. = "[caliber] [name]"
 	if (spent)
 		. = "spent [.]"
+	if (label)
+		. = "[.] ([label])"
 
 
 
@@ -41,6 +46,8 @@
 
 	var/leaves_residue = TRUE
 	var/caliber = ""					//Which kind of guns it can be loaded into
+	/// String. Additional label used for `_get_ammo_casing_name()`. Should be things like 'practice', 'blank', 'AP', 'FMJ', etc.
+	var/label
 	var/projectile_type					//The bullet type to create when New() is called
 	var/obj/item/projectile/BB = null	//The loaded bullet - make it so that the projectiles are created only when needed?
 	var/spent_icon = "pistolcasing-spent"

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -159,6 +159,56 @@
 		)
 		return TRUE
 
+
+	if (istype(tool, /obj/item/ammo_magazine))
+		if (length(stored_ammo) >= max_ammo)
+			USE_FEEDBACK_FAILURE("\The [src] is full.")
+			return TRUE
+		var/obj/item/ammo_magazine/donor_magazine = tool
+		if (length(donor_magazine.stored_ammo) <= 0)
+			USE_FEEDBACK_FAILURE("\The [donor_magazine] is empty.")
+			return TRUE
+		if (donor_magazine.caliber != caliber)
+			USE_FEEDBACK_FAILURE("\The [donor_magazine]'s ammunition does not fit \the [src].")
+			return TRUE
+
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts transferring bullets from \a [tool] to \a [src]."),
+			SPAN_NOTICE("You start transferring bullets from \the [tool] to \the [src].")
+		)
+		var/partial = FALSE
+		var/count = 0
+		while (length(donor_magazine.stored_ammo))
+			if (!do_after(user, 0.5 SECONDS, src, DO_PUBLIC_UNIQUE) || !user.use_sanity_check(src, tool))
+				partial = TRUE
+				break
+			if (length(donor_magazine.stored_ammo) <= 0)
+				USE_FEEDBACK_FAILURE("\The [donor_magazine] is empty.")
+				partial = TRUE
+				break
+			var/obj/item/ammo_casing/ammo_casing = donor_magazine.stored_ammo[length(donor_magazine.stored_ammo)]
+			if (!load_casing(ammo_casing))
+				partial = TRUE
+				break
+			donor_magazine.stored_ammo -= ammo_casing
+			donor_magazine.update_icon()
+			count++
+
+		if (!count)
+			user.visible_message(
+				SPAN_NOTICE("\The [user] fails to transfer any bullets from \a [tool] to \a [src]."),
+				SPAN_NOTICE("Your fail to transfer any bullets from \the [tool] to \the [src].")
+			)
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] [partial ? "partially " : null]transfers bullets from \a [tool] to \a [src]."),
+			SPAN_NOTICE("You [partial ? "partially " : null]transfer bullets from \the [tool] to \the [src].")
+		)
+		update_icon()
+		donor_magazine.update_icon()
+		return TRUE
+
+
 	return ..()
 
 

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -17,9 +17,11 @@
 	var/fall_sounds = list('sound/weapons/guns/casingfall1.ogg','sound/weapons/guns/casingfall2.ogg','sound/weapons/guns/casingfall3.ogg')
 
 
-/obj/item/ammo_casing/Initialize()
-	if(ispath(projectile_type))
+/obj/item/ammo_casing/Initialize(mapload, spawn_empty = FALSE)
+	if (ispath(projectile_type) && !spawn_empty)
 		BB = new projectile_type(src)
+	if (spawn_empty)
+		update_icon()
 	if(randpixel)
 		pixel_x = rand(-randpixel, randpixel)
 		pixel_y = rand(-randpixel, randpixel)

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -1,3 +1,33 @@
+/**
+ * Determines the full descriptive name for an ammo casing.
+ *
+ * Global proc so it also functions with uninitialized type paths.
+ *
+ * **Parameters**:
+ * - `ammo_casing` (Object or path).
+ * - `spent` (Boolean, default `FALSE`). Only used if `ammo_casing` is a path. Whether the casing is considered spent or not. Otherwise, this is defined based on the presence of `ammo_casing.BB`.
+ *
+ * Returns string.
+ */
+/proc/_get_ammo_casing_name(obj/item/ammo_casing/ammo_casing, spent = FALSE)
+	if (!ammo_casing)
+		return
+	var/name
+	var/caliber
+	if (ispath(ammo_casing))
+		name = initial(ammo_casing.name)
+		caliber = initial(ammo_casing.caliber)
+	else
+		name = ammo_casing.name
+		caliber = ammo_casing.caliber
+		spent = !ammo_casing.BB
+
+	. = "[caliber] [name]"
+	if (spent)
+		. = "spent [.]"
+
+
+
 /obj/item/ammo_casing
 	name = "bullet casing"
 	desc = "A bullet casing."
@@ -97,6 +127,10 @@
 		to_chat(user, "Its caliber is [caliber].")
 	if (!BB)
 		to_chat(user, "This one is spent.")
+
+
+/obj/item/ammo_casing/proc/get_ammo_casing_name()
+	return _get_ammo_casing_name(src)
 
 
 //An item that holds casings and can be used to put them inside guns

--- a/code/modules/projectiles/ammunition.dm
+++ b/code/modules/projectiles/ammunition.dm
@@ -306,6 +306,7 @@
 		FEEDBACK_UNEQUIP_FAILURE(user, ammo_casing)
 		return FALSE
 
+	playsound(src, 'sound/weapons/guns/interaction/shotgun_instert.ogg', 10, TRUE)
 	ammo_casing.forceMove(src)
 	stored_ammo += ammo_casing
 	update_icon()
@@ -342,6 +343,7 @@
 		target_mob.put_in_hands(ammo_casing)
 	else
 		ammo_casing.forceMove(target)
+	playsound(src, 'sound/weapons/guns/interaction/bullet_insert.ogg', 10, TRUE)
 
 	return ammo_casing
 
@@ -364,6 +366,7 @@
 
 	var/list/removed = list()
 	for (var/obj/item/ammo_casing/ammo_casing in stored_ammo)
+		playsound(src, pick(ammo_casing.fall_sounds), 10, TRUE)
 		ammo_casing.forceMove(target)
 		ammo_casing.set_dir(pick(GLOB.alldirs))
 		removed += ammo_casing

--- a/code/modules/projectiles/ammunition/bullets.dm
+++ b/code/modules/projectiles/ammunition/bullets.dm
@@ -8,11 +8,13 @@
 
 /obj/item/ammo_casing/pistol/rubber
 	desc = "A rubber pistol bullet casing."
+	label = "rubber"
 	projectile_type = /obj/item/projectile/bullet/pistol/rubber
 	icon_state = "pistolcasing_r"
 
 /obj/item/ammo_casing/pistol/practice
 	desc = "A practice pistol bullet casing."
+	label = "practice"
 	projectile_type = /obj/item/projectile/bullet/pistol/practice
 	icon_state = "pistolcasing_p"
 
@@ -25,11 +27,13 @@
 
 /obj/item/ammo_casing/pistol/small/rubber
 	desc = "A small pistol rubber bullet casing."
+	label = "rubber"
 	projectile_type = /obj/item/projectile/bullet/pistol/rubber/holdout
 	icon_state = "smallcasing_r"
 
 /obj/item/ammo_casing/pistol/small/practice
 	desc = "A small pistol practice bullet casing."
+	label = "practice"
 	projectile_type = /obj/item/projectile/bullet/pistol/practice
 	icon_state = "smallcasing_p"
 
@@ -85,6 +89,7 @@
 	desc = "A blank shell."
 	icon_state = "blshell"
 	spent_icon = "blshell-spent"
+	label = "blank"
 	projectile_type = /obj/item/projectile/bullet/blank
 	matter = list(MATERIAL_STEEL = 60)
 
@@ -93,6 +98,7 @@
 	desc = "A practice shell."
 	icon_state = "pshell"
 	spent_icon = "pshell-spent"
+	label = "practice"
 	projectile_type = /obj/item/projectile/bullet/shotgun/practice
 	matter = list(MATERIAL_STEEL = 60)
 
@@ -138,6 +144,7 @@
 
 /obj/item/ammo_casing/rifle/practice
 	desc = "A rifle practice bullet casing."
+	label = "practice"
 	projectile_type = /obj/item/projectile/bullet/rifle/practice
 	icon_state = "riflecasing_p"
 
@@ -163,10 +170,12 @@
 
 /obj/item/ammo_casing/rifle/military/light
 	desc = "A low-power military rifle bullet casing."
+	label = "low-power"
 	projectile_type = /obj/item/projectile/bullet/rifle/military
 
 /obj/item/ammo_casing/rifle/military/practice
 	desc = "A military rifle practice bullet casing."
+	label = "practice"
 	projectile_type = /obj/item/projectile/bullet/rifle/military/practice
 	icon_state = "rifle_mil_p"
 

--- a/code/modules/psionics/equipment/null_ammo.dm
+++ b/code/modules/psionics/equipment/null_ammo.dm
@@ -8,6 +8,7 @@
 
 /obj/item/ammo_casing/pistol/magnum/nullglass
 	desc = "A revolver bullet casing with a nullglass coating."
+	label = "nullglass"
 	projectile_type = /obj/item/projectile/bullet/nullglass
 
 /obj/item/ammo_casing/pistol/magnum/nullglass/disrupts_psionics()


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
tweak: Existing "ammo boxes" have been renamed to "magazine boxes".
tweak: Adding and removing bullets from magazines now has a short timer per bullet. Dumping the entire magazine at once onto the ground by using it in your active hand is still instant.
rscadd: You can now transfer bullets between magazines of matching caliburs by using magazines on eachother. Have a bunch of partials you want to repack? That's a lot easier now.
rscadd: Clicking on a pile of bullets on the ground with a magazine or ammobox will now load bullets from the pile into the magazine/box. This intentionally does not work when clicking tables or racks, so you can still put empty boxes and magazines on those. If your pile is on a table/rack, click on the bullets themselves to start the process. For ammoboxes, if the pile has different ammo types and the box is empty, click on a specific bulelt to load that specific ammotype. Otherwise, it just picks one to load.
rscadd: Added proper ammunition boxes - Boxes that contain bullets instead of filled magazines. Ammo boxes can only hold a single type of ammunition at a time.
rscadd: Added various QOL functions for transferring bullets between bullet holders. Clicking magazines, ammoboxes, ammo casings, etc with other mags, boxes, etc will transfer rounds between them with short timers per round.
/:cl:

## Other Changes
- Added codex data for the ammoboxes. Even if the codex is still broken. I should fix that at some point.