### PR TITLE
Multi-Z Cable Fixes

### DIFF
--- a/code/datums/extensions/support_lattice.dm
+++ b/code/datums/extensions/support_lattice.dm
@@ -37,12 +37,7 @@
 
 	if(isCoil(C))
 		var/obj/item/stack/cable_coil/coil = C
-		var/obj/structure/lattice/L = locate(/obj/structure/lattice, T)
-		if(L)
-			coil.PlaceCableOnTurf(T, user)
-			return TRUE
-		else
-			to_chat(user, SPAN_WARNING("The cable needs something to be secured to."))
-			return TRUE
+		coil.PlaceCableOnTurf(T, user)
+		return TRUE
 
 	return FALSE

--- a/code/modules/power/cable_coil.dm
+++ b/code/modules/power/cable_coil.dm
@@ -221,6 +221,10 @@ GLOBAL_LIST_INIT(cable_default_colors, list(
 		if (!can_use(2))
 			to_chat(user, SPAN_WARNING("You don't have enough cable to hang a wire down."))
 			return
+		var/turf/below = GetBelow(target)
+		if (!below.is_plating())
+			USE_FEEDBACK_FAILURE("\The [below] below needs to have its tiling removed before you can lay a cable.")
+			return
 		to_dir = DOWN
 	var/from_dir = user.dir
 	if (user.loc != target)


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: It is now possible to lay multi-z cables again by clicking on an open space turf that does _not_ have a lattice.
tweak: Laying multi-z cables now requires the turf below to have its tiles removed.
/:cl: