### PR TITLE
limit overmap spawns from being on the map limits

### DIFF
--- a/code/modules/overmap/_defines.dm
+++ b/code/modules/overmap/_defines.dm
@@ -1,5 +1,5 @@
 //How far from the edge of overmap zlevel could randomly placed objects spawn
-#define OVERMAP_EDGE 2
+#define OVERMAP_EDGE 3
 //Dimension of overmap (squares 4 lyfe)
 var/global/list/map_sectors = list()
 


### PR DESCRIPTION
:cl: Mucker
tweak: Overmap hazards no longer spawn on grids where ships transition to when moving over map edges.
/:cl: