### PR TITLE
Bullet Hole Fixes

### DIFF
--- a/code/game/objects/effects/decals/bullet_holes.dm
+++ b/code/game/objects/effects/decals/bullet_holes.dm
@@ -6,3 +6,27 @@
 	layer = DECAL_LAYER
 	icon_state = "scorch"
 	anchored = TRUE
+
+
+/obj/overlay/bmark/use_grab(obj/item/grab/grab, list/click_params)
+	if (istype(loc, /turf/simulated/wall))
+		var/turf/simulated/wall/wall = loc
+		return wall.use_weapon(grab, click_params)
+
+	return ..()
+
+
+/obj/overlay/bmark/use_weapon(obj/item/weapon, mob/living/user, list/click_params)
+	if (istype(loc, /turf/simulated/wall))
+		var/turf/simulated/wall/wall = loc
+		return wall.use_weapon(weapon, user, click_params)
+
+	return ..()
+
+
+/obj/overlay/bmark/use_tool(obj/item/tool, mob/living/user, list/click_params)
+	if (istype(loc, /turf/simulated/wall))
+		var/turf/simulated/wall/wall = loc
+		return wall.use_tool(tool, user, click_params)
+
+	return ..()

--- a/code/game/objects/effects/decals/bullet_holes.dm
+++ b/code/game/objects/effects/decals/bullet_holes.dm
@@ -5,3 +5,4 @@
 	icon = 'icons/effects/effects.dmi'
 	layer = DECAL_LAYER
 	icon_state = "scorch"
+	anchored = TRUE

--- a/code/game/turfs/simulated/wall_attacks.dm
+++ b/code/game/turfs/simulated/wall_attacks.dm
@@ -168,6 +168,29 @@
 			kill_health()
 			return TRUE
 
+	// Bullet hole repair
+	if (isWelder(W) && (locate(/obj/overlay/bmark) in src))
+		var/obj/item/weldingtool/weldingtool = W
+		if (!weldingtool.can_use(1, user))
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts patching all the bullet holes in \the [src] with \a [W]."),
+			SPAN_NOTICE("You start patching all the bullet holes in \the [src] with \the [W].")
+		)
+		for (var/obj/overlay/bmark/bmark in src)
+			if (!user.do_skilled(0.5 SECONDS, SKILL_CONSTRUCTION, bmark) || !user.use_sanity_check(bmark, W))
+				return TRUE
+			if (!weldingtool.remove_fuel(1, user))
+				return TRUE
+			qdel(bmark)
+			playsound(src, 'sound/items/Welder.ogg', 10, 1)
+		user.visible_message(
+			SPAN_NOTICE("\The [user] finished patching \the [src]'s bullet holes with \a [W]."),
+			SPAN_NOTICE("You finish patching \the [src]'s bullet holes with \the [W].")
+		)
+		return TRUE
+
+
 	//THERMITE related stuff. Calls src.thermitemelt() which handles melting simulated walls and the relevant effects
 	if(thermite)
 		if(isWelder(W))


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Bullet holes are no longer draggable.
rscadd: Bullet holes can be fixed by using a welder on the wall.
tweak: Clicking on bullet holes with things now interacts directly with the wall.
/:cl: