### PR TITLE
Ghost clear_client_colors() fix

### DIFF
--- a/code/modules/mob/observer/ghost/ghost.dm
+++ b/code/modules/mob/observer/ghost/ghost.dm
@@ -167,7 +167,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if (admin_paralyzed)
 		to_chat(usr, SPAN_DEBUG("You cannot ghost while admin paralyzed."))
 		return
-	clear_client_colors()
 	if(stat == DEAD)
 		announce_ghost_joinleave(ghostize(1))
 	else
@@ -184,6 +183,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 			response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost, you won't be able to return to this body! You can't change your mind so choose wisely!)", "Are you sure you want to ghost?", "Ghost", "Stay in body")
 		if(response != "Ghost")
 			return
+		clear_client_colors()
 		log_and_message_admins("has ghosted.")
 		ghosted = TRUE
 		var/mob/observer/ghost/ghost = ghostize(0)	//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3


### PR DESCRIPTION
Relocates clear_client_colors() proc closer to the end of function so it won't clear client colors while asking you if you're sure you want to ghost. Currently affects detective vision, but might also affect other matrices in the future.

:cl: Baneuus
bugfix: Now trying to ghost won't clear client colors until you ghost.
/:cl: