### PR TITLE
Enforce usage of `*_REF` in callbacks

### DIFF
--- a/code/datums/callbacks.dm
+++ b/code/datums/callbacks.dm
@@ -3,7 +3,7 @@
 Callbacks wrap a target, callable, and arguments to pass. See the dm reference for call().
 When the target is GLOBAL_PROC, the callable is global - otherwise it is a datum (or dead) reference.
 Callbacks are created with the new keyword via a global alias like:
-- var/datum/callback/instance = new Callback(GLOBAL_PROC, /proc/get_area, someObject)
+- var/datum/callback/instance = new Callback(GLOBAL_PROC, GLOBAL_PROC_REF(get_area), someObject)
 Callbacks are thin - they should be used with invoke or invoke_async.
 
 ** Invocation

--- a/code/modules/weather/weather_init.dm
+++ b/code/modules/weather/weather_init.dm
@@ -33,7 +33,7 @@ INITIALIZE_IMMEDIATE(/obj/abstract/weather_system)
 
 	// If we're post-init, init immediately.
 	if(SSweather.initialized)
-		addtimer(new Callback(src, .proc/init_weather), 0)
+		addtimer(new Callback(src, PROC_REF(init_weather)), 0)
 
 // Start the weather effects from the highest point; they will propagate downwards during update.
 /obj/abstract/weather_system/proc/init_weather()

--- a/code/modules/weather/weather_mob_tracking.dm
+++ b/code/modules/weather/weather_mob_tracking.dm
@@ -15,7 +15,7 @@ var/global/list/current_mob_ambience = list()
 	var/mobref = weakref(M)
 	if(!(mobref in mobs_on_cooldown))
 		mobs_on_cooldown[mobref] = TRUE
-		addtimer(new Callback(src, .proc/clear_cooldown, mobref), delay)
+		addtimer(new Callback(src, PROC_REF(clear_cooldown), mobref), delay)
 		return TRUE
 	return FALSE
 

--- a/packs/legion/helpers/legion_recall.dm
+++ b/packs/legion/helpers/legion_recall.dm
@@ -35,7 +35,7 @@
 		return
 	var/mob/recallee = pick_n_take(remaining)
 	legion_recall(recallee)
-	addtimer(new Callback(GLOBAL_PROC, /proc/legion_mass_recall_recurse, remaining), 0.1 SECONDS)
+	addtimer(new Callback(GLOBAL_PROC, GLOBAL_PROC_REF(legion_mass_recall_recurse), remaining), 0.1 SECONDS)
 
 
 /client/proc/cmd_legion_mass_recall()

--- a/packs/legion/mob/legion_speculator.dm
+++ b/packs/legion/mob/legion_speculator.dm
@@ -153,7 +153,7 @@
 	)
 	cloaking = TRUE
 	animate(src, alpha = 0, time = 1 SECOND)
-	addtimer(new Callback(src, .proc/post_cloak, TRUE), 1 SECOND)
+	addtimer(new Callback(src, PROC_REF(post_cloak), TRUE), 1 SECOND)
 	playsound(loc, pick(cloak_sounds), 50, TRUE)
 
 
@@ -168,7 +168,7 @@
 	)
 	cloaking = TRUE
 	animate(src, alpha = 255, time = 1 SECOND)
-	addtimer(new Callback(src, .proc/post_cloak, FALSE), 1 SECOND)
+	addtimer(new Callback(src, PROC_REF(post_cloak), FALSE), 1 SECOND)
 	playsound(loc, pick(uncloak_sounds), 50, TRUE)
 
 
@@ -199,7 +199,7 @@
 	if (time < 2 SECONDS)
 		time = 2 SECONDS
 	uncloak()
-	addtimer(new Callback(src, .proc/cloak), time, TIMER_UNIQUE)
+	addtimer(new Callback(src, PROC_REF(cloak)), time, TIMER_UNIQUE)
 
 
 /// A brief cloaking flicker effect. Intended to partially reveal the mob's location without fully decloaking. See `FLICKER_TIME` for some configuration.

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -69,6 +69,7 @@ exactly 0 "istype /icon where isicon should be used" 'istype\(.*?,\s*/icon\s*\)'
 exactly 0 "istype /list where islist should be used" 'istype\(.*?,\s*/list\s*\)' -P
 exactly 0 "istype /atom where isloc should be used" 'istype\(.*?,\s*/atom\s*\)' -P
 exactly 0 "istype atom/movable where ismovable should be used" 'istype\(.*?,\s*/atom/movable\s*\)' -P
+exactly 0 "callback proc/ or verb/ where PROC_REF, VERB_REF, etc should be used" 'Callback\([\w/]*,\s*[\w\./]*proc' -P # Callback(src, .proc/foo) should be Callback(src, PROC_REF(foo)), or equivalent. See code\__defines\procs.dm
 # If you increase any of these numbers you're probably doing it wrong
 
 num=`find ./html/changelogs -not -name "*.yml" | wc -l`


### PR DESCRIPTION
NUFC.

Adds a test to enforce usage of `PROC_REF()`, `VERB_REF()`, etc instead of proc paths in Callbacks.