### PR TITLE
Email QOL

### DIFF
--- a/code/modules/modular_computers/NTNet/emails/email_message.dm
+++ b/code/modules/modular_computers/NTNet/emails/email_message.dm
@@ -3,6 +3,7 @@
 	stored_data = ""
 	var/title = ""
 	var/source = ""
+	var/recipient = ""
 	var/spam = FALSE
 	var/timestamp = ""
 	var/datum/computer_file/attachment = null
@@ -11,6 +12,7 @@
 	var/datum/computer_file/data/email_message/temp = ..()
 	temp.title = title
 	temp.source = source
+	temp.recipient = recipient
 	temp.spam = spam
 	temp.timestamp = timestamp
 	if(attachment)

--- a/code/modules/modular_computers/file_system/programs/generic/email_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/email_client.dm
@@ -244,12 +244,13 @@
 
 			if(message_source)
 				data["folder"] = folder
+				data["source_label"] = folder == "Sent" ? "Recipient" : "Source"
 				var/list/all_messages = list()
 				for(var/datum/computer_file/data/email_message/message in message_source)
 					all_messages.Add(list(list(
 						"title" = message.title,
 						"body" = digitalPencode2html(message.stored_data),
-						"source" = message.source,
+						"source" = folder == "Sent" ? message.recipient : message.source,
 						"timestamp" = message.timestamp,
 						"uid" = message.uid
 					)))
@@ -420,6 +421,7 @@
 		message.title = msg_title
 		message.stored_data = sanitize(msg_body, MAX_MESSAGE_LEN, FALSE)
 		message.source = current_account.login
+		message.recipient = msg_recipient
 		message.attachment = msg_attachment
 		if(!current_account.send_mail(msg_recipient, message))
 			error = "Error sending email: this address doesn't exist."

--- a/code/modules/modular_computers/file_system/programs/research/email_administration.dm
+++ b/code/modules/modular_computers/file_system/programs/research/email_administration.dm
@@ -47,7 +47,7 @@
 		data["current_account"] = current_account.login
 		data["cur_suspended"] = current_account.suspended
 		var/list/all_messages = list()
-		for(var/datum/computer_file/data/email_message/message in (current_account.inbox | current_account.spam | current_account.deleted))
+		for(var/datum/computer_file/data/email_message/message in (current_account.inbox | current_account.outbox | current_account.spam | current_account.deleted))
 			all_messages.Add(list(list(
 				"title" = message.title,
 				"source" = message.source,

--- a/code/modules/modular_computers/file_system/programs/research/email_administration.dm
+++ b/code/modules/modular_computers/file_system/programs/research/email_administration.dm
@@ -42,6 +42,7 @@
 		data["msg_body"] = digitalPencode2html(current_message.stored_data)
 		data["msg_timestamp"] = current_message.timestamp
 		data["msg_source"] = current_message.source
+		data["msg_recipient"] = current_message.recipient
 	else if(istype(current_account))
 		data["current_account"] = current_account.login
 		data["cur_suspended"] = current_account.suspended
@@ -50,6 +51,7 @@
 			all_messages.Add(list(list(
 				"title" = message.title,
 				"source" = message.source,
+				"recipient" = message.recipient,
 				"timestamp" = message.timestamp,
 				"uid" = message.uid
 			)))

--- a/code/modules/modular_computers/file_system/reports/people.dm
+++ b/code/modules/modular_computers/file_system/reports/people.dm
@@ -29,6 +29,7 @@
 	message.title = subject
 	message.stored_data = sanitize(body, MAX_MESSAGE_LEN, FALSE)
 	message.source = server.login
+	message.recipient = recipient
 	message.attachment = attach_report
 	server.send_mail(recipient, message)
 

--- a/code/modules/modular_computers/terminal/commands/log.dm
+++ b/code/modules/modular_computers/terminal/commands/log.dm
@@ -23,6 +23,7 @@
 	M.title = "!SENSITIVE! - NTNet System log backup"
 	M.stored_data = jointext(ntnet_global.logs, "<br>")
 	M.source = S.login
+	M.recipient = argument
 	if(!S.send_mail(argument, M))
 		return "[name]: Error; could not send email to '[argument]'."
 	if(!has_access(list(access_network_admin), user.GetAccess()))

--- a/code/modules/modular_computers/terminal/terminal_skill_fail.dm
+++ b/code/modules/modular_computers/terminal/terminal_skill_fail.dm
@@ -97,6 +97,7 @@ GLOBAL_LIST_AS(terminal_fails, init_subtypes(/datum/terminal_skill_fail))
 	M.title = "!SENSITIVE! - NTNet System log backup"
 	M.stored_data = jointext(ntnet_global.logs, "<br>")
 	M.source = S.login
+	M.recipient = EMAIL_BROADCAST
 	if(!S.send_mail(EMAIL_BROADCAST, M))
 		return list()
 	terminal.computer.add_log("Network log sent to: all")

--- a/nano/templates/email_administration.tmpl
+++ b/nano/templates/email_administration.tmpl
@@ -27,6 +27,12 @@
 			{{:data.msg_source}}&nbsp
 		</div>
 		<div class="itemLabel">
+			Recipient:
+		</div>
+		<div class="itemContent">
+			{{:data.msg_recipient}}
+		</div>
+		<div class="itemLabel">
 			Received at:
 		</div>
 		<div class="itemContent">
@@ -71,6 +77,7 @@
 		<table>
 			<tr>
 				<th>Source</th>
+				<th>Recipient</th>
 				<th>Title</th>
 				<th>Received at</th>
 				<th>Actions</th>
@@ -78,6 +85,7 @@
 			{{for data.messages}}
 				<tr>
 					<td>{{:value.source}}&nbsp</td>
+					<td>{{:value.recipient}}</td>
 					<td>{{:value.title}}&nbsp</td>
 					<td>{{:value.timestamp}}&nbsp</td>
 					<td>

--- a/nano/templates/email_client.tmpl
+++ b/nano/templates/email_client.tmpl
@@ -151,7 +151,7 @@
 		{{if data.messagecount}}
 			<table>
 				<tr>
-					<th>Source</th>
+					<th>{{:data.source_label}}</th>
 					<th>Title</th>
 					<th>Received at</th>
 					<th></th>


### PR DESCRIPTION
Some QOL tweaks to the Email Client and Email Administration UI.

## Changelog
:cl: SierraKomodo
tweak: Email programs now display message recipient in applicable screens, such as the Sent tab of the Email Client program, or when listing and viewing emails in Email Administration.
tweak: Email Administration now also displays sent emails when viewing specific accounts.
/:cl:

## Other Changes
- Added `recipient` to `/datum/computer_file/data/email_message`.