### PR TITLE
Let autopsy scanner only work on dead people

### DIFF
--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -166,7 +166,10 @@
 
 	return 1
 
-/obj/item/autopsy_scanner/proc/set_target(atom/new_target, user)
+/obj/item/autopsy_scanner/proc/set_target(mob/new_target, user)
+	if (new_target.stat != DEAD && new_target.stat != FAKEDEATH)
+		to_chat(user, SPAN_NOTICE("Scanned patient is currently alive. Aborting."))
+		return
 	if(target_name != new_target.name)
 		target_name = new_target.name
 		wdata.Cut()


### PR DESCRIPTION
:cl:
tweak: Autopsy scanner now only works on dead people.
/:cl:

Balance considerations as the scanner tells you the exact weapon type and such.

Will likely bring out a more formative autopsy rework eventually. Soon, maybe