### PR TITLE
Increase secure closet minimum damage threshold

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/_secure_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/_secure_closets.dm
@@ -6,7 +6,7 @@
 	setup = CLOSET_HAS_LOCK | CLOSET_CAN_BE_WELDED
 	locked = TRUE
 	health_max = 200
-	health_min_damage = 5
+	health_min_damage = 16
 
 /obj/structure/closet/secure_closet/slice_into_parts(obj/item/weldingtool/WT, mob/user)
 	to_chat(user, SPAN_NOTICE("\The [src] is too strong to be taken apart."))


### PR DESCRIPTION
Because this is far easier than trying to rebalance every atom's force values. And boy howdy are those numbers insanity (Did you know a toolbox has a force value of 20? That's 5 points more than an extended telebaton!).

New value effectively blocks most if not all common tools and non-dedicated weaponry items from damaging a secure closet. Secure closets in this context being any closet that can be locked. Including gun lockers.

Why 16 and not a nice multiple of 5?

Because pickaxes do 15 damage.

## Changelog
:cl: SierraKomodo
balance: Increased the minimum damage output needed to break open secure closets and lockers. Now you'll need a real weapon to force your way into these, instead of memeing them with a briefcase. 
/:cl: