### PR TITLE
Adds Separate Food Allergies

### DIFF
--- a/code/_global_vars/edible.dm
+++ b/code/_global_vars/edible.dm
@@ -39,7 +39,7 @@ GLOBAL_LIST_AS(proteinbar_flavors, list(
 	),
 	"mixed berry" = /datum/reagent/drink/juice/berry,
 	"peanut crunch" = list(
-		/datum/reagent/nutriment/peanutbutter,
-		/datum/reagent/nutriment/groundpeanuts
+		/datum/reagent/nutriment/peanut/peanutbutter,
+		/datum/reagent/nutriment/peanut/groundpeanuts
 	)
 ))

--- a/code/datums/traits/maluses/allergy.dm
+++ b/code/datums/traits/maluses/allergy.dm
@@ -49,7 +49,8 @@
 		/datum/reagent/nutriment/protein/egg,
 		/datum/reagent/nutriment/protein/shellfish,
 		/datum/reagent/nutriment/protein/fish,
-		/datum/reagent/nutriment/protein/cheese
+		/datum/reagent/nutriment/protein/cheese,
+		/datum/reagent/nutriment/peanut
 	)
 	addprompt = "Select food to make mob allergic to."
 	remprompt = "Select food to remove allergy to."

--- a/code/datums/traits/maluses/allergy.dm
+++ b/code/datums/traits/maluses/allergy.dm
@@ -1,21 +1,18 @@
 /singleton/trait/malus/allergy
 	name = "Allergy"
 	levels = list(TRAIT_LEVEL_MINOR, TRAIT_LEVEL_MAJOR)
+	abstract_type = /singleton/trait/malus/allergy
+
+/singleton/trait/malus/allergy/drug
+	name = "Drug Allergy"
 	maximum_count = 2
-	///Used to select which reagent mob is allergic to.
+
 	metaoptions = list(
 		/datum/reagent/antidexafen,
 		/datum/reagent/bicaridine,
 		/datum/reagent/dermaline,
-		/datum/reagent/drink/juice/apple,
-		/datum/reagent/drink/juice/berry,
-		/datum/reagent/drink/juice/garlic,
-		/datum/reagent/drink/juice/orange,
-		/datum/reagent/drink/kefir,
-		/datum/reagent/drink/thoom,
 		/datum/reagent/drugs/psilocybin,
 		/datum/reagent/drugs/three_eye,
-		/datum/reagent/ethanol,
 		/datum/reagent/hyperzine,
 		/datum/reagent/kelotane,
 		/datum/reagent/nanoblood,
@@ -29,8 +26,33 @@
 		/datum/reagent/toxin/carpotoxin,
 		/datum/reagent/toxin/venom
 	)
-	addprompt = "Select reagent to make mob allergic to."
-	remprompt = "Select reagent to remove allergy to."
+	addprompt = "Select drug to make mob allergic to."
+	remprompt = "Select drug to remove allergy to."
+	selectable = TRUE
+
+/singleton/trait/malus/allergy/food
+	name = "Food Allergy"
+	maximum_count = 2
+
+	metaoptions = list(
+		/datum/reagent/drink/juice/apple,
+		/datum/reagent/drink/juice/berry,
+		/datum/reagent/drink/juice/garlic,
+		/datum/reagent/drink/juice/orange,
+		/datum/reagent/ethanol,
+		/datum/reagent/drink/kefir,
+		/datum/reagent/drink/thoom,
+		/datum/reagent/ethanol/creme_de_menthe,
+		/datum/reagent/ethanol/gin,
+		/datum/reagent/ethanol/tequilla,
+		/datum/reagent/ethanol/vodka,
+		/datum/reagent/nutriment/protein/egg,
+		/datum/reagent/nutriment/protein/shellfish,
+		/datum/reagent/nutriment/protein/fish,
+		/datum/reagent/nutriment/protein/cheese
+	)
+	addprompt = "Select food to make mob allergic to."
+	remprompt = "Select food to remove allergy to."
 	selectable = TRUE
 
 /// Migrates allergies from lower save versions to higher ones.

--- a/code/datums/traits/traits.dm
+++ b/code/datums/traits/traits.dm
@@ -16,21 +16,21 @@
 	SHOULD_NOT_SLEEP(TRUE)
 	var/traits = GetTraits()
 	if(!traits)
-		return null
+		return FALSE
 
 	if (is_abstract(trait_type))
 		if (!meta_option)
-			return null
+			return FALSE
 		var/list/children_traits = GET_SINGLETON_SUBTYPE_LIST(trait_type)
 		for (var/singleton/trait/possible_trait in children_traits)
-			if (possible_trait.metaoptions && LAZYISIN(possible_trait.metaoptions, meta_option))
+			if (possible_trait.metaoptions && (meta_option in possible_trait.metaoptions))
 				var/list/interim = traits[possible_trait.type]
 				return interim[meta_option]
 	else
 		var/singleton/trait/trait = GET_SINGLETON(trait_type)
 		if (length(trait.metaoptions))
 			if (!meta_option)
-				return
+				return FALSE
 			var/list/interim = traits[trait_type]
 			return interim[meta_option]
 
@@ -55,6 +55,12 @@
 		return
 
 	return traits[trait_type]
+
+///Currently only used to update allergy masterlist in carbons whenever traits are modified
+/mob/living/carbon/proc/UpdateAllergyTraits()
+	allergy_list = list()
+	LAZYMERGELIST(allergy_list, traits[/singleton/trait/malus/allergy/drug])
+	LAZYMERGELIST(allergy_list, traits[/singleton/trait/malus/allergy/food])
 
 /mob/living/proc/SetTrait(trait_type, trait_level, meta_option)
 	SHOULD_NOT_SLEEP(TRUE)
@@ -82,17 +88,17 @@
 	return TRUE
 
 /mob/living/carbon/human/SetTrait(trait_type, trait_level, additional_option)
-	var/singleton/trait/T = GET_SINGLETON(trait_type)
-	if(!T.Validate(trait_level, additional_option))
-		return FALSE
-
 	if(!traits) // If traits haven't been setup before, check if we need to do so now
 		var/species_level = species.traits[trait_type]
 		if(species_level == trait_level) // Matched the default species trait level, ignore
 			return TRUE
 		traits = species.traits.Copy() // The setup is to simply copy the species list of traits
 
-	return ..(trait_type, trait_level, additional_option)
+	if (..(trait_type, trait_level, additional_option))
+		UpdateAllergyTraits()
+		return TRUE
+	else
+		return FALSE
 
 /mob/living/proc/RemoveTrait(trait_type, additional_option)
 	if (additional_option)
@@ -108,6 +114,7 @@
 		traits = species.traits.Copy()
 
 	..(trait_type, additional_option) // Could go through the trouble of nulling the traits list if it's again equal to the species list but eh
+	UpdateAllergyTraits()
 	traits = traits || list() // But we do ensure that humans don't null their traits list, to avoid copying from species again
 
 /proc/LetterizeSeverity(severity)
@@ -192,7 +199,6 @@
 	SHOULD_NOT_OVERRIDE(TRUE)
 	SHOULD_NOT_SLEEP(TRUE)
 	SHOULD_BE_PURE(TRUE)
-
 	if (length(metaoptions))
 		return (level in levels) && (meta_option in metaoptions)
 	else

--- a/code/datums/traits/traits.dm
+++ b/code/datums/traits/traits.dm
@@ -2,23 +2,39 @@
 /mob/living/proc/HasTrait(trait_type)
 	SHOULD_NOT_OVERRIDE(TRUE)
 	SHOULD_NOT_SLEEP(TRUE)
-	return (trait_type in GetTraits())
+	if (!is_abstract(trait_type))
+		return (trait_type in GetTraits())
+	var/list/children_traits = GET_SINGLETON_SUBTYPE_LIST(trait_type)
+	for (var/singleton/trait/trait in children_traits)
+		if (trait.type in GetTraits())
+			return TRUE
+	return FALSE
 
+///Can only feed abstract types into this proc if it's associated with a meta_option that is unique to one of the children
 /mob/living/proc/GetTraitLevel(trait_type, meta_option)
 	SHOULD_NOT_OVERRIDE(TRUE)
 	SHOULD_NOT_SLEEP(TRUE)
-	var/singleton/trait/trait = GET_SINGLETON(trait_type)
 	var/traits = GetTraits()
 	if(!traits)
 		return null
 
-	if (length(trait.metaoptions))
+	if (is_abstract(trait_type))
 		if (!meta_option)
-			return
-		var/list/interim = traits[trait_type]
-		return interim[meta_option]
+			return null
+		var/list/children_traits = GET_SINGLETON_SUBTYPE_LIST(trait_type)
+		for (var/singleton/trait/possible_trait in children_traits)
+			if (possible_trait.metaoptions && LAZYISIN(possible_trait.metaoptions, meta_option))
+				var/list/interim = traits[possible_trait.type]
+				return interim[meta_option]
+	else
+		var/singleton/trait/trait = GET_SINGLETON(trait_type)
+		if (length(trait.metaoptions))
+			if (!meta_option)
+				return
+			var/list/interim = traits[trait_type]
+			return interim[meta_option]
 
-	else return traits[trait_type]
+		else return traits[trait_type]
 
 /mob/living/proc/GetTraits()
 	SHOULD_NOT_SLEEP(TRUE)
@@ -121,6 +137,8 @@
 
 	for (var/trait in preferences)
 		var/trait_type = istext(trait) ? text2path(trait) : trait
+		if (is_abstract(trait_type))
+			continue
 		var/singleton/trait/selected = GET_SINGLETON(trait_type)
 		var/severity
 		if (!selected)

--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -322,7 +322,10 @@
 	display_name = "Allergy Autoinjector"
 	path = /obj/item/reagent_containers/hypospray/autoinjector/pouch_auto/allergy
 	cost = 1
-	allowed_traits = list(/singleton/trait/malus/allergy)
+	allowed_traits = list(
+		/singleton/trait/malus/allergy/food,
+		/singleton/trait/malus/allergy/drug
+	)
 
 /datum/gear/rosary
 	display_name = "rosary"

--- a/code/modules/cooking/recipes/recipes_cereals.dm
+++ b/code/modules/cooking/recipes/recipes_cereals.dm
@@ -53,7 +53,7 @@
 /singleton/cooking_recipe/pbtoast
 	appliance = COOKING_APPLIANCE_SKILLET | COOKING_APPLIANCE_MICROWAVE
 	required_reagents = list(
-		/datum/reagent/nutriment/peanutbutter = 5
+		/datum/reagent/nutriment/peanut/peanutbutter = 5
 	)
 	required_items = list(
 		/obj/item/reagent_containers/food/snacks/slice/bread

--- a/code/modules/cooking/recipes/recipes_mix.dm
+++ b/code/modules/cooking/recipes/recipes_mix.dm
@@ -212,7 +212,7 @@
 /singleton/cooking_recipe/pbjsandwich_cherry
 	required_reagents = list(
 		/datum/reagent/nutriment/cherryjelly = 5,
-		/datum/reagent/nutriment/peanutbutter = 5
+		/datum/reagent/nutriment/peanut/peanutbutter = 5
 	)
 	required_items = list(
 		/obj/item/reagent_containers/food/snacks/slice/bread,
@@ -223,7 +223,7 @@
 /singleton/cooking_recipe/pbjsandwich_slime
 	required_reagents = list(
 		/datum/reagent/slimejelly = 5,
-		/datum/reagent/nutriment/peanutbutter = 5
+		/datum/reagent/nutriment/peanut/peanutbutter = 5
 	)
 	required_items = list(
 		/obj/item/reagent_containers/food/snacks/slice/bread,

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -648,7 +648,7 @@
 	name = "peanut"
 	seed_name = "peanut"
 	display_name = "peanut plant"
-	chems = list(/datum/reagent/nutriment/groundpeanuts = list(3,5))
+	chems = list(/datum/reagent/nutriment/peanut/groundpeanuts = list(3,5))
 	kitchen_tag = "peanut"
 
 /datum/seed/peanuts/New()

--- a/code/modules/mob/living/carbon/allergy.dm
+++ b/code/modules/mob/living/carbon/allergy.dm
@@ -76,7 +76,8 @@ Also checks if medications that stop allergies from triggering are in system. Th
 		return
 	if (!HAS_TRAIT(src, /singleton/trait/malus/allergy))
 		return
-	var/list/allergy_list = traits[/singleton/trait/malus/allergy]
+	var/list/allergy_list = traits[/singleton/trait/malus/allergy/drug]
+	LAZYMERGELIST(allergy_list, traits[/singleton/trait/malus/allergy/food])
 
 	for (var/picked as anything in allergy_list)
 		var/datum/reagent/reagent = picked

--- a/code/modules/mob/living/carbon/allergy.dm
+++ b/code/modules/mob/living/carbon/allergy.dm
@@ -76,9 +76,6 @@ Also checks if medications that stop allergies from triggering are in system. Th
 		return
 	if (!HAS_TRAIT(src, /singleton/trait/malus/allergy))
 		return
-	var/list/allergy_list = traits[/singleton/trait/malus/allergy/drug]
-	LAZYMERGELIST(allergy_list, traits[/singleton/trait/malus/allergy/food])
-
 	for (var/picked as anything in allergy_list)
 		var/datum/reagent/reagent = picked
 		if (!(metabolized.has_reagent(reagent.type)) && !(picked in active_allergies))

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -45,5 +45,7 @@
 	var/stasis_value
 
 	var/player_triggered_sleeping = 0
+	///List with all food and drug allergies mob has; updated by UpdateAllergyTraits() whenever traits are modified.
+	var/list/allergy_list = list()
 	///Reagents towards which there is an active allergy.
 	var/list/active_allergies = list()

--- a/code/modules/modular_computers/file_system/reports/crew_record.dm
+++ b/code/modules/modular_computers/file_system/reports/crew_record.dm
@@ -87,7 +87,8 @@ GLOBAL_VAR_AS(arrest_security_status, "Arrest")
 
 	if(H)
 		if (H.HasTrait(/singleton/trait/malus/allergy))
-			var/list/allergies = H.GetMetaOptions(/singleton/trait/malus/allergy)
+			var/list/allergies = H.GetMetaOptions(/singleton/trait/malus/allergy/food)
+			LAZYMERGELIST(allergies, H.GetMetaOptions(/singleton/trait/malus/allergy/drug))
 			var/list/allergy_data = list()
 			var/severity
 			for (var/datum/reagent/picked as anything in allergies)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Food.dm
@@ -621,7 +621,11 @@
 	condiment_name = "mayonnaise"
 	condiment_desc = "Mayonnaise, used for centuries to make things edible."
 
-/datum/reagent/nutriment/groundpeanuts
+/datum/reagent/nutriment/peanut
+	name = "Peanuts"
+	description = "Raw peanuts."
+
+/datum/reagent/nutriment/peanut/groundpeanuts
 	name = "Ground Peanuts"
 	description = "Roughly ground peanuts."
 	taste_description = "peanut"
@@ -633,7 +637,7 @@
 	condiment_name = "sack of ground peanuts"
 	condiment_desc = "A sack full of crunchy ground peanuts."
 
-/datum/reagent/nutriment/peanutbutter
+/datum/reagent/nutriment/peanut/peanutbutter
 	name = "Peanut Butter"
 	description = "Clearer the better spread, exception for those who are deathly allergic."
 	taste_description = "peanut butter"

--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -1663,8 +1663,8 @@
 
 /singleton/reaction/peanutbutter
 	name = "Peanut Butter"
-	result = /datum/reagent/nutriment/peanutbutter
-	required_reagents = list(/datum/reagent/nutriment/groundpeanuts = 5, /datum/reagent/sugar = 1, /datum/reagent/sodiumchloride = 1)
+	result = /datum/reagent/nutriment/peanut/peanutbutter
+	required_reagents = list(/datum/reagent/nutriment/peanut/groundpeanuts = 5, /datum/reagent/sugar = 1, /datum/reagent/sodiumchloride = 1)
 	result_amount = 5
 	mix_message = "The solution thickens into a creamy, nutty spread."
 

--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -142,7 +142,7 @@
 	starting_reagents = list(/datum/reagent/oliveoil = 50)
 
 /obj/item/reagent_containers/food/condiment/peanutbutter
-	starting_reagents = list(/datum/reagent/nutriment/peanutbutter = 50)
+	starting_reagents = list(/datum/reagent/nutriment/peanut/peanutbutter = 50)
 
 /obj/item/reagent_containers/food/condiment/choconutspread
 	starting_reagents = list(/datum/reagent/nutriment/choconutspread = 50)
@@ -233,7 +233,7 @@
 	name = "peanut butter packet"
 	desc = "Contains 10u of peanut butter."
 	icon_state = "packet_medium"
-	starting_reagents = list(/datum/reagent/nutriment/peanutbutter = 10)
+	starting_reagents = list(/datum/reagent/nutriment/peanut/peanutbutter = 10)
 
 /obj/item/reagent_containers/food/condiment/small/packet/choconutspread
 	name = "NTella packet"

--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -3778,7 +3778,7 @@
 
 /obj/item/reagent_containers/food/snacks/saturn/Initialize()
 	.=..()
-	reagents.add_reagent(/datum/reagent/nutriment/groundpeanuts, 3)
+	reagents.add_reagent(/datum/reagent/nutriment/peanut/groundpeanuts, 3)
 
 
 /obj/item/reagent_containers/food/snacks/jupiter
@@ -3871,7 +3871,7 @@
 /obj/item/reagent_containers/food/snacks/weebonuts/Initialize()
 	.=..()
 	reagents.add_reagent(/datum/reagent/capsaicin, 1)
-	reagents.add_reagent(/datum/reagent/nutriment/groundpeanuts, 4)
+	reagents.add_reagent(/datum/reagent/nutriment/peanut/groundpeanuts, 4)
 
 /obj/item/reagent_containers/food/snacks/chocobanana
 	name = "choco banang"


### PR DESCRIPTION
🆑 emmanuelbassil
rscadd: Adds separate trait for food allergies; maximum of 2 allowed. Maximum allowed drug allergies is still 2; for a total of 4.
rscadd: Added allergies to egg, fish, shellfish, and cheese
rscadd: You will have to reselect all your allergies; existing allergies cleared out.
/🆑 

No real user facing changes except raising the allergy cap and separating food and drugs into two lists. Allergies still work exactly the same and there is no difference in symptoms or treatment between the two kinds. 

If you'd like to hold off on this until my microwave PR is merged; then I can properly add shellfish, fish, cheese, etc. allergies to this PR as well.