### PR TITLE
Adjusts mech crowbar eject timer

### DIFF
--- a/code/modules/mechs/mech_interaction.dm
+++ b/code/modules/mechs/mech_interaction.dm
@@ -374,7 +374,7 @@
 			SPAN_WARNING("\The [user] starts forcing \the [src]'s emergency [body.hatch_descriptor] release using \a [tool]."),
 			SPAN_WARNING("You start forcing \the [src]'s emergency [body.hatch_descriptor] release using \the [tool].")
 		)
-		if (!user.do_skilled((tool.toolspeed * 5) SECONDS, list(SKILL_DEVICES, SKILL_EVA), src) || !user.use_sanity_check(src, tool))
+		if (!do_after(user, 2 SECONDS, src, DO_DEFAULT | DO_USER_UNIQUE_ACT | DO_PUBLIC_PROGRESS))
 			return TRUE
 		if (!body)
 			USE_FEEDBACK_FAILURE("\The [src] has no cockpit to force.")


### PR DESCRIPTION
:cl: Fre3bie
tweak: Adjusts the timer on ejecting a locked mech with a crowbar to have a consistent short cooldown.
/:cl:

Currently you can eject someone from a locked mech instantly, so there's no way for the pilot to try preventing this by moving to interrupt the progress. This just changes it to a fixed timer which isn't terribly long, but long enough to allow a mech pilot to try escaping from the eject attempt.