### PR TITLE
Resolves issues with Skrell objects that would otherwise cause tests to fail

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -933,6 +933,7 @@
 #include "code\game\objects\items.dm"
 #include "code\game\objects\munition.dm"
 #include "code\game\objects\objs.dm"
+#include "code\game\objects\skrell_props.dm"
 #include "code\game\objects\structures.dm"
 #include "code\game\objects\topic.dm"
 #include "code\game\objects\auras\aura.dm"

--- a/code/game/jobs/access_datum.dm
+++ b/code/game/jobs/access_datum.dm
@@ -474,3 +474,10 @@ var/global/const/access_merchant = "ACCESS_MERCHANT" //301
 	id = access_merchant
 	desc = "Merchant"
 	access_type = ACCESS_TYPE_NONE
+
+var/global/const/access_skrellscoutship = "ACCESS_SKRELLSCOUT"
+
+/datum/access/skrellscoutship
+	id = access_skrellscoutship
+	desc = "SSV Crewman"
+	region = ACCESS_REGION_NONE

--- a/code/game/objects/skrell_props.dm
+++ b/code/game/objects/skrell_props.dm
@@ -1,0 +1,85 @@
+//Skrell props for awaymissions and ruins featuring Skrell items
+
+//Skrell Lights
+
+/obj/machinery/light/skrell
+	name = "skrellian light"
+	light_type = /obj/item/light/tube/skrell
+	desc = "Some kind of strange alien lighting technology."
+
+/obj/item/light/tube/skrell
+	name = "skrellian light filament"
+	color = LIGHT_COLOUR_SKRELL
+	b_colour = LIGHT_COLOUR_SKRELL
+	desc = "Some kind of strange alien lightbulb technology."
+	random_tone = FALSE
+
+/obj/item/light/tube/large/skrell
+	name = "skrellian light filament"
+	color = LIGHT_COLOUR_SKRELL
+	b_colour = LIGHT_COLOUR_SKRELL
+	desc = "Some kind of strange alien lightbulb technology."
+
+/obj/item/storage/box/lights/tubes/skrell
+	name = "box of replacement tubes"
+	icon_state = "lighttube"
+	startswith = list(/obj/item/light/tube/skrell = 17,
+					/obj/item/light/tube/large/skrell = 4)
+
+//Skrell Suit Dispensers
+
+/obj/machinery/suit_storage_unit/skrell
+	boots = /obj/item/clothing/shoes/magboots
+	color = "#00e1ff"
+	helmet = /obj/item/clothing/head/helmet/space/void/skrell/white
+	islocked = 1
+	name = "Skrell Suit Storage Unit (White)"
+	req_access = list("ACCESS_SKRELLSCOUT")
+	suit = /obj/item/clothing/suit/space/void/skrell/white
+
+/obj/machinery/suit_storage_unit/skrell/black
+	boots = /obj/item/clothing/shoes/magboots
+	color = "#00e1ff"
+	helmet = /obj/item/clothing/head/helmet/space/void/skrell/black
+	islocked = 1
+	name = "Skrell Suit Storage Unit (Black)"
+	req_access = list("ACCESS_SKRELLSCOUT")
+	suit = /obj/item/clothing/suit/space/void/skrell/black
+
+//Skrell Devices
+
+/obj/item/tape_roll/skrell
+	name = "modular adhesive dispenser"
+	desc = "A roll of sticky tape. Possibly for taping ducks... or was that ducts?"
+	icon = 'icons/obj/bureaucracy.dmi'
+	icon_state = "taperoll"
+	color = "#40e0d0"
+	w_class = ITEM_SIZE_SMALL
+
+/obj/machinery/space_heater/skrell
+	color = "#40e0d0"
+	name = "thermal induction generator"
+	desc = "Made by Krri'gli Corp using thermal induction technology, this heater is guaranteed not to set anything, or anyone, on fire."
+	set_temperature = T0C+40
+
+/obj/machinery/vending/medical/skrell
+	req_access = list(access_skrellscoutship)
+
+/obj/machinery/power/apc/skrell
+	req_access = list(access_skrellscoutship)
+
+/obj/machinery/alarm/skrell
+	req_access = list(access_skrellscoutship)
+	target_temperature = T0C+40
+
+/obj/machinery/alarm/skrell/Initialize()
+	. = ..()
+	TLV["pressure"] =		list(ONE_ATMOSPHERE*0.80,ONE_ATMOSPHERE*0.90,ONE_ATMOSPHERE*1.30,ONE_ATMOSPHERE*1.40) /* kpa */
+	TLV["temperature"] =	list(T0C-26, T0C, T0C+80, T0C+90) // K
+
+/obj/machinery/alarm/skrell/server
+	target_temperature = T0C+10
+
+/obj/machinery/alarm/skrell/server/Initialize()
+	. = ..()
+	TLV["temperature"] =	list(T0C-26, T0C, T0C+30, T0C+40) // K

--- a/maps/away/skrellscoutship/skrellscoutship.dm
+++ b/maps/away/skrellscoutship/skrellscoutship.dm
@@ -49,14 +49,7 @@
 	)
 	call_webhook = WEBHOOK_SUBMAP_LOADED_SKRELL
 
-//Access + Loadout
-
-var/global/const/access_skrellscoutship = "ACCESS_SKRELLSCOUT"
-
-/datum/access/skrellscoutship
-	id = access_skrellscoutship
-	desc = "SSV Crewman"
-	region = ACCESS_REGION_NONE
+//Loadout
 
 /obj/item/card/id/skrellscoutship
 	color = COLOR_GRAY40
@@ -174,25 +167,6 @@ var/global/const/access_skrellscoutship = "ACCESS_SKRELLSCOUT"
 /datum/mil_rank/skrell_fleet
 	name = "NULL"
 
-/obj/machinery/power/apc/skrell
-	req_access = list(access_skrellscoutship)
-
-/obj/machinery/alarm/skrell
-	req_access = list(access_skrellscoutship)
-	target_temperature = T0C+40
-
-/obj/machinery/alarm/skrell/Initialize()
-	. = ..()
-	TLV["pressure"] =		list(ONE_ATMOSPHERE*0.80,ONE_ATMOSPHERE*0.90,ONE_ATMOSPHERE*1.30,ONE_ATMOSPHERE*1.40) /* kpa */
-	TLV["temperature"] =	list(T0C-26, T0C, T0C+80, T0C+90) // K
-
-/obj/machinery/alarm/skrell/server
-	target_temperature = T0C+10
-
-/obj/machinery/alarm/skrell/server/Initialize()
-	. = ..()
-	TLV["temperature"] =	list(T0C-26, T0C, T0C+30, T0C+40) // K
-
 /obj/machinery/power/smes/buildable/preset/skrell
 	uncreated_component_parts = list(
 		/obj/item/stock_parts/smes_coil/advanced = 2
@@ -202,9 +176,6 @@ var/global/const/access_skrellscoutship = "ACCESS_SKRELLSCOUT"
 	_input_on = TRUE
 	_output_on = TRUE
 	_fully_charged = TRUE
-
-/obj/machinery/vending/medical/skrell
-	req_access = list(access_skrellscoutship)
 
 /obj/machinery/power/apc/debug/skrell
 	cell_type = /obj/item/cell/infinite
@@ -246,66 +217,3 @@ var/global/const/access_skrellscoutship = "ACCESS_SKRELLSCOUT"
 		/obj/item/clothing/gloves,
 		/obj/item/gun/energy/gun/skrell
 		)
-
-//Skell Lights
-
-/obj/machinery/light/skrell
-	name = "skrellian light"
-	light_type = /obj/item/light/tube/skrell
-	desc = "Some kind of strange alien lighting technology."
-
-
-/obj/item/light/tube/skrell
-	name = "skrellian light filament"
-	color = LIGHT_COLOUR_SKRELL
-	b_colour = LIGHT_COLOUR_SKRELL
-	desc = "Some kind of strange alien lightbulb technology."
-	random_tone = FALSE
-
-/obj/item/light/tube/large/skrell
-	name = "skrellian light filament"
-	color = LIGHT_COLOUR_SKRELL
-	b_colour = LIGHT_COLOUR_SKRELL
-	desc = "Some kind of strange alien lightbulb technology."
-
-
-/obj/item/storage/box/lights/tubes/skrell
-	name = "box of replacement tubes"
-	icon_state = "lighttube"
-	startswith = list(/obj/item/light/tube/skrell = 17,
-					/obj/item/light/tube/large/skrell = 4)
-
-//Skrell Suit Dispensers
-/obj/machinery/suit_storage_unit/skrell
-	boots = /obj/item/clothing/shoes/magboots
-	color = "#00e1ff"
-	helmet = /obj/item/clothing/head/helmet/space/void/skrell/white
-	islocked = 1
-	name = "Skrell Suit Storage Unit (White)"
-	req_access = list("ACCESS_SKRELLSCOUT")
-	suit = /obj/item/clothing/suit/space/void/skrell/white
-
-/obj/machinery/suit_storage_unit/skrell/black
-	boots = /obj/item/clothing/shoes/magboots
-	color = "#00e1ff"
-	helmet = /obj/item/clothing/head/helmet/space/void/skrell/black
-	islocked = 1
-	name = "Skrell Suit Storage Unit (Black)"
-	req_access = list("ACCESS_SKRELLSCOUT")
-	suit = /obj/item/clothing/suit/space/void/skrell/black
-
-//Skrell Devices
-
-/obj/item/tape_roll/skrell
-	name = "modular adhesive dispenser"
-	desc = "A roll of sticky tape. Possibly for taping ducks... or was that ducts?"
-	icon = 'icons/obj/bureaucracy.dmi'
-	icon_state = "taperoll"
-	color = "#40e0d0"
-	w_class = ITEM_SIZE_SMALL
-
-/obj/machinery/space_heater/skrell
-	color = "#40e0d0"
-	name = "thermal induction generator"
-	desc = "Made by Krri'gli Corp using thermal induction technology, this heater is guaranteed not to set anything, or anyone, on fire."
-	set_temperature = T0C+40


### PR DESCRIPTION
This moves Skrell items (and the Skrell access) that would otherwise cause tests to fail out of skrellscoutship.dm into the new skrell_props.dm. These items (and the access) are used in the Skrell biodome ruin, and if skrellscoutship was ever not included, this would cause errors parsing the ruin map file.

The fact that you don't have separate map tests for ruins specifically seems like something of an oversight, because that's how this was caught on Urist (we have a separate test just for ruins and other map templates that we use). Hopefully this PR can save a headache for another confused downstream.