### PR TITLE
connection tweaks 1

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -295,10 +295,6 @@
 
 	var/static/minimum_byond_build = 1647
 
-	var/static/login_export_addr
-
-	var/static/warn_if_staff_same_ip = FALSE
-
 	var/static/enter_allowed = TRUE
 
 	var/static/player_limit = FALSE
@@ -459,6 +455,47 @@
 	var/static/deletion_starts_paused = TRUE
 
 	var/static/enable_cold_mist = FALSE
+
+	/// Whether we should skip warning about connections with CID collisions
+	var/static/skip_conn_warn_cid_all = FALSE
+
+	/**
+	* If skip_conn_warn_cid_all is falsy, an optional list of CIDs to skip anyway
+	* Set by using the config option skip_conn_warn_cid multiple times:
+	* skip_conn_warn_cid 14138560
+	* skip_conn_warn_cid 10964753
+	* skip_conn_warn_cid 16383642
+	*/
+	var/static/list/skip_conn_warn_cid_list
+
+	/// Whether we should skip warning about connections with address collisions
+	var/static/skip_conn_warn_address_all = FALSE
+
+	/**
+	* If skip_conn_warn_address_all is falsy, an optional list of addresses to skip anyway
+	* Set by using the config option skip_conn_warn_address multiple times:
+	* skip_conn_warn_address 0.0.0.0
+	* skip_conn_warn_address 0.0.0.1
+	* skip_conn_warn_address 0.0.0.2
+	*/
+	var/static/list/skip_conn_warn_address_list
+
+	/**
+	* An optional list of ckeys to skip warning about connection detail collisions
+	* Set by using the config option skip_conn_warn_address multiple times:
+	* skip_conn_warn_ckey loomingwombat2
+	* skip_conn_warn_ckey exadv1
+	* skip_conn_warn_ckey p99gnf
+	*/
+	var/static/list/skip_conn_warn_ckey_list
+
+	/// Whether we should warn the triggering client about connection detail collisions
+	var/static/skip_conn_warn_client = FALSE
+
+	/// The message to display to clients if they have a collision and don't match a skip_conn* rule
+	var/static/conn_warn_client_message = "You share some connection details with another \
+	connected player. Using more than one account at a time is not allowed. If this is your \
+	first time seeing this message, please contact staff by using the AdminHelp command."
 
 
 /datum/configuration/New()
@@ -738,8 +775,6 @@
 				minimum_byond_version = text2num(value)
 			if ("minimum_byond_build")
 				minimum_byond_build = text2num(value)
-			if ("login_export_addr")
-				login_export_addr = value
 			if ("irc_bot_host")
 				irc_bot_host = value
 			if ("main_irc")
@@ -894,12 +929,32 @@
 				warn_autoban_duration = max(1, text2num(value))
 			if ("run_empty_levels")
 				run_empty_levels = TRUE
-			if ("warn_if_staff_same_ip")
-				warn_if_staff_same_ip = TRUE
 			if ("deletion_starts_paused")
 				deletion_starts_paused = TRUE
 			if ("enable_cold_mist")
 				enable_cold_mist = TRUE
+			if ("skip_conn_warn_cid_all")
+				skip_conn_warn_cid_all = TRUE
+			if ("skip_conn_warn_cid")
+				if (!islist(value))
+					value = list(value)
+				skip_conn_warn_cid_list = value
+			if ("skip_conn_warn_address_all")
+				skip_conn_warn_address_all = TRUE
+			if ("skip_conn_warn_address")
+				if (!islist(value))
+					value = list(value)
+				skip_conn_warn_address_list = value
+			if ("skip_conn_warn_ckey")
+				if (!islist(value))
+					value = list(value)
+				for (var/i = 1 to length(value))
+					value[i] = ckey(value[i])
+				skip_conn_warn_ckey_list = value
+			if ("skip_conn_warn_client")
+				skip_conn_warn_client = TRUE
+			if ("conn_warn_client_message")
+				conn_warn_client_message = value
 			else
 				log_misc("Unknown setting in config/config.txt: '[name]'")
 

--- a/code/modules/admin/DB ban/functions.dm
+++ b/code/modules/admin/DB ban/functions.dm
@@ -86,8 +86,8 @@
 
 	if(ismob(banned_mob))
 		ckey = LAST_CKEY(banned_mob)
-		computerid = banned_mob.computer_id
-		ip = banned_mob.lastKnownIP
+		computerid = banned_mob.last_cid
+		ip = banned_mob.last_address
 		if(banned_mob.client)
 			computerid = banned_mob.client.computer_id
 			ip = banned_mob.client.address

--- a/code/modules/admin/connectioncheck/bancheck_functions.dm
+++ b/code/modules/admin/connectioncheck/bancheck_functions.dm
@@ -311,4 +311,4 @@
 		return
 	if (isnull(bans))
 		bans = fetch_bans()
-	_show_associated_bans(user, bans, ckey ? ckey : last_ckey, lastKnownIP, computer_id)
+	_show_associated_bans(user, bans, ckey ? ckey : last_ckey, last_address, last_cid)

--- a/code/modules/admin/connectioncheck/connectioncheck_functions.dm
+++ b/code/modules/admin/connectioncheck/connectioncheck_functions.dm
@@ -93,7 +93,7 @@
 	RETURN_TYPE(/list)
 	if (client)
 		return client.fetch_connections()
-	return _fetch_connections(ckey ? ckey : last_ckey, lastKnownIP, computer_id)
+	return _fetch_connections(ckey ? ckey : last_ckey, last_address, last_cid)
 
 
 /**
@@ -275,4 +275,4 @@
 		return
 	if (isnull(connections))
 		connections = fetch_connections()
-	_show_associated_connections(user, connections, ckey ? ckey : last_ckey, lastKnownIP, computer_id)
+	_show_associated_connections(user, connections, ckey ? ckey : last_ckey, last_address, last_cid)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -886,7 +886,7 @@
 					to_chat(usr, SPAN_DANGER("This mob's occupant has changed from [given_key] to [mob_key]. Please try again."))
 					show_player_panel(M)
 					return
-				AddBan(mob_key, M.computer_id, reason, usr.ckey, 1, mins)
+				AddBan(mob_key, M.last_cid, reason, usr.ckey, 1, mins)
 				var/mins_readable = time_to_readable(mins MINUTES)
 				ban_unban_log_save("[usr.client.ckey] has banned [mob_key]. - Reason: [reason] - This will be removed in [mins_readable].")
 				notes_add(mob_key,"[usr.client.ckey] has banned [mob_key]. - Reason: [reason] - This will be removed in [mins_readable].",usr)
@@ -917,9 +917,9 @@
 				switch(alert(usr,"IP ban?",,"Yes","No","Cancel"))
 					if("Cancel")	return
 					if("Yes")
-						AddBan(mob_key, M.computer_id, reason, usr.ckey, 0, 0, M.lastKnownIP)
+						AddBan(mob_key, M.last_cid, reason, usr.ckey, 0, 0, M.last_address)
 					if("No")
-						AddBan(mob_key, M.computer_id, reason, usr.ckey, 0, 0)
+						AddBan(mob_key, M.last_cid, reason, usr.ckey, 0, 0)
 				to_chat(M, SPAN_DANGER("You have been banned by [usr.client.ckey].\nReason: [reason]."))
 				to_chat(M, SPAN_WARNING("This is a ban until appeal."))
 				if(config.banappeals)

--- a/code/modules/admin/verbs/player_list.dm
+++ b/code/modules/admin/verbs/player_list.dm
@@ -34,7 +34,7 @@
 		entry = replacetext_char(entry, "{KEY}", replacetext_char(player.key, strip_symbols, ""))
 		entry = replacetext_char(entry, "{ANTAG}", is_special_character(player) ? "true" : "false")
 		entry = replacetext_char(entry, "{REF}", "\ref[player]")
-		entry = replacetext_char(entry, "{ADDR}", player.lastKnownIP)
+		entry = replacetext_char(entry, "{ADDR}", player.last_address)
 		entries[index] = entry
 		--index
 	var/doc = replacetext_char(file2text("html/pages/player_list.html"), "{REF_SRC}", "\ref[src]")

--- a/code/modules/admin/view_variables/view_variables_global.dm
+++ b/code/modules/admin/view_variables/view_variables_global.dm
@@ -54,7 +54,6 @@ GLOBAL_TYPED_NEW(debug_real_globals, /datum/debug_real_globals)
 		"sqlport",
 		"comms_password",
 		"ban_comms_password",
-		"login_export_addr",
 		"admin_verbs_default",
 		"admin_verbs_admin",
 		"admin_verbs_ban",

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -37,7 +37,7 @@
 	var/received_irc_pm = -99999
 
 	/// Prevents people from being spammed about multikeying every time their mob changes
-	var/warned_about_multikeying = TRUE
+	var/warned_about_multikeying = FALSE
 
 	/// If the database is available, how old the account is in days
 	var/player_age = "Requires database"

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -220,32 +220,32 @@
 		// computer_id and IP are not updated magically on their own in offline mobs -walter0o
 
 		// host -> self
-		var/h2s_id = host.computer_id
-		var/h2s_ip= host.lastKnownIP
-		host.computer_id = null
-		host.lastKnownIP = null
+		var/h2s_id = host.last_cid
+		var/h2s_ip= host.last_address
+		host.last_cid = null
+		host.last_address = null
 
 		src.ckey = host.ckey
 
-		if(!src.computer_id)
-			src.computer_id = h2s_id
+		if(!src.last_cid)
+			src.last_cid = h2s_id
 
-		if(!host_brain.lastKnownIP)
-			src.lastKnownIP = h2s_ip
+		if(!host_brain.last_address)
+			src.last_address = h2s_ip
 
 		// brain -> host
-		var/b2h_id = host_brain.computer_id
-		var/b2h_ip= host_brain.lastKnownIP
-		host_brain.computer_id = null
-		host_brain.lastKnownIP = null
+		var/b2h_id = host_brain.last_cid
+		var/b2h_ip= host_brain.last_address
+		host_brain.last_cid = null
+		host_brain.last_address = null
 
 		host.ckey = host_brain.ckey
 
-		if(!host.computer_id)
-			host.computer_id = b2h_id
+		if(!host.last_cid)
+			host.last_cid = b2h_id
 
-		if(!host.lastKnownIP)
-			host.lastKnownIP = b2h_ip
+		if(!host.last_address)
+			host.last_address = b2h_ip
 
 	qdel(host_brain)
 

--- a/code/modules/mob/living/simple_animal/borer/borer_hud.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_hud.dm
@@ -52,29 +52,29 @@
 	worm.host.add_language(LANGUAGE_BORER_GLOBAL)
 
 	// host -> brain
-	var/h2b_id = worm.host.computer_id
-	var/h2b_ip=  worm.host.lastKnownIP
-	worm.host.computer_id = null
-	worm.host.lastKnownIP = null
+	var/h2b_id = worm.host.last_cid
+	var/h2b_ip=  worm.host.last_address
+	worm.host.last_cid = null
+	worm.host.last_address = null
 	qdel(worm.host_brain)
 	worm.host_brain = new(worm)
 	worm.host_brain.ckey = worm.host.ckey
 	worm.host_brain.SetName(worm.host.name)
-	if(!worm.host_brain.computer_id)
-		worm.host_brain.computer_id = h2b_id
-	if(!worm.host_brain.lastKnownIP)
-		worm.host_brain.lastKnownIP = h2b_ip
+	if(!worm.host_brain.last_cid)
+		worm.host_brain.last_cid = h2b_id
+	if(!worm.host_brain.last_address)
+		worm.host_brain.last_address = h2b_ip
 
 	// self -> host
-	var/s2h_id = worm.computer_id
-	var/s2h_ip= worm.lastKnownIP
-	worm.computer_id = null
-	worm.lastKnownIP = null
+	var/s2h_id = worm.last_cid
+	var/s2h_ip= worm.last_address
+	worm.last_cid = null
+	worm.last_address = null
 	worm.host.ckey = worm.ckey
-	if(!worm.host.computer_id)
-		worm.host.computer_id = s2h_id
-	if(!worm.host.lastKnownIP)
-		worm.host.lastKnownIP = s2h_ip
+	if(!worm.host.last_cid)
+		worm.host.last_cid = s2h_id
+	if(!worm.host.last_address)
+		worm.host.last_address = s2h_ip
 	worm.controlling = TRUE
 	worm.host.verbs += /mob/living/carbon/proc/release_control
 	worm.host.verbs += /mob/living/carbon/proc/punish_host

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -66,14 +66,14 @@
 	var/obj/item/organ/external/affecting = H.get_organ(BP_HEAD)
 	affecting.implants -= src
 
-	var/s2h_id = src.computer_id
-	var/s2h_ip= src.lastKnownIP
-	src.computer_id = null
-	src.lastKnownIP = null
-	if(!H.computer_id)
-		H.computer_id = s2h_id
-	if(!H.lastKnownIP)
-		H.lastKnownIP = s2h_ip
+	var/s2h_id = src.last_cid
+	var/s2h_ip= src.last_address
+	src.last_cid = null
+	src.last_address = null
+	if(!H.last_cid)
+		H.last_cid = s2h_id
+	if(!H.last_address)
+		H.last_address = s2h_ip
 
 /mob/living/carbon/human/proc/jumpstart()
 	set category = "Abilities"

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -2,44 +2,42 @@
 	last_address = client.address
 	last_cid = client.computer_id
 	last_ckey = ckey
-	if(config.log_access)
-		log_access("Login: [key_name(src)] from [last_address ? last_address : "localhost"]-[last_cid] || BYOND v[client.byond_version]")
-		var/is_multikeying = 0
-		if (config.warn_if_staff_same_ip || !check_rights(R_MOD, FALSE, client))
-			for(var/mob/M in GLOB.player_list)
-				if(M == src)	continue
-				if( M.key && (M.key != key) )
-					var/matches
-					if( (M.last_address == client.address) )
-						matches += "IP ([client.address])"
-					if( (client.connection != "web") && (M.last_cid == client.computer_id) )
-						if(matches)	matches += " and "
-						matches += "ID ([client.computer_id])"
-						is_multikeying = 1
-					if(matches)
-						if(M.client)
-							message_admins("[SPAN_DANGER("<B>Notice:</B>")] [SPAN_INFO("<A href='byond://?src=\ref[usr];priv_msg=\ref[src]'>[key_name_admin(src)]</A> has the same [matches] as <A href='byond://?src=\ref[usr];priv_msg=\ref[M]'>[key_name_admin(M)]</A>.")]", 1)
-							log_access("Notice: [key_name(src)] has the same [matches] as [key_name(M)].")
-						else
-							message_admins("[SPAN_DANGER("<B>Notice:</B>")] [SPAN_INFO("<A href='byond://?src=\ref[usr];priv_msg=\ref[src]'>[key_name_admin(src)]</A> has the same [matches] as [key_name_admin(M)] (no longer logged in).")]", 1)
-							log_access("Notice: [key_name(src)] has the same [matches] as [key_name(M)] (no longer logged in).")
-		if(is_multikeying && !client.warned_about_multikeying)
-			client.warned_about_multikeying = 1
-			spawn(1 SECOND)
-				to_chat(src, "<b>WARNING:</b> It would seem that you are sharing connection or computer with another player. If you haven't done so already, please contact the staff via the Adminhelp verb to resolve this situation. Failure to do so may result in administrative action. You have been warned.")
+	if (config.log_access)
+		var/log_addr = last_address ? last_address : "localhost"
+		log_access("Login: [key_name(src)] from [log_addr]-[last_cid] || BYOND v[client.byond_version]")
+	if (ckey in config.skip_conn_warn_ckey_list)
+		return
+	var/warn_cid = !config.skip_conn_warn_cid_all && !(last_cid in config.skip_conn_warn_cid_list)
+	var/warn_address = !config.skip_conn_warn_address_all && !(last_address in config.skip_conn_warn_address_list)
+	var/skip_ckey = islist(config.skip_conn_warn_ckey_list)
+	if (!warn_cid && !warn_address)
+		return
+	var/list/warn = list()
+	for (var/mob/other as anything in GLOB.player_list)
+		if (other == src)
+			continue
+		if (other.key == key)
+			continue
+		if (skip_ckey && (ckey(other.key) in config.skip_conn_warn_ckey_list))
+			continue
+		if (warn_address && other.last_address == last_address)
+			warn[other] += list("ADDR")
+		if (warn_cid && other.last_cid == last_cid)
+			warn[other] += list("CID")
+	if (!length(warn))
+		return
+	for (var/i = 1 to length(warn))
+		var/mob/other = warn[i]
+		warn[i] = "[key_name(other, TRUE)] \[[jointext(warn[other], ", ")]\]"
+	message_admins("Notice: [key_name(src, TRUE)] shares connection details:\n•  [jointext(warn, "\n•  ")]")
+	if (config.skip_conn_warn_client)
+		return
+	if (client.warned_about_multikeying)
+		return
+	client.warned_about_multikeying = TRUE
+	spawn (2 SECONDS)
+		to_chat(src, SPAN_WARNING(config.conn_warn_client_message))
 
-	if(config.login_export_addr)
-		spawn(-1)
-			var/list/params = new
-			params["login"] = 1
-			params["key"] = client.key
-			if(isnum(client.player_age))
-				params["server_age"] = client.player_age
-			params["ip"] = client.address
-			params["clientid"] = client.computer_id
-			params["roundid"] = game_id
-			params["name"] = real_name || name
-			world.Export("[config.login_export_addr]?[list2params(params)]", null, 1)
 
 /mob/proc/maybe_send_staffwarns(action)
 	if(client?.staffwarn)

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -1,20 +1,18 @@
-//handles setting lastKnownIP and computer_id for use by the ban systems as well as checking for multikeying
-/mob/proc/update_Login_details()
-	//Multikey checks and logging
-	lastKnownIP	= client.address
-	computer_id	= client.computer_id
+/mob/proc/update_login_details()
+	last_address = client.address
+	last_cid = client.computer_id
 	last_ckey = ckey
 	if(config.log_access)
-		log_access("Login: [key_name(src)] from [lastKnownIP ? lastKnownIP : "localhost"]-[computer_id] || BYOND v[client.byond_version]")
+		log_access("Login: [key_name(src)] from [last_address ? last_address : "localhost"]-[last_cid] || BYOND v[client.byond_version]")
 		var/is_multikeying = 0
 		if (config.warn_if_staff_same_ip || !check_rights(R_MOD, FALSE, client))
 			for(var/mob/M in GLOB.player_list)
 				if(M == src)	continue
 				if( M.key && (M.key != key) )
 					var/matches
-					if( (M.lastKnownIP == client.address) )
+					if( (M.last_address == client.address) )
 						matches += "IP ([client.address])"
-					if( (client.connection != "web") && (M.computer_id == client.computer_id) )
+					if( (client.connection != "web") && (M.last_cid == client.computer_id) )
 						if(matches)	matches += " and "
 						matches += "ID ([client.computer_id])"
 						is_multikeying = 1
@@ -65,7 +63,7 @@
 	if (!GLOB.player_list.Find(src))
 		ADD_SORTED(GLOB.player_list, src, GLOBAL_PROC_REF(cmp_mob_key))
 
-	update_Login_details()
+	update_login_details()
 	world.update_status()
 
 	maybe_send_staffwarns("joined the round")

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -32,8 +32,8 @@
 	var/list/client_images = list() // List of images applied to/removed from the client on login/logout
 	var/datum/mind/mind
 
-	var/lastKnownIP = null
-	var/computer_id = null
+	var/last_address
+	var/last_cid
 	var/last_ckey
 
 	var/stat = CONSCIOUS //Whether a mob is alive or dead. TODO: Move this to living - Nodrak

--- a/code/modules/mob/new_player/login.dm
+++ b/code/modules/mob/new_player/login.dm
@@ -1,5 +1,5 @@
 /mob/new_player/Login()
-	update_Login_details()	//handles setting lastKnownIP and computer_id for use by the ban systems as well as checking for multikeying
+	update_login_details()
 	if (config.motd)
 		to_chat(src, "<div class=\"motd\">[config.motd]</div>", handle_whitespace=FALSE)
 	to_chat(src, "<div class='info'>Game ID: <div class='danger'>[game_id]</div></div>")

--- a/config/example/config.txt
+++ b/config/example/config.txt
@@ -465,3 +465,49 @@ RADIATION_LOWER_LIMIT 0.15
 ## Uncomment this to bypass empty z-level checks in certain subsystems. For testing and development purposes only.
 ## Not recommended for live use.
 #RUN_EMPTY_LEVELS
+
+## SKIP_CONN_WARN_CID_ALL
+## Bool. Default: Off
+## Whether we should skip warning staff and players about connections with CID collisions
+#SKIP_CONN_WARN_CID_ALL
+
+## SKIP_CONN_WARN_CID
+## Multi-List. Default: None Set
+## If SKIP_CONN_WARN_CID_ALL is not set, an optional list of CIDs to skip anyway
+## Add lines of 'SKIP_CONN_WARN_CID CID' to add entries, eg:
+#SKIP_CONN_WARN_CID 14138560
+#SKIP_CONN_WARN_CID 10964753
+
+## SKIP_CONN_WARN_ADDRESS_ALL
+## Bool. Default: Off
+## Whether we should skip warning about connections with address (IP) collisions
+#SKIP_CONN_WARN_ADDRESS_ALL
+
+## SKIP_CONN_WARN_ADDRESS
+## Multi-List. Default: Empty
+## If SKIP_CONN_WARN_ADDRESS_ALL is not set, an optional list of addresses (IPs) to skip anyway
+## Add lines of 'SKIP_CONN_WARN_ADDRESS ADDRESS' to add entries, eg:
+#SKIP_CONN_WARN_ADDRESS 3.33.130.190
+#SKIP_CONN_WARN_ADDRESS 213.186.33.5
+
+## SKIP_CONN_WARN_CKEY
+## Multi-List. Default: Empty
+## An optional list of ckeys to skip warning about connection detail collisions
+## Members of this list are mapped to ckey(entry) - you may use key here instead
+## Add lines of 'SKIP_CONN_WARN_CKEY ckeyable' to add entries, eg:
+#SKIP_CONN_WARN_CKEY exadv1
+#SKIP_CONN_WARN_CKEY Looming Wombat 99
+
+## SKIP_CONN_WARN_CLIENT
+## Bool. Default: Off
+## Whether we should warn the triggering client about connection detail collisions
+#SKIP_CONN_WARN_CLIENT
+
+## CONN_WARN_CLIENT_MESSAGE
+## Text. Default: Builtin
+## The message we should display to clients if they appear to be sharing an address or machine with
+## another client, after respecting SKIP_CONN_* rules. If not set, the default message is sent:
+## "You share some connection details with another connected player. Using more than one account at
+## a time is not allowed. If this is your first time seeing this message, please contact staff by
+## using the AdminHelp command."
+#CONN_WARN_CLIENT_MESSAGE It looks like you're multi-keying. Please stop that!

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -48,7 +48,7 @@ exactly 25 "text2path uses" 'text2path'
 exactly 5 "update_icon() override" '/update_icon\((.*)\)'  -P
 exactly 4 "goto use" 'goto '
 exactly 1 "NOOP match" 'NOOP'
-exactly 326 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
+exactly 325 "spawn uses" '^\s*spawn\s*\(\s*(-\s*)?\d*\s*\)' -P
 exactly 0 "tag uses" '\stag = ' -P '**/*.dmm'
 exactly 0 "anchored = 0/1" 'anchored\s*=\s*\d' -P
 exactly 2 "density = 0/1" 'density\s*=\s*\d' -P


### PR DESCRIPTION
Added various config options for how shared connection details between clients are warned about (or not), plus a tweak to the presentation of how the warning is shown to admins. Also bugfixes the warning never actually being shown to players. Whoops!

![arJSF6YW](https://github.com/user-attachments/assets/69730cd0-923d-45c9-b087-67741cc283c6)
![m4q3UCLq](https://github.com/user-attachments/assets/1f1672da-cc82-491c-899a-e305601fb53a)
