### PR TITLE
Fix rig wearer not updating when equipped using the strip panel

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -962,6 +962,12 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 /obj/item/proc/equip_delay_after(mob/user, slot, equip_flags)
 	return
 
+
+/// Proc called when when the item has been equipped. Unlike `equip_delay_*`, this is always called.
+/obj/item/proc/post_equip_item(mob/user, slot, equip_flags)
+	return
+
+
 /obj/item/OnTopic(href, href_list, datum/topic_state/state)
 	. = ..()
 

--- a/code/modules/clothing/spacesuits/rig/rig.dm
+++ b/code/modules/clothing/spacesuits/rig/rig.dm
@@ -734,9 +734,6 @@
 		SPAN_ITALIC("You can hear metal clicking and fabric rustling."),
 		range = 5
 	)
-	wearer = user
-	wearer.wearing_rig = src
-	update_icon()
 
 /obj/item/rig/space/equip_delay_after(mob/user, slot, equip_flags)
 	user.visible_message(
@@ -744,6 +741,11 @@
 		SPAN_NOTICE("You finish putting on \the [src]."),
 		range = 5
 	)
+
+/obj/item/rig/post_equip_item(mob/user, slot, equip_flags)
+	wearer = user
+	wearer.wearing_rig = src
+	update_icon()
 
 /obj/item/rig/proc/toggle_piece(piece, mob/initiator, deploy_mode)
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -39,6 +39,7 @@
 			return
 		I.equip_delay_after(src, slot, equip_flags)
 	equip_to_slot(I, slot, equip_flags & TRYEQUIP_REDRAW)
+	I.post_equip_item(src, slot, equip_flags)
 	return TRUE
 
 


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Fixes a bug where HCMs would refuse to deploy if someone put the rig on you, instead of you equipping it yourself.
/:cl:

## Other Changes
- Added `post_equip_item()` proc to items which is called at the end of `equip_to_slot_if_possible()` similarly to `equip_delay_after()` - Except _always_ called instead of only if the equip action is allowing delay timers.