### PR TITLE
Sestrisite Language Fix

### DIFF
--- a/code/modules/culture_descriptor/culture/cultures_human.dm
+++ b/code/modules/culture_descriptor/culture/cultures_human.dm
@@ -259,7 +259,6 @@
 	citizens of Sestris enjoy a generally high standard of living and many can be found within the ranks of the ICCG Defense Forces. Those from Amelie, \
 	within Sestris itself are immensely proud of their Franco heratige, with many holding on to some of their cultural roots. "
 	language = LANGUAGE_HUMAN_RUSSIAN
-	secondary_langs = list(LANGUAGE_HUMAN_EURO)
 	economic_power = 1.3
 
 /singleton/cultural_info/culture/human/confederate_putkari


### PR DESCRIPTION
:cl:Retrokinesis
bugfix: Characters with Sestrisite culture can now actually select languages.
/:cl:

Makes Sestrisite culture equivalent to other ICCG cultures in requiring Pan-Slavic and permitting other languages, as current behavior requires Pan-Slavic and then gives ZAC as the only other choice.
