### PR TITLE
Adds limits to allergy count

### DIFF
--- a/code/datums/traits/maluses/allergy.dm
+++ b/code/datums/traits/maluses/allergy.dm
@@ -1,6 +1,7 @@
 /singleton/trait/malus/allergy
 	name = "Allergy"
 	levels = list(TRAIT_LEVEL_MINOR, TRAIT_LEVEL_MAJOR)
+	maximum_count = 2
 	///Used to select which reagent mob is allergic to.
 	metaoptions = list(
 		/datum/reagent/antidexafen,

--- a/code/datums/traits/traits.dm
+++ b/code/datums/traits/traits.dm
@@ -123,12 +123,17 @@
 		var/trait_type = istext(trait) ? text2path(trait) : trait
 		var/singleton/trait/selected = GET_SINGLETON(trait_type)
 		var/severity
+
 		if (length(selected.metaoptions))
 			var/list/interim = preferences[trait]
 			var/list/final_interim = list()
+			var/trait_count
 			for (var/metaoption in interim)
+				if (selected.maximum_count && trait_count >= selected.maximum_count)
+					break
 				var/metaoption_type = istext(metaoption) ? text2path(metaoption) : metaoption
 				severity = interim[metaoption]
+				trait_count++
 				LAZYSET(final_interim, metaoption_type, severity)
 			LAZYSET(final_preferences, trait_type, final_interim)
 
@@ -156,6 +161,8 @@
 	var/list/forbidden_species = list()
 	///Determines if trait can be selected in character setup
 	var/selectable = FALSE
+	///Maximum amount of allowable traits during character setup. Only applies to traits with metaoptions. Null by default; which means no limit.
+	var/maximum_count
 
 /singleton/trait/New()
 	if(type == abstract_type)

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -689,6 +689,18 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 		if (!selected || !istype(selected))
 			return
 
+		if (selected.maximum_count && length(pref.picked_traits[selected.type]) >= selected.maximum_count)
+			to_chat(usr, SPAN_WARNING("\The [selected.name] trait can only be selected [selected.maximum_count] times."))
+			return
+
+		for (var/existing_type as anything in pref.picked_traits)
+			var/singleton/trait/existing_trait = GET_SINGLETON(existing_type)
+			if (!existing_trait || !istype(existing_trait))
+				continue
+			if (LAZYISIN(existing_trait.incompatible_traits, selected.type) || LAZYISIN(selected.incompatible_traits, existing_type))
+				to_chat(usr, SPAN_WARNING("\The [selected.name] trait is incompatible with [existing_trait.name]."))
+				return
+
 		var/list/possible_levels = selected.levels
 		var/selected_level
 		if (length(possible_levels) > 1)
@@ -711,14 +723,6 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 
 			var/additional_input = input(user, "[selected.addprompt]", "Select Option") as null | anything in sanitized_metaoptions
 			additional_data = sanitized_metaoptions[additional_input]
-
-		for (var/existing_type as anything in pref.picked_traits)
-			var/singleton/trait/existing_trait = GET_SINGLETON(existing_type)
-			if (!existing_trait || !istype(existing_trait))
-				continue
-			if (LAZYISIN(existing_trait.incompatible_traits, selected.type) || LAZYISIN(selected.incompatible_traits, existing_type))
-				to_chat(usr, SPAN_WARNING("The [selected.name] trait is incompatible with [existing_trait.name]."))
-				return
 
 		if (additional_data)
 			var/list/interim = list()


### PR DESCRIPTION
🆑 emmanuelbassil
tweak: Allergies are now limited to two per character. Larger allergy lists should automatically be pruned down.
/🆑 

Was asked to do this. I tested it with my bloated allergy list saved locally; and the sanitize proc should clean up save files with more than 2 allergies.