### PR TITLE
change cancel interact key to alt+x

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -98,7 +98,6 @@
 \tCtrl+2 = disarm-intent
 \tCtrl+3 = grab-intent
 \tCtrl+4 = harm-intent
-\tESC = cancel current timed action
 \tF1 = adminhelp
 \tF2 = ooc
 \tF3 = say
@@ -112,6 +111,7 @@
 \tCtrl + Click = drag
 \tShift + Click = examine
 \tAlt + Click = show entities on turf
+\tAlt+x = cancel current timed action
 \tCtrl + Alt + Click = point"})
 
 	var/robot_hotkey_mode = SPAN_COLOR("purple", {"Hotkey-Mode: (hotkey-mode must be on)
@@ -146,7 +146,6 @@
 \tCtrl+2 = activate module 2
 \tCtrl+3 = activate module 3
 \tCtrl+4 = toggle intents
-\tESC = cancel current timed action
 \tF1 = adminhelp
 \tF2 = ooc
 \tF3 = say
@@ -158,6 +157,7 @@
 \tCtrl + Click = drag or bolt doors
 \tShift + Click = examine or open doors
 \tAlt + Click = show entities on turf
+\tAlt+e = cancel current timed action
 \tCtrl + Shift + Click = electrify doors
 \tCtrl + Alt + Click = point"})
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -186,7 +186,7 @@ macro "borghotkeymode"
 		name = "Numpad8"
 		command = "body-toggle-head"
 	elem
-		name = "ESCAPE"
+		name = "ALT+X"
 		command = "Cancel-Current-Action"
 	elem
 		name = "F1"
@@ -374,7 +374,7 @@ macro "macro"
 		name = "CTRL+Subtract"
 		command = "move-down"
 	elem
-		name = "ESCAPE"
+		name = "ALT+X"
 		command = "Cancel-Current-Action"
 	elem
 		name = "F1"


### PR DESCRIPTION
:cl: Mucker
tweak: Changed the key to cancel your current interaction to ALT+X. Escape now clears the hotbar input again.
/:cl: