### PR TITLE
Emotes Dont Sleep

### DIFF
--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -110,13 +110,7 @@
 		to_chat(src, "You are unable to emote.")
 		return
 
-	var/input
-	if(!message)
-		input = sanitize(input(src,"Choose an emote to display.") as text|null)
-	else
-		input = message
-
-	if(input)
+	if(message)
 		message = format_emote(src, message)
 	else
 		return

--- a/code/modules/emotes/emote_mob.dm
+++ b/code/modules/emotes/emote_mob.dm
@@ -24,18 +24,6 @@
 		if(act == "me")
 			return custom_emote(m_type, message)
 
-		if(act == "custom")
-			if(!message)
-				message = sanitize(input("Enter an emote to display.") as text|null)
-			if(!message)
-				return
-			if (!m_type)
-				if(alert(src, "Is this an audible emote?", "Emote", "Yes", "No") == "No")
-					m_type = VISIBLE_MESSAGE
-				else
-					m_type = AUDIBLE_MESSAGE
-			return custom_emote(m_type, message)
-
 	var/splitpoint = findtext(act, " ")
 	if(splitpoint > 0)
 		var/tempstr = act

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -12,7 +12,7 @@
 			speaking = get_any_good_language(set_default=TRUE)
 			if (!speaking)
 				to_chat(src, SPAN_WARNING("You don't know a language and cannot speak."))
-				emote("custom", AUDIBLE_MESSAGE, "[pick("grunts", "babbles", "gibbers", "jabbers", "burbles")] aimlessly.")
+				emote("me", AUDIBLE_MESSAGE, "[pick("grunts", "babbles", "gibbers", "jabbers", "burbles")] aimlessly.")
 				return
 
 	if(has_chem_effect(CE_VOICELOSS, 1))

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -17,6 +17,8 @@
 	set name = "Me"
 	set category = "IC"
 	message = sanitize(message)
+	if (!message)
+		return
 	if(use_me)
 		usr.emote("me",usr.emote_type,message)
 	else


### PR DESCRIPTION
Brings 104 errors when I add `SHOULD_NOT_SLEEP(TRUE)` to `/mob/proc/Life()` down to 85. Decided I'm going to do these one segment at a time, give it some time to check for issues, then do the next block.

Why?

Cause the next 50 or so errors are all related to radio code 8D

## Changelog
:cl: SierraKomodo
rscdel: Entering no text into the `me` prompt no longer opens a second prompt to type in a emote command; Just use the existing `say "{prefix}command"` system instead, if you ever used that box. (Somehow I doubt anyone even know that was a feature).
/:cl:

## Other Changes
- Removed the `"custom"` `m_type` option for `proc/emote()`. The one instance of this being referenced was swapped to the `"me"` type instead.