### PR TITLE
All unary machines are scannable

### DIFF
--- a/code/modules/atmospherics/components/unary/tank.dm
+++ b/code/modules/atmospherics/components/unary/tank.dm
@@ -54,9 +54,6 @@
 /obj/machinery/atmospherics/unary/tank/hide()
 	update_underlays()
 
-/obj/machinery/atmospherics/unary/tank/return_air()
-	return air_contents
-
 /obj/machinery/atmospherics/unary/tank/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(!isWrench(W))
 		return ..()

--- a/code/modules/atmospherics/components/unary/unary_base.dm
+++ b/code/modules/atmospherics/components/unary/unary_base.dm
@@ -90,3 +90,6 @@
 	update_underlays()
 
 	return null
+
+/obj/machinery/atmospherics/unary/return_air()
+	return air_contents


### PR DESCRIPTION
:cl:
tweak: All unary atmos devices (gas cooler, gas heater, vent, scrubber, injector and pressure tank) should now be properly scannable with a gas analyzer.
/:cl:

We can only wonder why pressure tanks had return_air but all the other devices with a single gas container didn't. Gas coolers and heaters can easily contain more gas than a canister so we aren't even talking about irrelevant, tiny volumes.

Next, binary devices should be looked at.