### PR TITLE
All binary machines are scannable

### DIFF
--- a/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
+++ b/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
@@ -123,3 +123,9 @@
 	node2 = null
 
 	. = ..()
+
+/obj/machinery/atmospherics/binary/return_air()			
+	if(air1.return_pressure() > air2.return_pressure())
+		return air1
+	else
+		return air2

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -115,12 +115,6 @@ Thus, the two variables affect pump operation are set in New():
 
 	return 1
 
-/obj/machinery/atmospherics/binary/pump/return_air()
-	if(air1.return_pressure() > air2.return_pressure())
-		return air1
-	else
-		return air2
-
 /obj/machinery/atmospherics/binary/pump/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
 	if(inoperable())
 		return


### PR DESCRIPTION
🆑
tweak: All binary atmos devices (pump, pressure regulator, circulator, oxygen regenerator) should now be properly scannable with a gas analyzer.
bugfix: Pressure regulator's exertion check should now work.
/:cl:

Similar case to the unary devices (#35197). No new code is really needed to make this work, just moved a working proc so it applies to all devices of the same class.