### PR TITLE
Self-examining shows more appropriate age text

### DIFF
--- a/code/modules/species/species_age_comparison.dm
+++ b/code/modules/species/species_age_comparison.dm
@@ -56,10 +56,10 @@
 			age_diff_descriptor = age_diff_descriptors[length(age_diff_descriptors)]
 
 	if (observer == observed)
-		return "You are of [age_descriptor] age for a [name]."
+		return "You are of [age_descriptor] age for \a [name]."
 
 	var/datum/pronouns/pronouns = observed.choose_from_pronouns()
 	if (age_diff_descriptor)
-		return "[pronouns.He] [pronouns.is] of [age_descriptor] age for a [name], [age_diff_descriptor] you."
+		return "[pronouns.He] [pronouns.is] of [age_descriptor] age for \a [name], [age_diff_descriptor] you."
 	else if (age_descriptor)
-		return "[pronouns.He] [pronouns.is] of [age_descriptor] age for a [name]."
+		return "[pronouns.He] [pronouns.is] of [age_descriptor] age for \a [name]."

--- a/code/modules/species/species_age_comparison.dm
+++ b/code/modules/species/species_age_comparison.dm
@@ -55,6 +55,9 @@
 		if (!age_diff_descriptor)
 			age_diff_descriptor = age_diff_descriptors[length(age_diff_descriptors)]
 
+	if (observer == observed)
+		return "You are of [age_descriptor] age for a [name]."
+
 	var/datum/pronouns/pronouns = observed.choose_from_pronouns()
 	if (age_diff_descriptor)
 		return "[pronouns.He] [pronouns.is] of [age_descriptor] age for a [name], [age_diff_descriptor] you."


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
tweak: examining yourself now shows "You are of X age for a SPECIES" instead of third person descriptions.
/:cl: