### PR TITLE
Bugfix: duplicate of supply pack paths

### DIFF
--- a/code/datums/supplypacks/security.dm
+++ b/code/datums/supplypacks/security.dm
@@ -128,7 +128,7 @@
 	containername = "weapons crate"
 	access = access_security
 
-/singleton/hierarchy/supply_pack/security/weapons
+/singleton/hierarchy/supply_pack/security/tasers
 	name = "Weapons - Disposable tasers"
 	contains = list(/obj/item/gun/energy/taser/disposable = 4)
 	cost = 30


### PR DESCRIPTION
Fixed funny thing. Now tasers crate won't override batons crate I guess.

🆑LordNest
bugfix: Now you can buy stunbatons from cargo 
/🆑