### PR TITLE
Makes light fixture overlays properly respect lighting modes

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -299,7 +299,10 @@
 	if(istype(lightbulb, /obj/item/light))
 		if (on)
 			AddOverlays(emissive_appearance(icon, _state))
-		AddOverlays(overlay_image(icon, _state, lightbulb.color))
+		if (current_mode in lightbulb.lighting_modes)
+			AddOverlays(overlay_image(icon, _state, lightbulb.lighting_modes[current_mode]["l_color"]))
+		else
+			AddOverlays(overlay_image(icon, _state, lightbulb.color))
 
 	if(on)
 


### PR DESCRIPTION
:cl:
bugfix: Lights now respect lighting mode (standard, emergency, etc) as well as bulb color.
/:cl:

Lighting overlay updates previously only relied on the bulb colour, and not the lighting mode colour, which meant that they wouldn't properly update when the lighting mode changed lightbulb colours. This fixes that issue.