### PR TITLE
Remove welding fuel icon from roundstart blurb

### DIFF
--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -580,6 +580,7 @@ SUBSYSTEM_DEF(jobs)
 	text = uppertext(text)
 
 	var/obj/effect/T = new()
+	T.icon_state = "nothing"
 	T.maptext_height = 64
 	T.maptext_width = 512
 	T.layer = FLOAT_LAYER


### PR DESCRIPTION
![dreamseeker_ztNWQi6fU8](https://github.com/user-attachments/assets/34016f77-898e-429f-b068-dabdb3f49295)