### PR TITLE
Cooler, hotter R-UST

### DIFF
--- a/code/modules/power/fusion/consoles/core_control.dm
+++ b/code/modules/power/fusion/consoles/core_control.dm
@@ -49,7 +49,7 @@
 			core["size"] =        C.owned_field ? "[C.owned_field.size] meter\s" : "Field offline."
 			core["instability"] = C.owned_field ? "[C.owned_field.percent_unstable * 100]%" : "Field offline."
 			core["temperature"] = C.owned_field ? "[C.owned_field.plasma_temperature + 295]K" : "Field offline."
-			core["powerstatus"] = "[C.avail()]/[C.active_power_usage] W"
+			core["powerstatus"] = "[Round(C.avail())]/[C.active_power_usage] W"
 			var/fuel_string = "<table width = '100%'>"
 			if(C.owned_field && LAZYLEN(C.owned_field.reactants))
 				for(var/reactant in C.owned_field.reactants)

--- a/code/modules/power/fusion/core/_core.dm
+++ b/code/modules/power/fusion/core/_core.dm
@@ -34,6 +34,8 @@
 		fusion.set_tag(null, initial_id_tag)
 
 /obj/machinery/power/fusion_core/Process()
+	if (powernet && owned_field)
+		powernet.apcs_overload(0, 1, 1)
 	if(MACHINE_IS_BROKEN(src) || !powernet || !owned_field)
 		Shutdown()
 

--- a/code/modules/power/fusion/core/core_field.dm
+++ b/code/modules/power/fusion/core/core_field.dm
@@ -202,9 +202,9 @@
 			radiation += radiate
 
 	check_instability()
-	Radiate()
 	if(radiation)
-		SSradiation.radiate(src, round(radiation*0.001))
+		SSradiation.radiate(src, radiation*0.04)
+	Radiate()
 	return 1
 
 /obj/fusion_em_field/proc/check_instability()

--- a/code/modules/power/fusion/fusion_reactions.dm
+++ b/code/modules/power/fusion/fusion_reactions.dm
@@ -39,13 +39,18 @@ var/global/list/fusion_reactions
 //  supermatter
 
 // Gaseous/reagent fuels
-// hydrogen
+//  hydrogen
 //  helium
 //  lithium
 //  boron
 
-// Basic power production reactions.
-// This is not necessarily realistic, but it makes a basic failure more spectacular.
+// Things that probably should be avoided
+//  nitrogen
+//  oxygen
+//  phoron
+
+// H2 shouldn't really be used for this but adding more gases will make a big mess
+
 /singleton/fusion_reaction/hydrogen_hydrogen
 	p_react = GAS_HYDROGEN
 	s_react = GAS_HYDROGEN
@@ -59,14 +64,16 @@ var/global/list/fusion_reactions
 	s_react = GAS_DEUTERIUM
 	energy_consumption = 1
 	energy_production = 2
+	products = list(GAS_TRITIUM = 0.5, GAS_HELIUM = 1)
 	priority = 0
+	radiation = 1
 
-// Advanced production reactions (todo)
 /singleton/fusion_reaction/deuterium_helium
 	p_react = GAS_DEUTERIUM
 	s_react = GAS_HELIUM
 	energy_consumption = 1
 	energy_production = 5
+	minimum_reaction_temperature = 10000
 	radiation = 2
 
 /singleton/fusion_reaction/deuterium_tritium
@@ -75,45 +82,144 @@ var/global/list/fusion_reactions
 	energy_consumption = 1
 	energy_production = 1
 	products = list(GAS_HELIUM = 1)
-	instability = 0.5
 	radiation = 3
 
 /singleton/fusion_reaction/deuterium_lithium
 	p_react = GAS_DEUTERIUM
 	s_react = "lithium"
 	energy_consumption = 2
-	energy_production = 0
+	energy_production = 2
 	radiation = 3
-	products = list(GAS_TRITIUM= 1)
+	products = list(GAS_HELIUM = 2)
+
+/singleton/fusion_reaction/hydrogen_lithium
+	p_react = GAS_HYDROGEN
+	s_react = "lithium"
+	energy_consumption = 1
+	energy_production = 2
+	products = list(GAS_HELIUM = 2)
 	instability = 1
 
-// Unideal/material production reactions
+/singleton/fusion_reaction/helium_lithium
+	p_react = GAS_HELIUM
+	s_react = "lithium"
+	energy_consumption = 1
+	energy_production = 5
+	instability = 1
+	radiation = 1
+
+/singleton/fusion_reaction/helium_helium
+	p_react = GAS_HELIUM
+	s_react = GAS_HELIUM
+	energy_consumption = 2
+	energy_production = 4
+	minimum_reaction_temperature = 30000
+	priority = 10
+	radiation = 3
+
+/singleton/fusion_reaction/hydrogen_nitrogen
+	p_react = GAS_HYDROGEN
+	s_react = GAS_NITROGEN
+	energy_consumption = 2
+	energy_production = 3
+	products = list(GAS_HELIUM = 1, "carbon" = 1)
+	minimum_reaction_temperature = 30000
+	radiation = 2
+
+/singleton/fusion_reaction/carbon_carbon
+	p_react = "carbon"
+	s_react = "carbon"
+	energy_consumption = 3
+	energy_production = 2
+	products = list(GAS_HELIUM = 2, GAS_NEON = 0.5, GAS_HYDROGEN = 0.5, GAS_OXYGEN = 0.5, "sodium" = 1)
+	instability = 1
+	minimum_reaction_temperature = 30000
+	radiation = 10
+
+/singleton/fusion_reaction/hydrogen_carbon
+	p_react = GAS_HYDROGEN
+	s_react = "carbon"
+	energy_consumption = 4
+	energy_production = 5
+	minimum_reaction_temperature = 50000
+	radiation = 10
+
+/singleton/fusion_reaction/hydrogen_oxygen
+	p_react = GAS_HYDROGEN
+	s_react = GAS_OXYGEN
+	energy_consumption = 3
+	energy_production = 2
+	products = list(GAS_NITROGEN = 1, GAS_HELIUM = 1)
+	minimum_reaction_temperature = 50000
+	radiation = 10
+
+/singleton/fusion_reaction/helium_neon
+	p_react = GAS_HELIUM
+	s_react = GAS_NEON
+	energy_consumption = 2
+	energy_production = 3
+	products = list("silicon" = 1)
+	minimum_reaction_temperature = 50000
+	radiation = 12
+
 /singleton/fusion_reaction/oxygen_oxygen
 	p_react = GAS_OXYGEN
 	s_react = GAS_OXYGEN
-	energy_consumption = 10
-	energy_production = 0
-	instability = 5
+	energy_consumption = 3
+	energy_production = 2
+	products = list("silicon"= 1, "phosphorus"= 1, "sulfur"= 1, GAS_HELIUM = 0.5, GAS_HYDROGEN = 2, GAS_DEUTERIUM = 0.5)
+	minimum_reaction_temperature = 60000
+	instability = 2
 	radiation = 5
-	products = list("silicon"= 1)
 
-/singleton/fusion_reaction/iron_iron
+/singleton/fusion_reaction/helium_silicon
+	p_react = GAS_HELIUM
+	s_react = "silicon"
+	energy_consumption = 3
+	energy_production = 2
+	products = list("sulfur" = 10)
+	minimum_reaction_temperature = 60000
+	instability = 1
+	radiation = 3
+
+/singleton/fusion_reaction/helium_sulfur
+	p_react = GAS_HELIUM
+	s_react = "sulfur"
+	energy_consumption = 3
+	energy_production = 2
+	products = list(GAS_ARGON = 1)
+	minimum_reaction_temperature = 70000
+	instability = 1
+	radiation = 3
+
+/singleton/fusion_reaction/helium_argon
+	p_react = GAS_HELIUM
+	s_react = GAS_ARGON
+	energy_consumption = 3
+	energy_production = 1
+	products = list("titanium" = 10)
+	minimum_reaction_temperature = 70000
+	instability = 1
+	radiation = 3
+
+/singleton/fusion_reaction/helium_titanium
+	p_react = GAS_HELIUM
+	s_react = "titanium"
+	energy_consumption = 3
+	energy_production = 0
+	products = list("iron" = 10)
+	minimum_reaction_temperature = 80000
+	instability = 1
+	radiation = 3
+
+/singleton/fusion_reaction/phoron_iron
 	p_react = "iron"
-	s_react = "iron"
-	products = list("silver" = 10, "gold" = 10, "platinum" = 10) // Not realistic but w/e
-	energy_consumption = 10
+	s_react = GAS_PHORON
+	energy_consumption = 5
 	energy_production = 0
 	instability = 2
-	minimum_reaction_temperature = 10000
-
-/singleton/fusion_reaction/phoron_hydrogen
-	p_react = GAS_HYDROGEN
-	s_react = GAS_PHORON
-	energy_consumption = 10
-	energy_production = 0
-	instability = 5
-	products = list("mhydrogen" = 1)
-	minimum_reaction_temperature = 8000
+	products = list("silver" = 30, "gold" = 20, "platinum" = 10)
+	radiation = 5
 
 // VERY UNIDEAL REACTIONS.
 /singleton/fusion_reaction/phoron_supermatter

--- a/code/modules/xgm/gases.dm
+++ b/code/modules/xgm/gases.dm
@@ -14,6 +14,7 @@
 	name = "Nitrogen"
 	specific_heat = 20	// J/(mol*K)
 	molar_mass = 0.028	// kg/mol
+	flags = XGM_GAS_FUSION_FUEL
 	symbol_html = "N<sub>2</sub>"
 	symbol = "N2"
 
@@ -141,6 +142,7 @@
 	name = "Argon"
 	specific_heat = 10	// J/(mol*K)
 	molar_mass = 0.018	// kg/mol
+	flags = XGM_GAS_FUSION_FUEL
 	symbol_html = "Ar"
 	symbol = "Ar"
 
@@ -158,6 +160,7 @@
 	name = "Neon"
 	specific_heat = 20	// J/(mol*K)
 	molar_mass = 0.01	// kg/mol
+	flags = XGM_GAS_FUSION_FUEL
 	symbol_html = "Ne"
 	symbol = "Ne"
 


### PR DESCRIPTION
:cl:
tweak: R-UST now has many new fusion reactions and some existing reactions are improved.
tweak: Nitrogen, neon and argon are now usable in fusion. For now there aren't any neon or argon canisters though.
tweak: Power output value in core control console is now rounded.
balance: R-UST gets much hotter and also emits small amounts of radiation.
balance: The fusion core will now overload connected APCs when turned on.
/:cl:

So what does this actually change? You can't just stand around in the fusion room, there are rads in there now. You also can't just safely hotwire the core anymore. The "basic" hydrogen & deuterium fusion setup should work without any issues.
Most fusion reactions are viable now, this doesn't make all of them actually good (or safe) but they do more than just cause instability and make the reactor go boom.
For the 0.5% of engineers that sometimes touch the kinetic harvester, the fusion core can now produce harvestable titanium and iron with proper usage. Precious metals are now produced with phoron and iron, but this expensive reaction should also produce more metal.