### PR TITLE
Splits awards into their own loadout category

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1625,6 +1625,7 @@
 #include "code\modules\client\preference_setup\loadout\loadout.dm"
 #include "code\modules\client\preference_setup\loadout\lists\accessories.dm"
 #include "code\modules\client\preference_setup\loadout\lists\augments.dm"
+#include "code\modules\client\preference_setup\loadout\lists\awards.dm"
 #include "code\modules\client\preference_setup\loadout\lists\clothing.dm"
 #include "code\modules\client\preference_setup\loadout\lists\earwear.dm"
 #include "code\modules\client\preference_setup\loadout\lists\eyegear.dm"

--- a/code/modules/client/preference_setup/loadout/lists/accessories.dm
+++ b/code/modules/client/preference_setup/loadout/lists/accessories.dm
@@ -60,23 +60,6 @@
 	flags = GEAR_HAS_COLOR_SELECTION
 
 
-/datum/gear/accessory/ntaward
-	display_name = "corporate award selection"
-	description = "A medal or ribbon awarded to corporate personnel for significant accomplishments."
-	path = /obj/item/storage/medalbox
-	cost = 6
-	flags = GEAR_HAS_NO_CUSTOMIZATION | GEAR_HAS_EXTENDED_DESCRIPTION
-
-
-/datum/gear/accessory/ntaward/New()
-	..()
-	var/ntawards = list()
-	ntawards["sciences medal"] = /obj/item/storage/medalbox/corp_science
-	ntawards["distinguished service"] = /obj/item/storage/medalbox/corp_service
-	ntawards["command medal"] = /obj/item/storage/medalbox/corp_command
-	gear_tweaks += new/datum/gear_tweak/path(ntawards)
-
-
 /datum/gear/accessory/armband_security
 	display_name = "security armband"
 	path = /obj/item/clothing/accessory/armband

--- a/code/modules/client/preference_setup/loadout/lists/awards.dm
+++ b/code/modules/client/preference_setup/loadout/lists/awards.dm
@@ -1,0 +1,21 @@
+/datum/gear/award
+	sort_category = "Awards"
+	category = /datum/gear/award
+	slot = slot_tie
+
+/datum/gear/award/ntaward
+	display_name = "corporate award, service medal"
+	description = "A silver medal awarded to employees for distinguished service in support of corporate interests."
+	path = /obj/item/storage/medalbox/corp_service
+	cost = 6
+	flags = GEAR_HAS_NO_CUSTOMIZATION
+
+/datum/gear/award/ntaward/science
+	display_name = "corporate award, sciences medal"
+	description = "A bronze medal awarded to employees for signifigant contributions to the fields of science or engineering."
+	path = /obj/item/storage/medalbox/corp_science
+
+/datum/gear/award/ntaward/command
+	display_name = "corporate award, command medal"
+	description = "A gold medal awarded to employees for service as the Captain of a corporate facility, station, or vessel."
+	path = /obj/item/storage/medalbox/corp_command

--- a/maps/torch/loadout/loadout_accessories.dm
+++ b/maps/torch/loadout/loadout_accessories.dm
@@ -1,58 +1,3 @@
-/datum/gear/accessory/solgov_award_military
-	display_name = "SolGov military award selection"
-	description = "A selection of military awards awarded by the Sol Central Government."
-	path = /obj/item/storage/medalbox/sol
-	cost = 6
-	allowed_branches = SOLGOV_BRANCHES
-	flags = GEAR_HAS_NO_CUSTOMIZATION | GEAR_HAS_EXTENDED_DESCRIPTION
-
-/datum/gear/accessory/solgov_award_military/New()
-	..()
-	var/solmilitary = list()
-	solmilitary["Bronze Heart"] = /obj/item/storage/medalbox/sol/bronze_heart
-	solmilitary["Home Guard medal"] = /obj/item/storage/medalbox/sol/home_guard
-	solmilitary["Iron Star"] = /obj/item/storage/medalbox/sol/iron_star
-	solmilitary["Combat Medical Award"] = /obj/item/storage/medalbox/sol/medical
-	solmilitary["Armed Forces medal"] = /obj/item/storage/medalbox/sol/armed_forces
-	solmilitary["Silver Sword"] = /obj/item/storage/medalbox/sol/silver_sword
-	solmilitary["Superior Service Cross"] = /obj/item/storage/medalbox/sol/service_cross
-	solmilitary["Medal of Honor"] = /obj/item/storage/medalbox/sol/medal_of_honor
-	gear_tweaks += new/datum/gear_tweak/path(solmilitary)
-
-/datum/gear/accessory/solgov_award_civilian
-	display_name = "SolGov civilian award selection"
-	description = "A selection of civilian awards awarded by the Sol Central Government."
-	path = /obj/item/storage/medalbox/sol
-	cost = 3
-	flags = GEAR_HAS_NO_CUSTOMIZATION | GEAR_HAS_EXTENDED_DESCRIPTION
-
-/datum/gear/accessory/solgov_award_civilian/New()
-	..()
-	var/solcivilian = list()
-	solcivilian["Expeditionary Medal"] = /obj/item/storage/medalbox/sol/expeditionary
-	solcivilian["Sapientarian Peace Award"] = /obj/item/storage/medalbox/sol/sapientarian
-	solcivilian["Distinguished Service Medal"] = /obj/item/storage/medalbox/sol/service
-	gear_tweaks += new/datum/gear_tweak/path(solcivilian)
-
-/datum/gear/accessory/solgov_award_ribbons
-	display_name = "SolGov ribbon selection"
-	description = "A selection of decorations and medal ribbons awarded by the Sol Central Government."
-	path = /obj/item/clothing/accessory/ribbon/solgov
-	cost = 3
-	allowed_branches = SOLGOV_BRANCHES
-	flags = GEAR_HAS_NO_CUSTOMIZATION
-
-/datum/gear/accessory/solgov_award_ribbons/New()
-	..()
-	var/solribbons = list()
-	solribbons["Marksmanship ribbon"] = /obj/item/clothing/accessory/ribbon/solgov/marksman
-	solribbons["Peacekeeping ribbon"] = /obj/item/clothing/accessory/ribbon/solgov/peace
-	solribbons["Frontier ribbon"] = /obj/item/clothing/accessory/ribbon/solgov/frontier
-	solribbons["Instructor ribbon"] = /obj/item/clothing/accessory/ribbon/solgov/instructor
-	solribbons["Combat Action ribbon"] = /obj/item/clothing/accessory/ribbon/solgov/combat
-	solribbons["Gaia Conflict ribbon"] = /obj/item/clothing/accessory/ribbon/solgov/gaiaconflict
-	solribbons["Distinguished unit ribbon"] = /obj/item/clothing/accessory/ribbon/solgov/distinguished_unit
-	gear_tweaks += new/datum/gear_tweak/path(solribbons)
 
 /datum/gear/accessory/tags
 	display_name = "dog tags"
@@ -150,9 +95,6 @@
 	flags = GEAR_HAS_NO_CUSTOMIZATION
 
 /datum/gear/accessory/armband_nt
-	allowed_branches = CIVILIAN_BRANCHES
-
-/datum/gear/accessory/ntaward
 	allowed_branches = CIVILIAN_BRANCHES
 
 /datum/gear/accessory/tie

--- a/maps/torch/loadout/loadout_awards.dm
+++ b/maps/torch/loadout/loadout_awards.dm
@@ -1,3 +1,20 @@
+/datum/gear/award/solgov_award_civilian
+	display_name = "SolGov civilian award, Expeditionary"
+	description = "An iron medal awarded by the SCG for individuals who have participated in missions outside the borders of the Sol Central Government."
+	path = /obj/item/storage/medalbox/sol/expeditionary
+	cost = 3
+	flags = GEAR_HAS_NO_CUSTOMIZATION | GEAR_HAS_EXTENDED_DESCRIPTION
+
+/datum/gear/award/solgov_award_civilian/sapientarian
+	display_name = "SolGov civilian award, Sapientarian Peace Award"
+	description = "A copper medal awarded by the SCG for individuals who have contributed substantially to sapient rights or fostered greater brotherhood between sapient species. It is embossed with a date, text, and an image of famous Expeditionary Corps sapientarian, Samuel Carr."
+	path = /obj/item/storage/medalbox/sol/sapientarian
+
+/datum/gear/award/solgov_award_civilian/service
+	display_name = "SolGov civilian award, Distinguished Service Medal"
+	description = "A golden sun medal awarded by the SCG to nonmilitary individuals who have made exceptional contributions to the Sol Central Government."
+	path = /obj/item/storage/medalbox/sol/service
+
 /datum/gear/award/solgov_award_military
 	display_name = "SolGov military award, Bronze Heart"
 	description = "A bronze heart awarded by the SCG for members of the SCG Defense Forces who suffer injury or death in a combat zone."
@@ -40,23 +57,6 @@
 	display_name = "SolGov military award, Medal of Honor"
 	description = "An ornate golden medal awarded and conferred by the SCG Secretary-General to members of the SCG Defense Forces who have committed acts of 'conspicuous gallantry beyond the call of duty.'"
 	path = /obj/item/storage/medalbox/sol/medal_of_honor
-
-/datum/gear/award/solgov_award_civilian
-	display_name = "SolGov civilian award, Expeditionary"
-	description = "An iron medal awarded by the SCG for individuals who have participated in missions outside the borders of the Sol Central Government."
-	path = /obj/item/storage/medalbox/sol/expeditionary
-	cost = 3
-	flags = GEAR_HAS_NO_CUSTOMIZATION | GEAR_HAS_EXTENDED_DESCRIPTION
-
-/datum/gear/award/solgov_award_civilian/sapientarian
-	display_name = "SolGov civilian award, Sapientarian Peace Award"
-	description = "A copper medal awarded by the SCG for individuals who have contributed substantially to sapient rights or fostered greater brotherhood between sapient species. It is embossed with a date, text, and an image of famous Expeditionary Corps sapientarian, Samuel Carr."
-	path = /obj/item/storage/medalbox/sol/sapientarian
-
-/datum/gear/award/solgov_award_civilian/service
-	display_name = "SolGov civilian award, Distinguished Service Medal"
-	description = "A golden sun medal awarded by the SCG to nonmilitary individuals who have made exceptional contributions to the Sol Central Government."
-	path = /obj/item/storage/medalbox/sol/service
 
 /datum/gear/award/solgov_award_ribbons
 	display_name = "SolGov ribbon, Marksmanship"

--- a/maps/torch/loadout/loadout_awards.dm
+++ b/maps/torch/loadout/loadout_awards.dm
@@ -1,0 +1,100 @@
+/datum/gear/award/solgov_award_military
+	display_name = "SolGov military award, Bronze Heart"
+	description = "A bronze heart awarded by the SCG for members of the SCG Defense Forces who suffer injury or death in a combat zone."
+	path = /obj/item/storage/medalbox/sol/bronze_heart
+	cost = 6
+	allowed_branches = SOLGOV_BRANCHES
+	flags = GEAR_HAS_NO_CUSTOMIZATION
+
+/datum/gear/award/solgov_award_military/home_guarrd
+	display_name = "SolGov military award, Home Guard"
+	description = "A bronze medal awarded by the SCG for members of the SCG Defense Forces who have helped defend the border regions of Sol."
+	path = /obj/item/storage/medalbox/sol/home_guard
+
+/datum/gear/award/solgov_award_military/iron_star
+	display_name = "SolGov military award, Iron Star"
+	description = "An iron star awarded by the SCG to members of the SCG Defense Forces who have performed acts of 'meritorious achievements or service.'"
+	path = /obj/item/storage/medalbox/sol/iron_star
+
+/datum/gear/award/solgov_award_military/medical
+	display_name = "SolGov military award, Combat Medical Award"
+	description = "An electrum heart medal with a Staff of Hermes and sanguine cross, awarded by the SCG to individuals who have served as medical personnel in an active combat zone."
+	path = /obj/item/storage/medalbox/sol/medical
+
+/datum/gear/award/solgov_award_military/armed_forces
+	display_name = "SolGov military award, Armed Forces"
+	description = "A brass medal awarded by the SCG for members of the SCG Defense Forces who have performed distinguishing acts outside of direct combat with an enemy."
+	path = /obj/item/storage/medalbox/sol/armed_forces
+
+/datum/gear/award/solgov_award_military/silver_sword
+	display_name = "SolGov military award, Silver Sword"
+	description = "A silver medal awarded by the SCG for members of the SCG Defense Forces who have demonstrated exceptional valor in combat."
+	path = /obj/item/storage/medalbox/sol/silver_sword
+
+/datum/gear/award/solgov_award_military/service_cross
+	display_name = "SolGov military award, Superior Service Cross"
+	description = "A copper cross awarded by the SCG for members of the SCG Defense Forces who have performed acts of incredible valor against an enemy of Sol."
+	path = /obj/item/storage/medalbox/sol/service_cross
+
+/datum/gear/award/solgov_award_military/medal_of_honor
+	display_name = "SolGov military award, Medal of Honor"
+	description = "An ornate golden medal awarded and conferred by the SCG Secretary-General to members of the SCG Defense Forces who have committed acts of 'conspicuous gallantry beyond the call of duty.'"
+	path = /obj/item/storage/medalbox/sol/medal_of_honor
+
+/datum/gear/award/solgov_award_civilian
+	display_name = "SolGov civilian award, Expeditionary"
+	description = "An iron medal awarded by the SCG for individuals who have participated in missions outside the borders of the Sol Central Government."
+	path = /obj/item/storage/medalbox/sol/expeditionary
+	cost = 3
+	flags = GEAR_HAS_NO_CUSTOMIZATION | GEAR_HAS_EXTENDED_DESCRIPTION
+
+/datum/gear/award/solgov_award_civilian/sapientarian
+	display_name = "SolGov civilian award, Sapientarian Peace Award"
+	description = "A copper medal awarded by the SCG for individuals who have contributed substantially to sapient rights or fostered greater brotherhood between sapient species. It is embossed with a date, text, and an image of famous Expeditionary Corps sapientarian, Samuel Carr."
+	path = /obj/item/storage/medalbox/sol/sapientarian
+
+/datum/gear/award/solgov_award_civilian/service
+	display_name = "SolGov civilian award, Distinguished Service Medal"
+	description = "A golden sun medal awarded by the SCG to nonmilitary individuals who have made exceptional contributions to the Sol Central Government."
+	path = /obj/item/storage/medalbox/sol/service
+
+/datum/gear/award/solgov_award_ribbons
+	display_name = "SolGov ribbon, Marksmanship"
+	description = "A military ribbon awarded to members of the SCG Defense Forces for good marksmanship scores in training. Common in the days of energy weapons."
+	path = /obj/item/clothing/accessory/ribbon/solgov/marksman
+	cost = 3
+	allowed_branches = SOLGOV_BRANCHES
+	flags = GEAR_HAS_NO_CUSTOMIZATION
+
+/datum/gear/award/solgov_award_ribbons/peace
+	display_name = "SolGov ribbon, Peacekeeping"
+	description = "A military ribbon awarded to members of the SCG Defense Forces for service during a peacekeeping operation."
+	path = /obj/item/clothing/accessory/ribbon/solgov/peace
+
+/datum/gear/award/solgov_award_ribbons/frontier
+	display_name = "SolGov ribbon, Frontier"
+	description = "A military ribbon awarded to members of the SCG Defense Forces for service along the frontier."
+	path = /obj/item/clothing/accessory/ribbon/solgov/frontier
+
+/datum/gear/award/solgov_award_ribbons/instructor
+	display_name = "SolGov ribbon, Instructor"
+	description = "A military ribbon awarded to members of the SCG Defense Forces for service as an instructor or professional development agent."
+	path = /obj/item/clothing/accessory/ribbon/solgov/instructor
+
+/datum/gear/award/solgov_award_ribbons/combat
+	display_name = "SolGov ribbon, Combat Action"
+	description = "A military ribbon awarded to members of the SCG Defense Forces for serving in active combat. Colloquially known as 'blood gold.'"
+	path = /obj/item/clothing/accessory/ribbon/solgov/combat
+
+/datum/gear/award/solgov_award_ribbons/gaiaconflict
+	display_name = "SolGov ribbon, Gaia Conflict"
+	description = "A military ribbon awarded to members of the SCG Defense Forces for serving in the Gaia Conflict."
+	path = /obj/item/clothing/accessory/ribbon/solgov/gaiaconflict
+
+/datum/gear/award/solgov_award_ribbons/distinguished_unit
+	display_name = "SolGov ribbon, Distinguished Unit"
+	description = "A military ribbon awarded to members of the SCG Defense Forces for service as part of a unit that has performed a distinguishing act of valor."
+	path = /obj/item/clothing/accessory/ribbon/solgov/distinguished_unit
+
+/datum/gear/award/ntaward
+	allowed_branches = CIVILIAN_BRANCHES

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -145,6 +145,7 @@
 
 	#include "loadout/_defines.dm"
 	#include "loadout/loadout_accessories.dm"
+	#include "loadout/loadout_awards.dm"
 	#include "loadout/loadout_ec_skillbadges.dm"
 	#include "loadout/loadout_eyes.dm"
 	#include "loadout/loadout_gloves.dm"


### PR DESCRIPTION
🆑 Cakey
rscadd: Awards are now classed under their own loadout category, and have been split up into individual awards to allow the selection of multiple awards from their respective categories.
/🆑

I thought about adding the ability to select the same loadout item multiple times but that seemed like a lot of effort for this.