### PR TITLE
Wire examine labels for master electricians

### DIFF
--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -10,18 +10,18 @@
 	wire_count = 12
 	window_y = 570
 	descriptions = list(
-		new /datum/wire_description(AIRLOCK_WIRE_IDSCAN, "This wire is connected to the ID scanning panel.", SKILL_EXPERIENCED),
-		new /datum/wire_description(AIRLOCK_WIRE_MAIN_POWER1, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(AIRLOCK_WIRE_MAIN_POWER2, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(AIRLOCK_WIRE_DOOR_BOLTS, "This wire runs down to the very base of the airlock."),
-		new /datum/wire_description(AIRLOCK_WIRE_BACKUP_POWER1, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(AIRLOCK_WIRE_BACKUP_POWER2, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(AIRLOCK_WIRE_OPEN_DOOR, "This wire connects to the door motors."),
-		new /datum/wire_description(AIRLOCK_WIRE_AI_CONTROL, "This wire connects to automated control systems."),
-		new /datum/wire_description(AIRLOCK_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(AIRLOCK_WIRE_SAFETY, "This wire connects to a safety override."),
-		new /datum/wire_description(AIRLOCK_WIRE_SPEED, "This wire appears to connect to the airlock's proximity detector modules."),
-		new /datum/wire_description(AIRLOCK_WIRE_LIGHT, "This wire powers the airlock's built-in lighting.", SKILL_EXPERIENCED)
+		new /datum/wire_description(AIRLOCK_WIRE_IDSCAN, "This wire is connected to the ID scanning panel.", "ID", SKILL_EXPERIENCED),
+		new /datum/wire_description(AIRLOCK_WIRE_MAIN_POWER1, "This wire seems to be carrying a heavy current.", "Power"),
+		new /datum/wire_description(AIRLOCK_WIRE_MAIN_POWER2, "This wire seems to be carrying a heavy current.", "Power"),
+		new /datum/wire_description(AIRLOCK_WIRE_DOOR_BOLTS, "This wire runs down to the very base of the airlock.", "Bolt"),
+		new /datum/wire_description(AIRLOCK_WIRE_BACKUP_POWER1, "This wire seems to be carrying a heavy current.", "Power"),
+		new /datum/wire_description(AIRLOCK_WIRE_BACKUP_POWER2, "This wire seems to be carrying a heavy current.", "Power"),
+		new /datum/wire_description(AIRLOCK_WIRE_OPEN_DOOR, "This wire connects to the door motors.", "Motor"),
+		new /datum/wire_description(AIRLOCK_WIRE_AI_CONTROL, "This wire connects to automated control systems.", "AI"),
+		new /datum/wire_description(AIRLOCK_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current.", "Power"),
+		new /datum/wire_description(AIRLOCK_WIRE_SAFETY, "This wire connects to a safety override.", "Safety"),
+		new /datum/wire_description(AIRLOCK_WIRE_SPEED, "This wire appears to connect to the airlock's proximity detector modules.", "Timing"),
+		new /datum/wire_description(AIRLOCK_WIRE_LIGHT, "This wire powers the airlock's built-in lighting.", "Light", SKILL_EXPERIENCED)
 	)
 
 var/global/const/AIRLOCK_WIRE_IDSCAN = 1

--- a/code/datums/wires/alarm.dm
+++ b/code/datums/wires/alarm.dm
@@ -2,11 +2,11 @@
 	holder_type = /obj/machinery/alarm
 	wire_count = 5
 	descriptions = list(
-		new /datum/wire_description(AALARM_WIRE_IDSCAN, "This wire is connected to the ID scanning panel.", SKILL_EXPERIENCED),
-		new /datum/wire_description(AALARM_WIRE_POWER, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(AALARM_WIRE_SYPHON, "This wire runs to atmospherics logic circuits of some sort."),
-		new /datum/wire_description(AALARM_WIRE_AI_CONTROL, "This wire connects to automated control systems."),
-		new /datum/wire_description(AALARM_WIRE_AALARM, "This wire gives power to the actual alarm mechanism.")
+		new /datum/wire_description(AALARM_WIRE_IDSCAN, "This wire is connected to the ID scanning panel.", "ID", SKILL_EXPERIENCED),
+		new /datum/wire_description(AALARM_WIRE_POWER, "This wire seems to be carrying a heavy current.", "Power"),
+		new /datum/wire_description(AALARM_WIRE_SYPHON, "This wire runs to atmospherics logic circuits of some sort.", "Siphon"),
+		new /datum/wire_description(AALARM_WIRE_AI_CONTROL, "This wire connects to automated control systems.", "AI"),
+		new /datum/wire_description(AALARM_WIRE_AALARM, "This wire gives power to the actual alarm mechanism.", "Alarm")
 	)
 
 var/global/const/AALARM_WIRE_IDSCAN = 1

--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -7,10 +7,10 @@
 	holder_type = /obj/machinery/power/apc
 	wire_count = 4
 	descriptions = list(
-		new /datum/wire_description(APC_WIRE_IDSCAN, "This wire is connected to the ID scanning panel.", SKILL_EXPERIENCED),
-		new /datum/wire_description(APC_WIRE_MAIN_POWER1, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(APC_WIRE_MAIN_POWER2, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(APC_WIRE_AI_CONTROL, "This wire connects to automated control systems.")
+		new /datum/wire_description(APC_WIRE_IDSCAN, "This wire is connected to the ID scanning panel.", "ID", SKILL_EXPERIENCED),
+		new /datum/wire_description(APC_WIRE_MAIN_POWER1, "This wire seems to be carrying a heavy current.", "Main Power"),
+		new /datum/wire_description(APC_WIRE_MAIN_POWER2, "This wire seems to be carrying a heavy current.", "Main Power"),
+		new /datum/wire_description(APC_WIRE_AI_CONTROL, "This wire connects to automated control systems.", "AI")
 	)
 
 /datum/wires/apc/GetInteractWindow(mob/user)

--- a/code/datums/wires/camera.dm
+++ b/code/datums/wires/camera.dm
@@ -5,10 +5,10 @@
 	holder_type = /obj/machinery/camera
 	wire_count = 6
 	descriptions = list(
-		new /datum/wire_description(CAMERA_WIRE_FOCUS, "This wire runs to the camera's lens adjustment motors."),
-		new /datum/wire_description(CAMERA_WIRE_POWER, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(CAMERA_WIRE_LIGHT, "This wire seems connected to the built-in light.", SKILL_EXPERIENCED),
-		new /datum/wire_description(CAMERA_WIRE_ALARM, "This wire is connected to a remote signaling device of some sort.")
+		new /datum/wire_description(CAMERA_WIRE_FOCUS, "This wire runs to the camera's lens adjustment motors.", "Focus"),
+		new /datum/wire_description(CAMERA_WIRE_POWER, "This wire seems to be carrying a heavy current.", "Power"),
+		new /datum/wire_description(CAMERA_WIRE_LIGHT, "This wire seems connected to the built-in light.", "Light", SKILL_EXPERIENCED),
+		new /datum/wire_description(CAMERA_WIRE_ALARM, "This wire is connected to a remote signaling device of some sort.", "Alarm")
 	)
 
 /datum/wires/camera/GetInteractWindow(mob/user)

--- a/code/datums/wires/fabricator.dm
+++ b/code/datums/wires/fabricator.dm
@@ -7,9 +7,9 @@
 	holder_type = /obj/machinery/fabricator
 	wire_count = 6
 	descriptions = list(
-		new /datum/wire_description(AUTOLATHE_HACK_WIRE, "This wire appears to lead to an auxiliary data storage unit."),
-		new /datum/wire_description(AUTOLATHE_SHOCK_WIRE, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(AUTOLATHE_DISABLE_WIRE, "This wire is connected to the power switch.", SKILL_EXPERIENCED)
+		new /datum/wire_description(AUTOLATHE_HACK_WIRE, "This wire appears to lead to an auxiliary data storage unit.", "Contraband"),
+		new /datum/wire_description(AUTOLATHE_SHOCK_WIRE, "This wire seems to be carrying a heavy current.", "Shock"),
+		new /datum/wire_description(AUTOLATHE_DISABLE_WIRE, "This wire is connected to the power switch.", "Power", SKILL_EXPERIENCED)
 	)
 
 /datum/wires/fabricator/GetInteractWindow(mob/user)

--- a/code/datums/wires/nuclearbomb.dm
+++ b/code/datums/wires/nuclearbomb.dm
@@ -3,9 +3,9 @@
 	random = 1
 	wire_count = 7
 	descriptions = list(
-		new /datum/wire_description(NUCLEARBOMB_WIRE_LIGHT, "This wire seems to connect to the small light on the device.", SKILL_EXPERIENCED),
-		new /datum/wire_description(NUCLEARBOMB_WIRE_TIMING, "This wire connects to the time display."),
-		new /datum/wire_description(NUCLEARBOMB_WIRE_SAFETY, "This wire connects to a safety override.")
+		new /datum/wire_description(NUCLEARBOMB_WIRE_LIGHT, "This wire seems to connect to the small light on the device.", "Light", SKILL_EXPERIENCED),
+		new /datum/wire_description(NUCLEARBOMB_WIRE_TIMING, "This wire connects to the time display.", "Timer"),
+		new /datum/wire_description(NUCLEARBOMB_WIRE_SAFETY, "This wire connects to a safety override.", "Safety")
 	)
 
 var/global/const/NUCLEARBOMB_WIRE_LIGHT		= 1

--- a/code/datums/wires/particle_accelerator.dm
+++ b/code/datums/wires/particle_accelerator.dm
@@ -2,10 +2,10 @@
 	wire_count = 5
 	holder_type = /obj/machinery/particle_accelerator/control_box
 	descriptions = list(
-		new /datum/wire_description(PARTICLE_TOGGLE_WIRE, "This wire seems to connect to the main power toggle.", SKILL_EXPERIENCED),
-		new /datum/wire_description(PARTICLE_STRENGTH_WIRE, "This wire connects to the primary magnets."),
-		new /datum/wire_description(PARTICLE_INTERFACE_WIRE, "This wire appears connected to the user panel."),
-		new /datum/wire_description(PARTICLE_LIMIT_POWER_WIRE, "This wire connects to the primary magnets.")
+		new /datum/wire_description(PARTICLE_TOGGLE_WIRE, "This wire seems to connect to the main power toggle.", "Power", SKILL_EXPERIENCED),
+		new /datum/wire_description(PARTICLE_STRENGTH_WIRE, "This wire connects to the primary magnets.", "Magnets"),
+		new /datum/wire_description(PARTICLE_INTERFACE_WIRE, "This wire appears connected to the user panel.", "Interface"),
+		new /datum/wire_description(PARTICLE_LIMIT_POWER_WIRE, "This wire connects to the primary magnets.", "Magnets")
 	)
 
 var/global/const/PARTICLE_TOGGLE_WIRE = 1 // Toggles whether the PA is on or not.

--- a/code/datums/wires/radio.dm
+++ b/code/datums/wires/radio.dm
@@ -2,9 +2,9 @@
 	holder_type = /obj/item/device/radio
 	wire_count = 3
 	descriptions = list(
-		new /datum/wire_description(WIRE_SIGNAL, "This wire connects several radio components."),
-		new /datum/wire_description(WIRE_RECEIVE, "This wire runs to the radio reciever.", SKILL_EXPERIENCED),
-		new /datum/wire_description(WIRE_TRANSMIT, "This wire runs to the radio transmitter.")
+		new /datum/wire_description(WIRE_SIGNAL, "This wire connects several radio components.", "Power"),
+		new /datum/wire_description(WIRE_RECEIVE, "This wire runs to the radio reciever.", "Receive", SKILL_EXPERIENCED),
+		new /datum/wire_description(WIRE_TRANSMIT, "This wire runs to the radio transmitter.", "Transmit")
 	)
 
 var/global/const/WIRE_SIGNAL = 1

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -3,10 +3,10 @@
 	holder_type = /mob/living/silicon/robot
 	wire_count = 4
 	descriptions = list(
-		new /datum/wire_description(BORG_WIRE_LAWCHECK, "This wire runs to the unit's law module."),
-		new /datum/wire_description(BORG_WIRE_MAIN_POWER, "This wire seems to be carrying a heavy current.", SKILL_EXPERIENCED),
-		new /datum/wire_description(BORG_WIRE_LOCKED_DOWN, "This wire connects to the unit's safety override."),
-		new /datum/wire_description(BORG_WIRE_AI_CONTROL, "This wire connects to automated control systems.")
+		new /datum/wire_description(BORG_WIRE_LAWCHECK, "This wire runs to the unit's law module.", "Laws"),
+		new /datum/wire_description(BORG_WIRE_MAIN_POWER, "This wire seems to be carrying a heavy current.", "Power", SKILL_EXPERIENCED),
+		new /datum/wire_description(BORG_WIRE_LOCKED_DOWN, "This wire connects to the unit's safety override.", "Lockdown"),
+		new /datum/wire_description(BORG_WIRE_AI_CONTROL, "This wire connects to automated control systems.", "AI")
 	)
 
 var/global/const/BORG_WIRE_LAWCHECK = 1

--- a/code/datums/wires/shield_generator.dm
+++ b/code/datums/wires/shield_generator.dm
@@ -2,10 +2,10 @@
 	holder_type = /obj/machinery/power/shield_generator
 	wire_count = 5
 	descriptions = list(
-		new /datum/wire_description(SHIELDGEN_WIRE_POWER, "This wire seems to be carrying a heavy current.", SKILL_EXPERIENCED),
-		new /datum/wire_description(SHIELDGEN_WIRE_HACK, "This wire seems designed to enable a manual override."),
-		new /datum/wire_description(SHIELDGEN_WIRE_CONTROL, "This wire connects to the main control panel."),
-		new /datum/wire_description(SHIELDGEN_WIRE_AICONTROL, "This wire connects to automated control systems.")
+		new /datum/wire_description(SHIELDGEN_WIRE_POWER, "This wire seems to be carrying a heavy current.", "Power", SKILL_EXPERIENCED),
+		new /datum/wire_description(SHIELDGEN_WIRE_HACK, "This wire seems designed to enable a manual override.", "Override"),
+		new /datum/wire_description(SHIELDGEN_WIRE_CONTROL, "This wire connects to the main control panel.", "Interface"),
+		new /datum/wire_description(SHIELDGEN_WIRE_AICONTROL, "This wire connects to automated control systems.", "AI")
 	)
 
 var/global/const/SHIELDGEN_WIRE_POWER = 1			// Cut to disable power input into the generator. Pulse does nothing. Mend to restore.

--- a/code/datums/wires/smartfridge.dm
+++ b/code/datums/wires/smartfridge.dm
@@ -2,9 +2,9 @@
 	holder_type = /obj/machinery/smartfridge
 	wire_count = 3
 	descriptions = list(
-		new /datum/wire_description(SMARTFRIDGE_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(SMARTFRIDGE_WIRE_THROW, "This wire leads to the item dispensor force controls."),
-		new /datum/wire_description(SMARTFRIDGE_WIRE_IDSCAN, "This wire is connected to the ID scanning panel.", SKILL_EXPERIENCED)
+		new /datum/wire_description(SMARTFRIDGE_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current.", "Shock"),
+		new /datum/wire_description(SMARTFRIDGE_WIRE_THROW, "This wire leads to the item dispensor force controls.", "Throw"),
+		new /datum/wire_description(SMARTFRIDGE_WIRE_IDSCAN, "This wire is connected to the ID scanning panel.", "ID", SKILL_EXPERIENCED)
 	)
 
 /datum/wires/smartfridge/secure

--- a/code/datums/wires/smes.dm
+++ b/code/datums/wires/smes.dm
@@ -2,11 +2,11 @@
 	holder_type = /obj/machinery/power/smes/buildable
 	wire_count = 5
 	descriptions = list(
-		new /datum/wire_description(SMES_WIRE_RCON, "This wire runs to a remote signaling mechanism."),
-		new /datum/wire_description(SMES_WIRE_INPUT, "This seems to be the primary input.", SKILL_EXPERIENCED),
-		new /datum/wire_description(SMES_WIRE_OUTPUT, "This seems to be the primary output.", SKILL_EXPERIENCED),
-		new /datum/wire_description(SMES_WIRE_GROUNDING, "This wire appeas to connect directly to the floor.", SKILL_EXPERIENCED),
-		new /datum/wire_description(SMES_WIRE_FAILSAFES, "This wire appears to connect to a failsafe mechanism.")
+		new /datum/wire_description(SMES_WIRE_RCON, "This wire runs to a remote signaling mechanism.", "RCON"),
+		new /datum/wire_description(SMES_WIRE_INPUT, "This seems to be the primary input.", "Input", SKILL_EXPERIENCED),
+		new /datum/wire_description(SMES_WIRE_OUTPUT, "This seems to be the primary output.", "Output", SKILL_EXPERIENCED),
+		new /datum/wire_description(SMES_WIRE_GROUNDING, "This wire appeas to connect directly to the floor.", "Ground", SKILL_EXPERIENCED),
+		new /datum/wire_description(SMES_WIRE_FAILSAFES, "This wire appears to connect to a failsafe mechanism.", "Failsafe")
 	)
 
 var/global/const/SMES_WIRE_RCON = 1		// Remote control (AI and consoles), cut to disable

--- a/code/datums/wires/suit_storage_unit.dm
+++ b/code/datums/wires/suit_storage_unit.dm
@@ -2,9 +2,9 @@
 	holder_type = /obj/machinery/suit_cycler
 	wire_count = 3
 	descriptions = list(
-		new /datum/wire_description(SUIT_STORAGE_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(SUIT_STORAGE_WIRE_SAFETY, "This wire seems connected to a safety override", SKILL_EXPERIENCED),
-		new /datum/wire_description(SUIT_STORAGE_WIRE_LOCKED, "This wire is connected to the ID scanning panel.")
+		new /datum/wire_description(SUIT_STORAGE_WIRE_ELECTRIFY, "This wire seems to be carrying a heavy current.", "Shock"),
+		new /datum/wire_description(SUIT_STORAGE_WIRE_SAFETY, "This wire seems connected to a safety override", "Safety", SKILL_EXPERIENCED),
+		new /datum/wire_description(SUIT_STORAGE_WIRE_LOCKED, "This wire is connected to the ID scanning panel.", "Lock")
 	)
 
 var/global/const/SUIT_STORAGE_WIRE_ELECTRIFY	= 1

--- a/code/datums/wires/taperecorder.dm
+++ b/code/datums/wires/taperecorder.dm
@@ -2,7 +2,7 @@
 	holder_type = /obj/item/device/taperecorder
 	wire_count = 1
 	descriptions = list(
-		new /datum/wire_description(TAPE_WIRE_TOGGLE, "This wire runs to the play/stop toggle.", SKILL_TRAINED)
+		new /datum/wire_description(TAPE_WIRE_TOGGLE, "This wire runs to the play/stop toggle.", "Toggle", SKILL_TRAINED)
 	)
 
 var/global/const/TAPE_WIRE_TOGGLE = 1

--- a/code/datums/wires/transfer_valve.dm
+++ b/code/datums/wires/transfer_valve.dm
@@ -3,11 +3,11 @@
 	holder_type = /obj/item/device/transfer_valve
 	wire_count = 5
 	descriptions = list(
-		new /datum/wire_description(TTV_WIRE_TOGGLEVALVE, "This wire is connected to the valve latch controllers.", SKILL_EXPERIENCED),
-		new /datum/wire_description(TTV_WIRE_GASRELEASE, "This wire seems to be connected directly to the tank latch.", SKILL_TRAINED),
-		new /datum/wire_description(TTV_WIRE_DISARM, "This wire seems to be connected to the internal structural controller.", SKILL_TRAINED),
-		new /datum/wire_description(TTV_WIRE_DEVICECHANGE, "This wire seems to be connected to the attached mechanism.", SKILL_TRAINED),
-		new /datum/wire_description(TTV_WIRE_RNG, "This red wire seems to go over every little nook and cranny of the bomb.")
+		new /datum/wire_description(TTV_WIRE_TOGGLEVALVE, "This wire is connected to the valve latch controllers.", "Valve", SKILL_EXPERIENCED),
+		new /datum/wire_description(TTV_WIRE_GASRELEASE, "This wire seems to be connected directly to the tank latch.", "Tank", SKILL_TRAINED),
+		new /datum/wire_description(TTV_WIRE_DISARM, "This wire seems to be connected to the internal structural controller.", "Disarm", SKILL_TRAINED),
+		new /datum/wire_description(TTV_WIRE_DEVICECHANGE, "This wire seems to be connected to the attached mechanism.", "Rewire", SKILL_TRAINED),
+		new /datum/wire_description(TTV_WIRE_RNG, "This red wire seems to go over every little nook and cranny of the bomb.", "Valve")
 	)
 
 var/global/const/TTV_WIRE_TOGGLEVALVE =  FLAG(0)

--- a/code/datums/wires/wire_description.dm
+++ b/code/datums/wires/wire_description.dm
@@ -2,11 +2,15 @@
 	var/index
 	var/description
 	var/skill_level = SKILL_MASTER
+	/// String. Short label displayed on the wire panel UI for high-skill electricians.
+	var/label = "???"
 
-/datum/wire_description/New(index, description, skill_level)
+/datum/wire_description/New(index, description, label, skill_level)
 	src.index = index
 	if(description)
 		src.description = description
+	if (label)
+		src.label = label
 	if(skill_level)
 		src.skill_level = skill_level
 	..()

--- a/code/datums/wires/wires.dm
+++ b/code/datums/wires/wires.dm
@@ -22,8 +22,8 @@ var/global/list/wireColours = list("red", "blue", "green", "darkred", "orange", 
 
 	var/table_options = " align='center'"
 	var/row_options1 = " width='80px'"
-	var/row_options2 = " width='320px'"
-	var/window_x = 450
+	var/row_options2 = " width='370px'"
+	var/window_x = 500
 	var/window_y = 470
 
 	var/list/descriptions // Descriptions of wires (datum/wire_description) for use with examining.
@@ -116,6 +116,10 @@ var/global/list/wireColours = list("red", "blue", "green", "darkred", "orange", 
 	if(!user.skill_check(SKILL_ELECTRICAL, SKILL_BASIC))
 		wires_used = shuffle(wires_used)
 
+	var/show_labels = FALSE
+	if (user.skill_check(SKILL_ELECTRICAL, SKILL_MASTER))
+		show_labels = TRUE
+
 	for(var/colour in wires_used)
 		html += "<tr>"
 		html += "<td[row_options1]>[SPAN_COLOR(colour, "&#9724;")][capitalize(colour)]</td>"
@@ -123,7 +127,14 @@ var/global/list/wireColours = list("red", "blue", "green", "darkred", "orange", 
 		html += "<A href='?src=\ref[src];action=1;cut=[colour]'>[IsColourCut(colour) ? "Mend" :  "Cut"]</A>"
 		html += " <A href='?src=\ref[src];action=1;pulse=[colour]'>Pulse</A>"
 		html += " <A href='?src=\ref[src];action=1;attach=[colour]'>[IsAttached(colour) ? "Detach" : "Attach"] Signaller</A>"
-		html += " <A href='?src=\ref[src];action=1;examine=[colour]'>Examine</A></td></tr>"
+		var/label = "Examine"
+		if (show_labels)
+			var/datum/wire_description/wire_description = get_description(GetIndex(colour))
+			if (wire_description && wire_description.skill_level <= SKILL_MASTER)
+				label = "[label] ([wire_description.label])"
+			else
+				label = "[label] (???)"
+		html += " <A href='?src=\ref[src];action=1;examine=[colour]'>[label]</A></td></tr>"
 	html += "</table>"
 	html += "</div>"
 

--- a/code/game/machinery/stasis_cage.dm
+++ b/code/game/machinery/stasis_cage.dm
@@ -347,9 +347,9 @@ var/global/const/STASISCAGE_WIRE_LOCK      = 4
 	wire_count = 3
 	window_y = 500
 	descriptions = list(
-		new /datum/wire_description(STASISCAGE_WIRE_SAFETY, "This wire is connected to the internal biometric sensors.", SKILL_EXPERIENCED),
-		new /datum/wire_description(STASISCAGE_WIRE_RELEASE, "This wire is connected to the automated lid latches.", SKILL_TRAINED),
-		new /datum/wire_description(STASISCAGE_WIRE_LOCK, "This wire is connected to the lid motors.", SKILL_TRAINED)
+		new /datum/wire_description(STASISCAGE_WIRE_SAFETY, "This wire is connected to the internal biometric sensors.", "Safety", SKILL_EXPERIENCED),
+		new /datum/wire_description(STASISCAGE_WIRE_RELEASE, "This wire is connected to the automated lid latches.", "Release", SKILL_TRAINED),
+		new /datum/wire_description(STASISCAGE_WIRE_LOCK, "This wire is connected to the lid motors.", "Lock", SKILL_TRAINED)
 	)
 
 

--- a/code/game/machinery/teleporter/beacon.dm
+++ b/code/game/machinery/teleporter/beacon.dm
@@ -254,9 +254,9 @@ var/global/const/TELEBEACON_WIRE_SIGNALLER = 4
 	wire_count = 3
 	window_y = 500
 	descriptions = list(
-		new /datum/wire_description(TELEBEACON_WIRE_POWER, "This wire is connected to the power supply unit.", SKILL_EXPERIENCED),
-		new /datum/wire_description(TELEBEACON_WIRE_RELAY, "This wire is connected to the remote relay device.", SKILL_MASTER),
-		new /datum/wire_description(TELEBEACON_WIRE_SIGNALLER, "This wire is connected to a speaker and several indicator lights.", SKILL_EXPERIENCED)
+		new /datum/wire_description(TELEBEACON_WIRE_POWER, "This wire is connected to the power supply unit.", "Power", SKILL_EXPERIENCED),
+		new /datum/wire_description(TELEBEACON_WIRE_RELAY, "This wire is connected to the remote relay device.", "Relay", SKILL_MASTER),
+		new /datum/wire_description(TELEBEACON_WIRE_SIGNALLER, "This wire is connected to a speaker and several indicator lights.", "Signal", SKILL_EXPERIENCED)
 	)
 
 

--- a/code/game/machinery/vending/_wires.dm
+++ b/code/game/machinery/vending/_wires.dm
@@ -9,10 +9,10 @@
 	var/const/WIRE_SCAN_ID = FLAG(3)
 
 	descriptions = list(
-		new /datum/wire_description (WIRE_THROW_PRODUCTS, "This wire leads to the item dispensor force controls."),
-		new /datum/wire_description (WIRE_SHOW_CONTRABAND, "This wire appears connected to a reserve inventory compartment."),
-		new /datum/wire_description (WIRE_SHOCK_USERS, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description (WIRE_SCAN_ID, "This wire is connected to the ID scanning panel.", SKILL_EXPERIENCED)
+		new /datum/wire_description (WIRE_THROW_PRODUCTS, "This wire leads to the item dispensor force controls.", "Throw"),
+		new /datum/wire_description (WIRE_SHOW_CONTRABAND, "This wire appears connected to a reserve inventory compartment.", "Contraband"),
+		new /datum/wire_description (WIRE_SHOCK_USERS, "This wire seems to be carrying a heavy current.", "Shock"),
+		new /datum/wire_description (WIRE_SCAN_ID, "This wire is connected to the ID scanning panel.", "ID", SKILL_EXPERIENCED)
 	)
 
 

--- a/code/modules/clothing/spacesuits/rig/rig_wiring.dm
+++ b/code/modules/clothing/spacesuits/rig/rig_wiring.dm
@@ -9,11 +9,11 @@
 	holder_type = /obj/item/rig
 	wire_count = 5
 	descriptions = list(
-		new /datum/wire_description(RIG_SECURITY, "This wire is connected to the ID scanning panel."),
-		new /datum/wire_description(RIG_AI_OVERRIDE, "This wire connects to automated control systems."),
-		new /datum/wire_description(RIG_SYSTEM_CONTROL, "This wire seems to be carrying a heavy current."),
-		new /datum/wire_description(RIG_INTERFACE_LOCK, "This wire connects to the interface panel.", SKILL_EXPERIENCED),
-		new /datum/wire_description(RIG_INTERFACE_SHOCK, "This wire seems to be carrying a heavy current.")
+		new /datum/wire_description(RIG_SECURITY, "This wire is connected to the ID scanning panel.", "ID"),
+		new /datum/wire_description(RIG_AI_OVERRIDE, "This wire connects to automated control systems.", "AI"),
+		new /datum/wire_description(RIG_SYSTEM_CONTROL, "This wire seems to be carrying a heavy current.", "Power"),
+		new /datum/wire_description(RIG_INTERFACE_LOCK, "This wire connects to the interface panel.", "Interface", SKILL_EXPERIENCED),
+		new /datum/wire_description(RIG_INTERFACE_SHOCK, "This wire seems to be carrying a heavy current.", "Power")
 	)
 
 /*


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
rscadd: Characters with master electrical engineering now have little labels next to each identifiable wire telling you what they are, saving you the time of pressing examine on each one.
/:cl:

## Screenshots
![He5TjbSXWL](https://github.com/user-attachments/assets/374f913c-fee6-40c6-b70a-7514b846f6a3)

![jnaYwWG7K0](https://github.com/user-attachments/assets/83cd7144-c114-455a-a837-5376ff7a72ea)
