### PR TITLE
Baneuus: fixed emag chameleon behavior

### DIFF
--- a/code/datums/extensions/chameleon.dm
+++ b/code/datums/extensions/chameleon.dm
@@ -311,12 +311,12 @@
 /datum/extension/chameleon/emag
 	expected_type = /obj/item/card
 	chameleon_choices = list(
-		/obj/item/card/emag,
-		/obj/item/card/union,
-		/obj/item/card/data,
-		/obj/item/card/data/full_color,
-		/obj/item/card/data/disk,
-		/obj/item/card/id
+		"Broken ID Card" = /obj/item/card/emag,
+		"ID Card" = /obj/item/card/id,
+		"Union Card" = /obj/item/card/union,
+		"Data Card" = /obj/item/card/data,
+		"Data Card (Full Color)" = /obj/item/card/data/full_color,
+		"Floppy Disk" = /obj/item/card/data/disk
 	)
 
 /datum/extension/chameleon/emag/GetItemDisguiseType(singleton/hierarchy/outfit/outfit)


### PR DESCRIPTION
:cl: Baneuus
bugfix: Fixed emag chameleon behavior.
/:cl:

alt because it needed a squash and the author disallowed edits.

closes #35059