### PR TITLE
Harm intent to dissolve pill bottle in ChemMaster

### DIFF
--- a/code/game/objects/items/weapons/storage/pill_bottle.dm
+++ b/code/game/objects/items/weapons/storage/pill_bottle.dm
@@ -36,7 +36,7 @@
 			P.resolve_attackby(target ,user)
 			return TRUE
 
-	if (istype(target, /obj/machinery/chem_master))
+	if (istype(target, /obj/machinery/chem_master) && user.a_intent != I_HURT)
 		return FALSE
 
 	if (isobj(target) && target.is_open_container() && target.reagents)


### PR DESCRIPTION
:cl: Banditoz
tweak: You can now dissolve pill bottles into a ChemMaster with harm intent.
/:cl:

See #35099, keeps the original fix in, but still allows dissolving pill bottles with harm intent active.