### PR TITLE
Reduces hangar access

### DIFF
--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -39,7 +39,7 @@
 	access = list(
 		access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 		access_teleporter, access_eva, access_tech_storage, access_atmospherics, access_janitor, access_construction,
-		access_tcomsat, access_solgov_crew, access_seneng, access_hangar, access_network, access_network_admin, access_radio_eng
+		access_tcomsat, access_solgov_crew, access_seneng, access_network, access_network_admin, access_radio_eng
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/power_monitor,
@@ -100,7 +100,7 @@
 	access = list(
 		access_engine, access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 		access_teleporter, access_eva, access_tech_storage, access_atmospherics, access_janitor, access_construction,
-		access_solgov_crew, access_hangar, access_network, access_radio_eng
+		access_solgov_crew, access_network, access_radio_eng
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/power_monitor,
@@ -154,7 +154,7 @@
 	access = list(
 		access_engine_equip, access_maint_tunnels, access_external_airlocks, access_emergency_storage,
 		access_eva, access_tech_storage, access_janitor, access_construction,
-		access_solgov_crew, access_hangar, access_radio_eng
+		access_solgov_crew, access_radio_eng
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/power_monitor,

--- a/maps/torch/job/medical_jobs.dm
+++ b/maps/torch/job/medical_jobs.dm
@@ -132,7 +132,7 @@
 		access_medical, access_morgue, access_maint_tunnels,
 		access_external_airlocks, access_emergency_storage,
 		access_eva, access_surgery, access_medical_equip,
-		access_solgov_crew, access_hangar, access_radio_med
+		access_solgov_crew, access_radio_med
 	)
 
 	software_on_spawn = list(/datum/computer_file/program/suit_sensors,


### PR DESCRIPTION
🆑PurplePineapple
tweak: Engineer Trainee, Engineer, Senior Engineer, and Medical Technician no longer have hangar access.
/🆑

This may not be well received so, I'll explain briefly.

**Currently, the following jobs have Hangar access:**
- All heads of staff.
- All exploration staff
- All supply staff
- All science staff
- All engineering staff
- Medical Technicians

**Excluding heads of staff, the following do not actually have departmental equipment in the hangar or a job to do in the hangar:**
- All engineering staff
- Medical Technicians

____________________________________________________________________

Repairing damage is Engineering's job, however they are not granted access to other departments that are not theirs for this freely and need to be let in by that department's staff. To repair viruses to the brig or E-ARM they're either let in, or have to unlock the door with their tools. This is the case for everywhere except specifically the hangar.

Similarly, Medical Technicians are responsible for responding to emergencies but they are not granted free access to any other departments besides their own. Under any other circumstances (Gunfight in the bridge, injury in the engine room, etc) they would need to be let in by that department's staff.

The hangar is primarily deck crew and exploration's area and they should primarily control who enters their workspace.