### PR TITLE
blood overlay handling rework

### DIFF
--- a/code/game/turfs/simulated.dm
+++ b/code/game/turfs/simulated.dm
@@ -84,10 +84,10 @@
 				var/obj/item/clothing/shoes/S = H.shoes
 				if(istype(S))
 					S.handle_movement(src, MOVING_QUICKLY(H))
-					if(S.track_blood && S.blood_DNA)
+					if(S.blood_transfer_amount && S.blood_DNA)
 						bloodDNA = S.blood_DNA
 						bloodcolor = S.blood_color
-						S.track_blood--
+						S.blood_transfer_amount--
 			else
 				if(H.track_blood && H.feet_blood_DNA)
 					bloodDNA = H.feet_blood_DNA

--- a/code/modules/clothing/_clothing.dm
+++ b/code/modules/clothing/_clothing.dm
@@ -873,7 +873,7 @@ BLIND     // can't see anything
 	)
 	slot_flags = SLOT_OCLOTHING
 	item_flags = ITEM_FLAG_WASHER_ALLOWED
-	blood_overlay_type = "suit"
+	blood_overlay_type = "suitblood"
 	siemens_coefficient = 0.9
 	w_class = ITEM_SIZE_NORMAL
 

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -32,7 +32,7 @@
 	name = "armor"
 	desc = "An armored vest that protects against some damage."
 	icon_state = "armor"
-	blood_overlay_type = "armor"
+	blood_overlay_type = "armorblood"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	cold_protection = UPPER_TORSO|LOWER_TORSO
 	heat_protection = UPPER_TORSO|LOWER_TORSO
@@ -69,7 +69,7 @@
 	desc = "An armored jacket used in special operations."
 	icon_state = "detective"
 	item_state = "detective"
-	blood_overlay_type = "coat"
+	blood_overlay_type = "coatblood"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|ARMS
 	cold_protection = UPPER_TORSO|LOWER_TORSO|ARMS
 	heat_protection = UPPER_TORSO|LOWER_TORSO|ARMS
@@ -80,7 +80,7 @@
 	name = "armor"
 	desc = "An armored vest with a detective's badge on it."
 	icon_state = "detective-armor"
-	blood_overlay_type = "armor"
+	blood_overlay_type = "armorblood"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	armor = list(
 		melee = ARMOR_MELEE_RESISTANT,
@@ -98,7 +98,7 @@
 	desc = "Someone separated our Chief Science Officer from their own head!"
 	active = 0.0
 	icon_state = "reactiveoff"
-	blood_overlay_type = "armor"
+	blood_overlay_type = "armorblood"
 	armor = null
 
 
@@ -283,7 +283,7 @@
 	name = "makeshift armor"
 	desc = "A pair of sheets held together by rods and wires, meant to cover your upper body and back."
 	icon_state = "makeshift-armor"
-	blood_overlay_type = "armor"
+	blood_overlay_type = "armorblood"
 	armor = list(
 		melee = ARMOR_MELEE_KNIVES,
 		bullet = ARMOR_BALLISTIC_SMALL,
@@ -303,7 +303,7 @@
 	icon_state = "pcarrier"
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA, ACCESSORY_SLOT_ARMOR_CHEST, ACCESSORY_SLOT_ARMOR_ARMS, ACCESSORY_SLOT_ARMOR_LEGS, ACCESSORY_SLOT_ARMOR_STORAGE, ACCESSORY_SLOT_ARMOR_MISC)
 	restricted_accessory_slots = list(ACCESSORY_SLOT_ARMOR_CHEST, ACCESSORY_SLOT_ARMOR_ARMS, ACCESSORY_SLOT_ARMOR_LEGS, ACCESSORY_SLOT_ARMOR_STORAGE)
-	blood_overlay_type = "armor"
+	blood_overlay_type = "armorblood"
 	flags_inv = 0
 
 	sprite_sheets = list(

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -8,7 +8,7 @@
 	desc = "A basic blue apron."
 	icon_state = "apron"
 	item_state = "apron"
-	blood_overlay_type = "armor"
+	blood_overlay_type = "armorblood"
 	body_parts_covered = 0
 	species_restricted = null
 	allowed = list (/obj/item/reagent_containers/spray/plantbgone,/obj/item/device/scanner/plant,/obj/item/seeds,/obj/item/reagent_containers/glass/bottle,/obj/item/material/minihoe)
@@ -66,7 +66,7 @@
 	desc = "A basic, dull, white chef's apron."
 	icon_state = "apronchef"
 	species_restricted = null
-	blood_overlay_type = "armor"
+	blood_overlay_type = "armorblood"
 	body_parts_covered = 0
 
 //Security
@@ -94,7 +94,7 @@
 	desc = "A rugged canvas trenchcoat, designed and created by TX Fabrication Corp. The coat is externally impact resistant - perfect for your next act of autodefenestration!"
 	icon_state = "detective"
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
-	blood_overlay_type = "coat"
+	blood_overlay_type = "coatblood"
 	body_parts_covered = UPPER_TORSO|ARMS
 	allowed = list(
 		/obj/item/tank/oxygen_emergency,
@@ -166,7 +166,7 @@
 	name = "hazard vest"
 	desc = "A high-visibility vest used in work zones."
 	icon_state = "hazard"
-	blood_overlay_type = "armor"
+	blood_overlay_type = "armorblood"
 	species_restricted = null
 	allowed = list (
 		/obj/item/device/scanner/gas,
@@ -229,7 +229,7 @@
 	name = "high visibility jacket"
 	desc = "A loose-fitting, high visibility jacket to help crew be recognizable in high traffic areas with large industrial equipment. Don't catch the Charon's landing gear with your teeth!"
 	icon_state = "highvis"
-	blood_overlay_type = "coat"
+	blood_overlay_type = "coatblood"
 	body_parts_covered = UPPER_TORSO|ARMS
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
 
@@ -238,7 +238,7 @@
 	name = "suit jacket"
 	desc = "A snappy dress jacket."
 	icon_state = "suitjacket"
-	blood_overlay_type = "coat"
+	blood_overlay_type = "coatblood"
 	body_parts_covered = UPPER_TORSO|ARMS
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
 
@@ -246,7 +246,7 @@
 	name = "double-breasted suit jacket"
 	desc = "A snappy, double-breasted dress jacket."
 	icon_state = "suitjacket_double"
-	blood_overlay_type = "coat"
+	blood_overlay_type = "coatblood"
 	body_parts_covered = UPPER_TORSO|ARMS
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
 
@@ -267,7 +267,7 @@
 	name = "first responder jacket"
 	desc = "A high-visibility jacket worn by medical first responders."
 	icon_state = "fr_jacket"
-	blood_overlay_type = "armor"
+	blood_overlay_type = "armorblood"
 	allowed = list(
 		/obj/item/stack/medical,
 		/obj/item/reagent_containers/dropper,
@@ -298,7 +298,7 @@
 	name = "chest-rig"
 	desc = "A grey chest-rig with black pouches. For when you wish you had more hands."
 	icon_state = "chest-rig"
-	blood_overlay_type = "armor"
+	blood_overlay_type = "armorblood"
 	allowed = list(
 		/obj/item/device/flashlight,
 		/obj/item/tank/oxygen_emergency,
@@ -320,7 +320,7 @@
 	name = "hazard chest-rig"
 	desc = "A grey chest-rig with black pouches and orange markings worn by engineers. It has an 'Engineer' tag on its chest."
 	icon_state = "engi-chest-rig"
-	blood_overlay_type = "armor"
+	blood_overlay_type = "armorblood"
 	allowed = list (
 		/obj/item/device/flashlight,
 		/obj/item/tank/oxygen_emergency,
@@ -345,7 +345,7 @@
 	name = "\improper MT chest-rig"
 	desc = "A white chest-rig with black pouches worn by medical first responders. It has a 'Medic' tag on its chest."
 	icon_state = "med-chest-rig"
-	blood_overlay_type = "armor"
+	blood_overlay_type = "armorblood"
 	allowed = list(
 		/obj/item/device/flashlight,
 		/obj/item/tank/oxygen_emergency,
@@ -368,7 +368,7 @@
 	name = "surgical apron"
 	desc = "A sterile blue apron for performing surgery."
 	icon_state = "surgical"
-	blood_overlay_type = "armor"
+	blood_overlay_type = "armorblood"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO
 	allowed = list(
 		/obj/item/stack/medical,

--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -2,7 +2,7 @@
 	name = "labcoat"
 	desc = "A suit that protects against minor chemical spills."
 	icon_state = "labcoat"
-	blood_overlay_type = "coat"
+	blood_overlay_type = "coatblood"
 	body_parts_covered = UPPER_TORSO|ARMS
 	allowed = list(/obj/item/device/scanner/gas,/obj/item/stack/medical,/obj/item/reagent_containers/dropper,/obj/item/reagent_containers/syringe,/obj/item/reagent_containers/hypospray,/obj/item/device/scanner/health,/obj/item/device/flashlight/pen,/obj/item/reagent_containers/glass/bottle,/obj/item/reagent_containers/glass/beaker,/obj/item/reagent_containers/pill,/obj/item/storage/pill_bottle,/obj/item/paper)
 	armor = list(

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -12,7 +12,7 @@
 	name = "blue laser tag armour"
 	desc = "Blue Pride, Galaxy Wide."
 	icon_state = "bluetag"
-	blood_overlay_type = "armor"
+	blood_overlay_type = "armorblood"
 	item_flags = null
 	body_parts_covered = UPPER_TORSO
 	allowed = list (/obj/item/gun/energy/lasertag/blue)
@@ -22,7 +22,7 @@
 	name = "red laser tag armour"
 	desc = "Reputed to go faster."
 	icon_state = "redtag"
-	blood_overlay_type = "armor"
+	blood_overlay_type = "armorblood"
 	item_flags = null
 	body_parts_covered = UPPER_TORSO
 	allowed = list (/obj/item/gun/energy/lasertag/red)
@@ -391,7 +391,7 @@
 	desc = "A black raincloak belonging to an agent of the Sol Federal Police. It is almost certainly wind and waterproof."
 	icon_state = "agent_raincloak"
 	valid_accessory_slots = list(ACCESSORY_SLOT_INSIGNIA)
-	blood_overlay_type = "coat"
+	blood_overlay_type = "coatblood"
 
 /obj/item/clothing/suit/storage/mbill
 	name = "shipping jacket"

--- a/code/modules/clothing/under/accessories/armor_plate.dm
+++ b/code/modules/clothing/under/accessories/armor_plate.dm
@@ -65,7 +65,7 @@
 	slot_flags = SLOT_OCLOTHING //can wear in suit slot as well
 	slot = ACCESSORY_SLOT_UTILITY
 	w_class = ITEM_SIZE_NORMAL
-	blood_overlay_type = "armor"
+	blood_overlay_type = "armorblood"
 	icon_state = "undervest"
 
 

--- a/code/modules/detectivework/forensics.dm
+++ b/code/modules/detectivework/forensics.dm
@@ -181,12 +181,14 @@ var/global/const/FINGERPRINT_COMPLETE = 6
 		return
 	if(M.gloves && istype(M.gloves,/obj/item/clothing/gloves))
 		var/obj/item/clothing/gloves/G = M.gloves
-		if(G.transfer_blood) //bloodied gloves transfer blood to touched objects
-			if(add_blood(G.bloody_hands_mob)) //only reduces the bloodiness of our gloves if the item wasn't already bloody
-				G.transfer_blood--
+		if(G.blood_transfer_amount >= 1) //bloodied gloves transfer blood to touched objects
+			var/taken = rand(1, G.blood_transfer_amount)
+			if(add_blood_custom(G.blood_color, taken, G.blood_DNA)) //only reduces the bloodiness of our gloves if the item wasn't already bloody
+				G.blood_transfer_amount -= taken
 	else if(M.bloody_hands)
-		if(add_blood(M.bloody_hands_mob))
-			M.bloody_hands--
+		var/taken = rand(1, M.bloody_hands)
+		if(add_blood_custom(M.hand_blood_color, taken, M.hands_blood_DNA))
+			M.bloody_hands -= taken
 
 	var/fibertext
 	var/item_multiplier = istype(src,/obj/item)?1.2:1

--- a/code/modules/detectivework/tools/rag.dm
+++ b/code/modules/detectivework/tools/rag.dm
@@ -1,17 +1,10 @@
 /mob
 	var/bloody_hands = null
-	var/mob/living/carbon/human/bloody_hands_mob
 	var/track_blood = 0
+	var/list/hands_blood_DNA
 	var/list/feet_blood_DNA
 	var/track_blood_type
 	var/feet_blood_color
-
-/obj/item/clothing/gloves
-	var/transfer_blood = 0
-	var/mob/living/carbon/human/bloody_hands_mob
-
-/obj/item/clothing/shoes
-	var/track_blood = 0
 
 /obj/item/reagent_containers/glass/rag
 	name = "rag"

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -42,6 +42,8 @@
 	if(!init())
 		return INITIALIZE_HINT_QDEL
 
+	assailant.transfer_bloody_hands(affecting, target_zone)
+
 	var/obj/item/organ/O = get_targeted_organ()
 	SetName("[initial(name)] ([O.name])")
 	GLOB.dismembered_event.register(affecting, src, PROC_REF(on_organ_loss))

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -246,6 +246,7 @@
 				else
 					M.visible_message(SPAN_NOTICE("[M] hugs [src] to make [P.him] feel better!"), \
 								SPAN_NOTICE("You hug [src] to make [P.him] feel better!"))
+
 				if(M.fire_stacks >= (src.fire_stacks + 3))
 					src.fire_stacks += 1
 					M.fire_stacks -= 1

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -449,9 +449,12 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 	if (ishuman(target))
 		var/target_zone = check_zone(H.zone_sel.selecting)
 		var/mob/living/carbon/human/h_target = target
+		H.transfer_bloody_hands(target, target_zone)
 		if (target_zone == BP_HEAD && h_target.get_organ(target_zone))
 			H.visible_message(SPAN_NOTICE("[H] pats [h_target]'s head to make [t_him] feel better!"), SPAN_NOTICE("You pat [h_target]'s head to make [t_him] feel better!"))
 			return
+		else
+			H.transfer_bloody_body(target, BP_CHEST)
 
 	H.visible_message(SPAN_NOTICE("[H] hugs [target] to make [t_him] feel better!"), SPAN_NOTICE("You hug [target] to make [t_him] feel better!"))
 


### PR DESCRIPTION
🆑 Cakey
tweak: Filth overlays like blood and oil now tracks a transferral value for each item. Items with filth transferral will transfer their blood/oil to whatever they interact with.
tweak: interacting with items with bloody hands or gloves will transfer that blood/oil to the item depending on how filthy you are.
tweak: Squashed some legacy values related to blood overlays for items like shoes and items in general
tweak: Forensic DNA from blood will now transfer to items when interacting with them with bloody hands/gloves
tweak: Hugging people or grabbing them while covered in blood/oil will transfer it.
bugfix: Fixed coat and armor layered filth overlays using incorrect icon states
/🆑

Tried to modernise blood overlay code a bit by adding more custom proccalls for applying blood that isn't directly from a human. All other code routes through these custom procs. It's still all named after blood rather than a generic filth system because I couldn't be bothered

Also added some new procs that can be called to transfer filth from items directly to other items.

![image](https://github.com/user-attachments/assets/d4fb024a-ad4e-4a42-b39e-409b86c3a67b)
