### PR TITLE
Pipes dont die in fire again

### DIFF
--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -37,6 +37,9 @@
 /obj/machinery/atmospherics/pipe/hides_under_flooring()
 	return level != ATOM_LEVEL_OVER_TILE
 
+/obj/machinery/atmospherics/pipe/fire_act()
+	return FALSE
+
 /obj/machinery/atmospherics/pipe/on_death()
 	burst()
 


### PR DESCRIPTION
:cl:
bugfix: Pipes do not die in fires once again
/:cl:

Pipes usually die either to overpressure from internal atmosphere, or (now) whacking it with stuff. Dying to external fires made nacelles pretty dangerous and unable to be used in burn mode (and potentially other scenarios)
