### PR TITLE
Add legion recall procs

### DIFF
--- a/packs/legion/_globals.dm
+++ b/packs/legion/_globals.dm
@@ -41,3 +41,7 @@ GLOBAL_LIST_AS(legion_last_words_player, list(\
 	list("Brock Bunten", "This isn't what was supposed to happen. They're intelligent. They're understanding. Why the hell did they eat Schmidt? I just wanted to try talking. I just want to understand- no, NO, NO, STAY AWAY! AH, FUCK, LET GO, FUCK, MY NECK, STOP, I CAN'T DO THAT-- AHHHH!--"),\
 	list("Karl Emberchest", "GET THE HELL OUTTA HERE!")\
 ))
+
+
+/// List of all legion mobs, for use by procs that affect all or a majority of said mobs.
+GLOBAL_LIST_EMPTY(all_legion_mobs)

--- a/packs/legion/_pack.dm
+++ b/packs/legion/_pack.dm
@@ -5,6 +5,7 @@
 #include "ai/legion_ai_reaver.dm"
 
 #include "helpers/legion_narrate.dm"
+#include "helpers/legion_recall.dm"
 #include "helpers/legion_warp_effect.dm"
 
 #include "mob/legion_bellator.dm"

--- a/packs/legion/helpers/legion_recall.dm
+++ b/packs/legion/helpers/legion_recall.dm
@@ -1,0 +1,58 @@
+/**
+ * Triggers a warp effect and relocates the mob to destination, if provided, or deletes it.
+ */
+/proc/legion_recall(mob/recallee, turf/destination)
+	if (destination && !isturf(destination))
+		destination = get_turf(destination)
+	recallee.visible_message(
+		SPAN_WARNING("\The [recallee] suddenly warps away!"),
+		SPAN_LEGION("The Nexus recalls you[destination ? " to a new location" : null]...")
+	)
+	legion_warp_effect(get_turf(recallee))
+	if (destination)
+		recallee.dropInto(destination)
+	else
+		qdel(recallee)
+
+
+/**
+ * Triggers a sequence of "recalls" on legion mobs in connected z-levels, representation a mass retreat, exodus, etc.
+ *
+ * There is a 0.1 second delay between each mob being yoinked for added flair.
+ */
+/proc/legion_mass_recall(affected_z)
+	var/list/connected_z = GetConnectedZlevels(affected_z)
+	var/list/mobs_to_recall = list()
+
+	for (var/mob/mob in GLOB.all_legion_mobs)
+		if (get_z(mob) in connected_z)
+			mobs_to_recall += mob
+
+	legion_mass_recall_recurse(mobs_to_recall)
+
+/proc/legion_mass_recall_recurse(list/remaining)
+	if (!length(remaining))
+		return
+	var/mob/recallee = pick_n_take(remaining)
+	legion_recall(recallee)
+	addtimer(new Callback(GLOBAL_PROC, /proc/legion_mass_recall_recurse, remaining), 0.1 SECONDS)
+
+
+/client/proc/cmd_legion_mass_recall()
+	set category = "Special Verbs"
+	set name = "Legion Mass Recall"
+	set desc = "'Recalls' all legion mobs in connected z-levels."
+
+	if (!check_rights(R_ADMIN))
+		return
+
+	var/z_level = input(usr, "Which z-level? Your own z-level is entered by default.", "Legion Narrate", get_z(usr)) as null | num
+	if (!z_level)
+		return
+
+	legion_mass_recall(z_level)
+
+
+/// Helper proc for admins to call directly on a mob to run `legion_recall()` on it.
+/mob/proc/legion_recall_me(turf/destination)
+	legion_recall(src, destination)

--- a/packs/legion/mob/legion_hivebot.dm
+++ b/packs/legion/mob/legion_hivebot.dm
@@ -18,6 +18,7 @@
 	base_attack_cooldown = max(base_attack_cooldown - 1 SECOND, 1 SECOND)
 	can_escape = TRUE
 	melee_attack_delay = max(melee_attack_delay - 2, 0)
+	GLOB.all_legion_mobs += src
 	if (beacon)
 		linked_beacon = beacon
 
@@ -26,6 +27,8 @@
 	if (linked_beacon)
 		linked_beacon.linked_mobs -= src
 		linked_beacon = null
+	if (is_legion)
+		GLOB.all_legion_mobs -= src
 
 	. = ..()
 

--- a/packs/legion/mob/legion_mob.dm
+++ b/packs/legion/mob/legion_mob.dm
@@ -47,10 +47,12 @@
 
 	add_language(LANGUAGE_HUMAN_EURO)
 	add_language(LANGUAGE_LEGION_GLOBAL)
+	GLOB.all_legion_mobs += src
 
 
 /mob/living/simple_animal/hostile/legion/Destroy()
 	clear_beacon()
+	GLOB.all_legion_mobs -= src
 	return ..()
 
 


### PR DESCRIPTION
Cherry picked from the event branches.

## Changelog
:cl: SierraKomodo
rscadd: Legion mobs can now be "recalled" by the legion, either to another location or off the map entirely. This process is currently only triggered manually by admins.
admin: Added "Legion Mass Recall" verb to the "Special Verbs" section that runs the recall process on all mobs in the global legion list that are on a given z-level and its connections.
admin: Added `legion_recall_me()` proc that can be manually called on a mob to have it perform a legion recall.
/:cl:

## Other Changes
- Added `GLOB.all_legion_mobs`, a list of all legion mobs. This is automatically populated by `Initialize()` for legion mob subtypes, and `legionify()` for hivebot conversions.