### PR TITLE
Upgraded body scanners check for mutation existence

### DIFF
--- a/code/_helpers/medical_scans.dm
+++ b/code/_helpers/medical_scans.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/human/proc/get_raw_medical_data(tag = FALSE)
+/mob/living/carbon/human/proc/get_raw_medical_data(tag = FALSE, mutations = FALSE)
 	RETURN_TYPE(/list)
 	var/mob/living/carbon/human/H = src
 	var/list/scan = list()
@@ -105,6 +105,12 @@
 		scan["blind"] = TRUE
 	if(H.sdisabilities & NEARSIGHTED)
 		scan["nearsight"] = TRUE
+	if(mutations)
+		scan["mutations"] = FALSE
+		for(var/block in 1 to length(assigned_blocks))
+			if(H.dna.GetSEState(block))
+				scan["mutations"] = TRUE
+				break;
 	return scan
 
 /proc/display_medical_data_header(list/scan, skill_level = SKILL_DEFAULT)
@@ -241,6 +247,12 @@
 
 		if(scan["paralysis"])
 			subdat += "<tr><td><strong>Paralysis Summary:</strong></td><td>approx. [scan["paralysis"]/4] seconds left</td></tr>"
+
+		if(!isnull(scan["mutations"]))
+			if(scan["mutations"])
+				subdat += "<tr><td><strong>[SPAN_BAD("Unknown genetic mutations detected.")]</strong></td></tr>"
+			else
+				subdat += "<tr><td><strong>No genetic mutations present.</strong></td></tr>"
 
 		dat += subdat
 

--- a/code/game/machinery/body_scanner.dm
+++ b/code/game/machinery/body_scanner.dm
@@ -12,6 +12,7 @@
 	construct_state = /singleton/machine_construction/default/panel_closed
 	uncreated_component_parts = null
 	stat_immune = 0
+	var/scan_for_present_mutations = FALSE
 
 	machine_name = "body scanner"
 	machine_desc = "A full-body scanning suite that provides a complete health assessment of a patient placed inside. Requires an adjacent console to operate."
@@ -168,6 +169,10 @@
 					A.ex_act(severity)
 				qdel(src)
 
+/obj/machinery/bodyscanner/RefreshParts()
+	..()
+	var/tier = clamp(total_component_rating_of_type(/obj/item/stock_parts/scanning_module), 0, 10)
+	scan_for_present_mutations = tier >= 4
 
 /obj/machinery/bodyscanner/Destroy()
 	if(occupant)

--- a/code/game/machinery/body_scanner_console.dm
+++ b/code/game/machinery/body_scanner_console.dm
@@ -111,7 +111,7 @@
 		data["printEnabled"] = TRUE
 		data["eraseEnabled"] = TRUE
 		data["pushEnabled"] = TRUE
-		data["scan"] = connected.occupant.get_raw_medical_data(TRUE)
+		data["scan"] = connected.occupant.get_raw_medical_data(TRUE, connected.scan_for_present_mutations)
 		data["html_scan_header"] = display_medical_data_header(data["scan"], user.get_skill_value(SKILL_MEDICAL))
 		data["html_scan_health"] = display_medical_data_health(data["scan"], user.get_skill_value(SKILL_MEDICAL))
 		data["html_scan_body"] = display_medical_data_body(data["scan"], user.get_skill_value(SKILL_MEDICAL))

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -398,7 +398,7 @@
 
 	if(!H)	return
 
-	var/dat = display_medical_data(H.get_raw_medical_data(), SKILL_MAX)
+	var/dat = display_medical_data(H.get_raw_medical_data(mutations = TRUE), SKILL_MAX)
 
 	dat += text("<BR><A href='byond://?src=\ref[];mach_close=scanconsole'>Close</A>", usr)
 	show_browser(usr, dat, "window=scanconsole;size=430x600")


### PR DESCRIPTION
:cl: Banditoz
rscadd: Upgraded scanning modules inside of body scanners will now detect the presence of genetic mutations, generally caused by artifacts or radiation.
/:cl:

Requires at least an upgrade to two advanced scanning modules, or one phasic module.

The new row won't be present if the upgrade wasn't done.

With mutations:
![ShareX_ejzjtJvsVe](https://github.com/user-attachments/assets/f1feb2d6-9e37-4a77-9f2d-45ddf66d3963)

Without mutations:
![dreamseeker_aKAfU4ZnQA](https://github.com/user-attachments/assets/6ac118b8-9f30-4398-b4d8-e3b1150325cc)