### PR TITLE
Fix invalid defib paddles icon before they're first used

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -553,9 +553,12 @@
 */
 /obj/item/shockpaddles/linked
 	var/obj/item/defibrillator/base_unit
+	icon_state = "defibpaddles0"
 
 /obj/item/shockpaddles/linked/New(newloc, obj/item/defibrillator/defib)
 	base_unit = defib
+	if(base_unit.bcell)
+		icon_state = "defibpaddles1"
 	..(newloc)
 
 /obj/item/shockpaddles/linked/Destroy()


### PR DESCRIPTION
:cl: Banditoz
bugfix: Fix invalid defibrillator paddles icon before they're first used.
/:cl:

Fixes #34824