### PR TITLE
Notify staff when clients connect to the server

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -218,6 +218,7 @@
 	// This turns out to be a touch too much when a bunch of people are connecting at once from a restart during init.
 	if (GAME_STATE & RUNLEVELS_DEFAULT)
 		spawn()
+		log_and_message_staff(SPAN_NOTICE("[key_name_admin(src)] has connected to the server."))
 		if (!check_rights(R_MOD, FALSE, src))
 			// Check connections
 			var/list/connections = fetch_connections()


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
admin: Staff are now notified in chat whenever a client connects to the server.
/:cl: