### PR TITLE
[Tweak] ID Card Program: Branch and Rank Update

### DIFF
--- a/nano/templates/identification_computer.tmpl
+++ b/nano/templates/identification_computer.tmpl
@@ -69,7 +69,23 @@
 		{{:helper.link(data.id_email_password, 'pencil', {'action' : 'edit', 'epswd' : 1})}}
 	  </div>
 	</div>
-	
+
+	<div class='item'>
+	  <div class='itemLabel'>
+		Branch:
+	  </div>
+	  <div class='itemContent'>
+		{{:data.id_military_branch}}
+	  </div>
+	</div>
+	<div class='item'>
+	  <div class='itemLabel'>
+		Rank:
+	  </div>
+	  <div class='itemContent'>
+		{{:data.id_military_rank}}
+	  </div>
+	</div>
 
 	<div class='item'>
 	  <div class='itemLabel'>
@@ -86,7 +102,7 @@
 		{{:helper.link(data.assignments ? "Hide assignments" : "Show assignments", 'gear', {'action' : 'togglea'})}}
 	<div class='item'>
 	  <span id='allvalue.jobsslot'>
-		
+
 	  </span>
 	</div>
 	<div class='item'>
@@ -117,7 +133,7 @@
 				{{:helper.link(value.display_name, '', {'action' : 'assign', 'assign_target' : value.job}, data.id_rank == value.job ? 'disabled' : null)}}
 			  {{/for}}
 			</td>
-		  </tr>	  
+		  </tr>
 		  <tr>
 			<th style="color: '#FFA500';">Engineering</th>
 			<td>
@@ -146,7 +162,7 @@
 			<th style="color: '#DD0000';">Security</th>
 			<td>
 			  {{for data.security_jobs}}
-			{{:helper.link(value.display_name, '', {'action' : 'assign', 'assign_target' : value.job}, data.id_rank == value.job ? 'disabled' : null)}}
+				{{:helper.link(value.display_name, '', {'action' : 'assign', 'assign_target' : value.job}, data.id_rank == value.job ? 'disabled' : null)}}
 			  {{/for}}
 			</td>
 		  </tr>
@@ -166,7 +182,7 @@
 			  {{/for}}
 			</td>
 		  </tr>
-		  
+
 		  <tr>
 			<th style="color: '#88b764';">Service</th>
 			<td>
@@ -204,6 +220,37 @@
 	  {{/if}}
 	</div>
 
+	<div class='item'>
+	  <h3>Select Branch</h3>
+	  <div id="military-branches">
+		<table>
+			<tr>
+				<td>
+				{{for data.military_branches}}
+					{{:helper.link(value.display_name, '', {'action' : 'set_military_branch', 'branch_target' : value.branch}, data.id_military_branch == value.branch ? 'disabled' : null)}}
+				{{/for}}
+				</td>
+			</tr>
+		</table>
+	  </div>
+	</div>
+	{{if data.military_ranks}}
+	<div class='item'>
+	  <h3>Select Rank</h3>
+	  <div id="military-ranks">
+		<table>
+			<tr>
+				<td>
+				{{for data.military_ranks}}
+					{{:helper.link(value.display_name, '', {'action' : 'set_military_rank', 'rank_target' : value.rank}, data.id_military_rank == value.rank ? 'disabled' : null)}}
+				{{/for}}
+				</td>
+			</tr>
+		</table>
+	  </div>
+	</div>
+	{{/if}}
+
 	{{if data.centcom_access}}
 	  <div class='item'>
 		<h2>Central Command</h2>
@@ -211,7 +258,7 @@
 	  <div class='item' style='width: 100%'>
 		{{for data.all_centcom_access}}
 		  <div class='itemContentWide'>
-		  {{:helper.link(value.desc, '', {'action' : 'access', 'access_target' : value.ref, 'allowed' : value.allowed}, null, value.allowed ? 'selected' : null)}}
+			{{:helper.link(value.desc, '', {'action' : 'access', 'access_target' : value.ref, 'allowed' : value.allowed}, null, value.allowed ? 'selected' : null)}}
 		  </div>
 		{{/for}}
 	  </div>


### PR DESCRIPTION
# Add Branch and Rank Modification to ID Card Modification Program

## Description
This PR enhances the `card_mod` program to allow modification of `military_branch` and `military_rank` fields on ID cards. The changes enable players to update military branch and rank directly through the ID card modification interface.

### Changes
- **Code Updates**:
  - Modified `/datum/nano_module/program/card_mod` and `/datum/computer_file/program/card_mod` to support reading and setting `military_branch` and `military_rank` on ID cards.
  - Added initialization of `selected_branch` in `ui_interact` to automatically set it to the current `military_branch` of the inserted ID card, ensuring the rank selection list is displayed immediately when a branch is set.
  - Added new `Topic` actions: `set_military_branch` and `set_military_rank` for updating the respective fields, with "Unset" option to clear them.
  - Updated the `print` action to include `military_branch` and `military_rank` in the access report.
  - Ensured `military_branch` and `military_rank` are cleared when terminating an ID card.

- **UI Updates**:
  - Updated `identification_computer.tmpl` "Details" section, displaying current `military_branch` and `military_rank`, and providing selection lists for both.
  - Added a fallback message ("Please select a military branch first.") when no branch is selected, improving user experience.

## Changelog

:cl: KandJX
tweak: The ID card modification program can update an ID card's branch and rank.
tweak: Added military branch and rank to the access report printout.
/:cl: