### PR TITLE
resolve issue 35248

### DIFF
--- a/code/modules/reagents/reagent_containers/food/condiment.dm
+++ b/code/modules/reagents/reagent_containers/food/condiment.dm
@@ -132,6 +132,7 @@
 	starting_reagents = list(/datum/reagent/nutriment/flour = 50)
 
 /obj/item/reagent_containers/food/condiment/mint
+	name = "mint essential oil"
 	starting_reagents = list(/datum/reagent/nutriment/mint = 15)
 
 /obj/item/reagent_containers/food/condiment/soysauce


### PR DESCRIPTION
:cl:
bugfix: Mint oil shows up with the correct name in booze-o-mats.
/:cl:

fixes #35248

Not ideal but I'm not redoing that entire stack to resolve an order of operations that only causes a UI issue.
