### PR TITLE
Enable find/refresh for >=516 browsers

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -160,6 +160,9 @@
 	GLOB.clients += src
 	GLOB.ckey_directory[ckey] = src
 
+	if(byond_version >= 516)
+		winset(src, null, list("browser-options" = "find,refresh"))
+
 	//Admin Authorisation
 	holder = admin_datums[ckey]
 	if(holder)


### PR DESCRIPTION
:cl: Banditoz
tweak: 516 clients can now use the browser's Ctrl+F find dialog, and F5 refresh, if needed.
/:cl: