### PR TITLE
Add intent-based actions to card decks

### DIFF
--- a/code/modules/codex/entries/misc.dm
+++ b/code/modules/codex/entries/misc.dm
@@ -29,3 +29,8 @@
 	If the message displays something more severe, like being completely comatose or having a full system failure, the player has voluntarily ghosted while still alive - this means that the character won't return back to the round as a player, short of invervention from an admin. For clarity, these cases will also always mention that the player won't be recovering or waking up any time soon.<br><br>\
 	\
 	The server's rules likely have special clauses regarding SSD players. Check the rule list before you touch a player who's disconnected or take any actions on them."
+
+/datum/codex_entry/cards
+	associated_paths = list(/obj/item/deck)
+	display_name = "Deck of Cards"
+	mechanics_text = "You can use harm intent to deal a new card face up while clicking on something, and similarly grab intent to deal a card face down. Both intents let you deal to a hand of cards you can interact with."

--- a/code/modules/games/cards.dm
+++ b/code/modules/games/cards.dm
@@ -95,6 +95,43 @@
 		return TRUE
 	return ..()
 
+/// Attack handler to deal cards, as an alterantive to the deal/draw verbs
+/obj/item/deck/use_before(atom/target, mob/living/user, click_parameters)
+	if (!(isobj(target)))
+		return FALSE
+	if (!length(cards) && (user.a_intent == I_HELP || user.a_intent == I_DISARM))
+		to_chat(user, SPAN_WARNING("There are no cards in the deck."))
+		return FALSE
+	if (istype(target, /obj/item/deck))
+		var/obj/item/deck/other_deck = target
+		var/datum/playingcard/drawn_card = cards[1]
+		other_deck.cards += drawn_card
+		cards -= drawn_card
+		other_deck.update_icon()
+		visible_message(SPAN_NOTICE("[user] puts a card on top of \the [target]."), SPAN_NOTICE("You put a card on top of \the [target]."))
+		return TRUE
+	else if (istype(target, /obj/item/hand))
+		var/obj/item/hand/target_hand = target
+		var/datum/playingcard/drawn_card = cards[1]
+		target_hand.cards += drawn_card
+		cards -= drawn_card
+		target_hand.update_icon(user.dir)
+		visible_message(SPAN_NOTICE("[user] deals a card face [target_hand.concealed ? "down" : "up"]."), SPAN_NOTICE("You deal a card face [target_hand.concealed ? "down" : "up"]"))
+		return TRUE
+	else if (user.a_intent == I_GRAB || user.a_intent == I_HURT)
+		// target isn't a deck or hand, create a new hand
+		var/obj/item/hand/hand = new(target.loc)
+		var/concealed = user.a_intent != I_HURT
+		hand.cards += cards[1]
+		cards -= cards[1]
+		hand.concealed = concealed
+		hand.pixel_x = text2num(click_parameters["icon-x"]) - 16
+		hand.pixel_y = text2num(click_parameters["icon-y"]) - 16
+		hand.update_icon(user.dir)
+		visible_message(SPAN_NOTICE("[user] deals a card face [concealed ? "down" : "up"]."), SPAN_NOTICE("You deal a card face [concealed ? "down" : "up"]."))
+		return TRUE
+	return FALSE
+
 /obj/item/deck/verb/draw_card()
 
 	set category = "Object"


### PR DESCRIPTION
* Harm to deal a card face up, or add to a hand of cards
* Grab to deal a card face down, or add to a hand of cards

https://github.com/user-attachments/assets/d6ed77ba-91e1-44bd-b973-d14f1ab70f94

:cl: Banditoz
tweak: Added intent-based actions to card decks. You can use harm intent to deal a new card face up while clicking on something, and similarly grab intent to deal a card face down. Both intents let you deal to a hand of cards you can interact with.
/:cl: