### PR TITLE
Antag skill selection UI/UX rework

### DIFF
--- a/nano/css/shared.css
+++ b/nano/css/shared.css
@@ -30,7 +30,7 @@ hr {
     height: 1px;
 }
 
-.link, .linkOn, .linkOff, .selected, .disabled, .yellowButton, .redButton {
+.link, .linkOn, .linkOff, .selected, .warning, .disabled, .yellowButton, .redButton {
     float: left;
     min-width: 15px;
     height: 16px;
@@ -80,6 +80,16 @@ a.white:hover {
 .linkOn, a.linkOn:link, a.linkOn:visited, a.linkOn:active, a.linkOn:hover, .selected, a.selected:link, a.selected:visited, a.selected:active, a.selected:hover {
     color: #ffffff;
     background: #2f943c;
+}
+
+.linkWarning, a.linkWarning:link, a.linkWarning:visited, a.linkWarning:active, a.linkWarning:hover, .warning, a.warning:link, a.warning:visited, a.warning:active, a.warning:hover {
+    color: #ffffff;
+    background: #ff5805;
+}
+
+.warning:hover {
+    color: #ffffff !important;
+    background: #cc7f58 !important;
 }
 
 .linkOff, a.linkOff:link, a.linkOff:visited, a.linkOff:active, a.linkOff:hover, .disabled, a.disabled:link, a.disabled:visited, a.disabled:active, a.disabled:hover {

--- a/nano/templates/skill_ui_antag.tmpl
+++ b/nano/templates/skill_ui_antag.tmpl
@@ -1,30 +1,27 @@
 <center><h2>Skills for {{:data.name}}</h2></center>
-<h3>Current assignment: {{:data.job}}</h3>
+<h3>Current assignment: {{:data.job}}{{if data.job !== data.special_role}}, {{:data.special_role}}{{/if}}</h3>
 {{if data.can_choose}}
 	<h3>Choose extra skills:</h3>
 	{{for data.selection_data}}
-		<div class='item'>
-			<div class = 'itemLabel'>
+		<div class="item">
+			<div class="itemLabel">
 				{{:value.name}}
 			</div>
-			<div class = 'itemContent'>
+			<div class="itemContent">
 				Remaining: {{:value.remaining}}
 			</div>
 		</div>
-		<div class='block'>
-			{{for value.selected :selected_value:selected_key}}
-				{{:helper.link(selected_value.name, null, {'remove_skill' : selected_value.ref})}}<br><br>
-			{{/for}}
-		</div>	
-		{{:helper.link("Add", null, {'add_skill' : value.level}, value.remaining ? null : 'disabled')}}
 	{{/for}}
-	<br><br>
-	{{:helper.link("Submit selection", null, {'submit' : 1})}}
 {{else}}
 	<h3>You may not reselect your skills.</h3>
 	{{:helper.link("Ask admins for a reset", null, {'admin_reset' : 1})}}
 {{/if}}
-<center><h2>Current Skills</h2></center>
+{{if data.can_choose}}
+	<center><h2>Choose extra skills:</h2></center>
+	{{:helper.link("Submit selection", null, {'submit' : 1})}}
+{{else}}
+	<center><h2>Current skills</h2></center>
+{{/if}}
 <table style="width:100%">
 {{for data.skills_by_cat}}
 	<tr>
@@ -35,16 +32,28 @@
 	{{for value.skills :skill_value:skill_key}}
 		<tr>
 		<td>
-		<div class="itemLabel">
+		<div class="itemLabel" style="width: 100% !important; max-width: 100%;">
 			{{:skill_value.name}}:
 		</div>
 		</td>
 		{{for skill_value.levels :level_value:level_key}}
 			<td>
 			{{if !level_value.blank}}
-			<div class={{if level_value.selected}}'selected'{{else}}'null'{{/if}}>
-				{{:level_value.name}}
-			</div>
+				<div>
+				{{if level_value.selected}}
+					{{:helper.link(level_value.name, null, {}, null, 'selected')}}
+				{{else !data.can_choose}}
+					{{:helper.link(level_value.name, null, {}, null, 'disabled')}}
+				{{else !level_value.selected}}
+					{{if level_value.marked_for_selection}}
+						{{:helper.link(level_value.name, null, {'remove_skill' : level_value.val, 'skill' : skill_value.ref}, null, 'warning')}}
+					{{else !level_value.marked_for_selection && !level_value.limit_exceeded}}
+						{{:helper.link(level_value.name, null, {'add_skill' : level_value.val, 'skill' : skill_value.ref}, null)}}
+					{{else !level_value.marked_for_selection && level_value.limit_exceeded}}
+						{{:helper.link(level_value.name, null, {}, null, 'disabled')}}
+					{{/if}}
+				{{/if}}
+				</div>
 			{{/if}}
 			</td>
 		{{/for}}
@@ -52,4 +61,4 @@
 	{{/for}}
 {{/for}}
 </table>
-
+{{if data.can_choose}}{{:helper.link("Submit selection", null, {'submit' : 1})}}{{/if}}


### PR DESCRIPTION
* Makes selecting antag skills more like character setup, where you press buttons on a table
* Orange skill levels are what you have selected, before you submit your selection. Press it again to deselect it, giving you the bonus back to use somewhere else.
* Buttons are greyed out if you don't have any bonuses in that level.
* Skills you already have are now filled in with green by levels that proceed it, e.x. basic would also fill in unskilled.

### Examples
#### Video
https://github.com/user-attachments/assets/e098a31d-7e1a-461e-a92a-2978c2c7b7ee
#### Screenshot
![bq5uaZphqp](https://github.com/user-attachments/assets/5eac702e-0ed8-485a-b8f6-a6770abdc367)

:cl: Banditoz
tweak: The antag skill selection UI has been reworked. You now press buttons on the skill table, like in the character setup menu, instead of a separate list pop-up.
admin: In the admin skill selection menu, the selected level's proceeding lesser levels are now filled in with green, like in the character setup menu.
/:cl:
