### PR TITLE
Fix floating chat icon size

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1061,6 +1061,7 @@ window "mapwindow"
 		saved-params = "icon-size"
 		on-show = ".winset\"mainwindow.mainvsplit.left=mapwindow\""
 		on-hide = ".winset\"mainwindow.mainvsplit.left=\""
+		style = "img.icon { width: auto; height: auto; }"
 	elem "lobbybrowser"
 		type = BROWSER
 		pos = 0,0


### PR DESCRIPTION
:cl: Banditoz
bugfix: Fix floating chat icon size.
/:cl:

See https://www.byond.com/forum/post/2967731#comment26887686

<img width="363" height="266" alt="dreamseeker_o730MfSwOd" src="https://github.com/user-attachments/assets/d7e4e4b4-5615-4463-8b2a-21306342cabc" />
