### PR TITLE
hardsuit defibs require two hands free

### DIFF
--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -533,6 +533,33 @@
 	safety = 0
 	wielded = 1
 
+	/// The defib module these paddles provide behavior for
+	var/obj/item/rig_module/device/defib/module
+
+/obj/item/shockpaddles/rig/Destroy()
+	if (module)
+		module.device = null
+		module = null
+	return ..()
+
+/obj/item/shockpaddles/rig/update_twohanding()
+	return
+
+/obj/item/shockpaddles/rig/can_use(mob/living/user, mob/living/carbon/human/target)
+	. = ..()
+	if (!.)
+		return
+	var/mob/living/carbon/human/wearer = module?.holder?.wearer
+	if (!wearer)
+		return FALSE
+	if (!wearer.HandsEmpty())
+		if (wearer == user)
+			to_chat(user, SPAN_WARNING("You need two hands free to do that."))
+		else
+			to_chat(user, SPAN_WARNING("\The [wearer] needs two hands free to do that."))
+		return FALSE
+	return TRUE
+
 /obj/item/shockpaddles/rig/check_charge(charge_amt)
 	if(istype(src.loc, /obj/item/rig_module/device/defib))
 		var/obj/item/rig_module/device/defib/module = src.loc

--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -48,6 +48,11 @@
 	use_power_cost = 0//Already handled by defib, but it's 150 Wh, normal defib takes 100
 	device = /obj/item/shockpaddles/rig
 
+/obj/item/rig_module/device/defib/Initialize()
+	. = ..()
+	var/obj/item/shockpaddles/rig/paddles = device
+	paddles.module = src
+
 /obj/item/rig_module/device/drill
 	name = "hardsuit mounted drill"
 	desc = "A very heavy diamond-tipped drill."


### PR DESCRIPTION
:cl:
bugfix: Hardsuit defibs don't become unusable by entering a bad wield state.
tweak: Hardsuit defibs require both hands free.
/:cl:

closes #35083
fixes #34825
