### PR TITLE
fix bsd flush triggering on moderate

### DIFF
--- a/code/game/machinery/bluespace_drive.dm
+++ b/code/game/machinery/bluespace_drive.dm
@@ -180,7 +180,6 @@
 	///List of mobs that can be swapped around when the pulse hits
 	var/list/mob/living/mobs_to_switch = list()
 	var/obj/machinery/bluespacedrive/parent
-	var/interlude_teleport_chance = 0
 	var/affect_chance = 0
 
 /datum/bubble_effect/bluespace_pulse/New(center_x, center_y, z, initial_radius, delta, parent)
@@ -238,7 +237,13 @@
 
 		//swap places with another mob
 		for (var/mob/living/mob as anything in mobs_to_switch)
+			var/swap_chance = affect_chance
 			if (!(mob.z in zlevels))
+				continue
+			if (istype(mob.loc, /turf/space) || istype(being.loc, /turf/space))
+				swap_chance = 10 //lots of mobs in space can cause the entire ship to get spaced, so lower the chance
+
+			if (prob(swap_chance))
 				continue
 
 			if (mob != being)

--- a/code/modules/events/bsd_instability.dm
+++ b/code/modules/events/bsd_instability.dm
@@ -109,7 +109,7 @@
 				next_zap = world.time + rand(5, 20) SECONDS
 	if (activeFor != (endWhen - 30))
 		return
-	if (flush_running)
+	if (flush_running || severity <= EVENT_LEVEL_MODERATE)
 		return
 	flush_running = TRUE
 	command_announcement.Announce(


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed the BSD flush triggering on the moderate level event.
tweak: Reduced the likelihood of being swapped with mobs in space (so that carp swarms don't space all the crew).
/:cl: