### PR TITLE
Fix hardsuit thrusters

### DIFF
--- a/code/modules/clothing/spacesuits/rig/modules/utility.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/utility.dm
@@ -373,21 +373,9 @@
 /obj/item/rig_module/maneuvering_jets/activate()
 	if(!..())
 		return FALSE
-	if(active)
-		return 0
-
-	active = 1
-
-	spawn(1)
-		if(suit_overlay_active)
-			suit_overlay = suit_overlay_active
-		else
-			suit_overlay = null
-		holder.update_icon()
-
 	if(!jets.on)
 		jets.toggle()
-	return 1
+	return TRUE
 
 /obj/item/rig_module/maneuvering_jets/deactivate()
 	if(!..())

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -48,7 +48,7 @@ exactly 25 "text2path uses" 'text2path'
 exactly 5 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 4 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 328 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 327 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 0 "anchored = 0/1" 'anchored\s*=\s*\d' -P
 exactly 2 "density = 0/1" 'density\s*=\s*\d' -P


### PR DESCRIPTION
:cl: Banditoz
bugfix: Fix hardsuit thrusters never activating.
/:cl:

The base `/obj/item/rig_module/proc/activate()` proc manipulates the `active` var, along with the child. The child proc immediately toggles it back off if toggled on. This removes the child's toggling.