### PR TITLE
Fix for positronic brains 2

### DIFF
--- a/code/modules/ghosttrap/trap.dm
+++ b/code/modules/ghosttrap/trap.dm
@@ -37,22 +37,23 @@ var/global/list/ghost_traps
 	..()
 
 // Check for bans, proper atom types, etc.
-/datum/ghosttrap/proc/assess_candidate(mob/observer/ghost/candidate, mob/target, feedback = TRUE)
-	if (!target)
-		to_chat(candidate, "This occupation request is no longer valid.")
-		return FALSE
+/datum/ghosttrap/proc/assess_candidate(mob/observer/ghost/candidate, mob/target, feedback = TRUE, no_target = FALSE)
+	if(!no_target)
+		if (!target)
+			to_chat(candidate, "This occupation request is no longer valid.")
+			return FALSE
+
+		if(request_timeouts[target] && world.time > request_timeouts[target])
+			if (feedback)
+				to_chat(candidate, "This occupation request is no longer valid.")
+			return FALSE
+
+		if(target.key)
+			if (feedback)
+				to_chat(candidate, "The target is already occupied.")
+			return FALSE
 
 	if(!candidate.MayRespawn(feedback, minutes_since_death))
-		return FALSE
-
-	if(request_timeouts[target] && world.time > request_timeouts[target])
-		if (feedback)
-			to_chat(candidate, "This occupation request is no longer valid.")
-		return FALSE
-
-	if(target.key)
-		if (feedback)
-			to_chat(candidate, "The target is already occupied.")
 		return FALSE
 
 	if(islist(ban_checks))

--- a/code/modules/organs/internal/species/ipc.dm
+++ b/code/modules/organs/internal/species/ipc.dm
@@ -38,7 +38,7 @@
 		if(iscarbon(loc))
 			init(loc)
 		else
-			brainmob = new()
+			brainmob = new(src)
 	robotize()
 	unshackle()
 	update_icon()
@@ -164,7 +164,7 @@
 	if (brainmob.mind && brainmob.mind.special_role)
 		return
 	var/datum/ghosttrap/T = get_ghost_trap("positronic brain")
-	if (!T.assess_candidate(user))
+	if (!T.assess_candidate(user, brainmob))
 		return
 	var/possess = alert(user, "Do you wish to become \the [src]?", "Become [src]?", "Yes", "No")
 	if (possess != "Yes")

--- a/code/modules/spells/artifacts/spellbound_servants.dm
+++ b/code/modules/spells/artifacts/spellbound_servants.dm
@@ -206,10 +206,11 @@
 /obj/cleanable/spellbound/attack_hand(mob/user)
 	if(last_called > world.time )
 		return
+	visible_message(SPAN_WARNING("\The [src] pulses with a small burst of light, for a few seconds."))
 	last_called = world.time + 30 SECONDS
 	var/datum/ghosttrap/G = get_ghost_trap("wizard familiar")
 	for(var/mob/observer/ghost/ghost in GLOB.player_list)
-		if(G.assess_candidate(ghost,null,FALSE))
+		if(G.assess_candidate(ghost,null,FALSE,TRUE))
 			to_chat(ghost,"[SPAN_NOTICE("<b>A wizard is requesting a Spell-Bound Servant!</b>")] (<a href='byond://?src=\ref[src];master=\ref[user]'>Join</a>)")
 
 /obj/cleanable/spellbound/CanUseTopic(mob)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Fixed my mistake. Braimobs are no longer created into the nothingness. (into black screen) Additionally fixes assess_canditate check, so ghosts could also join into the brain through click.

:cl: Builder13
bugfix: Fixed my mistake for positronic brain acivation.
bugfix: Fixed wizard familliar runes.
/:cl: