### PR TITLE
Remove unathi wound/organ regen (Keeps their limb regen)

### DIFF
--- a/code/game/objects/auras/regenerating_aura.dm
+++ b/code/game/objects/auras/regenerating_aura.dm
@@ -110,9 +110,10 @@
 	return TRUE
 
 /obj/aura/regenerating/human/unathi
-	nutrition_damage_mult = 2
-	brute_mult = 2
-	organ_mult = 4
+	brute_mult = 0
+	fire_mult = 0
+	tox_mult = 0
+	organ_mult = 0
 	regen_message = "<span class='warning'>You feel a soothing sensation as your ORGAN mends...</span>"
 	grow_chance = 2
 	grow_threshold = 150
@@ -121,6 +122,9 @@
 
 /obj/aura/regenerating/human/unathi/can_toggle()
 	return FALSE
+
+/obj/aura/regenerating/human/unathi/can_regenerate_organs()
+	return can_toggle()
 
 // Default return; we're just logging.
 /obj/aura/regenerating/human/unathi/aura_check_weapon(obj/item/weapon, mob/attacker, click_params)
@@ -145,26 +149,15 @@
 		H.apply_damage(5, DAMAGE_TOXIN)
 		H.adjust_nutrition(3)
 		return AURA_FALSE
-	nutrition_damage_mult = 2
-	brute_mult = 2
-	organ_mult = 4
-	grow_chance = 2
-	var/obj/machinery/optable/optable = locate() in get_turf(H)
-	if (optable?.suppressing && H.sleeping)
-		nutrition_damage_mult = 1
-		brute_mult = 1
-		organ_mult = 2
-		grow_chance = 1
 
 	return ..()
 
-/obj/aura/regenerating/human/unathi/can_regenerate_organs()
-	return can_toggle()
 
 /obj/aura/regenerating/human/unathi/external_regeneration_effect(obj/item/organ/external/O, mob/living/carbon/human/H)
 	to_chat(H, SPAN_DANGER("With a shower of fresh blood, a new [O.name] forms."))
 	H.visible_message(SPAN_DANGER("With a shower of fresh blood, a length of biomass shoots from [H]'s [O.amputation_point], forming a new [O.name]!"))
 	H.adjust_nutrition(-external_nutrition_mult)
+	H.adjustHalLoss(10)
 	var/datum/reagent/blood/B = locate(/datum/reagent/blood) in H.vessel.reagent_list
 	blood_splatter(H,B,1)
 	O.set_dna(H.dna)
@@ -184,8 +177,3 @@
 /obj/aura/regenerating/human/diona/external_regeneration_effect(obj/item/organ/external/O, mob/living/carbon/human/H)
 	to_chat(H, SPAN_WARNING("Some of your nymphs split and hurry to reform your [O.name]."))
 	H.adjust_nutrition(-external_nutrition_mult)
-
-/obj/aura/regenerating/human/unathi/yeosa
-	brute_mult = 1.5
-	organ_mult = 3
-	tox_mult = 2

--- a/code/modules/species/station/lizard_subspecies.dm
+++ b/code/modules/species/station/lizard_subspecies.dm
@@ -18,10 +18,6 @@
 	their culture has diverged majorly from the Sinta, spending less time performing acts of violence and more time socializing. \
 	Their biology is heavily attuned to surviving Moghes' dangerous waters, including gills, fins, and a venomous bite."
 
-	base_auras = list(
-		/obj/aura/regenerating/human/unathi/yeosa
-		)
-
 	additional_available_cultural_info = list(
 		TAG_CULTURE = list(
 			CULTURE_UNATHI_YEOSA_ABYSS,


### PR DESCRIPTION
:cl:
balance: Unathi no longer regen organ/external wounds. They don't lose nutrition from it. They keep limb regeneration.
/:cl:

Controversial PR but:
- Unathi wound regeneration is pretty iffy balance-wise and has been for a good while. They can either get up from shrugging rifle rounds (provided they're well fed), or they go into a coma and never wake up. This gets rid of that hassle. 
- Unathi still keep their resistances and everything. Nothing has changed outside of not being able to regenerate wounds anymore. Unathi are still *tough* to kill, but neither are they tough to *keep down*, nor are they really susceptible to just dying. Or giving medical annoyances over cutting and having to plan workarounds for it.
- Regenerating limbs exists, and will still eat away nutrition for that regeneration. It will also give the unathi pain when it sprouts out.
- Kept their `low nutrition = tox`. Why? Makes sense for unathi to *need* protein for sustenance. If that doesn't make sense, I can probably remove it - but that quirks up the balance with limb regeneration and they likely will serve better with it. Won't have cases of lost nutrition over regular wound healing anymore, though.