### PR TITLE
Legion tweaks

### DIFF
--- a/packs/legion/mob/legion_bellator.dm
+++ b/packs/legion/mob/legion_bellator.dm
@@ -9,8 +9,8 @@
 	pixel_x = -16
 	pixel_y = -16
 
-	maxHealth = 200
-	health = 200
+	maxHealth = 300
+	health = 300
 	armor_type = /datum/extension/armor
 	natural_armor = list(
 		"melee" = ARMOR_MELEE_RESISTANT,

--- a/packs/legion/mob/legion_mob.dm
+++ b/packs/legion/mob/legion_mob.dm
@@ -56,6 +56,13 @@
 	return ..()
 
 
+/mob/living/simple_animal/hostile/legion/bullet_act(obj/item/projectile/Proj)
+	if (istype(Proj, /obj/item/projectile/beam/legion))
+		return PROJECTILE_FORCE_MISS
+
+	. = ..()
+
+
 /mob/living/simple_animal/hostile/legion/get_bullet_impact_effect_type(def_zone)
 	return BULLET_IMPACT_METAL
 


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
balance: Legion laser beams (The dark purple/black ones) now go through legion mobs instead of impacting them in tight spaces (Not hacked bots, just the bespoke ones). Beware the horde.
balance: Increased legion bellator health.
/:cl: