### PR TITLE
Adds uniform selection to character prefs

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1640,6 +1640,8 @@
 #include "code\modules\client\preference_setup\loadout\lists\xenowear.dm"
 #include "code\modules\client\preference_setup\occupation\occupation.dm"
 #include "code\modules\client\preference_setup\occupation\skill_selection.dm"
+#include "code\modules\client\preference_setup\occupation\uniform_selection.dm"
+#include "code\modules\client\preference_setup\uniform\uniform.dm"
 #include "code\modules\clothing\_clothing.dm"
 #include "code\modules\clothing\_clothing_flags.dm"
 #include "code\modules\clothing\buttons.dm"

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -395,6 +395,18 @@ SUBSYSTEM_DEF(jobs)
 	// Equip custom gear loadout, replacing any job items
 	var/list/spawn_in_storage = list()
 	var/list/loadout_taken_slots = list()
+
+	if(H.client.prefs.Uniform(job))
+		var/uniform_id = "[H.real_name], [H.char_rank], [H.char_branch]"
+		if(!GLOB.uniform_issued_items[uniform_id])
+			GLOB.uniform_issued_items[uniform_id] = list()
+		var/list/checkedout = GLOB.uniform_issued_items[uniform_id]
+		for(var/thing in H.client.prefs.Uniform(job))
+			var/item = new thing(H.loc)
+			if(!H.equip_to_appropriate_slot(item, TRUE, TRUE, TRUE, TRUE))
+				spawn_in_storage.Add(item)
+			checkedout += item
+
 	if(H.client.prefs.Gear() && job.loadout_allowed)
 		for(var/thing in H.client.prefs.Gear())
 			var/datum/gear/G = gear_datums[thing]

--- a/code/modules/client/preference_setup/general/05_preview.dm
+++ b/code/modules/client/preference_setup/general/05_preview.dm
@@ -27,18 +27,25 @@
 			previewJob = SSjobs.get_by_title(job_high)
 	else
 		return
+	var/list/loadout_taken_slots = list()
 	if(preview_job && previewJob)
 		mannequin.job = previewJob.title
 		var/datum/mil_branch/branch = GLOB.mil_branches.get_branch(branches[previewJob.title])
 		var/datum/mil_rank/rank = GLOB.mil_branches.get_rank(branches[previewJob.title], ranks[previewJob.title])
 		previewJob.equip_preview(mannequin, player_alt_titles[previewJob.title], branch, rank)
+		var/list/preview_gear = preview_job ? Uniform(previewJob) : list()
+		if(preview_gear)
+			for(var/thing in Uniform(previewJob))
+				var/item = new thing(mannequin.loc)
+				var/slot = mannequin.equip_to_appropriate_slot(item, TRUE, TRUE, TRUE, TRUE)
+				if(slot)
+					loadout_taken_slots |= slot
 		update_icon = TRUE
 	if(!(mannequin.species.appearance_flags && mannequin.species.appearance_flags & SPECIES_APPEARANCE_HAS_UNDERWEAR))
 		if(all_underwear)
 			all_underwear.Cut()
 	if(preview_gear && !(previewJob && preview_job && (previewJob.type == /datum/job/ai || previewJob.type == /datum/job/cyborg)))
 		// Equip custom gear loadout, replacing any job items
-		var/list/loadout_taken_slots = list()
 		for(var/thing in Gear())
 			var/datum/gear/G = gear_datums[thing]
 			if(G)
@@ -55,7 +62,7 @@
 				if(!permitted)
 					continue
 				if(G.slot && G.slot != slot_tie && !(G.slot in loadout_taken_slots) && G.spawn_on_mob(mannequin, gear_list[gear_slot][G.display_name]))
-					loadout_taken_slots.Add(G.slot)
+					loadout_taken_slots |= G.slot
 					update_icon = TRUE
 	if(update_icon)
 		mannequin.update_icons()

--- a/code/modules/client/preference_setup/occupation/uniform_selection.dm
+++ b/code/modules/client/preference_setup/occupation/uniform_selection.dm
@@ -1,0 +1,125 @@
+GLOBAL_LIST_EMPTY(uniform_issued_items)
+/datum/preferences/var/list/uniforms_by_job	= list()	   //List of uniform prefs assigned to each job
+
+/*	Outfit structures
+	branch
+	branch/department
+	branch/department/officer
+	branch/department/officer/command
+
+	The one exception to the above is the command department, due to the fact that you have to be an officer to
+	be in command, and there are no variants as a result. Also no special CO uniform :(
+*/
+/proc/find_uniforms(datum/mil_rank/user_rank, datum/mil_branch/user_branch, department, include_pt = TRUE, include_dress = TRUE)
+	var/singleton/hierarchy/mil_uniform/user_outfit = GET_SINGLETON(/singleton/hierarchy/mil_uniform)
+	var/mil_uniforms = user_outfit
+	for(var/singleton/hierarchy/mil_uniform/child in user_outfit.children)
+		if(is_type_in_list(user_branch, child.branches))
+			user_outfit = child
+	if(user_outfit == mil_uniforms) //We haven't found a branch
+		return null //Return no uniforms, which will cause the machine to spit out an error.
+
+	// we have found a branch.
+	if(department == COM) //Command only has one variant and they have to be an officer
+		for(var/singleton/hierarchy/mil_uniform/child in user_outfit.children)
+			if(child.departments & COM)
+				user_outfit = child
+				for(var/singleton/hierarchy/mil_uniform/seniorchild in user_outfit.children) //Check for variants of command outfits
+					if(user_rank.sort_order >= seniorchild.min_rank && user_outfit.min_rank < seniorchild.min_rank)
+						user_outfit = seniorchild
+	else
+		var/tmp_department = department
+		tmp_department &= ~COM //Parse departments, with complete disconsideration to the command flag (so we don't flag 2 outfit trees)
+
+		for(var/singleton/hierarchy/mil_uniform/child in user_outfit.children) //find base department outfit
+			if(child.departments & tmp_department)
+				user_outfit = child
+				break
+		for(var/singleton/hierarchy/mil_uniform/child in user_outfit.children) //find highest applicable ranking department outfit
+			if(user_rank.sort_order >= child.min_rank && user_outfit.min_rank < child.min_rank)
+				user_outfit = child
+		if(department & COM) //user is in command of their department
+			if(user_outfit.children[1])// Command outfit exists
+				user_outfit = user_outfit.children[1]
+				for(var/singleton/hierarchy/mil_uniform/child in user_outfit.children) //Check for variants of command outfits
+					if(user_rank.sort_order >= child.min_rank && user_outfit.min_rank < child.min_rank)
+						user_outfit = child
+
+	return populate_uniforms(user_outfit, include_pt, include_dress) //Generate uniform lists.
+
+/proc/populate_uniforms(singleton/hierarchy/mil_uniform/user_outfit, include_pt = TRUE, include_dress = TRUE)
+	var/list/res = list()
+	if(include_pt)
+		res["PT"] = list(
+			user_outfit.pt_under,
+			user_outfit.pt_shoes
+			)
+
+	res["Utility"] = list(
+		user_outfit.utility_under,
+		user_outfit.utility_shoes,
+		user_outfit.utility_hat
+		)
+	if (user_outfit.utility_extra)
+		res["Utility Extras"] = user_outfit.utility_extra
+
+	res["Service"] = list(
+		user_outfit.service_under,
+		user_outfit.service_skirt,
+		user_outfit.service_over,
+		user_outfit.service_shoes,
+		user_outfit.service_heels,
+		user_outfit.service_hat,
+		user_outfit.service_gloves
+		)
+	if(user_outfit.service_extra)
+		res["Service Extras"] = user_outfit.service_extra
+
+	if(include_dress)
+		res["Dress"] = list(
+			user_outfit.dress_under,
+			user_outfit.dress_skirt,
+			user_outfit.dress_over,
+			user_outfit.dress_shoes,
+			user_outfit.dress_heels,
+			user_outfit.dress_hat,
+			user_outfit.dress_gloves
+			)
+		if(user_outfit.dress_extra)
+			res["Dress Extras"] = user_outfit.dress_extra
+
+	return res
+
+/proc/uniform_contains_clothing(datum/mil_rank/user_rank, datum/mil_branch/user_branch, department, obj/item/clothing/clothing)
+
+/datum/preferences/proc/Uniform(datum/job/job)
+	return job ? uniforms_by_job[job.title] : list()
+
+/datum/category_item/player_setup_item/occupation/proc/open_uniform_setup(mob/user, datum/job/job)
+	panel = new(user, "uniform-selection", "Uniform Selection: [job.title]", 350, 590, src)
+	panel.set_content(generate_uniform_content(job))
+	panel.open()
+
+/datum/category_item/player_setup_item/occupation/proc/get_selected_uniform_list(datum/job/job)
+	return job ? pref.uniforms_by_job[job.title] : list()
+
+/datum/category_item/player_setup_item/occupation/proc/generate_uniform_content(datum/job/job)
+	var/dat = list()
+	var/list/uniforms = list()
+	if(job)
+		var/datum/mil_branch/player_branch = pref.branches[job.title] ? GLOB.mil_branches.get_branch(pref.branches[job.title]) : null
+		var/datum/mil_rank/player_rank = pref.ranks[job.title] ? GLOB.mil_branches.get_rank(player_branch.name, pref.ranks[job.title]) : null
+		uniforms = find_uniforms(player_rank, player_branch, job.department_flag, FALSE, FALSE)
+	var/list/selected_outfit = get_selected_uniform_list(job)
+	for(var/uniform_type in uniforms)
+		dat += "<b>[uniform_type]</b>"
+		var/list/uniform = uniforms[uniform_type]
+		for(var/piece in uniform)
+			if(piece)
+				var/obj/item/clothing/C = piece
+				if("[piece]" in selected_outfit)
+					dat += "[SPAN_CLASS("linkOn", "[sanitize(initial(C.name))]")]<a href='byond://?src=\ref[src];remove_uniform=\ref[piece];uniform_job=[job.title]'>X</a>"
+				else
+					dat += "<a href='byond://?src=\ref[src];add_uniform=\ref[piece];uniform_job=[job.title]'>[sanitize(initial(C.name))]</a>"
+		dat += "<hr>"
+	return jointext(dat, "<br>")

--- a/code/modules/client/preference_setup/uniform/uniform.dm
+++ b/code/modules/client/preference_setup/uniform/uniform.dm
@@ -1,0 +1,32 @@
+/singleton/hierarchy/mil_uniform
+	name = "Master outfit hierarchy"
+	hierarchy_type = /singleton/hierarchy/mil_uniform
+	var/list/branches = null
+	var/departments = 0
+	var/min_rank = 0
+
+	var/pt_under = null
+	var/pt_shoes = null
+
+	var/utility_under = null
+	var/utility_shoes = null
+	var/utility_hat = null
+	var/utility_extra = null
+
+	var/service_under = null
+	var/service_skirt = null
+	var/service_over = null
+	var/service_shoes = null
+	var/service_heels = null
+	var/service_hat = null
+	var/service_gloves = null
+	var/service_extra = null
+
+	var/dress_under = null
+	var/dress_skirt = null
+	var/dress_over = null
+	var/dress_shoes = null
+	var/dress_heels = null
+	var/dress_hat = null
+	var/dress_gloves = null
+	var/dress_extra = null

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -63,7 +63,7 @@
 
 
 /// Place I into the first slot it fits in the order of slots_by_priority, returning the slot or falsy.
-/mob/proc/equip_to_appropriate_slot(obj/item/I, skip_storage, skip_timer)
+/mob/proc/equip_to_appropriate_slot(obj/item/I, skip_storage, skip_timer, destroy_on_fail, force_equip)
 	var/static/list/slots_by_priority = list(
 		slot_back, slot_wear_id, slot_w_uniform, slot_wear_suit,
 		slot_wear_mask, slot_head, slot_shoes, slot_gloves, slot_l_ear,
@@ -75,11 +75,15 @@
 	var/equip_flags = TRYEQUIP_REDRAW | TRYEQUIP_SILENT
 	if (skip_timer)
 		equip_flags |= TRYEQUIP_INSTANT
+	if (force_equip)
+		equip_flags |= TRYEQUIP_FORCE
 	for (var/slot in slots_by_priority)
 		if (skip_storage && (slot == slot_s_store || slot == slot_l_store || slot == slot_r_store))
 			continue
 		if (equip_to_slot_if_possible(I, slot, equip_flags))
 			return slot //slot is truthy; we can return it for info
+	if(destroy_on_fail)
+		qdel(I)
 
 
 //Checks if a given slot can be accessed at this time, either to equip or unequip I

--- a/maps/torch/datums/uniforms.dm
+++ b/maps/torch/datums/uniforms.dm
@@ -1,35 +1,3 @@
-/singleton/hierarchy/mil_uniform
-	name = "Master outfit hierarchy"
-	hierarchy_type = /singleton/hierarchy/mil_uniform
-	var/list/branches = null
-	var/departments = 0
-	var/min_rank = 0
-
-	var/pt_under = null
-	var/pt_shoes = null
-
-	var/utility_under = null
-	var/utility_shoes = null
-	var/utility_hat = null
-	var/utility_extra = null
-
-	var/service_under = null
-	var/service_skirt = null
-	var/service_over = null
-	var/service_shoes = null
-	var/service_heels = null
-	var/service_hat = null
-	var/service_gloves = null
-	var/service_extra = null
-
-	var/dress_under = null
-	var/dress_skirt = null
-	var/dress_over = null
-	var/dress_shoes = null
-	var/dress_heels = null
-	var/dress_hat = null
-	var/dress_gloves = null
-	var/dress_extra = null
 
 /singleton/hierarchy/mil_uniform/ec
 	name = "Master EC outfit"


### PR DESCRIPTION
🆑 Cakey
rscadd: You can now pre-select your uniform for your jobs via the occupation tab. The options available will match the clothing available to your branch and rank just like in uniform vendors, minus dress and PT.
/🆑

<img width="1177" height="472" alt="image" src="https://github.com/user-attachments/assets/618e2008-51aa-4266-bda0-4d7609cc5486" />

<img width="445" height="602" alt="image" src="https://github.com/user-attachments/assets/552e8906-9324-44c9-bd41-873a0768f888" />

<img width="433" height="242" alt="image" src="https://github.com/user-attachments/assets/f8f1209b-fd5e-432f-a10a-baf516c1e6bb" />
