### PR TITLE
Obfuscates job in the radio logs

### DIFF
--- a/code/game/machinery/telecomms/logbrowser.dm
+++ b/code/game/machinery/telecomms/logbrowser.dm
@@ -82,7 +82,7 @@
 
 					if(universal_translate || C.parameters["uspeech"] || C.parameters["intelligible"])
 						dat += "<u>[SPAN_COLOR("#18743e", "Data type")]</u>: [C.input_type]<br>"
-						dat += "<u>[SPAN_COLOR("#18743e", "Source")]</u>: [C.parameters["name"]] (Job: [C.parameters["job"]])<br>"
+						dat += "<u>[SPAN_COLOR("#18743e", "Source")]</u>: [C.parameters["name"]]<br>"
 						dat += "<u>[SPAN_COLOR("#18743e", "Class")]</u>: [race]<br>"
 						dat += "<u>[SPAN_COLOR("#18743e", "Contents")]</u>: \"[C.parameters["message"]]\"<br>"
 						if(language)


### PR DESCRIPTION
:cl:
tweak: Radio logs no longer display job.
/:cl:

Apparently the magical ability of radio waves to somehow read your ID is abused by some people, and in generally does not make sense.