### PR TITLE
Use constant width and height for img size in nanoui header

### DIFF
--- a/nano/templates/layout_default_header.tmpl
+++ b/nano/templates/layout_default_header.tmpl
@@ -3,16 +3,16 @@
 		<div class='item'>
 			<table><tr>
 			{{if data.PC_batteryicon && data.PC_showbatteryicon}}
-				<td><img src='{{:data.PC_batteryicon}}'>
+				<td><img width='40px' height='22px' src='{{:data.PC_batteryicon}}'>
 			{{/if}}
 			{{if data.PC_batterypercent && data.PC_showbatteryicon}}
 				<td><b>{{:data.PC_batterypercent}}</b>
 			{{/if}}
 			{{if data.PC_ntneticon}}
-				<td><img src='{{:data.PC_ntneticon}}'>
+				<td><img width='40px' height='22px' src='{{:data.PC_ntneticon}}'>
 			{{/if}}
 			{{if data.PC_apclinkicon}}
-				<td><img src='{{:data.PC_apclinkicon}}'>
+				<td><img width='40px' height='22px' src='{{:data.PC_apclinkicon}}'>
 			{{/if}}
 			{{if data.PC_stationtime}}
 				<td><b>{{:data.PC_stationtime}}<b>


### PR DESCRIPTION
Should help stop most of the page jumps/jitters visible on 516 clients when nano refreshes.
Partially fixes #35160

:cl: Banditoz
bugfix: Fix consoles jittering on refresh on 516 clients.
/:cl: