### PR TITLE
Reworks Opiates

### DIFF
--- a/code/__defines/chemistry.dm
+++ b/code/__defines/chemistry.dm
@@ -42,6 +42,7 @@
 #define CE_ENERGETIC     "energetic"    // Speeds up stamina recovery.
 #define	CE_VOICELOSS     "whispers"     // Lowers the subject's voice to a whisper
 #define CE_STIMULANT     "stimulants"   // Makes it harder to disarm someone
+#define CE_OPIATES       "opiates"      // Person is on opiates; used to suppress gasp reflex and constrict pupils.
 
 //reagent flags
 #define IGNORE_MOB_SIZE    FLAG_01

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -144,10 +144,10 @@
 		if(H.getBrainLoss() > 15)
 			to_chat(user, SPAN_NOTICE("There's visible lag between left and right pupils' reactions."))
 
-		var/list/pinpoint = list(/datum/reagent/tramadol/oxycodone=1,/datum/reagent/tramadol=5)
+		var/list/pinpoint = list()
 		var/list/dilating = list(/datum/reagent/drugs/hextro=5,/datum/reagent/drugs/mindbreaker=1,/datum/reagent/adrenaline=1)
 		var/datum/reagents/ingested = H.get_ingested_reagents()
-		if(H.reagents.has_any_reagent(pinpoint) || ingested.has_any_reagent(pinpoint))
+		if(H.reagents.has_any_reagent(pinpoint) || ingested.has_any_reagent(pinpoint) || H.on_opiates())
 			to_chat(user, SPAN_NOTICE("\The [H]'s pupils are already pinpoint and cannot narrow any more."))
 		else if(H.shock_stage >= 30 || H.reagents.has_any_reagent(dilating) || ingested.has_any_reagent(dilating))
 			to_chat(user, SPAN_NOTICE("\The [H]'s pupils narrow slightly, but are still very dilated."))

--- a/code/modules/mob/living/carbon/breathe.dm
+++ b/code/modules/mob/living/carbon/breathe.dm
@@ -19,7 +19,7 @@
 
 	if(losebreath>0) //Suffocating so do not take a breath
 		losebreath--
-		if (prob(10) && !is_asystole() && active_breathe) //Gasp per 10 ticks? Sounds about right.
+		if (prob(10) && !is_asystole() && active_breathe && !on_opiates()) //Gasp per 10 ticks? Sounds about right.
 			emote("gasp")
 	else
 		//Okay, we can breathe, now check if we can get air

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -14,7 +14,6 @@
 	var/datum/reagents/metabolism/bloodstr = null
 	var/datum/reagents/metabolism/touching = null
 	var/losebreath = 0 //if we failed to breathe last tick
-
 	var/coughedtime = null
 
 	var/cpr_time = 1.0

--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -1166,3 +1166,8 @@
 		return
 
 	return !ai_holder
+
+/mob/living/carbon/proc/on_opiates()
+	if (CE_OPIATES in chem_effects)
+		return TRUE
+	else return FALSE

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Medicine.dm
@@ -265,52 +265,62 @@
 	taste_description = "sourness"
 	reagent_state = LIQUID
 	color = "#cb68fc"
-	overdose = 30
+	overdose = 30 //Overdose for opiates handles effects unrelated to sedation but the chemical itself. Oversedation is handled under affect_blood by a different system
 	scannable = 1
 	metabolism = 0.05
 	ingest_met = 0.02
 	flags = IGNORE_MOB_SIZE
 	value = 3.1
-	var/pain_power = 80 //magnitide of painkilling effect
-	var/effective_dose = 0.5 //how many units it need to process to reach max power
+	var/pain_power = 10 //magnitide of painkilling effect
 
+///This runs once even if two kinds of opiates are in the body.
 /datum/reagent/tramadol/affect_blood(mob/living/carbon/M, removed)
-	var/effectiveness = 1
-	if(M.chem_doses[type] < effective_dose) //some ease-in ease-out for the effect
-		effectiveness = M.chem_doses[type]/effective_dose
-	else if(volume < effective_dose)
-		effectiveness = volume/effective_dose
-	M.add_chemical_effect(CE_PAINKILLER, pain_power * effectiveness)
-	if(M.chem_doses[type] > 0.5 * overdose)
-		M.add_chemical_effect(CE_SLOWDOWN, 1)
-		if(prob(1))
-			M.slurring = max(M.slurring, 10)
-	if(M.chem_doses[type] > 0.75 * overdose)
-		M.add_chemical_effect(CE_SLOWDOWN, 1)
-		if(prob(5))
-			M.slurring = max(M.slurring, 20)
-	if(M.chem_doses[type] > overdose)
-		M.add_chemical_effect(CE_SLOWDOWN, 1)
-		M.slurring = max(M.slurring, 30)
-		if(prob(1))
-			M.Weaken(2)
-			M.drowsyness = max(M.drowsyness, 5)
+	if (CE_OPIATES in M.chem_effects) //Already processed opiates once this tick; will not do so again.
+		return
+	var/total_opiate_dose = 0
+	var/opiate_count = 0
+	var/maximum_opiate_dose = M.species.maximum_opiate_dose
+	for (var/datum/reagent/tramadol/opiate in M.chem_doses)
+		total_opiate_dose += (opiate.pain_power) * M.chem_doses[opiate] //Stronger opiates contribute more to effect or reaching OD.
+		opiate_count++  //Having more than one opiate amplifies their effects
+	if (opiate_count > 1)
+		total_opiate_dose *= max(1, 1 + ((opiate_count - 1)/10)) //Amplifying effect of multiple opiates
+
+	M.add_chemical_effect(CE_PAINKILLER, total_opiate_dose)
+
 	var/boozed = isboozed(M)
 	if(boozed)
 		M.add_chemical_effect(CE_ALCOHOL_TOXIC, 1)
-		M.add_chemical_effect(CE_BREATHLOSS, 0.1 * boozed) //drinking and opiating makes breathing kinda hard
+		maximum_opiate_dose *= max(0.05,(1 - (boozed * 0.1))) //Drinking decreases the threshold for opiates to cut off breathing
 	if(isfast(M))
-		M.add_chemical_effect(CE_BREATHLOSS, 0.5)
-		M.add_chemical_effect(CE_SLOWDOWN, 2) //hyperzine reacts negatively with opiates
+		M.add_chemical_effect(CE_SLOWDOWN, 2)
+		maximum_opiate_dose *= 0.5
+	if (opiate_count > 1) //Mixing multiple opiates has an amplifying effect
+		maximum_opiate_dose *= max(0.05, (1 - ((opiate_count-1)/10)))
 
+	if (total_opiate_dose)
+		M.add_chemical_effect(CE_OPIATES, 1)
+	if (total_opiate_dose > 0.25 * maximum_opiate_dose)
+		M.add_chemical_effect(CE_SLOWDOWN, 1)
+	if (total_opiate_dose > 0.5 * maximum_opiate_dose)
+		M.add_chemical_effect(CE_SLOWDOWN, 1)
+		if (prob(5))
+			M.slurring = max(M.slurring, 10)
+	if (total_opiate_dose > 0.75 * maximum_opiate_dose)
+		M.add_chemical_effect(CE_SLOWDOWN, 1)
+		if (prob(10))
+			M.slurring = max(M.slurring, 20)
+	if (total_opiate_dose > maximum_opiate_dose)
+		M.add_chemical_effect(CE_SLOWDOWN, 1)
+		M.AdjustSleeping(5)
+		M.losebreath = max(10, M.losebreath + 1)
+
+
+///Class-effect overdose is handled under affect_blood; this proc handles overdose unique to having too much of the chemical in the body; not opiate breathing suppression.
 /datum/reagent/tramadol/overdose(mob/living/carbon/M)
 	..()
 	M.hallucination(120, 30)
 	M.druggy = max(M.druggy, 10)
-	M.add_chemical_effect(CE_PAINKILLER, pain_power*0.5) //extra painkilling for extra trouble
-	M.add_chemical_effect(CE_BREATHLOSS, 0.6) //Have trouble breathing, need more air
-	if(isboozed(M))
-		M.add_chemical_effect(CE_BREATHLOSS, 0.2) //Don't drink and OD on opiates folks
 	if(isfast(M))
 		M.add_chemical_effect(CE_NOPULSE, 1)
 		var/obj/item/organ/internal/heart = M.internal_organs_by_name[BP_HEART] //heart damage + arrest
@@ -345,8 +355,7 @@
 	color = "#800080"
 	scannable = 1
 	overdose = 20
-	pain_power = 200
-	effective_dose = 2
+	pain_power = 100
 
 /datum/reagent/deletrathol
 	name = "Deletrathol"

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -131,6 +131,8 @@ GLOBAL_LIST_EMPTY(mob_ref_to_species_name)
 	var/halloss_message_self = "The pain is too severe for you to keep going..."
 
 	var/limbs_are_nonsolid
+	/// Pain_power adjusted maximum opiate effect a species can tolerate before it stops breathing. Is modified by alcohol/hyperzine use.
+	var/maximum_opiate_dose = 40
 	var/spawns_with_stack = 0
 	// Environment tolerance/life processes vars.
 	var/breath_pressure = 16                                    // Minimum partial pressure safe for breathing, kPa


### PR DESCRIPTION
🆑 emmanuelbassil
balance: Reworks how opiate ODs work. Tramadol/Oxy's individual OD threshold now only handle non-sedating effects/hallucinations. Threshold for sedation is calculated differently.
balance: Each species has a cutoff for how much opiates they can tolerate; and the closer you get to the threshold the more sedating effects. All species have a similar cutoff for now.
balance: Sedating effects now scale up as pain control potency increases; up to a maximum threshold. 
balance: Once the maximum threshold is reached, the patient falls asleep and all breathing is stopped until metabolized opiate levels drop below the threshold.
balance: Drinking alcohol decreases the threshold by 10 to 20%, depending on the alcohol. Being on hyperzine decreases the threshold by 50%
balance: Having multiple opiates in the body increases the potency of both but also decreases the threshold of getting side effects. 
balance: There is no maximum potency for opiates; pain control is directly proportional to metabolized dose up to infinity.
tweak: Having any opiate metabolites in your system will constrict pupils. Past behavior used to constrict pupils before opiates metabolized and actually started working. 
/🆑 

Reworked how opiates work to more closely resemble real life. Also bothered me how allergies and opiates caused oxloss in the same way; despite working differently. The bonus is that now, someone zoinked out on opiates that does not have a CE_BREATHLOSS drug or lung damage can now last for 2 minutes without breathing until oxloss kicks in; which is more realistic.

Remaining to do before this is ready:

- [ ] Add Narcan-like effect to ethylredoxrazine; which will quickly get rid of opiate metabolite products. Downside is that this will also bring the pain roaring back.
- [ ] Pass by CE_BREATHLOSS to make sure it just means decreased efficiency in getting air into the lungs; not decreased breathing rate.
- [ ] Add traits for opiate sensitivity/resistance
- [ ] Find a better way to not duplicate opiate effect other than returning
- [ ] Switch losebreath to neurologic failure instead due to CE_OPIATES; more elegant. 
- [ ] Have sex and age affect sensitivity (?) 
- [ ] Discuss w/ species maintainers if they'd like their species to be more or less resistant to opiate sedation.
- [ ] Potentially have pain killing effect use total_opiate doses; and have painkilling effect scale up with dose.
- [ ] Make Opiates help with air hunger
- [ ] Testing! Testing! Testing!