### PR TITLE
Buffs plasma cutter, restores exosuit autofire, moves autofire to cli…

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -522,21 +522,16 @@ GLOBAL_LIST_INIT(click_catchers, create_click_catcher())
 	. = 1
 
 /client/MouseDown(object, location, control, params)
-	var/delay = mob.CanMobAutoclick(object, location, params)
-	if(delay)
-		selected_target[1] = object
-		selected_target[2] = params
-		while(selected_target[1])
-			Click(selected_target[1], location, control, selected_target[2])
-			sleep(delay)
+	var/datum/click_handler/click_handler = usr.GetClickHandler()
+	click_handler.OnMouseDown(object, location, params)
 
 /client/MouseUp(object, location, control, params)
-	selected_target[1] = null
+	var/datum/click_handler/click_handler = usr.GetClickHandler()
+	click_handler.OnMouseUp(object, location, params)
 
 /client/MouseDrag(src_object,atom/over_object,src_location,over_location,src_control,over_control,params)
-	if(selected_target[1] && over_object.IsAutoclickable())
-		selected_target[1] = over_object
-		selected_target[2] = params
+	var/datum/click_handler/click_handler = usr.GetClickHandler()
+	click_handler.OnMouseDrag(over_object, params)
 
 /mob/proc/CanMobAutoclick(object, location, params)
 	return

--- a/code/_onclick/click_handling.dm
+++ b/code/_onclick/click_handling.dm
@@ -103,11 +103,76 @@ var/global/const/CLICK_HANDLER_REMOVE_IF_NOT_TOP    = FLAG(1)
 /datum/click_handler/proc/OnDblClick(atom/A, params)
 	return
 
+/**
+ * Called on MouseDown by `/client/MouseDown()` when this is the mob's currently active click handler.
+ *
+ * **Parameters**:
+ * - `object` - The atom mouse is underneath.
+ * - `location` - the turf, stat panel, grid cell, etc. containing the object where it was clicked
+ * - `params` (list of strings) - List of click parameters. See BYOND's `CLick()` documentation.
+ *
+ * Has no return value.
+ */
+/datum/click_handler/proc/OnMouseDown(object, location, params)
+	return
+
+/**
+ * Called on MouseUp by `/client/MouseUp()` when this is the mob's currently active click handler.
+ *
+ * **Parameters**:
+ * - `object` - The atom underneath mouse.
+ * - `location` - the turf, stat panel, grid cell, etc. containing the object where it was clicked
+ * - `params` (list of strings) - List of click parameters. See BYOND's `CLick()` documentation.
+ *
+ * Has no return value.
+ */
+/datum/click_handler/proc/OnMouseUp(object, location, params)
+	return
+
+/**
+ * Called on MouseUp by `/client/MouseDrag()` when this is the mob's currently active click handler.
+ *
+ * **Parameters**:
+ * - `over_object` - The new atom underneath mouse.
+ * - `params` (list of strings) - List of click parameters. See BYOND's `CLick()` documentation.
+ *
+ * Has no return value.
+ */
+/datum/click_handler/proc/OnMouseDrag(atom/over_object, params)
+	return
+
+/datum/click_handler/proc/CanAutoClick(object, location, params)
+	return
+
+/datum/click_handler/default
+	/// Holds click params [2] and a reference [1] to the atom under the cursor on MouseDown/Drag
+	var/list/selected_target = list(null, null)
+
 /datum/click_handler/default/OnClick(atom/A, params)
 	user.ClickOn(A, params)
 
 /datum/click_handler/default/OnDblClick(atom/A, params)
 	user.DblClickOn(A, params)
+
+/datum/click_handler/default/OnMouseDown(object, location, params)
+	var/delay = CanAutoClick(object, location, params)
+	if(delay)
+		selected_target[1] = object
+		selected_target[2] = params
+		while(selected_target[1])
+			OnClick(selected_target[1], selected_target[2])
+			sleep(delay)
+
+/datum/click_handler/default/OnMouseUp(object, location, params)
+	selected_target[1] = null
+
+/datum/click_handler/default/OnMouseDrag(atom/over_object, params)
+	if(selected_target[1] && over_object && over_object.IsAutoclickable()) //Over object could be null, for example if dragging over darkness
+		selected_target[1] = over_object
+		selected_target[2] = params
+
+/datum/click_handler/default/CanAutoClick(object, location, params)
+	return user.CanMobAutoclick(object, location, params)
 
 /**
  * Returns the mob's currently active click handler.

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -27,9 +27,6 @@
 	/// A message to show to online staff when joining, if any
 	var/staffwarn
 
-	/// Holds click params [2] and a reference [1] to the atom under the cursor on MouseDown/Drag
-	var/list/selected_target = list(null, null)
-
 	/// Whether or not the client is currently playing the "ship hum" ambience sound
 	var/playing_vent_ambience = FALSE
 

--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -697,11 +697,12 @@
 /obj/item/gun/energy/plasmacutter/mounted/mech
 	use_external_power = TRUE
 	has_safety = FALSE
+	projectile_type = /obj/item/projectile/beam/plasmacutter/mech
 
 
 /obj/item/mech_equipment/mounted_system/taser/plasma
 	name = "mounted plasma cutter"
-	desc = "An industrial plasma cutter mounted onto the chassis of the mech. "
+	desc = "An industrial plasma cutter mounted onto the chassis of the mech. The additional size means increased coherency at longer range. "
 	icon_state = "mech_plasma"
 	holding_type = /obj/item/gun/energy/plasmacutter/mounted/mech
 	restricted_hardpoints = list(HARDPOINT_LEFT_HAND, HARDPOINT_RIGHT_HAND, HARDPOINT_LEFT_SHOULDER, HARDPOINT_RIGHT_SHOULDER)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -324,6 +324,14 @@
 	tracer_type = /obj/projectile/trilaser/tracer
 	impact_type = /obj/projectile/trilaser/impact
 
+//Exosuits have heavier cutters with less falloff
+/obj/item/projectile/beam/plasmacutter/mech
+		damage_falloff_list = list(
+		list(5, 0.80),
+		list(7, 0.60),
+		list(9, 0.40),
+	)
+
 /obj/item/projectile/beam/plasmacutter/on_impact(atom/A)
 	if(istype(A, /turf/simulated/mineral))
 		var/turf/simulated/mineral/M = A


### PR DESCRIPTION
🆑 CrimsonShrike
refactor: Changes to click handling, report issues with automatic weapons and click dragging.
tweak: The exosuit plasma cutters have a little under half the fallofff of regular plasma cutters.
fix: Exosuit automatic weapons wouldnt autofire.
/:cl:


What it says on tin, nothing big, makes rotary plasmacutter at least usable, though its still not a great weapon other than for cool factor.