### PR TITLE
Thermal Regulator Buff + Zombie Powder Reaction Temperature Tweak

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -343,8 +343,8 @@
 	result = /datum/reagent/toxin/zombiepowder
 	required_reagents = list(/datum/reagent/toxin/carpotoxin = 5, /datum/reagent/soporific = 5, /datum/reagent/copper = 5)
 	result_amount = 2
-	minimum_temperature = 90 CELSIUS
-	maximum_temperature = 99 CELSIUS
+	minimum_temperature = 80 CELSIUS
+	maximum_temperature = 89 CELSIUS
 	mix_message = "The solution boils off to form a fine powder."
 
 /singleton/reaction/mindbreaker

--- a/code/modules/reagents/heat_sources/thermal_regulator.dm
+++ b/code/modules/reagents/heat_sources/thermal_regulator.dm
@@ -26,13 +26,13 @@
 	var/list/permitted_types = list(/obj/item/reagent_containers/glass)
 	var/max_temperature =      200 CELSIUS
 	var/min_temperature =      -100  CELSIUS
-	var/heating_power =        10 // K
+	var/heating_power =        20 // K
 	var/last_temperature
 	var/target_temperature
 	var/obj/item/container
 
 /obj/machinery/reagent_temperature/Initialize()
-	target_temperature = 50 CELSIUS
+	target_temperature = 40 CELSIUS
 	. = ..()
 
 /obj/machinery/reagent_temperature/Destroy()


### PR DESCRIPTION
The old heating plates and cooling plates have been condensed into the new thermal regulator. This change means that if you need heat for a reaction after cooling the regulator, it takes a while to change the temperature (20 C to 100 C takes ~37 seconds and 20 C to -80 C takes ~49 seconds). So if you were making clonexadone (below -75 C) and then wanted to make synaptizine (above 30 C), it will take you a while to change temperatures. 

For QOL, the heating power was doubled which also increased the steps in changing temperature from 10 C to 20 C. 

The only chemical reaction affected by this change in steps in temperature change is zombie powder, so the chemical now is made in the range of 80-89 degrees C.

:cl: JebediahTechnic
tweak: Thermal regulator now has double the heating/cooling speed. The target temperature now starts at 40 degrees C instead of 50 degrees C.
tweak: Changing the temperature on the thermal regulator is now in steps of 20 C instead of 10 C.
tweak: Zombie powder is now created in a temperature range of 80-89 C.
/:cl: