### PR TITLE
split hangar substation into a full room, added console & map to expedition prep

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -256,7 +256,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/prepainted,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fifthdeck/aftstarboard)
 "aE" = (
 /obj/structure/disposalpipe/segment{
@@ -326,7 +326,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -335,7 +334,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/maintenance,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fifthdeck/aftstarboard)
 "aL" = (
@@ -358,11 +356,6 @@
 /obj/floor_decal/corner/brown/half,
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/aft)
@@ -899,18 +892,23 @@
 	icon_state = "1-4"
 	},
 /obj/structure/catwalk,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "bN" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/power/smes/buildable/preset/torch/hangar{
+	RCon_tag = "Substation - Hangar"
 	},
-/obj/wallframe_spawn/no_grille,
+/obj/structure/cable/cyan{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/cable/cyan{
+	d2 = 8;
+	icon_state = "0-8"
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
+/area/maintenance/substation/hangar)
 "bP" = (
 /obj/paint/silver,
 /turf/simulated/wall/titanium,
@@ -1461,12 +1459,6 @@
 "cZ" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "da" = (
@@ -1635,13 +1627,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
-"du" = (
-/obj/floor_decal/industrial/warning{
-	dir = 1;
-	icon_state = "warning"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "dv" = (
 /obj/floor_decal/techfloor{
 	dir = 1
@@ -2468,15 +2453,10 @@
 /turf/simulated/wall/walnut,
 /area/vacant/bar)
 "fB" = (
-/obj/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "fD" = (
@@ -2976,13 +2956,17 @@
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition/eva)
 "gG" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Hangar Substation"
 	},
-/turf/simulated/wall/prepainted,
-/area/maintenance/fifthdeck/fore)
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/maintenance/substation/hangar)
 "gH" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -3798,14 +3782,14 @@
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "iW" = (
+/obj/catwalk_plated,
 /obj/structure/cable/cyan{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d2 = 8;
+	icon_state = "1-8"
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/fore)
+/area/quartermaster/hangar)
 "iX" = (
 /obj/random/torchcloset,
 /obj/random/maintenance/solgov,
@@ -3815,11 +3799,6 @@
 /area/quartermaster/hangar)
 "iY" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/door/airlock/maintenance,
@@ -4400,6 +4379,11 @@
 /obj/machinery/light/spot{
 	dir = 1
 	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "ke" = (
@@ -4945,11 +4929,6 @@
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/hangar)
 "lm" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/portables_connector{
 	dir = 4
 	},
@@ -4958,11 +4937,6 @@
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
 "ln" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/techfloor,
@@ -5042,16 +5016,6 @@
 /obj/wallframe_spawn/reinforced/no_grille,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
-"lw" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/wallframe_spawn/reinforced/no_grille,
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
 "lx" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/anomaly_container,
@@ -5111,11 +5075,6 @@
 /obj/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
@@ -5123,11 +5082,6 @@
 /area/quartermaster/expedition/atmos)
 "lE" = (
 /obj/floor_decal/industrial/warning,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
 /area/quartermaster/expedition/atmos)
@@ -5375,36 +5329,9 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/exploration_shuttle/atmos)
-"mp" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 6
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/fore)
 "mq" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/fore)
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/expedition)
 "mr" = (
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
@@ -5423,21 +5350,6 @@
 	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/hangar)
-"mt" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/fore)
 "mv" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume/external_air{
 	id_tag = "petrov_shuttle_dock_pump"
@@ -5520,16 +5432,11 @@
 /obj/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/tele_beacon,
 /obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
@@ -5564,19 +5471,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "mI" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/fore)
+/area/maintenance/fifthdeck/aftstarboard)
 "mJ" = (
 /obj/structure/cable/green{
 	d1 = 2;
@@ -6111,13 +6009,20 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "nI" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/structure/catwalk,
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/simulated/wall/prepainted,
-/area/quartermaster/expedition/atmos)
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
 "nJ" = (
 /obj/machinery/light/spot,
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -6152,34 +6057,23 @@
 /turf/simulated/floor/tiled/monotile,
 /area/quartermaster/hangar)
 "nN" = (
-/obj/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "nO" = (
-/obj/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
+/obj/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "nP" = (
-/obj/catwalk_plated,
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
@@ -6187,10 +6081,11 @@
 	dir = 4
 	},
 /obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
 "nQ" = (
@@ -6537,20 +6432,19 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "or" = (
-/obj/structure/cable/cyan{
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
 /obj/structure/catwalk,
+/obj/structure/sign/warning/high_voltage{
+	dir = 4;
+	pixel_x = -32
+	},
 /turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/fore)
+/area/maintenance/fifthdeck/aftstarboard)
 "os" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
@@ -6686,6 +6580,14 @@
 /obj/catwalk_plated,
 /obj/machinery/camera/network/fifth_deck{
 	c_tag = "Hangar - Aft Starboard"
+	},
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/sign/warning/high_voltage{
+	pixel_y = 32
 	},
 /turf/simulated/floor/plating,
 /area/quartermaster/hangar)
@@ -6832,25 +6734,30 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "pe" = (
-/obj/structure/cable,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -32
-	},
 /obj/floor_decal/industrial/warning{
-	dir = 4;
+	dir = 1;
 	icon_state = "warning"
 	},
-/obj/machinery/power/terminal{
-	dir = 4
+/obj/machinery/power/apc{
+	name = "south bump";
+	pixel_y = -24
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
-/area/maintenance/substation/fifthdeck)
+/area/maintenance/substation/hangar)
 "pf" = (
 /obj/structure/sign/warning/high_voltage{
 	dir = 8
@@ -6945,7 +6852,7 @@
 	dir = 4;
 	icon_state = "pipe-c"
 	},
-/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "ps" = (
@@ -7065,6 +6972,11 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "pH" = (
@@ -7089,6 +7001,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
@@ -7272,14 +7189,11 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "qa" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/railing/mapped,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/fore)
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/table/steel,
+/obj/item/modular_computer/laptop/preset/custom_loadout/standard,
+/turf/simulated/floor/tiled,
+/area/quartermaster/expedition)
 "qb" = (
 /obj/structure/fuel_port{
 	pixel_x = 32
@@ -7292,14 +7206,19 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/guppy_hangar/start)
 "qc" = (
-/obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden,
+/obj/structure/railing/mapped{
+	dir = 4;
+	icon_state = "railing0-1"
+	},
+/obj/random/trash,
 /turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/fore)
+/area/maintenance/fifthdeck/aftstarboard)
 "qd" = (
 /obj/structure/dispenser/oxygen,
 /turf/simulated/floor/tiled/monotile,
@@ -7522,22 +7441,12 @@
 /obj/floor_decal/corner/brown/half,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/light,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/closet/firecloset,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/aft)
 "qE" = (
 /obj/floor_decal/corner/brown{
 	dir = 10
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
@@ -7546,11 +7455,6 @@
 	dir = 10
 	},
 /obj/machinery/light,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
 "qH" = (
@@ -7662,20 +7566,9 @@
 	dir = 4;
 	icon_state = "warning"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/fifthdeck)
-"qQ" = (
-/obj/machinery/door/blast/shutters{
-	id_tag = "hanger_atmos_storage";
-	name = "Storage Shutters"
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/tiled/dark,
-/area/quartermaster/expedition/atmos)
 "qR" = (
 /obj/floor_decal/corner/mauve{
 	dir = 6
@@ -7714,6 +7607,11 @@
 /obj/machinery/power/terminal{
 	dir = 4
 	},
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -32
+	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/fifthdeck)
 "qU" = (
@@ -7726,11 +7624,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/substation/fifthdeck)
 "qV" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -7756,11 +7649,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "qX" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
@@ -7785,6 +7673,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/fifthdeck)
 "qZ" = (
@@ -7834,6 +7723,7 @@
 	dir = 1;
 	icon_state = "warning"
 	},
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/fifthdeck)
 "re" = (
@@ -8054,37 +7944,35 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "rA" = (
-/obj/structure/cable/green{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/alarm{
+	dir = 4;
+	pixel_x = -24
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/fifthdeck/aftstarboard)
+"rB" = (
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/fore)
-"rB" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "rC" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/engineering{
+	name = "Hangar Substation"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/fore)
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/simulated/floor/tiled/steel_ridged,
+/area/maintenance/substation/hangar)
 "rD" = (
 /obj/structure/cable/green{
 	d1 = 1;
@@ -8109,10 +7997,7 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "rF" = (
-/obj/machinery/power/smes/buildable/preset/torch/hangar{
-	RCon_tag = "Substation - Hangar"
-	},
-/obj/structure/cable/cyan,
+/obj/wallframe_spawn/reinforced,
 /turf/simulated/floor/plating,
 /area/maintenance/substation/fifthdeck)
 "rG" = (
@@ -8278,11 +8163,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "rV" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 9
@@ -8510,20 +8390,43 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"sw" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fifthdeck/aftstarboard)
 "sx" = (
-/obj/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fifthdeck/aftstarboard)
+/obj/structure/sign/warning/high_voltage{
+	pixel_y = 32
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/substation/hangar)
 "sz" = (
-/obj/structure/reagent_dispensers/fueltank,
-/obj/floor_decal/industrial/outline/grey,
-/turf/simulated/floor/tiled/techfloor,
-/area/maintenance/fifthdeck/aftstarboard)
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/power/sensor{
+	name = "Powernet Sensor - Hangar Subgrid";
+	name_tag = "Hangar Subgrid"
+	},
+/obj/structure/cable/cyan,
+/obj/structure/cable/cyan{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/floor_decal/industrial/warning/corner{
+	dir = 1
+	},
+/obj/structure/catwalk,
+/turf/simulated/floor/plating,
+/area/maintenance/substation/hangar)
 "sA" = (
 /obj/structure/cable/cyan{
 	d1 = 4;
@@ -8801,14 +8704,8 @@
 /turf/simulated/floor/plating,
 /area/rnd/canister)
 "tm" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/wallframe_spawn/reinforced,
-/turf/simulated/floor/plating,
-/area/maintenance/substation/fifthdeck)
+/turf/simulated/floor/tiled/monotile,
+/area/quartermaster/expedition/eva)
 "tn" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/machinery/alarm{
@@ -8827,12 +8724,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "tp" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Expedition EVA Maintenance"
-	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/door/airlock/maintenance{
+	name = "Expedition EVA Maintenance"
+	},
 /turf/simulated/floor/tiled/steel_ridged,
 /area/quartermaster/expedition/eva)
 "tr" = (
@@ -9024,11 +8921,6 @@
 "tQ" = (
 /obj/floor_decal/corner/brown{
 	dir = 10
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/camera/network/fifth_deck{
 	c_tag = "Fifth Deck Hallway - Aft";
@@ -9259,7 +9151,6 @@
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fifthdeck/aft)
 "uo" = (
-/obj/catwalk_plated,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
@@ -9281,6 +9172,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/aft)
 "up" = (
@@ -9290,11 +9182,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
@@ -9451,11 +9338,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftport)
 "uI" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
@@ -9509,16 +9391,12 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/exploration_shuttle/atmos)
 "uO" = (
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing/mapped,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "uP" = (
@@ -9526,11 +9404,6 @@
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -9540,14 +9413,10 @@
 	icon_state = "railing0-1"
 	},
 /obj/structure/railing/mapped,
+/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "uQ" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -9556,11 +9425,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "uS" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 9
 	},
@@ -9666,7 +9530,7 @@
 "vj" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
-/obj/wallframe_spawn/no_grille,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "vm" = (
@@ -9973,16 +9837,17 @@
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/fifthdeck/aftport)
 "wt" = (
-/obj/floor_decal/industrial/warning{
-	dir = 1
+/obj/machinery/door/airlock/engineering{
+	name = "Hangar Substation"
 	},
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/turf/simulated/floor/tiled/monotile,
-/area/quartermaster/hangar)
+/obj/machinery/door/firedoor,
+/turf/simulated/floor/tiled/steel_ridged,
+/area/maintenance/substation/hangar)
 "wu" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/hologram/holopad/longrange,
@@ -10369,6 +10234,7 @@
 	dir = 4;
 	icon_state = "railing0-1"
 	},
+/obj/random/junk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "xN" = (
@@ -10393,11 +10259,6 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/cell1)
 "xP" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/railing/mapped,
 /obj/structure/railing/mapped{
 	dir = 4;
@@ -10464,18 +10325,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on,
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/eva)
-"ya" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/maintenance,
-/turf/simulated/floor/tiled/techfloor/grid,
-/area/maintenance/fifthdeck/fore)
 "yc" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
@@ -10524,13 +10373,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/cyan{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fifthdeck/aftstarboard)
 "yl" = (
 /obj/machinery/atmospherics/unary/vent_pump/on{
@@ -10672,16 +10520,15 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 9
-	},
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/catwalk,
 /obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
 	dir = 4
 	},
 /turf/simulated/floor/plating,
@@ -10995,12 +10842,11 @@
 /turf/simulated/floor/tiled/dark/monotile,
 /area/shuttle/petrov/control)
 "zL" = (
-/obj/structure/table/steel,
-/obj/item/device/flashlight/lamp/green,
-/turf/simulated/floor/wood/walnut{
-	icon_state = "walnut_broken0"
+/obj/machinery/computer/ship/navigation/telescreen{
+	pixel_y = 28
 	},
-/area/vacant/bar)
+/turf/simulated/floor/tiled,
+/area/quartermaster/expedition)
 "zO" = (
 /obj/floor_decal/industrial/hatch/yellow,
 /obj/machinery/r_n_d/destructive_analyzer,
@@ -11018,13 +10864,13 @@
 /turf/simulated/wall/r_wall/hull,
 /area/hallway/primary/fifthdeck/aft)
 "zW" = (
-/obj/structure/cable/cyan{
-	d2 = 2;
-	icon_state = "0-2"
-	},
 /obj/item/frame/apc,
 /obj/machinery/light/small{
 	dir = 1
+	},
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
 	},
 /turf/simulated/floor/wood/walnut,
 /area/vacant/bar)
@@ -11593,6 +11439,11 @@
 /area/shuttle/petrov/maint)
 "CB" = (
 /obj/random/trash,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
 "CC" = (
@@ -11667,11 +11518,6 @@
 /obj/floor_decal/industrial/warning/corner{
 	dir = 4;
 	icon_state = "warningcorner"
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 9
@@ -11769,16 +11615,6 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/maint)
-"Df" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "Dh" = (
 /obj/machinery/atmospherics/unary/vent_pump/high_volume{
 	dir = 1
@@ -11807,7 +11643,7 @@
 /turf/simulated/floor/plating,
 /area/vacant/bar)
 "Dm" = (
-/obj/structure/cable/cyan{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -11939,11 +11775,6 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/eva)
 "DF" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -12993,13 +12824,12 @@
 /area/maintenance/fifthdeck/aftport)
 "HU" = (
 /obj/floor_decal/industrial/outline/grey,
+/obj/random/tech_supply,
 /obj/structure/cable/cyan{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/table/steel,
-/obj/random/tech_supply,
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
 "HV" = (
@@ -13044,10 +12874,6 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/equipment)
-"Ia" = (
-/obj/structure/table/steel,
-/turf/simulated/floor/plating,
-/area/vacant/bar)
 "Ib" = (
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/analysis)
@@ -13068,6 +12894,9 @@
 	},
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/rnd)
+"Ig" = (
+/turf/simulated/wall/prepainted,
+/area/maintenance/substation/hangar)
 "Ih" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
@@ -13104,15 +12933,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
-"Iq" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "It" = (
 /obj/paint/silver,
 /turf/simulated/wall/titanium,
@@ -13329,6 +13149,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/catwalk,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/cyan{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Ju" = (
@@ -13727,11 +13552,11 @@
 /area/shuttle/petrov/isolation)
 "KW" = (
 /obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
-/obj/structure/cable/cyan{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -13819,6 +13644,8 @@
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/phoron)
 "Lj" = (
+/obj/structure/table/steel,
+/obj/item/device/flashlight/lamp/green,
 /turf/simulated/floor/wood/walnut{
 	icon_state = "walnut_broken5"
 	},
@@ -13912,7 +13739,7 @@
 "LB" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/random/trash,
-/obj/structure/catwalk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "LC" = (
@@ -13965,18 +13792,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/phoron)
-"LL" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
-	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "LM" = (
 /obj/structure/shuttle/engine/propulsion{
 	dir = 4
@@ -14002,14 +13817,14 @@
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/cell2)
 "LT" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light_switch{
 	pixel_x = 22;
 	pixel_y = -22
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/wood/walnut{
 	icon_state = "walnut_broken0"
@@ -14343,7 +14158,6 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Ni" = (
@@ -14653,6 +14467,16 @@
 	},
 /turf/simulated/floor/reinforced,
 /area/shuttle/petrov/cell1)
+"Ov" = (
+/obj/machinery/alarm{
+	pixel_y = 23;
+	req_access = list(list("ACCESS_ENGINE_EQUIP","ACCESS_ATMOS"))
+	},
+/obj/machinery/power/breakerbox/activated{
+	RCon_tag = "Hangar Substation Bypass"
+	},
+/turf/simulated/floor/plating,
+/area/maintenance/substation/hangar)
 "Oy" = (
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
@@ -14923,9 +14747,16 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/isolation)
 "PM" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/disposalpipe/segment,
-/turf/simulated/floor/plating,
+/obj/structure/sign/warning/high_voltage{
+	dir = 8;
+	pixel_x = 32
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/techfloor,
 /area/maintenance/fifthdeck/aftstarboard)
 "PO" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
@@ -15221,20 +15052,21 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/shuttle/petrov/hallwaya)
 "QX" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/floor_decal/industrial/warning{
+	dir = 1;
+	icon_state = "warning"
+	},
+/obj/machinery/light/small,
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/structure/catwalk,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/fore)
+/area/maintenance/substation/hangar)
 "QY" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -15387,11 +15219,6 @@
 /obj/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
@@ -15540,11 +15367,6 @@
 /obj/floor_decal/corner/brown{
 	dir = 5
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fifthdeck/aft)
 "Ss" = (
@@ -15663,9 +15485,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -15674,13 +15493,15 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/structure/catwalk,
-/turf/simulated/floor/plating,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/fifthdeck/aftstarboard)
 "SN" = (
 /obj/structure/table/rack{
@@ -15726,15 +15547,6 @@
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
-"SW" = (
-/obj/catwalk_plated,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/turf/simulated/floor/plating,
-/area/quartermaster/hangar)
 "Tc" = (
 /obj/floor_decal/industrial/warning,
 /obj/machinery/atmospherics/binary/pump,
@@ -15839,11 +15651,6 @@
 /turf/simulated/floor/tiled/white,
 /area/shuttle/petrov/isolation)
 "Tw" = (
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/railing/mapped,
 /obj/machinery/atmospherics/pipe/simple/hidden/universal,
 /turf/simulated/floor/plating,
@@ -16116,16 +15923,6 @@
 /obj/random/maintenance/solgov,
 /turf/simulated/floor/plating,
 /area/shuttle/petrov/isolation)
-"UE" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/random/junk,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "UF" = (
 /obj/structure/table/standard,
 /obj/item/device/integrated_circuit_printer,
@@ -16133,6 +15930,7 @@
 /area/shuttle/petrov/equipment)
 "UG" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/structure/bed/chair/office/dark,
 /turf/simulated/floor/tiled,
 /area/quartermaster/expedition)
 "UH" = (
@@ -16226,17 +16024,6 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/shuttle/petrov/hallwaya)
-"Ve" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/random/trash,
-/obj/structure/railing/mapped,
-/turf/simulated/floor/plating,
-/area/maintenance/fifthdeck/aftstarboard)
 "Vk" = (
 /obj/structure/bed/chair/office/light{
 	dir = 4
@@ -16457,6 +16244,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
 /obj/random/junk,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/railing/mapped,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
@@ -16476,6 +16264,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
+/obj/structure/reagent_dispensers/watertank,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "VZ" = (
@@ -16496,15 +16285,13 @@
 /area/space)
 "Wg" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
@@ -16586,7 +16373,6 @@
 	pixel_x = -24
 	},
 /obj/structure/cable/green,
-/obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "WF" = (
@@ -16715,16 +16501,10 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
 "Xp" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/catwalk,
-/obj/machinery/alarm{
-	dir = 4;
-	pixel_x = -24
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
@@ -16760,13 +16540,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "Xz" = (
+/obj/catwalk_plated,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
 	},
-/turf/simulated/floor/tiled,
-/area/hallway/primary/fifthdeck/aft)
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar)
 "XB" = (
 /obj/machinery/atmospherics/pipe/simple/visible{
 	dir = 4
@@ -16790,11 +16573,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/fore)
 "XE" = (
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/sign/warning/compressed_gas,
 /turf/simulated/wall/prepainted,
 /area/hallway/primary/fifthdeck/aft)
@@ -17086,7 +16864,7 @@
 /area/shuttle/petrov/hallwaya)
 "YH" = (
 /obj/random/obstruction,
-/obj/structure/cable/cyan{
+/obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
@@ -17268,7 +17046,6 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/guppy_hangar/start)
 "Zo" = (
-/obj/catwalk_plated,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -17283,11 +17060,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
+/obj/catwalk_plated,
 /turf/simulated/floor/plating,
 /area/hallway/primary/fifthdeck/aft)
 "Zp" = (
@@ -17373,6 +17146,7 @@
 "ZE" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fifthdeck/aftstarboard)
@@ -29672,15 +29446,15 @@ pO
 uL
 uO
 cZ
-ya
+iY
 ln
-or
-iW
-iW
-iW
-iW
-iW
-iW
+rH
+mh
+mh
+mh
+mh
+mh
+mh
 qV
 iY
 qX
@@ -29885,7 +29659,7 @@ pl
 OW
 qW
 tb
-rA
+uT
 ri
 rk
 pm
@@ -30087,7 +29861,7 @@ wF
 wF
 wF
 wF
-rB
+mh
 mh
 mh
 mh
@@ -30289,9 +30063,9 @@ iI
 lj
 jG
 wF
-rB
 mh
-ph
+mh
+mh
 ph
 pf
 ph
@@ -30491,10 +30265,10 @@ iK
 jw
 jH
 wF
-rB
+mh
 mk
+rB
 re
-pe
 qP
 qT
 qY
@@ -30671,7 +30445,7 @@ aa
 aa
 an
 an
-mp
+qV
 rV
 uI
 uI
@@ -30693,9 +30467,9 @@ ac
 jx
 jQ
 wF
-rC
-mI
-tm
+mh
+nk
+mh
 rF
 qU
 qZ
@@ -30873,7 +30647,7 @@ aa
 aa
 an
 an
-mq
+rI
 pT
 mh
 yq
@@ -30897,7 +30671,7 @@ wF
 wF
 fl
 nk
-ph
+mh
 ph
 ph
 ph
@@ -31075,7 +30849,7 @@ aa
 aa
 an
 an
-mq
+rI
 cd
 VA
 Zj
@@ -31277,7 +31051,7 @@ aa
 an
 an
 an
-mt
+rq
 QY
 ZN
 ZN
@@ -31479,7 +31253,7 @@ an
 an
 an
 an
-gG
+yq
 hS
 ce
 ce
@@ -31681,7 +31455,7 @@ an
 an
 Lf
 YW
-qa
+eN
 MP
 ce
 iw
@@ -32287,7 +32061,7 @@ an
 an
 aL
 mh
-qc
+mh
 gU
 ce
 hn
@@ -32489,7 +32263,7 @@ an
 ar
 aO
 mg
-QX
+mg
 Om
 ce
 iD
@@ -32691,7 +32465,7 @@ an
 bU
 lY
 lY
-nI
+lY
 lY
 ce
 ce
@@ -33501,9 +33275,9 @@ lY
 Zl
 lD
 lE
-qQ
-wt
-SW
+lZ
+EC
+aX
 ee
 bi
 ag
@@ -33705,7 +33479,7 @@ QA
 SE
 lZ
 EC
-ih
+aX
 ee
 ag
 ag
@@ -33907,7 +33681,7 @@ tV
 Hm
 lY
 hY
-ih
+aX
 ee
 aA
 aR
@@ -34109,7 +33883,7 @@ tV
 lz
 lY
 UH
-ih
+aX
 ee
 aA
 bf
@@ -34311,7 +34085,7 @@ lY
 lY
 lY
 md
-ih
+aX
 ee
 ag
 bg
@@ -34513,7 +34287,7 @@ iX
 fX
 aJ
 UH
-ih
+aX
 ee
 aB
 bh
@@ -34715,7 +34489,7 @@ ju
 fX
 lk
 UH
-ih
+aX
 ee
 aB
 bj
@@ -34917,7 +34691,7 @@ jX
 li
 aJ
 UH
-ih
+aX
 ee
 aB
 bk
@@ -35119,7 +34893,7 @@ aJ
 aJ
 aJ
 UH
-ih
+aX
 ee
 aB
 bh
@@ -35321,7 +35095,7 @@ fi
 hp
 aJ
 FZ
-ih
+aX
 ee
 aB
 bm
@@ -36330,7 +36104,7 @@ aW
 hi
 uF
 ms
-mF
+Xz
 nP
 mw
 mw
@@ -36532,7 +36306,7 @@ aW
 hi
 hb
 aJ
-aX
+ih
 cy
 Ho
 Ho
@@ -36546,7 +36320,7 @@ Ho
 Ho
 Ho
 nM
-ih
+aX
 kW
 Ho
 Ho
@@ -36748,7 +36522,7 @@ cj
 cj
 Gq
 fS
-ih
+aX
 ee
 bi
 bi
@@ -36936,7 +36710,7 @@ aW
 gT
 Ge
 aJ
-aX
+ih
 ee
 aZ
 bG
@@ -36950,7 +36724,7 @@ lU
 cj
 cj
 fS
-ih
+aX
 ee
 bi
 bi
@@ -37136,9 +36910,9 @@ mf
 Xk
 WD
 Ea
-Ea
+FR
 aJ
-aX
+ih
 ee
 aZ
 br
@@ -37152,7 +36926,7 @@ dE
 dM
 ef
 fS
-ih
+aX
 ee
 bi
 bi
@@ -37337,10 +37111,10 @@ ZG
 MC
 pG
 pI
-Ea
+PM
 CB
 aJ
-aX
+ih
 ee
 aZ
 gr
@@ -37354,7 +37128,7 @@ dF
 dN
 ef
 fS
-ih
+aX
 ee
 bi
 bi
@@ -37538,11 +37312,11 @@ ZG
 ZG
 MC
 pH
-du
-FR
-Ea
-aJ
-aX
+Ig
+Ig
+rC
+Ig
+ih
 ee
 aY
 qb
@@ -37556,7 +37330,7 @@ dG
 cj
 cj
 fS
-ih
+aX
 ee
 bi
 bi
@@ -37740,10 +37514,10 @@ ZG
 ZG
 aH
 Jf
-aW
-aW
-aW
-aJ
+Ig
+Ov
+pe
+Ig
 kd
 ee
 aY
@@ -37758,7 +37532,7 @@ cj
 cj
 bi
 fS
-ih
+aX
 ee
 bi
 bi
@@ -37942,10 +37716,10 @@ ZG
 ZG
 aH
 Um
-Ea
-sw
-sw
-aJ
+Ig
+bN
+QX
+Ig
 oI
 eH
 eT
@@ -37960,7 +37734,7 @@ eT
 eT
 eT
 fT
-ih
+aX
 eH
 eT
 eT
@@ -38144,11 +37918,11 @@ ZG
 ZG
 aH
 Um
-Ea
+Ig
 sx
 sz
-aJ
-aX
+gG
+iW
 aX
 aX
 il
@@ -38162,7 +37936,7 @@ kV
 oL
 HY
 Gw
-ih
+aX
 pb
 IO
 il
@@ -38346,11 +38120,11 @@ ZG
 ZG
 aH
 Um
-Ea
+Ig
+Ig
+wt
+Ig
 aW
-aW
-aJ
-aJ
 Qn
 Qn
 Qn
@@ -38364,7 +38138,7 @@ WU
 WU
 lv
 iS
-lw
+lv
 Fk
 Fk
 Fk
@@ -38549,8 +38323,8 @@ ZG
 KI
 al
 Cq
-Cq
-Cq
+or
+nI
 Cq
 bM
 Qn
@@ -38954,7 +38728,7 @@ fz
 NL
 fz
 fz
-fz
+Xp
 EX
 Es
 Qn
@@ -39155,8 +38929,8 @@ QL
 Ct
 Ne
 Lj
-zL
 fz
+Xp
 EX
 Xb
 tp
@@ -39167,12 +38941,12 @@ qr
 qq
 Lp
 UG
-UG
+qa
 sp
 WU
 qz
 um
-Xz
+UO
 hF
 xg
 UO
@@ -39356,21 +39130,21 @@ Xi
 QL
 MG
 av
-Ne
-Ia
+HE
 fz
+Xp
 EX
 Es
 Qn
-qd
-qj
-qm
-qp
+tm
+hq
+hq
+tm
 WU
-qe
-qf
-qh
-Eg
+zL
+gE
+gE
+mq
 ql
 qA
 un
@@ -39560,19 +39334,19 @@ TC
 HE
 yI
 XI
-XI
+Xp
 aD
 aK
 Qn
-Qn
-Qn
-Qn
-Qn
+qd
+qj
+qm
+qp
 WU
-WU
-WU
-WU
-WU
+qf
+qe
+qh
+Eg
 WU
 qB
 Sc
@@ -39765,16 +39539,16 @@ YH
 KW
 yk
 SM
-Df
-Xp
-Df
-Df
-bN
-Iq
-UE
-Ve
-Df
-LL
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
+aW
 XE
 Sr
 Zo
@@ -39967,13 +39741,13 @@ fz
 HU
 Nh
 yz
-AU
-AU
+mI
+rA
 LB
 pr
 vj
-PM
-PM
+vj
+vj
 VX
 ZE
 Wg
@@ -40175,7 +39949,7 @@ JY
 Hv
 wX
 xL
-xL
+qc
 sC
 ps
 Qg

--- a/maps/torch/torch_areas.dm
+++ b/maps/torch/torch_areas.dm
@@ -43,6 +43,9 @@
 /area/maintenance/substation/fifthdeck
 	name = "Fifth Deck Substation"
 
+/area/maintenance/substation/hangar
+	name = "Hangar Substation"
+
 //Fourth Deck (Z-1)
 /area/hallway/primary/fourthdeck/fore
 	name = "\improper Fourth Deck Fore Hallway"


### PR DESCRIPTION
:cl:
maptweak: Expedition prep has a console and space map.
maptweak: Split hangar substation out into a full substation.
/:cl:
The second was necessary for the first because wires. It will, however, give engineering better control over power going to hangar shuttles and the petrov.

![dreamseeker_QOWz8yKeQR](https://github.com/user-attachments/assets/968813d4-80e4-4cff-b9f8-5c472dbf4d62)

![dreamseeker_rzuI2hXPvs](https://github.com/user-attachments/assets/c8f4d34a-0977-481f-990b-f484e63fb2df)


02:45 PR woo

closes #35017