### PR TITLE
Deck Four Catwalk Access Gets Windows + Floating/Window Lights Removal

### DIFF
--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -2262,6 +2262,11 @@
 /obj/structure/lattice,
 /turf/simulated/open,
 /area/maintenance/fourthdeck/starboard)
+"hD" = (
+/obj/machinery/door/firedoor,
+/obj/wallframe_spawn/reinforced/no_grille,
+/turf/simulated/floor/plating,
+/area/quartermaster/hangar/catwalks)
 "hE" = (
 /obj/wallframe_spawn/no_grille,
 /turf/simulated/floor/plating,
@@ -4224,9 +4229,6 @@
 /area/maintenance/fourthdeck/starboard)
 "oV" = (
 /obj/machinery/atmospherics/unary/vent_pump/on,
-/obj/machinery/light{
-	dir = 1
-	},
 /obj/floor_decal/corner/green{
 	dir = 4
 	},
@@ -4738,7 +4740,6 @@
 /turf/simulated/floor/plating,
 /area/hallway/primary/fourthdeck/fore)
 "rg" = (
-/obj/machinery/light,
 /obj/floor_decal/corner/brown{
 	dir = 4
 	},
@@ -6782,7 +6783,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/aft)
 "xL" = (
@@ -12361,7 +12361,6 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/machinery/light,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/fourthdeck/fore)
 "QD" = (
@@ -14282,6 +14281,7 @@
 /obj/floor_decal/corner/brown{
 	dir = 1
 	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/monotile,
 /area/hallway/primary/fourthdeck/aft)
 "VQ" = (
@@ -32343,9 +32343,9 @@ TT
 TT
 fl
 fl
-le
+hD
 NR
-le
+hD
 le
 iI
 wS
@@ -36787,9 +36787,9 @@ PJ
 PJ
 PJ
 PJ
-Xn
+hD
 NR
-Xn
+hD
 we
 Xn
 Xn


### PR DESCRIPTION
Fore:
![Deck Four Change 1](https://github.com/user-attachments/assets/2aeb3cfb-293b-46b7-966e-987f995c3845)
Aft:
![Deck Four Change 2](https://github.com/user-attachments/assets/ac24ab64-4fdf-4cdc-b054-7fd475237105)

**Note:** The pictures are slightly outdated, the windows are now part of the "Upper Catwalk" area.

:cl: JebediahTechnic
maptweak: Added windows to deck four catwalk access so all can witness the glory of the catwalks.
maptweak: Removed floating/window lights from deck four, no magic allowed.
/:cl: