### PR TITLE
Harvester Tweaks

### DIFF
--- a/code/modules/tension/tension.dm
+++ b/code/modules/tension/tension.dm
@@ -25,7 +25,7 @@
 
 	var/potential_damage = 0
 	if(!projectiletype || ( ( get_dist(src, threatened) >= 1) && !will_point_blank ) ) // Melee damage.
-		potential_damage = (natural_weapon.force) / 2
+		potential_damage = (natural_weapon?.force) / 2
 
 		// Treat potential_damage as estimated DPS. If the enemy attacks twice as fast as usual, it will double the number.
 		potential_damage *= 1 SECOND / (base_attack_cooldown + melee_attack_delay)

--- a/packs/legion/ai/legion_ai_harvester.dm
+++ b/packs/legion/ai/legion_ai_harvester.dm
@@ -2,6 +2,7 @@
 	cooperative = FALSE // So that the harvester doesnt get confused receiving invalid targets from other mobs.
 	handle_corpse = TRUE
 	respect_confusion = FALSE
+	flee_when_outmatched = TRUE
 
 
 /datum/ai_holder/legion/harvester/list_targets()
@@ -55,3 +56,15 @@
 		FONT_LARGE(SPAN_DANGER("\The [holder] turns its focus on you!")),
 		VISIBLE_MESSAGE
 	)
+
+
+// Flee if there's more than 1 threat (Still standing mob) nearby.
+/datum/ai_holder/legion/harvester/special_flee_check()
+	var/list/dangers = list()
+
+	for (var/mob/living/living in range(vision_range, holder))
+		if (!living.get_threat(holder))
+			continue
+		dangers += living
+
+	return length(dangers) > 1

--- a/packs/legion/ai/legion_ai_harvester.dm
+++ b/packs/legion/ai/legion_ai_harvester.dm
@@ -68,3 +68,10 @@
 		dangers += living
 
 	return length(dangers) > 1
+
+
+/datum/ai_holder/legion/harvester/react_to_attack(atom/movable/attacker)
+	. = ..()
+	if (rand(0, 100) >= 100) // 5% chance when hit to be interrupted
+		return
+	holder.do_user_interrupted = world.time

--- a/packs/legion/mob/legion_harvester.dm
+++ b/packs/legion/mob/legion_harvester.dm
@@ -11,6 +11,7 @@
 
 	mob_size = MOB_LARGE
 	ai_holder = /datum/ai_holder/legion/harvester
+	mob_flags = MOB_FLAG_UNPINNABLE | MOB_FLAG_DO_USER_INTERRUPT
 
 	special_attack_min_range = 0
 	special_attack_max_range = 1

--- a/packs/legion/mob/legion_harvester.dm
+++ b/packs/legion/mob/legion_harvester.dm
@@ -102,6 +102,20 @@
 	return harvest_brain(A)
 
 
+/mob/living/simple_animal/hostile/legion/harvester/get_tension()
+	var/list/potential_threats = list()
+
+	for (var/thing in view(src))
+		if (!isliving(thing))
+			continue
+		var/mob/living/carbon/human/human = thing
+		if (human.incapacitated())
+			continue
+		potential_threats += human
+
+	return length(potential_threats)
+
+
 /**
  * Sets the harvester's harvesting state. Primarily used to synchronize the harvester's AI busy state.
  *


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
rscadd: Legion harvesters may flee if they're in danger.
rscadd: Legion harvesters that are currently harvesting from a mob can be interrupted if you hit them enough.
/:cl:

## Other Changes
- Fixes a runtime error in mob AI tension and danger checks associated with mobs that lack a natural weapon.