### PR TITLE
hardsuit thrusters don't work for floored/dead people

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -371,7 +371,8 @@
 	return 1
 
 /obj/item/rig_module/maneuvering_jets/activate()
-
+	if(!..())
+		return FALSE
 	if(active)
 		return 0
 


### PR DESCRIPTION
:cl: Runebyt3
bugfix: People cannot use thrusters anymore when floored or dead.
/:cl:
