### PR TITLE
Buffs to Helmet Lights and Floodlights

### DIFF
--- a/code/game/machinery/floodlight.dm
+++ b/code/game/machinery/floodlight.dm
@@ -18,7 +18,7 @@
 
 	//better laser, increased brightness & power consumption
 	var/l_power = 2.5 //brightness of light when on, can be negative
-	var/l_range = 7 //outer range of light when on, can be negative
+	var/l_range = 8 //outer range of light when on, can be negative
 
 /obj/machinery/floodlight/on_update_icon()
 	icon_state = "flood[panel_open ? "o" : ""][panel_open && get_cell() ? "b" : ""]0[use_power == POWER_USE_ACTIVE]"
@@ -33,17 +33,17 @@
 
 	// If the cell is almost empty rarely "flicker" the light. Aesthetic only.
 	if(prob(30))
-		set_light(l_range, l_power / 2, angle = LIGHT_WIDE)
+		set_light(l_range, l_power / 2, angle = LIGHT_VERY_WIDE)
 		spawn(20)
 			if(use_power)
-				set_light(l_range, l_power, angle = LIGHT_WIDE)
+				set_light(l_range, l_power, angle = LIGHT_VERY_WIDE)
 
 // Returns 0 on failure and 1 on success
 /obj/machinery/floodlight/proc/turn_on(loud = 0)
 	if(!is_powered())
 		return 0
 
-	set_light(l_range, l_power / 2, angle = LIGHT_WIDE)
+	set_light(l_range, l_power / 2, angle = LIGHT_VERY_WIDE)
 	update_use_power(POWER_USE_ACTIVE)
 	use_power_oneoff(active_power_usage)//so we drain cell if they keep trying to use it
 	update_icon()
@@ -80,4 +80,4 @@
 	l_range = light_mod*1.5 + initial(l_range)
 	change_power_consumption(initial(active_power_usage) * light_mod , POWER_USE_ACTIVE)
 	if(use_power)
-		set_light(l_range, l_power, angle = LIGHT_WIDE)
+		set_light(l_range, l_power, angle = LIGHT_VERY_WIDE)

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -509,6 +509,7 @@ BLIND     // can't see anything
 	var/image/light_overlay_image
 	var/light_overlay = "helmet_light"
 	var/light_applied
+	var/head_light_range = 4
 	var/brightness_on
 	var/on = 0
 
@@ -550,7 +551,7 @@ BLIND     // can't see anything
 
 /obj/item/clothing/head/proc/update_flashlight(mob/user = null)
 	if(on && !light_applied)
-		set_light(3, brightness_on, angle = LIGHT_WIDE)
+		set_light(head_light_range, brightness_on, angle = LIGHT_WIDE)
 		light_applied = 1
 	else if(!on && light_applied)
 		set_light(0)

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -3,8 +3,8 @@
 	desc = "A piece of headgear used in dangerous working conditions to protect the head. Comes with a built-in flashlight."
 	icon_state = "hardhat0_yellow"
 	action_button_name = "Toggle Headlamp"
-	head_light_range = 6 //light range when on
-	brightness_on = 0.5 //luminosity when on
+	head_light_range = 5 //light range when on
+	brightness_on = 0.8 //luminosity when on
 	light_overlay = "hardhat_light"
 	w_class = ITEM_SIZE_NORMAL
 	item_flags = null

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -3,6 +3,7 @@
 	desc = "A piece of headgear used in dangerous working conditions to protect the head. Comes with a built-in flashlight."
 	icon_state = "hardhat0_yellow"
 	action_button_name = "Toggle Headlamp"
+	head_light_range = 6 //light range when on
 	brightness_on = 0.5 //luminosity when on
 	light_overlay = "hardhat_light"
 	w_class = ITEM_SIZE_NORMAL

--- a/code/modules/clothing/spacesuits/rig/suits/station.dm
+++ b/code/modules/clothing/spacesuits/rig/suits/station.dm
@@ -65,6 +65,7 @@
 
 /obj/item/clothing/head/helmet/space/rig/industrial
 	light_overlay = "helmet_light_wide"
+	head_light_range = 5
 	camera = /obj/machinery/camera/network/helmet
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_IPC)
 
@@ -131,6 +132,7 @@
 
 /obj/item/clothing/head/helmet/space/rig/eva
 	light_overlay = "helmet_light_alt"
+	head_light_range = 5
 	camera = /obj/machinery/camera/network/helmet
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_IPC)
 	sprite_sheets = list(
@@ -220,6 +222,7 @@
 
 /obj/item/clothing/head/helmet/space/rig/ce
 	light_overlay = "helmet_light_alt"
+	head_light_range = 5
 	camera = /obj/machinery/camera/network/helmet
 	species_restricted = list(SPECIES_HUMAN,SPECIES_SKRELL,SPECIES_UNATHI,SPECIES_IPC)
 	sprite_sheets = list(

--- a/code/modules/clothing/spacesuits/void/station.dm
+++ b/code/modules/clothing/spacesuits/void/station.dm
@@ -65,6 +65,7 @@
 		rad = ARMOR_RAD_MINOR
 		)
 	light_overlay = "helmet_light_dual_alt"
+	head_light_range = 5
 	max_pressure_protection = ENG_VOIDSUIT_MAX_PRESSURE
 
 /obj/item/clothing/suit/space/void/mining
@@ -195,6 +196,7 @@
 		)
 	max_heat_protection_temperature = FIRE_HELMET_MAX_HEAT_PROTECTION_TEMPERATURE
 	light_overlay = "helmet_light_dual"
+	head_light_range = 5
 	max_pressure_protection = FIRESUIT_MAX_PRESSURE
 
 /obj/item/clothing/suit/space/void/atmos
@@ -239,6 +241,7 @@
 		rad = ARMOR_RAD_SHIELDED
 		)
 	light_overlay = "helmet_light_dual"
+	head_light_range = 5
 
 /obj/item/clothing/suit/space/void/engineering/alt
 	name = "reinforced engineering voidsuit"

--- a/code/modules/mechs/equipment/utility.dm
+++ b/code/modules/mechs/equipment/utility.dm
@@ -275,7 +275,7 @@
 
 	var/on = 0
 	var/l_power = 2
-	var/l_range = 6
+	var/l_range = 7
 	origin_tech = list(TECH_MATERIAL = 1, TECH_ENGINEERING = 1)
 
 /obj/item/mech_equipment/light/installed(mob/living/exosuit/_owner)

--- a/code/modules/skrell/skrell_rigs.dm
+++ b/code/modules/skrell/skrell_rigs.dm
@@ -20,6 +20,7 @@
 	name = "skrellian recon hardsuit helmet"
 	desc = "A powerful recon hardsuit with integrated power supply and atmosphere. It's impressive design perfectly tailors to the user's body."
 	light_overlay = "helmet_light_dual"
+	head_light_range = 5
 	species_restricted = list(SPECIES_SKRELL)
 	sprite_sheets = list(
 		SPECIES_SKRELL = 'icons/mob/species/skrell/onmob_head_rig_skrell.dmi'

--- a/maps/torch/items/clothing/solgov-head.dm
+++ b/maps/torch/items/clothing/solgov-head.dm
@@ -373,6 +373,7 @@
 
 /obj/item/clothing/head/helmet/space/void/engineering/alt/sol
 	light_overlay = "helmet_light_alt"
+	head_light_range = 5
 	icon = 'maps/torch/icons/obj/obj_head_solgov.dmi'
 	item_icons = list(slot_head_str = 'maps/torch/icons/mob/onmob_head_solgov.dmi')
 	sprite_sheets = list(
@@ -386,6 +387,7 @@
 
 /obj/item/clothing/head/helmet/space/void/atmos/alt/sol
 	light_overlay = "helmet_light_alt"
+	head_light_range = 5
 	icon = 'maps/torch/icons/obj/obj_head_solgov.dmi'
 	item_icons = list(slot_head_str = 'maps/torch/icons/mob/onmob_head_solgov.dmi')
 	sprite_sheets = list(
@@ -465,6 +467,7 @@
 		rad = ARMOR_RAD_RESISTANT
 		)
 	light_overlay = "helmet_light_dual_alt"
+	head_light_range = 5
 	tinted = FALSE
 	valid_accessory_slots = null
 	restricted_accessory_slots = null

--- a/maps/torch/items/rigs.dm
+++ b/maps/torch/items/rigs.dm
@@ -351,6 +351,7 @@
 	camera = /obj/machinery/camera/network/helmet
 	icon_state = "command_exp_rig"
 	light_overlay = "helmet_light_wide"
+	head_light_range = 5
 	brightness_on = 0.8
 
 /obj/item/clothing/suit/space/rig/command/exploration


### PR DESCRIPTION
Gives all helmets with lights a new variable, `head_light_range`, that is set to 4, which is the same range has the normal flashlight. Specific helmets such as the exploration, pathfinder, engineering, atmospherics, skrell voidsuit helmets and hardhats were given stronger lights to reflect their use on planets or specialized roles in the ship (repair/rescue). 

Floodlights were given a larger angle of illumination, `LIGHT_VERY_WIDE`, and given a slight increase to range.

New Helmets (4 Light Range):
![Regular Head Light](https://github.com/user-attachments/assets/02f5f2cb-2a38-4208-9804-ae0fb8932773)
New Helmets w/ Stronger Lights (5 Light Range):
![Powerful Head Light](https://github.com/user-attachments/assets/f32f6aff-23d1-42b5-af80-9eb8afacbadb)
New Floodlights (8 Light Range, Very Wide Angle):
![Floodlight Example](https://github.com/user-attachments/assets/75d5e41a-a860-4885-a979-22bb32f5782d)
Flares (Unchanged, for reference):
![Flares](https://github.com/user-attachments/assets/021b32ce-cca0-4ac8-96e2-5de408938a11)


:cl: JebediahTechnic
tweak: All helmet light ranges are now on par with regular flashlight ranges. Some helmets such as engineering/atmospheric helmets, exploration/pathfinder helmets, hardhats, and skrell recon helmets were given slightly stronger lights.
tweak: Floodlights have a wider angle of illumination and a slightly longer range.
/:cl: