### PR TITLE
adjust text length and dont encode nanoui stuff

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/email_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/email_client.dm
@@ -418,7 +418,7 @@
 
 		var/datum/computer_file/data/email_message/message = new()
 		message.title = msg_title
-		message.stored_data = sanitize(msg_body)
+		message.stored_data = sanitize(msg_body, MAX_MESSAGE_LEN, FALSE)
 		message.source = current_account.login
 		message.attachment = msg_attachment
 		if(!current_account.send_mail(msg_recipient, message))

--- a/code/modules/modular_computers/file_system/programs/generic/wordprocessor.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/wordprocessor.dm
@@ -167,10 +167,10 @@
 						)))
 				data["usbfiles"] = usbfiles
 	else if(PRG.open_file)
-		data["filedata"] = digitalPencode2html(sanitize(PRG.loaded_data, MAX_TEXTFILE_LENGTH))
+		data["filedata"] = digitalPencode2html(sanitize(PRG.loaded_data, MAX_TEXTFILE_LENGTH, FALSE))
 		data["filename"] = PRG.is_edited ? "[PRG.open_file]*" : PRG.open_file
 	else
-		data["filedata"] = digitalPencode2html(sanitize(PRG.loaded_data, MAX_TEXTFILE_LENGTH))
+		data["filedata"] = digitalPencode2html(sanitize(PRG.loaded_data, MAX_TEXTFILE_LENGTH, FALSE))
 		data["filename"] = "UNNAMED"
 
 	ui = SSnano.try_update_ui(user, src, ui_key, ui, data, force_open)

--- a/code/modules/modular_computers/file_system/reports/people.dm
+++ b/code/modules/modular_computers/file_system/reports/people.dm
@@ -27,7 +27,7 @@
 	var/datum/computer_file/data/email_account/server = ntnet_global.find_email_by_name(EMAIL_DOCUMENTS)
 	var/datum/computer_file/data/email_message/message = new()
 	message.title = subject
-	message.stored_data = sanitize(body)
+	message.stored_data = sanitize(body, MAX_MESSAGE_LEN, FALSE)
 	message.source = server.login
 	message.attachment = attach_report
 	server.send_mail(recipient, message)


### PR DESCRIPTION
:cl: Mucker
bugfix: Special characters are no longer encoded in the various text apps (example: ' will show as ' and not &#31 or whatever)
/:cl: