### PR TITLE
Fix invalid noticeboard icon if over 5 papers attached

### DIFF
--- a/code/modules/persistence/noticeboards.dm
+++ b/code/modules/persistence/noticeboards.dm
@@ -83,7 +83,7 @@
 	dismantle()
 
 /obj/structure/noticeboard/on_update_icon()
-	icon_state = "[base_icon_state][LAZYLEN(notices)]"
+	icon_state = "[base_icon_state][min(LAZYLEN(notices), 5)]"
 
 
 /obj/structure/noticeboard/use_tool(obj/item/tool, mob/user, list/click_params)


### PR DESCRIPTION
:cl: Banditoz
bugfix: The noticeboard will render correctly if there are over five papers attached.
/:cl: