### PR TITLE
Fixes Ion Thruster init

### DIFF
--- a/code/modules/overmap/ships/engines/ion_thruster.dm
+++ b/code/modules/overmap/ships/engines/ion_thruster.dm
@@ -45,13 +45,18 @@
 	construct_state = /singleton/machine_construction/default/panel_closed
 	var/datum/ship_engine/ion/controller
 	var/thrust_limit = 1
-	var/on = 1
+	var/on = 0
 	var/burn_cost = 750
 	var/generated_thrust = 2.5
 
 /obj/machinery/ion_engine/Initialize()
 	. = ..()
 	controller = new(src)
+	for(var/ship in SSshuttle.ships)
+		var/obj/overmap/visitable/ship/S = ship
+		if(S.check_ownership(src))
+			S.engines |= controller
+			break
 
 /obj/machinery/ion_engine/Destroy()
 	QDEL_NULL(controller)


### PR DESCRIPTION
:cl:
bugfix: Constructed ion thrusters now work properly
tweak: Ion Thrusters are not turned on by default
/:cl:
Currently ion thrusters are buildable, but practically unusable since they aren't controllable unless mapped in. I added a tiny part of code which apparently originates from #26787 to ion thrusters to fix it, and now they seem to link to a ship without any issues.

Tested this multiple times, and it seems to work perfectly (perhaps too well, but I'll leave balancing and other silliness to those who care about that). 
Also the thrusters are now shut down by default, this barely matters but machines with on/off switches really should not just turn on by themselves when they come into existence.
Partially fixes #34239, fully if it is actually intentional that the machine does not block movement.