### PR TITLE
Cleaner injectors

### DIFF
--- a/nano/templates/injector.tmpl
+++ b/nano/templates/injector.tmpl
@@ -1,0 +1,54 @@
+<div class="item">
+	<div class="itemLabel">
+		Power:
+	</div>
+	<div class="itemContent">
+		{{:helper.link(data.on? 'On' : 'Off', null, {'power' : 1})}}
+	</div>
+</div>
+
+<div class="item">
+	<div class="itemLabel">
+		ID:
+	</div>
+	<div class="itemContent">
+		<div style="clear: both;">
+			{{:helper.link('Set ID', null, {'settag' : 1}, null)}}&nbsp;{{:data.id}}&nbsp;
+		</div>
+	</div>
+</div>
+
+<div class="item">
+	<div class="itemLabel">
+		Maximum Flow Rate:
+	</div>
+	<div class="itemContent">
+		<div style="clear: both;">
+			{{:helper.link('Max', null, {'set_flow_rate' : 'max'}, null)}}
+			{{:helper.link('Set', null, {'set_flow_rate' : 'set'}, null)}}
+			<div style="float: left; width: 80px; text-align: center;">&nbsp;{{:(data.flow_rate)}} L/s&nbsp;</div>
+		</div>
+	</div>
+</div>
+
+<div class="item">
+	<div class="itemLabel">
+		Frequency:
+	</div>
+	<div class="itemContent">
+		<div style="clear: both;">
+			{{:helper.link('Set Frequency', null, {'setfreq' : 1}, null)}}&nbsp;{{:(data.frequency/10)}}&nbsp;
+		</div>
+	</div>
+</div>
+
+<div class="item">
+	<div class="itemLabel">
+		Flow Rate:
+	</div>
+	<div class="itemContent">
+		<div class="statusValue">
+			{{:(data.last_flow_rate/10)}} L/s
+		</div>
+	</div>
+</div>


### PR DESCRIPTION
:cl:
tweak: Injectors now use NanoUI and have better manual controls. Multitool not needed anymore.
/:cl:

Basically I gave it the same treatment the extractor received, basic nano template + easy to access UI. The old interface definitely looks better but this actually updates properly. Maybe should get rid of the single switch UI that vents have next.

Also cleaned up the _lies / kind of nonsense_ comments at the start of the file that seem to refer to an ancient version of the injector. Would have removed the inject() proc as well but it looks like that isn't completely unused.