### PR TITLE
Fixes pill bottle interaction with chemmasters

### DIFF
--- a/code/game/objects/items/weapons/storage/pill_bottle.dm
+++ b/code/game/objects/items/weapons/storage/pill_bottle.dm
@@ -36,6 +36,9 @@
 			P.resolve_attackby(target ,user)
 			return TRUE
 
+	if (istype(target, /obj/machinery/chem_master))
+		return FALSE
+
 	if (isobj(target) && target.is_open_container() && target.reagents)
 		if (!length(contents))
 			to_chat(user, SPAN_WARNING("\The [src] is empty!"))


### PR DESCRIPTION
:cl:
bugfix: Pill bottles should now enter chemmasters instead of trying to dissolve pills.
/:cl:
Fixes #34929
Note that this is a simple fix and doesn't actually improve chemmasters. At least I think that making pill dissolution a proper feature of the machine is not a bad idea at all, but that needs to be done by someone who can work the UI.