### PR TITLE
Coffee cups, flasks and vacuum flasks selected from the loadout retain custom names and descriptions.

### DIFF
--- a/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/drinkingglass.dm
@@ -28,9 +28,6 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 	atom_flags = ATOM_FLAG_OPEN_CONTAINER
 	temperature_coefficient = 4
 
-	var/custom_name
-	var/custom_desc
-
 /obj/item/reagent_containers/food/drinks/glass2/examine(mob/M)
 	. = ..()
 
@@ -148,10 +145,18 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 	underlays.Cut()
 	ClearOverlays()
 
+	if (!empty_name)
+		empty_name = name
+		if (empty_name != initial(name))
+			// Use loadout name tweaks over default base names when describing a glass of something.
+			base_name = empty_name
+	if (!empty_desc)
+		empty_desc = desc
+
 	if (length(reagents?.reagent_list))
 		var/datum/reagent/R = reagents.get_master_reagent()
 		SetName("[base_name] of [R.glass_name ? R.glass_name : "something"]")
-		desc = R.glass_desc || custom_desc || initial(desc)
+		desc = R.glass_desc || empty_desc
 
 		var/list/under_liquid = list()
 		var/list/over_liquid = list()
@@ -185,8 +190,8 @@ var/global/const/DRINK_ICON_NOISY = "noise"
 		AddOverlays(over_liquid)
 
 	else
-		SetName(custom_name || initial(name))
-		desc = custom_desc || initial(desc)
+		SetName(empty_name)
+		desc = empty_desc
 
 	var/side = "left"
 	for(var/item in extras)

--- a/code/modules/reagents/reagent_containers/drinkingglass/glass_types.dm
+++ b/code/modules/reagents/reagent_containers/drinkingglass/glass_types.dm
@@ -270,13 +270,6 @@
 	base_name = "beaglemug"
 	base_icon = "beaglemug"
 
-/obj/item/reagent_containers/food/drinks/glass2/coffeecup/custom/inherit_custom_item_data(datum/custom_item/citem)
-	. = ..()
-	if(citem.additional_data["base_name"])
-		base_name = citem.additional_data["base_name"] || base_name
-	custom_name = citem.item_name
-	custom_desc = citem.item_desc
-
 /obj/item/reagent_containers/food/drinks/glass2/pineapple
 	name = "pineapple mug"
 	desc = "A mug made from a hollowed pineapple. Tropical!"

--- a/code/modules/reagents/reagent_containers/food/drinks.dm
+++ b/code/modules/reagents/reagent_containers/food/drinks.dm
@@ -16,6 +16,9 @@
 	var/drink_offset_y = 0
 	var/shaken = FALSE
 
+	var/empty_name = null
+	var/empty_desc = null
+
 /obj/item/reagent_containers/food/drinks/on_reagent_change()
 	update_icon()
 	return
@@ -143,6 +146,12 @@
 
 /obj/item/reagent_containers/food/drinks/on_update_icon()
 	ClearOverlays()
+
+	if (!empty_name)
+		empty_name = name
+	if (!empty_desc)
+		empty_desc = desc
+
 	if(length(reagents.reagent_list) > 0)
 		if(base_name)
 			var/datum/reagent/R = reagents.get_master_reagent()
@@ -153,8 +162,8 @@
 			filling.color = reagents.get_color()
 			AddOverlays(filling)
 	else
-		SetName(initial(name))
-		desc = initial(desc)
+		SetName(empty_name)
+		desc = empty_desc
 
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -6337,7 +6337,7 @@
 	},
 /obj/structure/table/standard,
 /obj/item/reagent_containers/food/drinks/glass2/coffeecup/one{
-	custom_desc = "A white coffee cup, prominently featuring a #1 Gorpsman. Someone has scratched the C into a G."
+	desc = "A white coffee cup, prominently featuring a #1 Gorpsman. Someone has scratched the C into a G."
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/medicalhallway)


### PR DESCRIPTION
:cl: Zenithstar
bugfix: Coffee cups, flasks and vacuum flasks selected from the loadout retain custom names and descriptions.
rscdel: Unhooked drinking glasses from the old custom item subsystem.
/:cl:

I decided to search for more edge cases of gear tweaks getting overwritten by in-game behaviours. Also tore out some of the bones of the old custom item stuff that was specific to cups to avoid too much of a tangle there, since we're favouring gear tweaks now. Just let me know if that should remain as is.