### PR TITLE
Revamp Autopsy

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -1016,7 +1016,7 @@
 				to_chat(M, SPAN_DANGER("You land heavily on your [affecting.name]!"))
 				affecting.take_external_damage(damage, 0)
 				if(affecting.parent)
-					affecting.parent.add_autopsy_data("Misadventure", damage)
+					affecting.parent.add_autopsy_data("Misadventure", damage, INJURY_TYPE_BRUISE)
 			else
 				to_chat(H, SPAN_DANGER("You land heavily!"))
 				H.adjustBruteLoss(damage)

--- a/code/game/objects/items/weapons/autopsy.dm
+++ b/code/game/objects/items/weapons/autopsy.dm
@@ -1,62 +1,18 @@
 /obj/item/autopsy_scanner
-	name = "autopsy scanner"
-	desc = "Used to gather information on wounds."
+	name = "post-mortem analysis unit"
+	desc = "A Zeng-Hu design, refabricated and adopted by the majority of Sol and Gilgamesh. \
+			A tool for morticians, coroners and detectives."
 	icon = 'icons/obj/surgery_tools.dmi'
 	icon_state = "autopsy_scanner"
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 	w_class = ITEM_SIZE_SMALL
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 1)
-	var/list/datum/autopsy_data_scanner/wdata = list()
-	var/list/chemtraces = list()
+
+	var/mob/living/carbon/human/target = null
 	var/target_name = null
 	var/timeofdeath = null
+	var/display_string = ""
 
-/datum/autopsy_data_scanner
-	var/weapon = null // this is the DEFINITE weapon type that was used
-	var/list/organs_scanned = list() // this maps a number of scanned organs to
-									 // the wounds to those organs with this data's weapon type
-	var/organ_names = ""
-
-/datum/autopsy_data
-	var/weapon = null
-	var/pretend_weapon = null
-	var/damage = 0
-	var/hits = 0
-	var/time_inflicted = 0
-
-/datum/autopsy_data/proc/copy()
-	var/datum/autopsy_data/W = new
-	W.weapon = weapon
-	W.pretend_weapon = pretend_weapon
-	W.damage = damage
-	W.hits = hits
-	W.time_inflicted = time_inflicted
-	return W
-
-/obj/item/autopsy_scanner/proc/add_data(obj/item/organ/external/O)
-	if(!length(O.autopsy_data)) return
-
-	for(var/V in O.autopsy_data)
-		var/datum/autopsy_data/W = O.autopsy_data[V]
-
-		if(!W.pretend_weapon)
-			W.pretend_weapon = W.weapon
-
-
-		var/datum/autopsy_data_scanner/D = wdata[V]
-		if(!D)
-			D = new()
-			D.weapon = W.weapon
-			wdata[V] = D
-
-		if(!D.organs_scanned[O.name])
-			if(D.organ_names == "")
-				D.organ_names = O.name
-			else
-				D.organ_names += ", [O.name]"
-
-		qdel(D.organs_scanned[O.name])
-		D.organs_scanned[O.name] = W.copy()
 
 /obj/item/autopsy_scanner/verb/print_data()
 	set category = "Object"
@@ -66,124 +22,59 @@
 		to_chat(usr, "No.")
 		return
 
-	var/scan_data = ""
-
-	if(timeofdeath)
-		scan_data += "<b>Time of death:</b> [worldtime2stationtime(timeofdeath)]<br><br>"
-
-	var/n = 1
-	for(var/wdata_idx in wdata)
-		var/datum/autopsy_data_scanner/D = wdata[wdata_idx]
-		var/total_hits = 0
-		var/total_score = 0
-		var/list/weapon_chances = list() // maps weapon names to a score
-		var/age = 0
-
-		for(var/wound_idx in D.organs_scanned)
-			var/datum/autopsy_data/W = D.organs_scanned[wound_idx]
-			total_hits += W.hits
-
-			var/wname = W.pretend_weapon
-
-			if(wname in weapon_chances) weapon_chances[wname] += W.damage
-			else weapon_chances[wname] = max(W.damage, 1)
-			total_score+=W.damage
-
-
-			var/wound_age = W.time_inflicted
-			age = max(age, wound_age)
-
-		var/damage_desc
-
-		var/damaging_weapon = (total_score != 0)
-
-		// total score happens to be the total damage
-		switch(total_score)
-			if(0)
-				damage_desc = "Unknown"
-			if(1 to 5)
-				damage_desc = SPAN_COLOR("green", "negligible")
-			if(5 to 15)
-				damage_desc = SPAN_COLOR("green", "light")
-			if(15 to 30)
-				damage_desc = SPAN_COLOR("orange", "moderate")
-			if(30 to 1000)
-				damage_desc = SPAN_COLOR("red", "severe")
-
-		if(!total_score) total_score = length(D.organs_scanned)
-
-		scan_data += "<b>Weapon #[n]</b><br>"
-		if(damaging_weapon)
-			scan_data += "Severity: [damage_desc]<br>"
-			scan_data += "Hits by weapon: [total_hits]<br>"
-		scan_data += "Approximate time of wound infliction: [worldtime2stationtime(age)]<br>"
-		scan_data += "Affected limbs: [D.organ_names]<br>"
-		scan_data += "Possible weapons:<br>"
-		for(var/weapon_name in weapon_chances)
-			scan_data += "\t[100*weapon_chances[weapon_name]/total_score]% [weapon_name]<br>"
-
-		scan_data += "<br>"
-
-		n++
-
-	if(length(chemtraces))
-		scan_data += "<b>Trace Chemicals: </b><br>"
-		for(var/chemID in chemtraces)
-			scan_data += chemID
-			scan_data += "<br>"
-
 	for(var/mob/O in viewers(usr))
 		O.show_message(SPAN_NOTICE("\The [src] rattles and prints out a sheet of paper."), 1)
 
-	sleep(10)
-
-	var/obj/item/paper/P = new(usr.loc, "<tt>[scan_data]</tt>", "Autopsy Data ([target_name])")
+	playsound(loc, "sound/machines/dotprinter.ogg", 25, 1)
+	sleep(6)
+	var/a_data = ""
+	if(timeofdeath)
+		a_data += "<b>Time of death:</b> [worldtime2stationtime(timeofdeath)]<br><br>"
+	a_data += display_string
+	var/obj/item/paper/P = new(usr.loc, "<tt>[a_data]</tt>", "Autopsy Data ([target_name])")
 	if(istype(usr,/mob/living/carbon))
 		// place the item in the usr's hand if possible
 		usr.put_in_hands(P)
 
+
 /obj/item/autopsy_scanner/do_surgery(mob/living/carbon/human/M, mob/living/user)
 	if(!istype(M))
-		return 0
+		return FALSE
+
+	if(M.stat != DEAD && !(M.status_flags & FAKEDEATH))
+		FEEDBACK_FAILURE(user, "The patient is still alive. Aborting.")
+		return FALSE
 
 	set_target(M, user)
-
 	timeofdeath = M.timeofdeath
+	target = M
 
 	var/obj/item/organ/external/S = M.get_organ(user.zone_sel.selecting)
 	if(!S)
-		to_chat(usr, SPAN_WARNING("You can't scan this body part."))
+		FEEDBACK_FAILURE(user, "You can't scan this body part.")
 		return
 	if(!S.how_open())
-		to_chat(usr, SPAN_WARNING("You have to cut [S] open first!"))
+		FEEDBACK_FAILURE(user, "You have to cut [S] open first!")
 		return
+
+	if (!user.do_skilled(2 SECONDS, SKILL_MEDICAL, S, do_flags = DO_MEDICAL))
+		FEEDBACK_FAILURE(user, "You could not conduct the autopsy on \the [S].")
+
 	M.visible_message(SPAN_NOTICE("\The [user] scans the wounds on [M]'s [S.name] with [src]"))
 
-	add_data(S)
-	for(var/T in M.chem_doses)
-		var/datum/reagent/R = T
-		chemtraces |= initial(R.name)
+	display_string = M.GetWoundString(S)
 
-	return 1
+	return TRUE
+
 
 /obj/item/autopsy_scanner/proc/set_target(mob/new_target, user)
-	if (new_target.stat != DEAD && new_target.stat != FAKEDEATH)
-		to_chat(user, SPAN_NOTICE("Scanned patient is currently alive. Aborting."))
-		return
 	if(target_name != new_target.name)
 		target_name = new_target.name
-		wdata.Cut()
-		chemtraces.Cut()
 		timeofdeath = null
 		to_chat(user, SPAN_NOTICE("A new patient has been registered. Purging data for previous patient."))
 
-/obj/item/autopsy_scanner/use_after(obj/item/organ/external/target, mob/living/user, click_parameters)
-	if(!istype(target))
-		return FALSE
+	return target
 
-	set_target(target, user)
-	add_data(target)
-	return TRUE
 
 /obj/item/autopsy_scanner/attack_self(mob/user)
 	print_data(user)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -312,7 +312,7 @@
 	update_icon()
 
 //For things to apply special effects after damaging an organ, called by organ's take_damage
-/obj/proc/after_wounding(obj/item/organ/external/organ, datum/wound)
+/obj/proc/after_wounding(obj/item/organ/external/organ, datum/wound/wound)
 
 /**
  * Test for if stepping on a tile containing this obj is safe to do, used for things like landmines and cliffs.

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -42,3 +42,5 @@
 	var/player_triggered_sleeping = 0
 	///Reagents towards which there is an active allergy.
 	var/list/active_allergies = list()
+	///Wound Data for forensics.
+	var/list/datum/autopsy_data_lookup/wound_data = list()

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -331,6 +331,8 @@
 		if (R?.get_allergies())
 			msg += "[SPAN_CLASS("deptradio", "Allergies:")] <a href='byond://?src=\ref[src];allergies=1'>\[View\]</a>\n"
 
+	if(user.skill_check_multiple(list(SKILL_ANATOMY = SKILL_BASIC, SKILL_FORENSICS = SKILL_EXPERIENCED)))
+		msg += "[SPAN_CLASS("deptradio", "Basic Analysis:")] <a href='byond://?src=\ref[src];autopsy=1'>\[View\]</a>\n"
 
 	if(print_flavor_text()) msg += "[print_flavor_text()]\n"
 

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -536,6 +536,16 @@
 			W.remove_webbing(user)
 		return TOPIC_HANDLED
 
+	if (href_list["autopsy"])
+		if(stat != DEAD && !(status_flags & FAKEDEATH))
+			to_chat(user, SPAN_WARNING("There's not much that you can tell, they're not dead. Yet."))
+			return TOPIC_HANDLED
+
+		for(var/obj/item/organ/external/O in organs)
+			var/string = GetInitialAutopsy(O)
+			if (string)
+				to_chat(user, SPAN_NOTICE("[string] on \the [O.name]"))
+		return TOPIC_HANDLED
 
 	return ..()
 

--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -189,6 +189,7 @@
 
 			if (ai_holder)
 				ai_holder.react_to_attack(H)
+			affecting.add_autopsy_data("Melee", real_damage, INJURY_TYPE_BRUISE)
 
 		if (I_DISARM)
 			if (H.species)

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -284,7 +284,7 @@
 			updatehealth()
 			if(!isSynthetic() && length(organs))
 				var/obj/item/organ/external/O = pick(organs)
-				if(istype(O)) O.add_autopsy_data("Radiation Poisoning", damage)
+				if(istype(O)) O.add_autopsy_data("Radiation Poisoning", damage, INJURY_TYPE_BURN)
 
 	/** breathing **/
 

--- a/code/modules/mob/living/carbon/human/unarmed_attack.dm
+++ b/code/modules/mob/living/carbon/human/unarmed_attack.dm
@@ -271,7 +271,6 @@ var/global/list/sparring_attack_cache = list()
 	var/datum/pronouns/user_pronouns = user.choose_from_pronouns()
 
 	attack_damage = clamp(attack_damage, 1, 5)
-
 	var/shoe_text = shoes ? copytext(shoes.name, 1, -1) : "foot"
 	switch(attack_damage)
 		if(1 to 4)

--- a/code/modules/mob/skills/skill.dm
+++ b/code/modules/mob/skills/skill.dm
@@ -226,7 +226,7 @@ GLOBAL_LIST_EMPTY(skills)
 	levels = list( "Unskilled"			= "You know that detectives solve crimes. You may have some idea that it's bad to contaminate a crime scene, but you're not too clear on the details.",
 						"Basic"				= "You know how to avoid contaminating a crime scene. You know how to bag the evidence without contaminating it unduly.",
 						"Trained"			= "You are trained in collecting forensic evidence - fibers, fingerprints, the works. You know how autopsies are done, and might've assisted performing one.<br>- You can more easily detect fingerprints.<br>- You no longer contaminate evidence.",
-						"Experienced"		= "You're a pathologist, or detective. You've seen your share of bizarre cases, and spent a lot of time putting pieces of forensic puzzle together, so you're faster now.<br>- You can notice additional details upon examining, such as fibers, partial prints, and gunshot residue.",
+						"Experienced"		= "You're a pathologist, or detective. You've seen your share of bizarre cases, and spent a lot of time putting pieces of forensic puzzle together, so you're faster now.<br>- You can notice additional details upon examining, such as fibers, partial prints, and gunshot residue; as well as conduct a basic wound-check of corpses (provided you've done your homework on anatomy).",
 						"Master"		= "You're a big name in forensic science. You might be an investigator who cracked a famous case, or you published papers on new methods of forensics. Either way, if there's a forensic trail, you will find it, period.<br>- You can notice traces of wiped off blood.")
 
 

--- a/code/modules/organs/external/_external.dm
+++ b/code/modules/organs/external/_external.dm
@@ -1366,17 +1366,6 @@ Note that amputating the affected organ does in fact remove the infection from t
 		var/max_halloss = round(owner.species.total_health * 0.8 * ((100 - armor) / 100)) //up to 80% of passing out, further reduced by armour
 		add_pain(clamp(0, max_halloss - owner.getHalLoss(), 30))
 
-//Adds autopsy data for used_weapon.
-/obj/item/organ/external/proc/add_autopsy_data(used_weapon, damage)
-	var/datum/autopsy_data/W = autopsy_data[used_weapon]
-	if(!W)
-		W = new()
-		W.weapon = used_weapon
-		autopsy_data[used_weapon] = W
-
-	W.hits += 1
-	W.damage += damage
-	W.time_inflicted = world.time
 
 /obj/item/organ/external/proc/has_genitals()
 	return !BP_IS_ROBOTIC(src) && species && species.sexybits_location == organ_tag
@@ -1392,3 +1381,199 @@ Note that amputating the affected organ does in fact remove the infection from t
 		. += max_delay * 3/8
 	else if(BP_IS_ROBOTIC(src))
 		. += max_delay * CLAMP01(damage/max_damage)
+
+
+/*
+* AUTOPSY
+*/
+
+/datum/autopsy_data
+	var/weapon = null
+	var/damage = 0
+	var/hits = 0
+	var/dtype = null
+	var/time_inflicted = 0
+
+
+/datum/autopsy_data/proc/copy()
+	var/datum/autopsy_data/W = new
+	W.weapon = weapon
+	W.damage = damage
+	W.hits = hits
+	W.dtype = dtype
+	W.time_inflicted = time_inflicted
+	return W
+
+
+/datum/autopsy_data_lookup
+	/// Weapon Type used.
+	var/weapon = null
+	/// Maps scanned organ # to the wounds of those organs with this data's weapon type.
+	var/list/organs_scanned = list()
+	var/organ_names = ""
+
+
+//Adds autopsy data for used_weapon.
+/obj/item/organ/external/proc/add_autopsy_data(used_weapon, damage, damage_type)
+	if (!used_weapon)
+		return
+
+	var/datum/autopsy_data/W = autopsy_data[used_weapon]
+	if(!W)
+		W = new()
+		W.weapon = used_weapon
+		autopsy_data[used_weapon] = W
+
+	W.dtype = damage_type
+	W.hits += 1
+	W.damage += damage
+	W.time_inflicted = world.time
+
+
+/mob/living/carbon/human/proc/AutopsyDataFetch(obj/item/organ/external/O)
+	if(!length(O.autopsy_data))
+		return
+
+	for(var/V in O.autopsy_data)
+		var/datum/autopsy_data/W = O.autopsy_data[V]
+		var/datum/autopsy_data_lookup/D = wound_data[V]
+		if(!D)
+			D = new()
+			D.weapon = W.weapon
+			wound_data[V] = D
+
+		if(!D.organs_scanned[O.name])
+			if(D.organ_names == "")
+				D.organ_names = O.name
+			else
+				D.organ_names += ", [O.name]"
+
+		qdel(D.organs_scanned[name])
+		D.organs_scanned[name] = W.copy()
+
+
+/mob/living/carbon/human/proc/GetWoundString(obj/item/organ/external/O)
+	AutopsyDataFetch(O)
+	var/w_string = ""
+	var/n = 1
+	for(var/wound_data_idx in wound_data)
+		var/datum/autopsy_data_lookup/D = wound_data[wound_data_idx]
+		var/total_hits = 0
+		var/total_score = 0
+		var/age = ""
+		var/damage_variety = ""
+
+		for(var/wound_idx in D.organs_scanned)
+			var/datum/autopsy_data/W = D.organs_scanned[wound_idx]
+			total_hits += W.hits
+			total_score += W.damage
+
+			var/wound_age = world.time - W.time_inflicted
+			switch (wound_age)
+				if (1 SECOND to 30 MINUTES)
+					age = SPAN_COLOR(COLOR_GRAY40, "Fresh")
+				if (30 MINUTES to 1 HOUR)
+					age = SPAN_COLOR(COLOR_GRAY20, "Old")
+				if (1 HOUR to 5 HOURS)
+					age = SPAN_COLOR(COLOR_GRAY15, "Very old")
+
+			if (!W.weapon)
+				return
+
+			if (!isprojectile(W.weapon))
+				var/obj/item/projectile/P = W.weapon
+				if (W.dtype == INJURY_TYPE_LASER)
+					damage_variety += SPAN_COLOR(COLOR_YELLOW_GRAY, "concentrated contact burns<br>")
+				else // Entry wounds are almost always smaller than exit wounds. Easier to figure out the exact caliber from entry wounds.
+					if (P.armor_penetration < 15)
+						damage_variety += SPAN_COLOR(COLOR_RED_GRAY, "small entry wound<br>")
+					if (P.armor_penetration >= 15 && P.armor_penetration <=35)
+						damage_variety += SPAN_COLOR(COLOR_RED_GRAY, "medium entry wound<br>")
+					if (P.armor_penetration > 35)
+						damage_variety += SPAN_COLOR(COLOR_RED_GRAY, "large entry wound<br>")
+					if (P.damage < 45)
+						damage_variety += SPAN_COLOR(COLOR_RED_GRAY, "small exit wound<br>")
+					if (P.damage >= 45)
+						damage_variety += SPAN_COLOR(COLOR_RED_GRAY, "large exit wound<br>")
+			else
+				if (W.dtype == INJURY_TYPE_BRUISE)
+					damage_variety += SPAN_COLOR(COLOR_RED_GRAY, "trauma<br>")
+				if (W.dtype == INJURY_TYPE_CUT)
+					damage_variety += SPAN_COLOR(COLOR_RED_GRAY, "abrasion<br>")
+				if (W.dtype == INJURY_TYPE_PIERCE)
+					damage_variety += SPAN_COLOR(COLOR_RED_GRAY, "puncture<br>")
+				if (W.dtype == INJURY_TYPE_BURN)
+					if (W.weapon == "Radiation Poisoning")
+						damage_variety += SPAN_COLOR(COLOR_YELLOW_GRAY, "radiation burns<br>")
+					if (W.weapon == "Acid Burns")
+						damage_variety += SPAN_COLOR(COLOR_YELLOW_GRAY, "chemical burns<br>")
+					else
+						damage_variety += SPAN_COLOR(COLOR_YELLOW_GRAY, "thermal burns<br>")
+
+		var/damage_desc
+
+		// total score happens to be the total damage
+		switch(total_score)
+			if(0)
+				damage_desc = "Unknown"
+			if(1 to 5)
+				damage_desc = SPAN_COLOR(COLOR_GREEN, "negligible")
+			if(5 to 15)
+				damage_desc = SPAN_COLOR(COLOR_DARK_GRAY, "light")
+			if(15 to 30)
+				damage_desc = SPAN_COLOR(COLOR_ORANGE, "moderate")
+			if(30 to 1000)
+				damage_desc = SPAN_COLOR(COLOR_RED, "severe")
+
+		if(!total_score)
+			total_score = length(D.organs_scanned)
+
+		w_string += "<b>Source #[n]</b><br>"
+		w_string += "Wound Types: [damage_desc]<br>"
+		w_string += "(<br>[damage_variety])<br>"
+		w_string += "Wound Count: [total_hits]<br>"
+		w_string += "(Approx.) Time of Wounding: [age]<br>"
+		w_string += "Affected Appendages: [D.organ_names]<br>"
+
+		w_string += "<br>"
+		n++
+
+	return w_string
+
+
+/mob/living/carbon/human/proc/GetInitialAutopsy(obj/item/organ/external/O)
+	AutopsyDataFetch(O)
+
+	var/w_string = null
+	var/d_string = null
+	for(var/wound_data_idx in wound_data)
+		var/datum/autopsy_data_lookup/D = wound_data[wound_data_idx]
+		if (!D)
+			continue
+		for(var/wound_idx in D.organs_scanned)
+			var/datum/autopsy_data/W = D.organs_scanned[wound_idx]
+			if (!W)
+				continue
+			if (isprojectile(W.weapon))
+				continue
+			if (W.dtype == INJURY_TYPE_BRUISE)
+				d_string = SPAN_COLOR(COLOR_RED_GRAY, "blunt-force trauma")
+			if (W.dtype == INJURY_TYPE_CUT)
+				d_string = SPAN_COLOR(COLOR_RED_GRAY, "lacerations")
+			if (W.dtype == INJURY_TYPE_PIERCE)
+				d_string = SPAN_COLOR(COLOR_RED_GRAY, "deep-cut wounds")
+			if (W.dtype == INJURY_TYPE_BURN)
+				if (W.weapon == "Radiation Poisoning")
+					d_string = SPAN_COLOR(COLOR_YELLOW_GRAY, "dark-red spots")
+				if (W.weapon == "Acid Burns")
+					d_string = SPAN_COLOR(COLOR_YELLOW_GRAY, "crackled, peeling skin")
+				else
+					d_string = SPAN_COLOR(COLOR_YELLOW_GRAY, "white, charred skin")
+
+			wound_data.Cut()
+
+		if (!d_string || d_string == "")
+			continue
+		w_string += "You see [d_string],"
+
+	return w_string

--- a/code/modules/organs/external/_external_damage.dm
+++ b/code/modules/organs/external/_external_damage.dm
@@ -30,9 +30,6 @@
 		if(prob(25))
 			owner.visible_message(SPAN_WARNING("\The [owner]'s crystalline [name] shines with absorbed energy!"))
 
-	if(used_weapon)
-		add_autopsy_data("[used_weapon]", brute + burn)
-
 	var/spillover = 0
 	var/pure_brute = brute
 	if(!is_damageable(brute + burn))
@@ -84,11 +81,11 @@
 
 	if(burn)
 		if(laser)
-			createwound(INJURY_TYPE_LASER, burn)
+			created_wound = createwound(INJURY_TYPE_LASER, burn)
 			if(owner && prob(40))
 				owner.IgniteMob()
 		else
-			createwound(INJURY_TYPE_BURN, burn)
+			created_wound = createwound(INJURY_TYPE_BURN, burn)
 
 	//Initial pain spike
 	add_pain(0.6*burn + 0.4*brute)
@@ -121,6 +118,7 @@
 
 	if(created_wound && isobj(used_weapon))
 		var/obj/O = used_weapon
+		add_autopsy_data(used_weapon, created_wound.damage, created_wound.damage_type)
 		O.after_wounding(src, created_wound)
 
 	return created_wound

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -17,7 +17,8 @@
 	var/yo = null
 	var/xo = null
 	var/current = null
-	var/shot_from = "" // name of the object which shot us
+	var/shot_from = "" // name of the object which shot us.
+	var/shot_caliber = "" // caliber of the firearm.
 	var/atom/original = null // the target clicked (not necessarily where the projectile is headed). Should probably be renamed to 'target' or something.
 	var/turf/starting = null // the projectile's starting turf
 	var/list/permutated = list() // we've passed through these atoms, don't try to hit them again
@@ -205,6 +206,10 @@
 	firer = user
 	shot_from = launcher.name
 	silenced = launcher.silenced
+
+	if (istype(launcher, /obj/item/gun/projectile))
+		var/obj/item/gun/projectile/P = launcher
+		shot_caliber = P.caliber
 
 	return launch(target, target_zone, x_offset, y_offset)
 
@@ -538,8 +543,9 @@
 /obj/item/projectile/proc/get_shrapnel()
 	if(shrapnel_type)
 		var/obj/item/SP = new shrapnel_type()
-		SP.SetName((name != "shrapnel")? "[name] shrapnel" : "shrapnel")
-		SP.desc += " It looks like it was fired from [shot_from]."
+		if (name != "shrapnel")
+			SP.SetName("[name] shrapnel")
+		SP.desc += " It looks like it is from a weapon firing [shot_caliber]."
 		return SP
 
 /obj/item/projectile/Process_Spacemove(allow_movement)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Dispenser.dm
@@ -368,6 +368,8 @@
 
 	if(removed < meltdose) // Not enough to melt anything
 		M.take_organ_damage(0, min(removed * power * 0.1, max_damage)) //burn damage, since it causes chemical burns. Acid doesn't make bones shatter, like brute trauma would.
+		for(var/obj/item/organ/external/affecting in M.organs)
+			affecting.add_autopsy_data(null, min(removed * power * 0.1, max_damage), INJURY_TYPE_BURN, "Acid Burns")
 	else
 		M.take_organ_damage(0, min(removed * power * 0.2, max_damage))
 		if(ishuman(M)) // Applies disfigurement
@@ -378,6 +380,7 @@
 					screamed = 1
 					H.emote("scream")
 				affecting.status |= ORGAN_DISFIGURED
+				affecting.add_autopsy_data("Acid Burns", min(removed * power * 0.2, max_damage), INJURY_TYPE_BURN)
 
 /datum/reagent/acid/touch_obj(obj/O)
 	if(O.unacidable)


### PR DESCRIPTION
:cl:
tweak: Autopsy scanners no longer give exact weapon. Instead, they give details on the wounds caused.
tweak: Projectile wounds have entry and exit wound definitions (if ballistic), based on armour-pen (in) and damage (out).
tweak: With basic anat and exp forensics, FTs can examine a corpse for a *VERY BASIC* summary of wounds that are the most damaging. Will require proper autopsy with a medical skill check on the scanner for full details.
/:cl:

Basic summary gives no special traits for ballistic vs melee that the scanner may. Or number of hits, or any smaller damages.

Have more changes for forensics, for another PR.