### PR TITLE
makes it so the warehouse actually has more then 2 sheets of glass

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -15944,8 +15944,12 @@
 	amount = 30
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/obj/item/stack/material/glass,
-/obj/item/stack/material/glass,
+/obj/item/stack/material/glass{
+	amount = 30
+	},
+/obj/item/stack/material/glass{
+	amount = 30
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/quartermaster/storage)
 "UM" = (


### PR DESCRIPTION
:cl:
bugfix: the glass in the supply warehouse now correctly has 30 sheets per stack, like the steel stored right next to it
/:cl: