### PR TITLE
Event listener debug to runtime logs

### DIFF
--- a/code/datums/observation/~cleanup.dm
+++ b/code/datums/observation/~cleanup.dm
@@ -44,7 +44,7 @@ GLOBAL_LIST_EMPTY(event_listen_count)
 	for(var/entry in GLOB.all_observable_events)
 		var/singleton/observ/event = entry
 		if(event.unregister_global(listener))
-			log_debug("[event] - [listener] was deleted while still registered to global events.")
+			crash_with("[event] - [listener] was deleted while still registered to global events.")
 			if(!(--listen_count))
 				return
 
@@ -56,7 +56,7 @@ GLOBAL_LIST_EMPTY(event_listen_count)
 		if(proc_owners)
 			for(var/proc_owner in proc_owners)
 				if(event.unregister(event_source, proc_owner))
-					log_debug("[event] - [event_source] was deleted while still being listened to by [proc_owner].")
+					crash_with("[event] - [event_source] was deleted while still being listened to by [proc_owner].")
 					if(!(--source_listener_count))
 						return
 
@@ -66,6 +66,6 @@ GLOBAL_LIST_EMPTY(event_listen_count)
 		var/singleton/observ/event = entry
 		for(var/event_source in event.event_sources)
 			if(event.unregister(event_source, listener))
-				log_debug("[event] - [listener] was deleted while still listening to [event_source].")
+				crash_with("[event] - [listener] was deleted while still listening to [event_source].")
 				if(!(--listener_count))
 					return


### PR DESCRIPTION
Because the debug logs alone are frankly not really helping. The stack traces and additional information provided by runtime logs hopefully will help figure out what exactly is leaving these hanging so I can fix them.