### PR TITLE
animate() lighting overlays

### DIFF
--- a/code/__defines/lighting.dm
+++ b/code/__defines/lighting.dm
@@ -4,6 +4,8 @@
 #define LIGHTING_Z_FACTOR       10 // Z diff is multiplied by this and LIGHTING_HEIGHT to get the final height of a light source. Affects how much darker A Z light gets with each level transitioned.
 #define LIGHTING_ROUND_VALUE    (1 / 200) //Value used to round lumcounts, values smaller than 1/255 don't matter (if they do, thanks sinking points), greater values will make lighting less precise, but in turn increase performance, VERY SLIGHTLY.
 
+#define LIGHTING_LIGHTSPEED     2 // How fast to animate light overlays
+
 #define LIGHTING_ICON 'icons/effects/lighting_overlay.dmi' // icon used for lighting shading effects
 #define LIGHTING_BASE_ICON_STATE "matrix"	// icon_state used for normal color-matrix based lighting overlays.
 #define LIGHTING_STATION_ICON_STATE "tubedefault"	// icon_state used for lighting overlays that are just displaying standard station lighting.
@@ -35,6 +37,16 @@
 		1, 1, 1, 0, \
 		1, 1, 1, 0, \
 		1, 1, 1, 0, \
+		0, 0, 0, 1  \
+	)               \
+
+#define BLACKNESS_MATRIX \
+	list            \
+	(               \
+		0, 0, 0, 0, \
+		0, 0, 0, 0, \
+		0, 0, 0, 0, \
+		0, 0, 0, 0, \
 		0, 0, 0, 1  \
 	)               \
 

--- a/code/modules/lighting/lighting_overlay.dm
+++ b/code/modules/lighting/lighting_overlay.dm
@@ -13,6 +13,7 @@
 
 	var/needs_update = FALSE
 	var/safe_to_delete = FALSE
+	var/new_lum = 0
 
 	#if WORLD_ICON_SIZE != 32
 	transform = matrix(WORLD_ICON_SIZE / 32, 0, (WORLD_ICON_SIZE - 32) / 2, 0, WORLD_ICON_SIZE / 32, (WORLD_ICON_SIZE - 32) / 2)
@@ -79,7 +80,7 @@
 		ca = corners[1] || dummy_lighting_corner
 
 	var/max = max(cr.cache_mx, cg.cache_mx, cb.cache_mx, ca.cache_mx)
-	luminosity = max > 0
+	new_lum = max > 0
 
 	var/rr = cr.cache_r
 	var/rg = cr.cache_g
@@ -97,17 +98,24 @@
 	var/ag = ca.cache_g
 	var/ab = ca.cache_b
 
+	var/new_color
+
 	if(rr + rg + rb + gr + gg + gb + br + bg + bb + ar + ag + ab >= 12)
 		icon_state = LIGHTING_TRANSPARENT_ICON_STATE
-		color = null
-	else if (!luminosity)
-		icon_state = LIGHTING_DARKNESS_ICON_STATE
 		color = null
 	else if (rr == LIGHTING_DEFAULT_TUBE_R && rg == LIGHTING_DEFAULT_TUBE_G && rb == LIGHTING_DEFAULT_TUBE_B && ALL_EQUAL)
 		icon_state = LIGHTING_STATION_ICON_STATE
 		color = null
 	else
 		icon_state = LIGHTING_BASE_ICON_STATE
+
+		// can't animate from null
+		if(isnull(color))
+			color = BLACKNESS_MATRIX
+			// if we animate from blackness we wanna set luminosity now
+			// so you can see the light overlay in the first place <3
+			luminosity = new_lum
+
 		if (islist(color))
 			// Does this even save a list alloc?
 			var/list/c_list = color
@@ -123,9 +131,9 @@
 			c_list[CL_MATRIX_AR] = ar
 			c_list[CL_MATRIX_AG] = ag
 			c_list[CL_MATRIX_AB] = ab
-			color = c_list
+			new_color = c_list
 		else
-			color = list(
+			new_color = list(
 				rr, rg, rb, 0,
 				gr, gg, gb, 0,
 				br, bg, bb, 0,
@@ -133,12 +141,23 @@
 				0, 0, 0, 1
 			)
 
+	if(color != BLACKNESS_MATRIX)
+		addtimer(new Callback(src, PROC_REF(update_luminosity)), LIGHTING_LIGHTSPEED)
+	animate(src, color = new_color, time = LIGHTING_LIGHTSPEED)
+
 	// If there's a Z-turf above us, update its shadower.
 	if (T.above)
 		if (T.above.shadower)
 			T.above.shadower.copy_lighting(src)
 		else
 			T.above.update_mimic()
+
+/atom/movable/lighting_overlay/proc/update_luminosity()
+	luminosity = new_lum
+
+	if (!luminosity)
+		icon_state = LIGHTING_DARKNESS_ICON_STATE
+		color = null
 
 #undef ALL_EQUAL
 


### PR DESCRIPTION
Animated light overlays!!!

Current issues:

adds a new variable to every lighting overlay and thus eating lots of memory (probably)

When you spam click a light switch lighting the icon doesnt update to the LIGHTING_BASE_ICON_STATE // FIXED????
After roundstart it takes like 5 seconds for the lighting overlays to show properly (only sometimes tho???) // FIXED????

🆑 Bam4000
tweak: light overlays are now animated
/:cl:

Is it really worth it tho?