### PR TITLE
Megaphones use your default language, and produce floating text

### DIFF
--- a/code/__defines/mobs.dm
+++ b/code/__defines/mobs.dm
@@ -501,3 +501,8 @@
 ///Flags assigned to carbon mobs trait_flags when they're actively having an allergy.
 #define MILD_ALLERGY FLAG_01
 #define SEVERE_ALLERGY FLAG_02
+
+// Runechat levels
+#define RUNECHAT_DEFAULT 0
+#define RUNECHAT_SMALL 1
+#define RUNECHAT_LARGE 2

--- a/code/game/objects/items/devices/megaphone.dm
+++ b/code/game/objects/items/devices/megaphone.dm
@@ -7,46 +7,34 @@
 	w_class = ITEM_SIZE_SMALL
 	obj_flags = OBJ_FLAG_CONDUCTIBLE
 
-	var/spamcheck = 0
-	var/emagged = FALSE
-	var/insults = 0
-	var/list/insultmsg = list("FUCK EVERYONE!", "I'M A TATER!", "ALL SECURITY TO SHOOT ME ON SIGHT!", "I HAVE A BOMB!", "CAPTAIN IS A COMDOM!", "FOR THE SYNDICATE!")
+	var/last_broadcasted = 0
 
 /obj/item/device/megaphone/attack_self(mob/living/user as mob)
 	if (user.client)
 		if(user.client.prefs.muted & MUTE_IC)
 			to_chat(src, SPAN_WARNING("You cannot speak in IC (muted)."))
 			return
-	if(user.silent)
+	if (user.silent)
 		return
-	if(spamcheck)
+	if (last_broadcasted && last_broadcasted + 2 SECONDS > world.time)
 		to_chat(user, SPAN_WARNING("\The [src] needs to recharge!"))
+		return
+	var/datum/language/current_spoken_language = user.get_audible_default_language()
+	if (!current_spoken_language)
+		to_chat(user, SPAN_WARNING("You do not have an audible language selected as your default!"))
 		return
 
 	var/message = sanitize(input(user, "Shout a message?", "Megaphone", null)  as text)
 	if(!message)
 		return
 	message = capitalize(message)
-	if ((src.loc == user && usr.stat == 0))
-		if(emagged)
-			if(insults)
-				for(var/mob/O in (viewers(user)))
-					O.show_message("<B>[user]</B> broadcasts, [FONT_LARGE("\"[pick(insultmsg)]\"")]",2) // 2 stands for hearable message
-				insults--
-			else
-				to_chat(user, SPAN_WARNING("*BZZZZzzzzzt*"))
-		else
-			for(var/mob/O in (viewers(user)))
-				O.show_message("<B>[user]</B> broadcasts, [FONT_LARGE("\"[message]\"")]",2) // 2 stands for hearable message
-
-		spamcheck = 1
-		spawn(20)
-			spamcheck = 0
-		return
-
-/obj/item/device/megaphone/emag_act(remaining_charges, mob/user)
-	if(!emagged)
-		to_chat(user, SPAN_WARNING("You overload \the [src]'s voice synthesizer."))
-		emagged = TRUE
-		insults = rand(1, 3)//to prevent dickflooding
-		return 1
+	if (src.loc == user && usr.stat == 0)
+		last_broadcasted = world.time
+		var/viewers = viewers(user)
+		var/clients = list()
+		for (var/mob/listener in viewers)
+			listener.hear_say(message, "broadcasts", current_spoken_language, "", FALSE, user, null, null, TRUE)
+			if (listener.client)
+				clients += listener.client
+		if (length(clients))
+			invoke_async(user, TYPE_PROC_REF(/atom/movable, animate_chat), message, current_spoken_language, RUNECHAT_LARGE, clients, "radio")

--- a/code/modules/mob/hear_say.dm
+++ b/code/modules/mob/hear_say.dm
@@ -1,4 +1,4 @@
-/mob/proc/hear_say(message, verb = "says", datum/language/language, alt_name, italics, mob/speaker, sound/speech_sound, sound_vol)
+/mob/proc/hear_say(message, verb = "says", datum/language/language, alt_name, italics, mob/speaker, sound/speech_sound, sound_vol, large_text = FALSE)
 	if (!client && !teleop)
 		return
 
@@ -112,7 +112,10 @@
 		teleop.on_hear_say({"[SPAN_CLASS("game say", "[display_controls][SPAN_NOTICE(SPAN_BOLD("NEAR YOU: "))][SPAN_CLASS("name", display_name)][alt_name] [display_message]")]"})
 		return
 
-	on_hear_say({"[SPAN_CLASS("game say", "[display_controls][SPAN_CLASS("name", display_name)][alt_name] [display_message]")]"})
+	var/final_message = {"[SPAN_CLASS("game say", "[display_controls][SPAN_CLASS("name", display_name)][alt_name] [display_message]")]"}
+	if (large_text)
+		final_message = "[FONT_LARGE(final_message)]"
+	on_hear_say(final_message)
 
 
 /mob/proc/on_hear_say(message)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -119,6 +119,12 @@ var/global/list/channel_to_radio_key = new
 /mob/living/proc/get_default_language()
 	return default_language
 
+/// Returns the current default lanauge *if* it's audible (excludes SIGNLANG, NONVERBAL, HIVEMIND)
+/mob/living/proc/get_audible_default_language()
+	if (!default_language || default_language.flags & (NONVERBAL | SIGNLANG | HIVEMIND))
+		return null
+	return default_language
+
 /mob/proc/is_muzzled()
 	return istype(wear_mask, /obj/item/clothing/mask/muzzle)
 

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -48,7 +48,7 @@ exactly 25 "text2path uses" 'text2path'
 exactly 5 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 4 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 328 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 327 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 0 "anchored = 0/1" 'anchored\s*=\s*\d' -P
 exactly 2 "density = 0/1" 'density\s*=\s*\d' -P


### PR DESCRIPTION
![dreamseeker_eM2NRi98oF](https://github.com/user-attachments/assets/130a0b32-08b1-4bcd-939a-6ad5f1e2a1af)

This uses the `radio` icon_state in the `floating_chat_icons.dmi` file; it appears unused. If there's plans for it, I can try to make a new icon.

Also includes some miscellaneous code cleanup, dropping the `spawn` use in favor of tracking `world.time` for megaphone cooldown.

:cl: Banditoz
tweak: Megaphones now use your current default audible language.
rscadd: Megaphones now produce floating text when used.
/:cl: