### PR TITLE
clean up server location config

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -4,9 +4,6 @@
 	/// server name (for world name / status)
 	var/static/server_name = "Space Station 13"
 
-	/// generate numeric suffix based on server port
-	var/static/server_suffix = FALSE
-
 	/// for topic status requests
 	var/static/game_version = "Baystation12"
 
@@ -196,9 +193,7 @@
 
 	var/static/debugparanoid = FALSE
 
-	var/static/serverurl
-
-	var/static/server
+	var/static/server_address
 
 	var/static/banappeals
 
@@ -611,14 +606,12 @@
 				respawn_menu_delay = respawn_menu_delay > 0 ? respawn_menu_delay : 0
 			if ("server_name")
 				server_name = value
-			if ("serversuffix")
-				server_suffix = TRUE
 			if ("hostedby")
 				hostedby = value
-			if ("serverurl")
-				serverurl = value
-			if ("server")
-				server = value
+			if ("server_address")
+				server_address = value
+				if (copytext(server_address, 1, 9) != "byond://")
+					server_address = "byond://[server_address]"
 			if ("banappeals")
 				banappeals = value
 			if ("wiki_url")

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -447,14 +447,13 @@ GLOBAL_VAR_INIT(world_topic_last, world.timeofday)
 
 	Master.Shutdown()
 
-	var/datum/chatOutput/co
-	for(var/client/C in GLOB.clients)
-		co = C.chatOutput
-		if(co)
-			co.ehjax_send(data = "roundrestart")
-	if(config.server)	//if you set a server location in config.txt, it sends you there instead of trying to reconnect to the same world address. -- NeoFite
-		for(var/client/C in GLOB.clients)
-			send_link(C, "byond://[config.server]")
+	var/datum/chatOutput/chat_output
+	for (var/client/client in GLOB.clients)
+		chat_output = client.chatOutput
+		if (chat_output)
+			chat_output.ehjax_send(data = "roundrestart")
+		if (config.server_address)
+			send_link(client, config.server_address)
 
 	if(config.wait_for_sigusr1_reboot && reason != 3)
 		text2file("foo", "reboot_called")

--- a/code/modules/ext_scripts/irc.dm
+++ b/code/modules/ext_scripts/irc.dm
@@ -45,13 +45,9 @@
 		export2irc(params)
 
 /proc/get_world_url()
-	. = "byond://"
-	if(config.serverurl)
-		. += config.serverurl
-	else if(config.server)
-		. += config.server
-	else
-		. += "[world.address]:[world.port]"
+	if (config.server_address)
+		return config.server_address
+	return "byond://[world.address]:[world.port]"
 
 /proc/send_to_admin_discord(type, message)
 	if(config.admin_discord && config.excom_address)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -195,12 +195,8 @@ GUEST_BAN
 ## Uncomment to 1 to jobban, leave commented out to allow these positions for everyone (but see GUEST_JOBBAN above and regular jobbans)
 # USEWHITELIST
 
-## set a server location for world reboot. Don't include the byond://, just give the address and port.
-#SERVER server.net:port
-
-## set a server URL for the IRC bot to use; like SERVER, don't include the byond://
-## Unlike SERVER, this one shouldn't break auto-reconnect
-#SERVERURL server.net:port
+## Set a server location for world rejoins. May be either "address:port" or "byond://address:port".
+#SERVER_ADDRESS server.address:port
 
 ## Wiki address
 ## Where your server's documentation lives


### PR DESCRIPTION
downstream beware

config pre-updated

--
removed config.serverurl
renamed config.server to server_address
renamed config.txt SERVER to SERVER_ADDRESS
config.txt SERVER_ADDRESS can be address:port OR byond://address:port
config.server_address tries to be "byond://address:port" internally

removed unused config.server_suffix

tweaked world/Reboot to be slightly more likely to send to all clients
before closing
