### PR TITLE
Allow admins to bypass most checks when making someone an antagonist

### DIFF
--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -219,9 +219,12 @@
 				return
 			var/result = antag.can_become_antag_detailed(src, TRUE)
 			if(result)
-				to_chat(usr, SPAN_WARNING("\The [src] could not be made into a [antag.role_text]! [result]."))
+				if(alert("Are you sure you want to bypass most checks and make [src] a [antag.role_text]? Failure reason:\n[result]", "Antag restriction check failed", "Yes", "No") != "Yes")
+					return
+			// last chance to bail out
+			if(alert("Are you sure you want to make [src] a [antag.role_text]?", "Are you sure?", "Yes", "No") != "Yes")
 				return
-			if(antag.add_antagonist(src, 1, 1, 0, 1, 1)) // Ignore equipment and role type for this.
+			if(antag.add_antagonist(src, TRUE, TRUE, FALSE, TRUE, TRUE, TRUE)) // Ignore most checks for this.
 				log_admin("[key_name_admin(usr)] made [key_name(src)] into a [antag.role_text].")
 			else
 				to_chat(usr, SPAN_WARNING("\The [src] could not be made into a [antag.role_text]!"))

--- a/code/game/antagonist/antagonist_add.dm
+++ b/code/game/antagonist/antagonist_add.dm
@@ -1,6 +1,6 @@
-/datum/antagonist/proc/add_antagonist(datum/mind/player, ignore_role, do_not_equip, move_to_spawn, do_not_announce, preserve_appearance)
+/datum/antagonist/proc/add_antagonist(datum/mind/player, ignore_role, do_not_equip, move_to_spawn, do_not_announce, preserve_appearance, bypass = FALSE)
 
-	if(!add_antagonist_mind(player, ignore_role))
+	if(!add_antagonist_mind(player, ignore_role, bypass=bypass))
 		return
 
 	if(base_to_load)
@@ -34,14 +34,14 @@
 		player.current.faction = faction
 	return 1
 
-/datum/antagonist/proc/add_antagonist_mind(datum/mind/player, ignore_role, nonstandard_role_type, nonstandard_role_msg)
+/datum/antagonist/proc/add_antagonist_mind(datum/mind/player, ignore_role, nonstandard_role_type, nonstandard_role_msg, bypass = FALSE)
 	if(!istype(player))
 		return 0
 	if(!player.current)
 		return 0
 	if(player in current_antagonists)
 		return 0
-	if(!can_become_antag(player, ignore_role))
+	if (!bypass && !can_become_antag(player, ignore_role))
 		return 0
 	current_antagonists |= player
 	GLOB.destroyed_event.register(player, src, PROC_REF(remove_antagonist))


### PR DESCRIPTION
Also adds a final "Are you sure?" prompt that should help prevent the wrong antag type being used.

:cl: Banditoz
admin: Most eligibility checks can now be bypassed when forcing someone to be an antagonist.
/:cl:

![dreamseeker_fM4Mx9rz6V](https://github.com/user-attachments/assets/80e121db-519f-4e33-a341-26db779d9272)
![dreamseeker_WyHtgTA4IN](https://github.com/user-attachments/assets/43e9d4ad-eee0-4623-96a4-076c212f56da)
