### PR TITLE
Fix empty jobs causing antag runtimes

### DIFF
--- a/code/game/antagonist/antagonist_update.dm
+++ b/code/game/antagonist/antagonist_update.dm
@@ -92,7 +92,7 @@
 		else
 			for(var/mob/M in GLOB.living_players)
 				var/datum/job/job = SSjobs.get_by_title(M.mind.assigned_role)
-				if(job.create_record)
+				if(job?.create_record)
 					count++
 
 		// Minimum: initial_spawn_target


### PR DESCRIPTION
NUFC.

Fixes a runtime caused by mobs that have no job assigned (I.e., admin-spawned player-controlled mobs) when autotraitor and other antag selection/spawning stuff runs.