### PR TITLE
Treats pressure tanks, connectors and omni devices as above turf

### DIFF
--- a/code/modules/atmospherics/components/omni_devices/omni_base.dm
+++ b/code/modules/atmospherics/components/omni_devices/omni_base.dm
@@ -6,7 +6,6 @@
 	icon = 'icons/atmos/omni_devices.dmi'
 	icon_state = "base"
 	initialize_directions = 0
-	level = ATOM_LEVEL_UNDER_TILE
 	layer = ABOVE_CATWALK_LAYER
 
 	var/configuring = 0

--- a/code/modules/atmospherics/components/portables_connector.dm
+++ b/code/modules/atmospherics/components/portables_connector.dm
@@ -17,7 +17,6 @@
 	var/on = 0
 	use_power = POWER_USE_OFF
 	uncreated_component_parts = null
-	level = ATOM_LEVEL_UNDER_TILE
 
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_FUEL
 	build_icon_state = "connector"

--- a/code/modules/atmospherics/components/unary/tank.dm
+++ b/code/modules/atmospherics/components/unary/tank.dm
@@ -9,7 +9,6 @@
 	var/start_pressure = 25*ONE_ATMOSPHERE
 	var/filling // list of gas ratios to use.
 
-	level = ATOM_LEVEL_UNDER_TILE
 	dir = 2
 	initialize_directions = 2
 	density = TRUE
@@ -37,7 +36,7 @@
 		update_icon()
 
 /obj/machinery/atmospherics/unary/tank/set_initial_level()
-	level = ATOM_LEVEL_UNDER_TILE // Always on top, apparently.
+	level = ATOM_LEVEL_OVER_TILE // Always on top, apparently.
 
 // required for paint sprayers to work due to an override in pipes.dm
 /obj/machinery/atmospherics/unary/tank/set_color(new_color)
@@ -120,7 +119,6 @@
 	color =  PIPE_COLOR_WHITE
 	connect_types = CONNECT_TYPE_REGULAR|CONNECT_TYPE_REGULAR|CONNECT_TYPE_SCRUBBER|CONNECT_TYPE_FUEL
 	w_class = ITEM_SIZE_HUGE
-	level = ATOM_LEVEL_UNDER_TILE
 	dir = SOUTH
 	constructed_path = /obj/machinery/atmospherics/unary/tank
 	pipe_class = PIPE_CLASS_UNARY


### PR DESCRIPTION
🆑 Hubblenaut
tweak: Mapped pressure tanks, connectors and omni devices are now treated as above turf when wrenching/unwrenching them. In particular, pressure tanks can now be built above turf.
/:cl:

This is in line with how pumps, walls and heat exchangers are treated right now.
Considering the comment in the pressure tank file, pressure tanks in particular seem to always have been meant above turf.

<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->