### PR TITLE
Pass `use_*` calls from grab item to grabbed mob

### DIFF
--- a/code/modules/mob/grab/grab_datum.dm
+++ b/code/modules/mob/grab/grab_datum.dm
@@ -272,8 +272,6 @@
 // Used when you want an effect to happen when the grab enters this state as an upgrade
 /datum/grab/proc/enter_as_up(obj/item/grab/G)
 
-/datum/grab/proc/item_attack(obj/item/grab/G, obj/item)
-
 /datum/grab/proc/resolve_item_attack(obj/item/grab/G, mob/living/carbon/human/user, obj/item/I, target_zone)
 	return FALSE
 

--- a/code/modules/mob/grab/grab_object.dm
+++ b/code/modules/mob/grab/grab_object.dm
@@ -299,8 +299,9 @@
 	return current_grab.force_stand
 
 /obj/item/grab/use_tool(obj/item/item, mob/living/user, list/click_params)
-	if(user == assailant)
-		current_grab.item_attack(src, item)
+	if (user == assailant)
+		return item.resolve_attackby(affecting, assailant, click_params)
+
 	return ..()
 
 /obj/item/grab/proc/can_absorb()


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
rscadd: Clicking on a grab in your inactive hand with an item in your active hand now uses that item on the grabbed mob. This includes attacking them if you're on harm intent.
/:cl:

## Other Changes
- Removed `/datum/grab/proc/item_attack()`. It did nothing on its own and had no overrides.