### PR TITLE
Service grippers can hold kitchen containers

### DIFF
--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -119,6 +119,7 @@
 	can_hold = list(
 		/obj/item/reagent_containers/glass,
 		/obj/item/reagent_containers/food,
+		/obj/item/reagent_containers/cooking_container,
 		/obj/item/seeds,
 		/obj/item/glass_extra,
 		/obj/item/clothing/mask/smokable,


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Service grippers can now hold the new kitchen equipment.
/:cl:

## Bug Fixes
- Fixes #35307