### PR TITLE
Examining teleporter consoles now show their ID

### DIFF
--- a/code/game/machinery/teleporter/console.dm
+++ b/code/game/machinery/teleporter/console.dm
@@ -30,6 +30,15 @@
 	id = "[random_id(/obj/machinery/computer/teleporter, 1000, 9999)]"
 	update_refs()
 
+/obj/machinery/computer/teleporter/examine(mob/user, distance)
+	. = ..()
+	var/adjacent = distance <= 2 || isobserver(user)
+	if (!adjacent || GET_FLAGS(stat, MACHINE_STAT_NOSCREEN))
+		return
+	if (id)
+		to_chat(user, SPAN_NOTICE("The console screen displays:") + " ID: [id]")
+	else
+		to_chat(user, SPAN_NOTICE("The console screen displays:") + " ID: " + SPAN_WARNING("<i>UNDEFINED</i>"))
 
 /obj/machinery/computer/teleporter/proc/update_refs()
 	for (var/dir in GLOB.cardinal)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
🆑  Titanized
rscadd: Teleporter consoles now display their ID when examined at a close distance.
/:cl:

This is mostly for hand teleporter and other integrated circuits reference.

id shouldn't ever be null but var edit exists so better be safe.