### PR TITLE
Add canon deaths to the chapel's memorial

### DIFF
--- a/maps/torch/structures/signs.dm
+++ b/maps/torch/structures/signs.dm
@@ -46,6 +46,16 @@
 	)
 
 
+/obj/structure/sign/memorial/torch
+	fallen = list(
+		"Senior Explorer Paula Wojciak | Expeditionary Corps",
+		"Senior Explorer Ziva Karim-Kirilisav | Expeditionary Corps",
+		"Petty Officer Third Class Tatyanna Svetka | Fleet",
+		"Lieutenant Adrian Schmidt | Expeditionary Corps",
+		"Ensign Brock Bunten | Expeditionary Corps"
+	)
+
+
 /obj/structure/sign/memorial/use_tool(obj/item/tool, mob/user, list/click_params)
 	// Dog Tags - Add dog tag
 	if (istype(tool, /obj/item/clothing/accessory/badge/solgov/tags))

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -17936,7 +17936,7 @@
 /turf/simulated/floor/reinforced/oxygen,
 /area/thruster/d3starboard)
 "SK" = (
-/obj/structure/sign/memorial,
+/obj/structure/sign/memorial/torch,
 /obj/structure/sign/double/solgovflag/left{
 	pixel_x = -16;
 	pixel_y = 32


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
tweak: The chapel's memorial stone now lists the names of all the current canon deaths.
/:cl: