### PR TITLE
Check if weather exists before is_outside in weather processing

### DIFF
--- a/code/controllers/subsystems/weather_atoms.dm
+++ b/code/controllers/subsystems/weather_atoms.dm
@@ -34,14 +34,14 @@ SUBSYSTEM_DEF(weather_atoms)
 			weather_atoms -= atom
 			continue
 
-		// Not outside, or not on a turf with a Z- weather is not relevant.
-		if(!atom.z || !atom.is_outside())
-			continue
-
 		// If weather does not exist, we don't care.
 		weather = atom.get_affecting_weather()
 		weather_state = weather?.weather_system?.current_state
 		if(!istype(weather_state))
+			continue
+
+		// Not outside, or not on a turf with a Z- weather is not relevant.
+		if(!atom.z || !atom.is_outside())
 			continue
 
 		// Process the atom and return early if needed.


### PR DESCRIPTION
Roughly halves the weather atoms subsystem processing time
No user facing changes

Before:
![tracy-profiler_rHBPZYy82t](https://github.com/user-attachments/assets/8f1ee45d-7bc9-4b0c-8383-8f460cc94014)

After:
![tracy-profiler_aZcOIdmWmx](https://github.com/user-attachments/assets/695256a8-5ff3-461d-b97a-a2274ede00ff)
