### PR TITLE
Increase name limit on pen -> food / Doubles name limit on serving bowl

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -46,7 +46,7 @@
 
 /obj/item/reagent_containers/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(istype(W, /obj/item/pen) || istype(W, /obj/item/device/flashlight/pen))
-		var/tmp_label = sanitizeSafe(input(user, "Enter a label for [name]", "Label", label_text), MAX_NAME_LEN)
+		var/tmp_label = sanitizeSafe(input(user, "Enter a label for [name]", "Label", label_text), MAX_LNAME_LEN)
 		if(length_char(tmp_label) > 10)
 			to_chat(user, SPAN_NOTICE("The label can be at most 10 characters long."))
 		else

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -24,7 +24,7 @@
 
 /obj/item/reagent_containers/food/condiment/use_tool(obj/item/W, mob/living/user, list/click_params)
 	if(istype(W, /obj/item/pen) || istype(W, /obj/item/device/flashlight/pen))
-		var/label = sanitizeSafe(input(user, "Enter a label for \the [name]", "Label", label_text), MAX_NAME_LEN)
+		var/label = sanitizeSafe(input(user, "Enter a label for \the [name]", "Label", label_text), MAX_LNAME_LEN)
 		if (!label)
 			return TRUE
 		AddLabel(label, user)

--- a/code/modules/reagents/reagent_containers/food/servingbowl.dm
+++ b/code/modules/reagents/reagent_containers/food/servingbowl.dm
@@ -63,7 +63,7 @@
 	set category = "Object"
 	if (renamed)
 		return
-	var/response = sanitizeSafe(input(usr, "Enter a new name for \the [src]."), 32)
+	var/response = sanitizeSafe(input(usr, "Enter a new name for \the [src]."), MAX_LNAME_LEN)
 	if (!response)
 		return
 	to_chat(usr, SPAN_ITALIC("You rename \the [src] to \"[response]\"."))


### PR DESCRIPTION
:cl:
tweak: Doubles name input on serving bowls. (32 -> 64)
tweak: Increases name input length on using pen to food (24 -> 64)
/:cl:

32 and 24 chars seemed a bit too short. We'll see how 64 works as it is the basic long name length.