### PR TITLE
Adds the ability to ready up as multiple characters

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -155,6 +155,8 @@
 
 	var/static/minimum_player_age = 0
 
+	var/static/maximum_queued_characters = 3
+
 	/// Allows ghosts to write in blood in cult rounds...
 	var/static/cult_ghostwriter = TRUE
 
@@ -871,6 +873,8 @@
 				disallowed_modes += value
 			if ("minimum_player_age")
 				minimum_player_age = text2num(value)
+			if ("maximum_queued_characters")
+				maximum_queued_characters = text2num(value)
 			if ("max_explosion_range")
 				max_explosion_range = text2num_or_default(value, max_explosion_range)
 			if ("game_version")

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -415,6 +415,16 @@
 	if(prefs)
 		prefs.open_setup_window(usr)
 
+/client/verb/character_priorities()
+	set name = "Character Priorities"
+	set category = "OOC"
+	if(!prefs)
+		return
+	if(config.maximum_queued_characters > 1)
+		prefs.open_prefs_ordering_panel(usr)
+	else
+		to_chat(usr, SPAN_WARNING("The character priority queue is currently disabled"))
+
 
 /client/MouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params)
 	. = ..()

--- a/code/modules/client/preference_setup/antagonism/01_candidacy.dm
+++ b/code/modules/client/preference_setup/antagonism/01_candidacy.dm
@@ -2,6 +2,10 @@
 	var/list/may_be_special_role
 	var/list/be_special_role
 
+/datum/preferences_slot
+	var/list/may_be_special_role
+	var/list/be_special_role
+
 /datum/category_item/player_setup_item/antagonism/candidacy
 	name = "Candidacy"
 	sort_order = 1
@@ -13,6 +17,10 @@
 /datum/category_item/player_setup_item/antagonism/candidacy/save_character(datum/pref_record_writer/W)
 	W.write("be_special", pref.be_special_role)
 	W.write("may_be_special", pref.may_be_special_role)
+
+/datum/category_item/player_setup_item/antagonism/candidacy/load_slot(datum/pref_record_reader/R, datum/preferences_slot/slot)
+	slot.be_special_role = R.read("be_special")
+	slot.may_be_special_role = R.read("may_be_special")
 
 /datum/category_item/player_setup_item/antagonism/candidacy/sanitize_character()
 	if(!istype(pref.be_special_role))
@@ -64,6 +72,7 @@
 			return TOPIC_HANDLED
 		pref.be_special_role |= href_list["add_special"]
 		pref.may_be_special_role -= href_list["add_special"]
+		refresh_slot_roles()
 		return TOPIC_REFRESH
 
 	if(href_list["del_special"])
@@ -71,11 +80,13 @@
 			return TOPIC_HANDLED
 		pref.be_special_role -= href_list["del_special"]
 		pref.may_be_special_role -= href_list["del_special"]
+		refresh_slot_roles()
 		return TOPIC_REFRESH
 
 	if(href_list["add_maybe"])
 		pref.be_special_role -= href_list["add_maybe"]
 		pref.may_be_special_role |= href_list["add_maybe"]
+		refresh_slot_roles()
 		return TOPIC_REFRESH
 
 	if(href_list["select_all"])
@@ -93,9 +104,17 @@
 				if(2)
 					pref.be_special_role |= id
 					pref.may_be_special_role -= id
+		refresh_slot_roles()
 		return TOPIC_REFRESH
 
 	return ..()
+
+/datum/category_item/player_setup_item/antagonism/candidacy/proc/refresh_slot_roles()
+	for(var/datum/preferences_slot/slot in pref.slot_priority_list)
+		if(slot.slot != pref.default_slot)
+			continue
+		slot.be_special_role = pref.be_special_role
+		slot.may_be_special_role = pref.may_be_special_role
 
 /datum/category_item/player_setup_item/antagonism/candidacy/proc/valid_special_roles(include_bans = TRUE)
 	var/list/private_valid_special_roles = list()

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -92,6 +92,10 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 	W.write("traits", pref.picked_traits)
 
 
+/datum/category_item/player_setup_item/physical/body/load_slot(datum/pref_record_reader/R, datum/preferences_slot/slot)
+	slot.age = R.read("age")
+
+
 /datum/category_item/player_setup_item/physical/body/sanitize_character()
 	pref.head_hair_color = sanitize_hexcolor(pref.head_hair_color)
 	pref.facial_hair_color = sanitize_hexcolor(pref.facial_hair_color)
@@ -299,6 +303,10 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		var/new_age = input(user, "Choose your character's age:\n([mob_species.min_age]-[mob_species.max_age])", CHARACTER_PREFERENCE_INPUT_TITLE, pref.age) as num|null
 		if(new_age && CanUseTopic(user))
 			pref.age = max(min(round(text2num(new_age)), mob_species.max_age), mob_species.min_age)
+			for(var/datum/preferences_slot/slot in pref.slot_priority_list)
+				if(slot.slot != pref.default_slot)
+					continue
+				slot.age = pref.age
 			pref.skills_allocated = pref.sanitize_skills(pref.skills_allocated)		// The age may invalidate skill loadouts
 			return TOPIC_REFRESH
 

--- a/code/modules/client/preference_setup/occupation/occupation.dm
+++ b/code/modules/client/preference_setup/occupation/occupation.dm
@@ -4,6 +4,13 @@
 #define JOB_LEVEL_MEDIUM 2
 #define JOB_LEVEL_HIGH   1
 
+/datum/preferences_slot
+	var/job_high = null
+	/// List of all things selected for medium weight
+	var/list/job_medium
+	/// List of all the things selected for low weight
+	var/list/job_low
+
 /datum/preferences
 	//Since there can only be 1 high job.
 	var/job_high = null
@@ -45,6 +52,11 @@
 	W.write("branches", pref.branches)
 	W.write("ranks", pref.ranks)
 	W.write("hiding_maps", pref.hiding_maps)
+
+/datum/category_item/player_setup_item/occupation/load_slot(datum/pref_record_reader/R, datum/preferences_slot/slot)
+	slot.job_high = R.read("job_high")
+	slot.job_medium = R.read("job_medium")
+	slot.job_low = R.read("job_low")
 
 /datum/category_item/player_setup_item/occupation/sanitize_character()
 	if(!istype(pref.job_medium))		pref.job_medium = list()
@@ -494,6 +506,13 @@
 		if(JOB_LEVEL_LOW)
 			pref.job_low |= job.title
 
+	for(var/datum/preferences_slot/slot in pref.slot_priority_list)
+		if(slot.slot != pref.default_slot)
+			continue
+		slot.job_high = pref.job_high
+		slot.job_medium = pref.job_medium
+		slot.job_low = pref.job_low
+
 	return 1
 
 /datum/preferences/proc/CorrectLevel(datum/job/job, level)
@@ -506,6 +525,18 @@
 		if(3)
 			return !!(job.title in job_low)
 	return 0
+
+/datum/preferences_slot/proc/CorrectLevel(datum/job/job, level)
+	if(!job || !level)
+		return FALSE
+	switch(level)
+		if(1)
+			return job_high == job.title
+		if(2)
+			return !!(job.title in job_medium)
+		if(3)
+			return !!(job.title in job_low)
+	return FALSE
 
 /**
  *  Prune a player's job preferences based on current branch, rank and species

--- a/code/modules/client/preference_setup/preference_setup.dm
+++ b/code/modules/client/preference_setup/preference_setup.dm
@@ -80,6 +80,10 @@ var/global/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 	for(var/datum/category_group/player_setup_category/PS in categories)
 		PS.load_preferences(R)
 
+/datum/category_collection/player_setup_collection/proc/load_slot(datum/pref_record_reader/R, datum/preferences_slot/slot)
+	for(var/datum/category_group/player_setup_category/PS in categories)
+		PS.load_slot(R, slot)
+
 /datum/category_collection/player_setup_collection/proc/save_preferences(datum/pref_record_writer/W)
 	for(var/datum/category_group/player_setup_category/PS in categories)
 		PS.save_preferences(W)
@@ -150,6 +154,10 @@ var/global/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 	for(var/datum/category_item/player_setup_item/player_setup_item in items)
 		player_setup_item.save_preferences(S)
 
+/datum/category_group/player_setup_category/proc/load_slot(savefile/S, datum/preferences_slot/slot)
+	for(var/datum/category_item/player_setup_item/player_setup_item in items)
+		player_setup_item.load_slot(S, slot)
+
 /datum/category_group/player_setup_category/proc/content(mob/user)
 	. = "<table style='width:100%'><tr style='vertical-align:top'><td style='width:50%'>"
 	var/current = 0
@@ -200,6 +208,12 @@ var/global/const/CHARACTER_PREFERENCE_INPUT_TITLE = "Character Preference"
 * Called when the item is asked to load user/global settings
 */
 /datum/category_item/player_setup_item/proc/load_preferences(datum/pref_record_reader/R)
+	return
+
+/*
+* Called when the item is asked to load character settings onto a reserve slot
+*/
+/datum/category_item/player_setup_item/proc/load_slot(datum/pref_record_reader/R, datum/preferences_slot/slot)
 	return
 
 /*

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -8,10 +8,17 @@
 
 #define MAX_LOAD_TRIES 5
 
+/datum/preferences_slot
+	var/slot
+	var/age
+
 /datum/preferences
 	//doohickeys for savefiles
 	var/is_guest = FALSE
 	var/default_slot = 1				//Holder so it doesn't default to slot 1, rather the last one used
+
+	var/use_slot_priority_list = FALSE
+	var/list/datum/preferences_slot/slot_priority_list = list()
 
 	// Cache, mapping slot record ids to character names
 	// Saves reading all the slot records when listing
@@ -186,6 +193,8 @@
 	if (href_list["close"])
 		popup = null
 
+	. = 1
+
 	if(href_list["save"])
 		save_preferences()
 		save_character()
@@ -196,7 +205,8 @@
 	else if(href_list["load"])
 		if(!IsGuestKey(usr.key))
 			open_load_dialog(usr, href_list["details"])
-			return 1
+	else if (href_list["order_prefs"])
+		open_prefs_ordering_panel(usr)
 	else if(href_list["changeslot"])
 		load_character(text2num(href_list["changeslot"]))
 		sanitize_preferences()
@@ -205,22 +215,49 @@
 		if (winget(usr, "preferences_browser", "is-visible") == "true")
 			open_setup_window(usr)
 
+	else if(href_list["resetslot"])
+		if(real_name != input("This will reset the current slot. Enter the character's full name to confirm."))
+			. = 0
+		else
+			load_character(SAVE_RESET)
+			sanitize_preferences()
+	else if(href_list["addslot"])
+		if(length(slot_priority_list) < config.maximum_queued_characters)
+			var/datum/preferences_slot/new_slot = new()
+			new_slot.slot = text2num(href_list["addslot"])
+			load_slot(new_slot)
+			slot_priority_list.Add(new_slot)
+			save_preferences()
+	else if(href_list["removeslot"])
+		var/slotnum = text2num(href_list["removeslot"])
+		for(var/datum/preferences_slot/slot in slot_priority_list)
+			if(slot.slot == slotnum)
+				slot_priority_list.Remove(slot)
+		save_preferences()
+	else if(href_list["moveslotup"])
+		var/slot = text2num(href_list["moveslotup"])
+		if(slot != 1)
+			slot_priority_list.Swap(slot, slot - 1)
+		save_preferences()
+	else if(href_list["moveslotdown"])
+		var/slot = text2num(href_list["moveslotdown"])
+		if(slot != length(slot_priority_list))
+			slot_priority_list.Swap(slot, slot + 1)
+		save_preferences()
+	else if (href_list["show_preferences_loaded"])
+		load_character(text2num(href_list["show_preferences_loaded"]))
+		open_setup_window(usr)
+	else
+		. = 0
+
+	if(href_list["refresh"])
 		if (istype(client.mob, /mob/new_player))
 			var/mob/new_player/M = client.mob
 			M.new_player_panel()
-
-		if (href_list["details"])
-			return 1
-	else if(href_list["resetslot"])
-		if(real_name != input("This will reset the current slot. Enter the character's full name to confirm."))
-			return 0
-		load_character(SAVE_RESET)
-		sanitize_preferences()
-	else
-		return 0
+	if(href_list["refreshslots"] && panel?.title == "Character Priorities")
+		open_prefs_ordering_panel(usr)
 
 	update_setup_window(usr)
-	return 1
 
 /datum/preferences/proc/copy_to(mob/living/carbon/human/character, is_preview_copy = FALSE)
 	// Sanitizing rather than saving as someone might still be editing when copy_to occurs.
@@ -391,7 +428,7 @@
 			name = "Character [i]"
 		if (i == default_slot)
 			name = "<b>[name]</b>"
-		dat += "<a href='byond://?src=\ref[src];changeslot=[i];[details?"details=1":""]'>[name]</a><br>"
+		dat += "<a href='byond://?src=\ref[src];changeslot=[i];[details?"details=1":""];refresh=1'>[name]</a><br>"
 
 	dat += "<hr>"
 	dat += "</center></tt>"
@@ -404,6 +441,50 @@
 		panel.close()
 		panel = null
 	close_browser(user, "window=saves")
+
+/datum/preferences/proc/open_prefs_ordering_panel(mob/user)
+	if (!client)
+		return
+	if (!SScharacter_setup.initialized)
+		return
+	var/list/dat = list()
+	dat += "<div align='center'><b>Select your character priorities (up to [config.maximum_queued_characters])</b><hr>"
+
+	dat += "<div align='right' style='width:45%;float:left;'><b>Inactive</b><br>"
+	for(var/i = 1 to config.character_slots)
+		var/active = FALSE
+		for(var/datum/preferences_slot/slot in slot_priority_list)
+			if(slot.slot == i)
+				active = TRUE
+				break
+		if(!active)
+			var/name = slot_names?[get_slot_key(i)]
+			if (!name)
+				name = "Character [i]"
+			dat += "<a href='byond://?src=\ref[src];show_preferences_loaded=[i]'>[name]</a>"
+			if(length(slot_priority_list) < config.maximum_queued_characters)
+				dat += "<a href='byond://?src=\ref[src];addslot=[i];refreshslots=1;refresh=1'>&gt;</a>"
+			dat += "<br>"
+	dat += "</div><div style='width:10%;float:center;'>   </div>"
+	dat += "<div align='left' style='width:45%;float:right;'><b>Active</b><br>"
+	for(var/i = 1 to length(slot_priority_list))
+		var/datum/preferences_slot/pref = client.prefs.slot_priority_list[i]
+		if(length(slot_priority_list) != 1)
+			dat += "<a href='byond://?src=\ref[src];removeslot=[pref.slot];refreshslots=1;refresh=1'>&lt;</a>"
+		var/name = slot_names?[get_slot_key(pref.slot)]
+		if (!name)
+			name = "Character [i]"
+		dat += "<a href='byond://?src=\ref[src];show_preferences_loaded=[i]'>[name]</a>"
+		if(i != 1)
+			dat += "<a href='byond://?src=\ref[src];moveslotup=[i];refreshslots=1;refresh=1'>&uarr;</a>"
+		if(i != length(slot_priority_list))
+			dat += "<a href='byond://?src=\ref[src];moveslotdown=[i];refreshslots=1;refresh=1'>&darr;</a>"
+		dat += "<br>"
+	dat += "</div></div>"
+
+	panel = new(user, "Character Priorities", "Character Priorities", 350, 390, src)
+	panel.set_content(dat.Join())
+	panel.open()
 
 /datum/preferences/proc/selected_jobs_titles(priority = JOB_PRIORITY_PICKED)
 	. = list()

--- a/code/modules/client/preferences_persist.dm
+++ b/code/modules/client/preferences_persist.dm
@@ -41,6 +41,17 @@
 	if(!R)
 		R = new /datum/pref_record_reader/null(PREF_SER_VERSION)
 	player_setup.load_preferences(R)
+	for(var/datum/preferences_slot/slot in slot_priority_list)
+		var/datum/pref_record_reader/SR = load_pref_record(get_slot_key(slot.slot))
+		if(!SR)
+			SR = new /datum/pref_record_reader/null(PREF_SER_VERSION)
+		player_setup.load_slot(SR, slot)
+
+/datum/preferences/proc/load_slot(datum/preferences_slot/slot)
+	var/datum/pref_record_reader/R = load_pref_record(get_slot_key(slot.slot))
+	if(!R)
+		R = new /datum/pref_record_reader/null(PREF_SER_VERSION)
+	player_setup.load_slot(R, slot)
 
 /datum/preferences/proc/save_preferences()
 	var/datum/pref_record_writer/json_list/W = new(PREF_SER_VERSION)

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -26,6 +26,8 @@ JOBS_HAVE_MINIMAL_ACCESS
 ## Unhash this entry to set a number of days since first connection below which a new or returning player will not be allowed to successfully connect to the server.
 #MINIMUM_PLAYER_AGE 7
 
+## Change this value to limit how many characters a player can add to their character ready priorities.
+MAXIMUM_QUEUED_CHARACTERS 3
 
 ## Unhash this entry to have certain antag roles require your account to be at least a certain number of days old for round start and auto-spawn selection.
 ## Non-automatic antagonist recruitment, such as being converted to cultism is not affected. Has the same database requirements and notes as USE_AGE_RESTRICTION_FOR_JOBS.


### PR DESCRIPTION
🆑 Cakey
rscadd: You can now select to ready up as multiple characters, each with their own job preferences. Character job and role preferences will all be considered as defined (slot 2 character's high pref will be prioritised over slot 1 character's med pref)
/🆑

CL speaks for itself mostly. Added a new window plus some user prefs to allow setting up list-based-readying rather than solo charcters. Player can swap between the two at will.

![image](https://github.com/user-attachments/assets/00bd5a45-a2e7-4f97-9e14-91f03df50ac7)
![image](https://github.com/user-attachments/assets/391784b1-6d0e-4ac3-800b-237483ca9a33)

