### PR TITLE
AI Door Hacking

### DIFF
--- a/code/modules/ai/ai_holder_combat.dm
+++ b/code/modules/ai/ai_holder_combat.dm
@@ -258,7 +258,15 @@
 
 // Pry open a door, if it's unpowered/broken
 /datum/ai_holder/proc/pry_door(obj/machinery/door/door)
-	return FALSE
+	. = FALSE
+	if (door.operable())
+		return FALSE
+
+	var/mob/living/simple_animal/holder_simple = holder
+	if (!prying && holder_simple.can_pry)
+		prying = TRUE
+		var/pry_time_holder = (door.pry_mod * holder_simple.pry_time)
+		return holder_simple.pry_door(holder_simple, pry_time_holder, door)
 
 // Despite the name, this can also be used to help clear a path without any destruction.
 /datum/ai_holder/proc/destroy_surroundings(direction, violent = TRUE)

--- a/code/modules/ai/ai_holder_combat.dm
+++ b/code/modules/ai/ai_holder_combat.dm
@@ -278,13 +278,15 @@
 				return FALSE
 			if (airlock.welded) // Welding check after the bolt check so the bot can still unbolt the door before trying to break it open.
 				return FALSE
-		return !!door.open()
+		door.open()
+		return TRUE
 
 	var/mob/living/simple_animal/holder_simple = holder
 	if (!prying && holder_simple.can_pry)
 		prying = TRUE
 		var/pry_time_holder = (door.pry_mod * holder_simple.pry_time)
-		return holder_simple.pry_door(holder_simple, pry_time_holder, door)
+		holder_simple.pry_door(holder_simple, pry_time_holder, door)
+		return TRUE
 
 	return FALSE
 

--- a/code/modules/ai/ai_holder_combat.dm
+++ b/code/modules/ai/ai_holder_combat.dm
@@ -12,6 +12,15 @@
 
 	var/prying = FALSE                      // True when the mob is trying to force open a door.
 
+	/// Bitflag (Any of `src.PRY_FLAG_*`). Bitflags used for configuring what and how this AI can pry. Not used if `holder.can_pry` is `FALSE`.
+	var/pry_flags = EMPTY_BITFIELD
+	/// This AI can only perform special unlocking if the AI control wire is intact.
+	var/const/PRY_FLAG_AI_CONTROL_ONLY = FLAG(0)
+	/// This AI can unbolt doors.
+	var/const/PRY_FLAG_UNBOLT = FLAG(1)
+	/// This AI can 'hack' open working doors.
+	var/const/PRY_FLAG_CAN_HACK = FLAG(2)
+
 	// Excludes doors, shutters and windows, which are processed separately
 	var/list/valid_obstacles_by_priority = list(
 		/obj/structure/closet,
@@ -258,15 +267,26 @@
 
 // Pry open a door, if it's unpowered/broken
 /datum/ai_holder/proc/pry_door(obj/machinery/door/door)
-	. = FALSE
 	if (door.operable())
-		return FALSE
+		if (!HAS_FLAGS(pry_flags, PRY_FLAG_CAN_HACK))
+			return FALSE
+		if (isairlock(door))
+			var/obj/machinery/door/airlock/airlock = door
+			if (HAS_FLAGS(pry_flags, PRY_FLAG_AI_CONTROL_ONLY) && airlock.ai_control_disabled)
+				return FALSE
+			if (airlock.locked && (!HAS_FLAGS(pry_flags, PRY_FLAG_UNBOLT) || !airlock.unlock()))
+				return FALSE
+			if (airlock.welded) // Welding check after the bolt check so the bot can still unbolt the door before trying to break it open.
+				return FALSE
+		return !!door.open()
 
 	var/mob/living/simple_animal/holder_simple = holder
 	if (!prying && holder_simple.can_pry)
 		prying = TRUE
 		var/pry_time_holder = (door.pry_mod * holder_simple.pry_time)
 		return holder_simple.pry_door(holder_simple, pry_time_holder, door)
+
+	return FALSE
 
 // Despite the name, this can also be used to help clear a path without any destruction.
 /datum/ai_holder/proc/destroy_surroundings(direction, violent = TRUE)

--- a/code/modules/ai/ai_holder_subtypes/simple_mob_ai.dm
+++ b/code/modules/ai/ai_holder_subtypes/simple_mob_ai.dm
@@ -12,17 +12,6 @@
 	wander = TRUE
 	base_wander_delay = 4
 
-/datum/ai_holder/simple_animal/pry_door(obj/machinery/door/door)
-	. = FALSE
-	if (door.operable())
-		return FALSE
-
-	var/mob/living/simple_animal/holder_simple = holder
-	if (!prying && holder_simple.can_pry)
-		prying = TRUE
-		var/pry_time_holder = (door.pry_mod * holder_simple.pry_time)
-		return holder_simple.pry_door(holder_simple, pry_time_holder, door)
-
 // For non-hostile animals, and pets like Ian and Runtime.
 /datum/ai_holder/simple_animal/passive
 	hostile = FALSE

--- a/packs/legion/ai/legion_ai_base.dm
+++ b/packs/legion/ai/legion_ai_base.dm
@@ -20,3 +20,5 @@
 
 	// Targeting
 	hostile = TRUE
+
+	pry_flags = PRY_FLAG_AI_CONTROL_ONLY | PRY_FLAG_UNBOLT | PRY_FLAG_CAN_HACK

--- a/packs/legion/ai/legion_ai_reaver.dm
+++ b/packs/legion/ai/legion_ai_reaver.dm
@@ -10,3 +10,5 @@
 
 	// Pathfinding
 	use_astar = TRUE
+
+	pry_flags = PRY_FLAG_AI_CONTROL_ONLY | PRY_FLAG_UNBOLT | PRY_FLAG_CAN_HACK


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: AI controlled mobs no longer attack doors while also trying to open them.
rscadd: Certain mobs can now "hack" open doors that are powered, and in some cases, even remotely lift door bolts.
/:cl:

## Other Changes
- Moved door prying logic from `/datum/ai_holder/simple_animal` to `/datum/ai_holder`; Makes no changes to what mobs have `can_pry` set.
- Added logic for AI to be able to "hack" open a working door instead of breaking and prying it. Relies on the new `pry_flags` bitfield.