### PR TITLE
Adds separate pipe layers for scrubbers and supply

### DIFF
--- a/code/__defines/__renderer.dm
+++ b/code/__defines/__renderer.dm
@@ -52,10 +52,12 @@
 	#define DECAL_PLATING_LAYER         1.02
 	#define DISPOSALS_PIPE_LAYER        1.03
 	#define LATTICE_LAYER               1.04
-	#define PIPE_LAYER                  1.05
-	#define WIRE_LAYER                  1.06
-	#define WIRE_TERMINAL_LAYER         1.07
-	#define ABOVE_WIRE_LAYER            1.08
+	#define SCRUBBERS_LAYER             1.05
+	#define SUPPLY_LAYER                1.06
+	#define PIPE_LAYER                  1.07
+	#define WIRE_LAYER                  1.08
+	#define WIRE_TERMINAL_LAYER         1.09
+	#define ABOVE_WIRE_LAYER            1.10
 	//TURF PLANE
 	//TURF_LAYER = 2
 	#define TURF_DETAIL_LAYER           2.01
@@ -66,25 +68,27 @@
 	#define ABOVE_AO_LAYER              2.05
 	#define RUNE_LAYER                  2.06
 	#define ABOVE_TILE_LAYER            2.07
-	#define EXPOSED_PIPE_LAYER          2.08
-	#define EXPOSED_WIRE_LAYER          2.09
-	#define ABOVE_EXPOSED_WIRE_LAYER    2.10
-	#define CATWALK_LAYER               2.11
-	#define ABOVE_CATWALK_LAYER         2.12
-	#define BLOOD_LAYER                 2.13
-	#define MOUSETRAP_LAYER             2.14
-	#define PLANT_LAYER                 2.15
+	#define EXPOSED_SCRUBBERS_LAYER     2.08
+	#define EXPOSED_SUPPLY_LAYER        2.09
+	#define EXPOSED_PIPE_LAYER          2.10
+	#define EXPOSED_WIRE_LAYER          2.11
+	#define ABOVE_EXPOSED_WIRE_LAYER    2.12
+	#define CATWALK_LAYER               2.13
+	#define ABOVE_CATWALK_LAYER         2.14
+	#define BLOOD_LAYER                 2.15
+	#define MOUSETRAP_LAYER             2.16
+	#define PLANT_LAYER                 2.17
 	//HIDING MOB
-	#define HIDING_MOB_LAYER            2.16
-	#define SHALLOW_FLUID_LAYER         2.17
-	#define MOB_SHADOW_LAYER            2.18
+	#define HIDING_MOB_LAYER            2.18
+	#define SHALLOW_FLUID_LAYER         2.19
+	#define MOB_SHADOW_LAYER            2.20
 	//OBJ
-	#define BELOW_DOOR_LAYER            2.19
-	#define OPEN_DOOR_LAYER             2.20
-	#define BELOW_TABLE_LAYER           2.21
-	#define TABLE_LAYER                 2.22
-	#define BELOW_OBJ_LAYER             2.23
-	#define STRUCTURE_LAYER             2.24
+	#define BELOW_DOOR_LAYER            2.21
+	#define OPEN_DOOR_LAYER             2.22
+	#define BELOW_TABLE_LAYER           2.23
+	#define TABLE_LAYER                 2.24
+	#define BELOW_OBJ_LAYER             2.25
+	#define STRUCTURE_LAYER             2.26
 	// OBJ_LAYER                        3
 	#define ABOVE_OBJ_LAYER             3.01
 	#define CLOSED_DOOR_LAYER           3.02

--- a/code/modules/atmospherics/atmospherics.dm
+++ b/code/modules/atmospherics/atmospherics.dm
@@ -19,6 +19,7 @@ Pipelines + Other Objects -> Pipe network
 	var/power_rating //the maximum amount of power the machine can use to do work, affects how powerful the machine is, in Watts
 
 	layer = EXPOSED_PIPE_LAYER
+	var/hidden_layer = PIPE_LAYER
 
 	var/connect_types = CONNECT_TYPE_REGULAR
 	var/connect_dir_type = SOUTH // Assume your dir is SOUTH. What dirs should you connect to?
@@ -58,7 +59,7 @@ Pipelines + Other Objects -> Pipe network
 
 /obj/machinery/atmospherics/hide(do_hide)
 	if(do_hide && level == ATOM_LEVEL_UNDER_TILE)
-		layer = PIPE_LAYER
+		layer = hidden_layer
 	else
 		reset_plane_and_layer()
 

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -345,6 +345,8 @@
 	connect_types = CONNECT_TYPE_SCRUBBER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
+	layer = EXPOSED_SCRUBBERS_LAYER
+	hidden_layer = SCRUBBERS_LAYER
 
 /obj/machinery/atmospherics/pipe/simple/visible/supply
 	name = "Air supply pipe"
@@ -353,6 +355,8 @@
 	connect_types = CONNECT_TYPE_SUPPLY
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
+	layer = EXPOSED_SUPPLY_LAYER
+	hidden_layer = SUPPLY_LAYER
 
 /obj/machinery/atmospherics/pipe/simple/visible/yellow
 	color = PIPE_COLOR_YELLOW
@@ -391,6 +395,8 @@
 	connect_types = CONNECT_TYPE_SCRUBBER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
+	layer = EXPOSED_SCRUBBERS_LAYER
+	hidden_layer = SCRUBBERS_LAYER
 
 /obj/machinery/atmospherics/pipe/simple/hidden/supply
 	name = "Air supply pipe"
@@ -399,6 +405,8 @@
 	connect_types = CONNECT_TYPE_SUPPLY
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
+	layer = EXPOSED_SUPPLY_LAYER
+	hidden_layer = SUPPLY_LAYER
 
 /obj/machinery/atmospherics/pipe/simple/hidden/yellow
 	color = PIPE_COLOR_YELLOW
@@ -605,6 +613,8 @@
 	connect_types = CONNECT_TYPE_SCRUBBER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
+	layer = EXPOSED_SCRUBBERS_LAYER
+	hidden_layer = SCRUBBERS_LAYER
 
 /obj/machinery/atmospherics/pipe/manifold/visible/supply
 	name="Air supply pipe manifold"
@@ -613,6 +623,8 @@
 	connect_types = CONNECT_TYPE_SUPPLY
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
+	layer = EXPOSED_SUPPLY_LAYER
+	hidden_layer = SUPPLY_LAYER
 
 /obj/machinery/atmospherics/pipe/manifold/visible/yellow
 	color = PIPE_COLOR_YELLOW
@@ -651,6 +663,8 @@
 	connect_types = CONNECT_TYPE_SCRUBBER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
+	layer = EXPOSED_SCRUBBERS_LAYER
+	hidden_layer = SCRUBBERS_LAYER
 
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply
 	name="Air supply pipe manifold"
@@ -659,6 +673,8 @@
 	connect_types = CONNECT_TYPE_SUPPLY
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
+	layer = EXPOSED_SUPPLY_LAYER
+	hidden_layer = SUPPLY_LAYER
 
 /obj/machinery/atmospherics/pipe/manifold/hidden/yellow
 	color = PIPE_COLOR_YELLOW
@@ -879,6 +895,8 @@
 	connect_types = CONNECT_TYPE_SCRUBBER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
+	layer = EXPOSED_SCRUBBERS_LAYER
+	hidden_layer = SCRUBBERS_LAYER
 
 /obj/machinery/atmospherics/pipe/manifold4w/visible/supply
 	name="4-way air supply pipe manifold"
@@ -887,6 +905,8 @@
 	connect_types = CONNECT_TYPE_SUPPLY
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
+	layer = EXPOSED_SUPPLY_LAYER
+	hidden_layer = SUPPLY_LAYER
 
 /obj/machinery/atmospherics/pipe/manifold4w/visible/yellow
 	color = PIPE_COLOR_YELLOW
@@ -925,6 +945,8 @@
 	connect_types = CONNECT_TYPE_SCRUBBER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
+	layer = EXPOSED_SCRUBBERS_LAYER
+	hidden_layer = SCRUBBERS_LAYER
 
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/supply
 	name="4-way air supply pipe manifold"
@@ -933,6 +955,8 @@
 	connect_types = CONNECT_TYPE_SUPPLY
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
+	layer = EXPOSED_SUPPLY_LAYER
+	hidden_layer = SUPPLY_LAYER
 
 /obj/machinery/atmospherics/pipe/manifold4w/hidden/yellow
 	color = PIPE_COLOR_YELLOW
@@ -1040,6 +1064,8 @@
 	connect_types = CONNECT_TYPE_SCRUBBER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
+	layer = EXPOSED_SCRUBBERS_LAYER
+	hidden_layer = SCRUBBERS_LAYER
 
 /obj/machinery/atmospherics/pipe/cap/visible/supply
 	name = "supply pipe endcap"
@@ -1048,6 +1074,8 @@
 	connect_types = CONNECT_TYPE_SUPPLY
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
+	layer = EXPOSED_SUPPLY_LAYER
+	hidden_layer = SUPPLY_LAYER
 
 /obj/machinery/atmospherics/pipe/cap/visible/fuel
 	name = "fuel pipe endcap"
@@ -1070,6 +1098,8 @@
 	connect_types = CONNECT_TYPE_SCRUBBER
 	icon_connect_type = "-scrubbers"
 	color = PIPE_COLOR_RED
+	layer = EXPOSED_SCRUBBERS_LAYER
+	hidden_layer = SCRUBBERS_LAYER
 
 /obj/machinery/atmospherics/pipe/cap/hidden/supply
 	name = "supply pipe endcap"
@@ -1078,6 +1108,8 @@
 	connect_types = CONNECT_TYPE_SUPPLY
 	icon_connect_type = "-supply"
 	color = PIPE_COLOR_BLUE
+	layer = EXPOSED_SUPPLY_LAYER
+	hidden_layer = SUPPLY_LAYER
 
 /obj/machinery/atmospherics/pipe/cap/hidden/fuel
 	name = "fuel pipe endcap"


### PR DESCRIPTION
🆑 Hubblenaut
tweak: Scrubber and supply pipe lines will now be rendered at their own layers to avoid cluttering.

Cleans up pipe rendering by introducing a set rendering order for scrubbers, supply, and other pipes.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->