### PR TITLE
"fix" /mob/Login() calls not working

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -60,7 +60,7 @@
 	var/logout_time = null
 
 /mob/Login()
-
+	..()
 	// Add to player list if missing
 	if (!GLOB.player_list.Find(src))
 		ADD_SORTED(GLOB.player_list, src, GLOBAL_PROC_REF(cmp_mob_key))


### PR DESCRIPTION
:cl: Mucker
bugfix: The skybox will no longer go white when aghosting (and maybe some other scenarios too).
/:cl: