### PR TITLE
Supermatter alarm is yellow

### DIFF
--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -684,6 +684,7 @@
 	construct_state = /singleton/machine_construction/default/item_chassis
 	base_type = /obj/machinery/rotating_alarm/supermatter
 
+	angle = 15
 	sound_file = 'sound/obj/machinery/rotating_alarm/supermatter.ogg'
 
 /obj/machinery/rotating_alarm/supermatter/Initialize()


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
tweak: The supermatter alarm is now yellow, to differentiate it from orange alert.
/:cl:

![dreamseeker_OKUnN7iLQz](https://github.com/user-attachments/assets/ca121fb6-f339-4c9c-81ac-31efa692d568)
