### PR TITLE
Uses Sleeping() proc consistently

### DIFF
--- a/code/game/gamemodes/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/changeling/powers/absorb.dm
@@ -134,5 +134,5 @@
 	if(changeling.absorbing_lethally == ABSORB_NONLETHAL)
 		changeling.geneticpoints += 2
 		changeling.max_geneticpoints += 2
-		T.Sleeping(200)
+		T.Sleeping(20)
 	return TRUE

--- a/code/game/machinery/OpTable.dm
+++ b/code/game/machinery/OpTable.dm
@@ -106,8 +106,8 @@
 	if(victim && !suppressing)
 		AddOverlays("table2-warning")
 	if(victim)
-		if(suppressing && victim.sleeping < 3)
-			victim.Sleeping(3 - victim.sleeping)
+		if(suppressing && victim.sleeping < 10)
+			victim.Sleeping(10)
 		return 1
 	return 0
 

--- a/code/game/objects/effects/effect_system.dm
+++ b/code/game/objects/effects/effect_system.dm
@@ -288,7 +288,7 @@ would spawn and follow the beaker, even if it is carried or thrown.
 /obj/effect/smoke/sleepy
 
 /obj/effect/smoke/sleepy/affect(mob/living/carbon/M as mob )
-	M:sleeping += 1
+	M.AdjustSleeping(1)
 	if (M.coughedtime != 1)
 		M.coughedtime = 1
 		M.emote("cough")

--- a/code/modules/emotes/definitions/visible.dm
+++ b/code/modules/emotes/definitions/visible.dm
@@ -115,7 +115,7 @@
 
 /singleton/emote/visible/faint/do_extra(mob/user)
 	if(istype(user) && user.sleeping <= 0)
-		user.sleeping += 10
+		user.Sleeping(10)
 
 /singleton/emote/visible/frown
 	key = "frown"

--- a/code/modules/mob/living/carbon/alien/life.dm
+++ b/code/modules/mob/living/carbon/alien/life.dm
@@ -55,7 +55,7 @@
 			adjustHalLoss(-3)
 			if (mind)
 				if(mind.active && client != null)
-					sleeping = max(sleeping-1, 0)
+					AdjustSleeping(-1)
 			blinded = 1
 			set_stat(UNCONSCIOUS)
 		else if(resting)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -234,9 +234,9 @@
 			if(show_ssd && ssd_check())
 				M.visible_message(SPAN_NOTICE("[M] shakes [src] trying to wake [P.him] up!"), \
 				SPAN_NOTICE("You shake [src], but they do not respond... Maybe they have S.S.D?"))
-			else if(lying || src.sleeping || player_triggered_sleeping)
-				src.player_triggered_sleeping = 0
-				src.sleeping = max(0,src.sleeping - 5)
+			else if(lying || sleeping || player_triggered_sleeping)
+				player_triggered_sleeping = 0
+				AdjustSleeping(-5)
 				M.visible_message(SPAN_NOTICE("[M] shakes [src] trying to wake [P.him] up!"), \
 									SPAN_NOTICE("You shake [src] trying to wake [P.him] up!"))
 			else

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -64,9 +64,9 @@
 
 	updatehealth()
 
-	if(src.sleeping)
+	if(sleeping)
 		Paralyse(3)
-		src.sleeping--
+		AdjustSleeping(-1)
 
 	if (resting) // Just in case. This breaks things so never allow robots to rest.
 		resting = FALSE

--- a/code/modules/organs/internal/species/ipc.dm
+++ b/code/modules/organs/internal/species/ipc.dm
@@ -283,9 +283,9 @@
 			owner.slurring += 6
 		if (damage > min_broken_damage)
 			if (prob(2))
-				if (prob(15) && owner.sleeping < 1)
+				if (prob(15) && !owner.sleeping)
 					owner.visible_message(SPAN_ITALIC("\The [owner] suddenly halts all activity."))
-					owner.sleeping += 10
+					owner.Sleeping(5)
 				else if (owner.anchored || isspace(get_turf(owner)))
 					owner.visible_message(SPAN_ITALIC("\The [owner] seizes and twitches!"))
 					owner.Stun(2)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drinks.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Drinks.dm
@@ -26,7 +26,7 @@
 		M.adjust_hydration(hydration * removed)
 	M.dizziness = max(0, M.dizziness + adj_dizzy)
 	M.drowsyness = max(0, M.drowsyness + adj_drowsy)
-	M.sleeping = max(0, M.sleeping + adj_sleepy)
+	M.AdjustSleeping(adj_sleepy)
 	if(adj_temp > 0 && M.bodytemperature < 310) // 310 is the normal bodytemp. 310.055
 		M.bodytemperature = min(310, M.bodytemperature + (adj_temp * TEMPERATURE_DAMAGE_COEFFICIENT))
 	if(adj_temp < 0 && M.bodytemperature > 310)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Ethanol.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Ethanol.dm
@@ -194,7 +194,7 @@
 	..()
 	M.dizziness = max(0, M.dizziness - 5)
 	M.drowsyness = max(0, M.drowsyness - 3)
-	M.sleeping = max(0, M.sleeping - 2)
+	M.AdjustSleeping(-2)
 	if(M.bodytemperature > 310)
 		M.bodytemperature = max(310, M.bodytemperature - (5 * TEMPERATURE_DAMAGE_COEFFICIENT))
 
@@ -575,7 +575,7 @@
 		return
 	var/sleep_chance = M.GetTraitLevel(/singleton/trait/malus/ethanol) || 1
 	if (prob(sleep_chance))
-		M.sleeping = max(M.sleeping, 1)
+		M.Sleeping(5)
 
 /datum/reagent/ethanol/bilk
 	name = "Bilk"

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -987,7 +987,7 @@
 	taste_description = "dental surgery"
 	reagent_state = LIQUID
 	color = COLOR_GRAY80
-	metabolism = 0.05 // So that low dosages have a chance to build up in the body.
+	metabolism = 1
 	var/do_giggle = TRUE
 
 /datum/reagent/nitrous_oxide/xenon
@@ -1000,12 +1000,14 @@
 /datum/reagent/nitrous_oxide/affect_blood(mob/living/carbon/M, removed)
 	if (IS_METABOLICALLY_INERT(M))
 		return
+	if (volume > 2)
+		M.Sleeping(10)
 	var/dosage = M.chem_doses[type]
-	if(dosage >= 1)
-		if(prob(5)) M.Sleeping(3)
+	if(dosage >= 10)
+		if (prob(5)) M.Sleeping(3)
 		M.dizziness =  max(M.dizziness, 3)
 		M.set_confused(3)
-	if(dosage >= 0.3)
+	if(dosage >= 2)
 		if(prob(5)) M.Paralyse(1)
 		M.drowsyness = max(M.drowsyness, 3)
 		M.slurring =   max(M.slurring, 3)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -346,7 +346,7 @@
 
 /datum/reagent/toxin/cyanide/affect_blood(mob/living/carbon/M, removed)
 	..()
-	M.sleeping += 1
+	M.AdjustSleeping(1)
 
 /datum/reagent/toxin/taxine
 	name = "Taxine"
@@ -648,7 +648,7 @@
 			M.add_chemical_effect(CE_SEDATE, 1)
 		M.drowsyness = max(M.drowsyness, 20)
 	else
-		M.sleeping = max(M.sleeping, 20)
+		M.Sleeping(20)
 		M.drowsyness = max(M.drowsyness, 60)
 		M.add_chemical_effect(CE_SEDATE, 1)
 	M.add_chemical_effect(CE_PULSE, -1)
@@ -679,7 +679,7 @@
 		M.Weaken(30)
 		M.eye_blurry = max(M.eye_blurry, 10)
 	else
-		M.sleeping = max(M.sleeping, 30)
+		M.Sleeping(30)
 
 	if(M.chem_doses[type] > 1 * threshold)
 		M.adjustToxLoss(removed)

--- a/code/modules/xenoarcheaology/finds/special.dm
+++ b/code/modules/xenoarcheaology/finds/special.dm
@@ -216,7 +216,7 @@
 			'sound/hallucinations/turn_around1.ogg',\
 			'sound/hallucinations/turn_around2.ogg',\
 			), 50, 1, -3)
-			M.sleeping = max(M.sleeping,rand(5,10))
+			M.Sleeping(rand(5, 10))
 			qdel(src)
 	else
 		STOP_PROCESSING(SSobj, src)


### PR DESCRIPTION
🆑 emmanuelbassil
balance: Nitrous oxide gas (anesthetic tank) sleeping effect wears off quickly once source of gas stopped; unlike previous behavior where it needs a very long time to wear off. 
balance: Nitrous oxide gas does not put you to sleep reliably unless a sufficiently high pressure source of NO2 is constantly delivered (1ATM for anesthetic tank which is an O2/N2O mix)
balance: Will no longer wake patient on neural suppressor up by shaking them once by mistake.
bugfix: Changeling non-lethal absorb no longer puts you to sleep for 15 minutes; now lasts for about 40 seconds
/🆑 

Makes use of the sleeping proc more consistent throughout code. 