### PR TITLE
Clamp mech and robot component health

### DIFF
--- a/code/modules/mechs/components/_components.dm
+++ b/code/modules/mechs/components/_components.dm
@@ -52,8 +52,7 @@
 		return 1
 
 /obj/item/mech_component/proc/update_health()
-	total_damage = brute_damage + burn_damage
-	if(total_damage > max_damage) total_damage = max_damage
+	total_damage = clamp(brute_damage + burn_damage, 0, max_damage)
 	var/prev_state = damage_state
 	damage_state = clamp(round((total_damage/max_damage) * 4), MECH_COMPONENT_DAMAGE_UNDAMAGED, MECH_COMPONENT_DAMAGE_DAMAGED_TOTAL)
 	if(damage_state > prev_state)

--- a/code/modules/mob/living/silicon/robot/component.dm
+++ b/code/modules/mob/living/silicon/robot/component.dm
@@ -199,9 +199,9 @@
 	var/max_dam = 30
 
 /obj/item/robot_parts/robot_component/proc/take_damage(brute_amt, burn_amt)
-	brute += brute_amt
-	burn += burn_amt
-	total_dam = brute+burn
+	brute = max(brute + brute_amt, 0)
+	burn = max(burn + burn_amt, 0)
+	total_dam = max(brute + burn, 0, max_dam)
 	if(total_dam >= max_dam)
 		var/obj/item/stock_parts/circuitboard/broken/broken_device = new (get_turf(src))
 		if(icon_state_broken != "broken")


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: It is no longer possible to 'overheal' mech and robot components.
/:cl:

## Bug Fixes
- Fixes #35286