### PR TITLE
Vox head loop

### DIFF
--- a/code/modules/organs/internal/species/vox.dm
+++ b/code/modules/organs/internal/species/vox.dm
@@ -226,11 +226,19 @@
 
 	return 1
 
+
 /obj/item/organ/internal/voxstack/removed()
 	var/obj/item/organ/external/head = owner.get_organ(parent_organ)
 	owner.visible_message(SPAN_DANGER("\The [src] rips gaping holes in \the [owner]'s [head.name] as it is torn loose!"))
 	do_backup()
-	..()
+	..()	// Removing stack before damaging organs, so it can't get broken during it.
+			// And so, we are safe from getting an infinite loop if the stack somehow forces a head to blow up.
+
+	head.take_external_damage(clamp(rand(15, 20), 0, head.min_broken_damage - head.get_damage()))	// Can't cause critical conditions such as fractures or decapitation.
+
+	for(var/obj/item/organ/internal/organ in head.contents)
+		organ.take_internal_damage(rand(30, 70))
+
 
 /obj/item/organ/internal/voxstack/proc/overwrite()
 	if(owner.mind && owner.ckey) //Someone is already in this body!


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
🆑 Daeberdir
add: Voxstack now again causes damage to your organs when it is torn away from you (was removed in #35001).
bugfix: Voxstack's `removed()` now cause no infinity loops, runtimes or illogical selfdamage.
tweak: Voxstack can't deal more damage to the head than its `min_broken_damage`.
/:cl:
## Looks fixed
![image](https://github.com/user-attachments/assets/63c63076-c989-4dae-ac7b-990921f06cca)
