### PR TITLE
Remove BO sec access

### DIFF
--- a/maps/torch/job/command_jobs.dm
+++ b/maps/torch/job/command_jobs.dm
@@ -402,7 +402,7 @@
 
 
 	access = list(
-		access_security, access_medical, access_engine, access_maint_tunnels, access_emergency_storage,
+		access_medical, access_engine, access_maint_tunnels, access_emergency_storage,
 		access_bridge, access_janitor, access_kitchen, access_cargo, access_mailsorting, access_RC_announce, access_keycard_auth,
 		access_solgov_crew, access_aquila, access_aquila_helm, access_guppy, access_guppy_helm, access_external_airlocks,
 		access_eva, access_hangar, access_cent_creed, access_explorer, access_expedition_shuttle, access_expedition_shuttle_helm, access_teleporter,

--- a/maps/torch/torch_presets.dm
+++ b/maps/torch/torch_presets.dm
@@ -12,7 +12,7 @@ var/global/const/NETWORK_FIFTH_DECK  = "Fifth Deck"
 		if(NETWORK_AQUILA)
 			return access_aquila
 		if(NETWORK_BRIDGE)
-			return access_heads
+			return list(list(access_torch_helm,access_heads))
 		if(NETWORK_CHARON)
 			return access_expedition_shuttle
 		if(NETWORK_HELMETS)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
🆑 Titanized
balance: Bridge officers no longer have security access.
tweak: Bridge camera network accepts either torch helm or head of staff access.
/:cl:

There isn't much of a reason for BOs to have security access, they are not part of the department.
BO is also a role open for newer players, so ideally it's best to avoid placing them in situations that could promote unwanted interactions.