### PR TITLE
Add verb for getting radio channels as borg

### DIFF
--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -48,7 +48,6 @@
 	if(distance > 1 || !radio_desc)
 		return
 
-	to_chat(user, "The following channels are available:")
 	to_chat(user, radio_desc)
 
 /obj/item/device/radio/headset/handle_message_mode(mob/living/M as mob, message, channel)
@@ -395,7 +394,7 @@
 		secure_radio_connections[ch_name] = radio_controller.add_object(src, radiochannels[ch_name],  RADIO_CHAT)
 
 	if(setDescription)
-		setupRadioDescription()
+		radio_desc = get_channels_as_string()
 
 /obj/item/device/radio/headset/proc/import_key_data(obj/item/device/encryptionkey/key)
 	if(!key)
@@ -408,14 +407,3 @@
 		src.translate_binary = 1
 	if(key.syndie)
 		src.syndie = 1
-
-/obj/item/device/radio/headset/proc/setupRadioDescription()
-	var/radio_text = ""
-	for(var/i = 1 to length(channels))
-		var/channel = channels[i]
-		var/key = get_radio_key_from_channel(channel)
-		radio_text += "[key] - [channel]"
-		if(i != length(channels))
-			radio_text += ", "
-
-	radio_desc = radio_text

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -221,6 +221,19 @@
 	else
 		STOP_PROCESSING(SSobj, src)
 
+/obj/item/device/radio/proc/get_channels_as_string()
+	if (!length(channels))
+		return "There are no extra channels available."
+	var/radio_text = "The following channels are available:\n"
+	for(var/i = 1 to length(channels))
+		var/channel = channels[i]
+		var/key = get_radio_key_from_channel(channel)
+		radio_text += "[key] - [channel]"
+		if(i != length(channels))
+			radio_text += ", "
+
+	return radio_text
+
 /obj/item/device/radio/CanUseTopic()
 	if(!on && !get_cell()) // We need to still be able to use the topic if we use power
 		return STATUS_CLOSE
@@ -683,6 +696,7 @@
 	var/mob/living/silicon/robot/myborg = null // Cyborg which owns this radio. Used for power checks
 	var/obj/item/device/encryptionkey/keyslot = null//Borg radios can handle a single encryption key
 	var/shut_up = 1
+	var/radio_desc = ""
 	icon = 'icons/obj/robot_component.dmi' // Cyborgs radio icons should look like the component.
 	icon_state = "radio"
 	canhear_range = 0
@@ -793,6 +807,7 @@
 			return
 
 		secure_radio_connections[ch_name] = radio_controller.add_object(src, radiochannels[ch_name],  RADIO_CHAT)
+	radio_desc = get_channels_as_string()
 
 /obj/item/device/radio/borg/Topic(href, href_list)
 	if(..())

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -358,6 +358,14 @@
 		to_chat(src, "You [locked ? "un" : ""]lock your panel.")
 		locked = !locked
 
+/mob/living/silicon/robot/verb/get_radio_channels()
+	set name = "Show Radio Channels"
+	set category = "Silicon Commands"
+
+	var/obj/item/device/radio/borg/borg_radio = silicon_radio
+	if (istype(borg_radio))
+		to_chat(src, borg_radio.radio_desc)
+
 /mob/living/silicon/robot/proc/self_diagnosis()
 	if(!is_component_functioning("diagnosis unit"))
 		return null


### PR DESCRIPTION
:cl: Banditoz
rscadd: Borgs can now click on Show Radio Channels under Silicon Commands to see what channels they have available, a la headsets.
/:cl:

Also adds no extra channels text when no radio keys installed.