### PR TITLE
Glasses and HUDs now use the same sound effects

### DIFF
--- a/code/modules/clothing/glasses/glasses.dm
+++ b/code/modules/clothing/glasses/glasses.dm
@@ -7,8 +7,8 @@
 		)
 	var/prescription = FALSE
 	off_state = "degoggles"
-	activation_sound = 'sound/machines/boop1.ogg'
-	deactivation_sound = null
+	activation_sound = sound('sound/machines/boop1.ogg', volume = 10)
+	deactivation_sound = sound('sound/effects/compbeep1.ogg', volume = 30)
 	var/obj/screen/overlay = null
 	var/obj/item/clothing/glasses/hud/hud = null	// Hud glasses, if any
 	electric = FALSE //if the glasses should be disrupted by EMP

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -7,8 +7,6 @@
 	gender = NEUTER
 	toggleable = TRUE
 	action_button_name = "Toggle HUD"
-	activation_sound = sound('sound/machines/boop1.ogg', volume = 10)
-	deactivation_sound = sound('sound/effects/compbeep1.ogg', volume = 30)
 
 	species_restricted = null
 

--- a/code/modules/clothing/under/accessories/goggle_mods.dm
+++ b/code/modules/clothing/under/accessories/goggle_mods.dm
@@ -17,7 +17,8 @@
 		SPECIES_VOX = 'icons/mob/species/vox/onmob_goggle_mod_vox.dmi',
 		SPECIES_HUMAN = 'icons/mob/onmob/onmob_goggle_mod.dmi'
 	)
-	activation_sound = 'sound/machines/boop1.ogg'
+	activation_sound = sound('sound/machines/boop1.ogg', volume = 10)
+	deactivation_sound = sound('sound/effects/compbeep1.ogg', volume = 30)
 
 /obj/item/clothing/accessory/glassesmod/attack_self(mob/user)
 	if(toggleable && !user.incapacitated())


### PR DESCRIPTION
While making the sound less loud I discovered there's already sensible sound and volumes for HUD glasses, so I just copied those over to be the default for all glasses. And for glassesmod accessories.

## Changelog
:cl: SierraKomodo
tweak: Toggleable glasses and accessories now use a quieter activation sound, and also make use of a deactivation sound. Sounds and values are identical to those already in use for HUDs.
/:cl: