### PR TITLE
unify dview mobs again on GLOB.dview_mob

### DIFF
--- a/code/__defines/__dview.dm
+++ b/code/__defines/__dview.dm
@@ -1,14 +1,14 @@
 //DVIEW defines
 
 #define FOR_DVIEW(type, range, center, invis_flags) \
-	global.dview_mob.loc = center; \
-	global.dview_mob.see_invisible = invis_flags; \
-	for(type in view(range, dview_mob))
+	GLOB.dview_mob.loc = center; \
+	GLOB.dview_mob.see_invisible = invis_flags; \
+	for(type in view(range, GLOB.dview_mob))
 
-#define END_FOR_DVIEW dview_mob.loc = null
+#define END_FOR_DVIEW GLOB.dview_mob.loc = null
 
 #define DVIEW(output, range, center, invis_flags) \
-	global.dview_mob.loc = center; \
-	global.dview_mob.see_invisible = invis_flags; \
-	output = view(range, dview_mob); \
-	global.dview_mob.loc = null;
+	GLOB.dview_mob.loc = center; \
+	GLOB.dview_mob.see_invisible = invis_flags; \
+	output = view(range, GLOB.dview_mob); \
+	GLOB.dview_mob.loc = null;

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -925,23 +925,6 @@ var/global/list/WALLITEMS = list(
 			colour += temp_col
 	return "#[colour]"
 
-GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
-
-//Version of view() which ignores darkness, because BYOND doesn't have it.
-/proc/dview(range = world.view, center, invis_flags = 0)
-	RETURN_TYPE(/list)
-	if(!center)
-		return
-
-	GLOB.dview_mob.loc = center
-	GLOB.dview_mob.see_invisible = invis_flags
-	. = view(range, GLOB.dview_mob)
-	GLOB.dview_mob.loc = null
-
-/mob/dview/Destroy()
-	SHOULD_CALL_PARENT(FALSE)
-	return QDEL_HINT_LETMELIVE
-
 /**
  * Sets the atom's color and light values to those of `origin`.
  *

--- a/code/modules/ai/ai_holder_targeting.dm
+++ b/code/modules/ai/ai_holder_targeting.dm
@@ -26,7 +26,7 @@
 /// Step 1, find out what we can see.
 /datum/ai_holder/proc/list_targets()
 	. = ohearers(vision_range, holder)
-	. -= global.dview_mob // Not the dview mob!
+	. -= GLOB.dview_mob
 
 	for (var/HM in range(vision_range, holder))
 		if (!(istype(HM, /obj/machinery/porta_turret) || \

--- a/code/modules/mob/dview.dm
+++ b/code/modules/mob/dview.dm
@@ -1,7 +1,5 @@
-//DVIEW is a hack that uses a mob with darksight in order to find lists of viewable stuff while ignoring darkness
-// Defines for dview are elsewhere.
+GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 
-var/global/mob/dview/dview_mob = new
 
 /mob/dview
 	anchored = TRUE
@@ -11,17 +9,24 @@ var/global/mob/dview/dview_mob = new
 	simulated = FALSE
 	virtual_mob = null
 
-/mob/dview/Destroy(force = FALSE)
+
+/mob/dview/Destroy()
 	SHOULD_CALL_PARENT(FALSE)
-	if (!force)
-		return QDEL_HINT_LETMELIVE
+	return QDEL_HINT_LETMELIVE
 
-	crash_with("Forced deletion of dview mob, this should not happen! : [log_info_line(src)]")
-
-	dview_mob = new
-	return QDEL_HINT_QUEUE
 
 /mob/dview/Initialize()
 	. = ..()
-	// We don't want to be in any mob lists; we're a dummy not a mob.
 	STOP_PROCESSING_MOB(src)
+
+
+// Version of view() which ignores darkness
+/proc/dview(range = world.view, center, invis_flags = EMPTY_BITFIELD)
+	RETURN_TYPE(/list)
+	if (!center)
+		return
+	var/mob/dview/dview_mob = GLOB.dview_mob
+	dview_mob.loc = center
+	dview_mob.see_invisible = invis_flags
+	. = view(range, dview_mob)
+	dview_mob.loc = null


### PR DESCRIPTION
o7 introduced a second dview mob instance as a bare global. Removed it in favor of the GLOB one.
