### PR TITLE
fix bluespace pulse not teleporting people

### DIFF
--- a/code/game/machinery/bluespace_drive.dm
+++ b/code/game/machinery/bluespace_drive.dm
@@ -149,9 +149,8 @@
 /// Creates an expanding bluespace pulse on all z-levels connected to the drive
 /obj/machinery/bluespacedrive/proc/do_pulse()
 	playsound(src, 'sound/effects/EMPulse.ogg', 100, TRUE)
-	var/datum/bubble_effect/bluespace_pulse/parent
 	for (var/level in GetConnectedZlevels(z))
-		parent = new (x, y, level, 1, 1, parent)
+		new /datum/bubble_effect/bluespace_pulse(x, y, level, 1, 1, src)
 
 
 /// Creates a blinding flash of light that will blind and deafen those in range, and change turfs to bluespace
@@ -183,7 +182,7 @@
 	var/interlude_teleport_chance = 0
 	var/affect_chance = 0
 
-/datum/bubble_effect/bluespace_pulse/New(obj/machinery/bluespacedrive/parent)
+/datum/bubble_effect/bluespace_pulse/New(center_x, center_y, z, initial_radius, delta, parent)
 	..()
 	src.parent = parent
 	START_PROCESSING(SSfastprocess, src)


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed the bluespace event not teleporting people with the pulse.
/:cl: