### PR TITLE
Add client screen recoil to projectile weapons

### DIFF
--- a/code/_helpers/maths.dm
+++ b/code/_helpers/maths.dm
@@ -62,6 +62,11 @@
 /// The cotangent of degrees
 #define Cot(degrees) (1 / tan(degrees))
 
+#define MODULUS_FLOAT(X, Y) ( (X) - (Y) * round((X) / (Y)) )
+
+// Will filter out extra rotations and negative rotations
+// E.g: 540 becomes 180. -180 becomes 180.
+#define SIMPLIFY_DEGREES(degrees) (MODULUS_FLOAT((degrees), 360))
 
 /// The 2-argument arctangent of x and y
 /proc/Atan2(x, y)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -323,6 +323,17 @@ var/global/list/organ_rel_size = list(
 		M.client.eye=oldeye
 		M.shakecamera = 0
 
+/proc/recoil_camera(mob/camera_mob, duration = 1, angle = 180, strength = 1, easing = CUBIC_EASING|EASE_OUT)
+	if(!camera_mob?.client || duration < 1 || !easing)
+		return
+	var/client/camera_client = camera_mob.client
+
+	angle = clamp(angle, 0, 360)
+	var/hypotenuse = strength*world.icon_size
+	var/offset_y = round(hypotenuse*sin(angle), 0.1)
+	var/offset_x = round(hypotenuse*-cos(angle), 0.1)
+	animate(camera_client, pixel_x = offset_x, pixel_y = offset_y, time = duration, easing = easing, flags = ANIMATION_RELATIVE)
+	animate(pixel_x = -offset_x, pixel_y = -offset_y, time = duration, easing = easing, flags = ANIMATION_RELATIVE)
 
 /mob/proc/abiotic(full_body = FALSE)
 	var/holding_simulated_item = FALSE

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -76,6 +76,14 @@
 	var/fire_anim = null
 	/// The amount your screen shakes when firing. Shouldn't be greater than 2 unless zoomed.
 	var/screen_shake = 0
+	/**
+	 * If this gun has client recoil, this stores info such as amount and duration.
+	 *
+	 * - "strength": How far to move the screen
+	 * - "duration": The length of the animation
+	 * - "easing": special type of easing to be used, can be null
+	 */
+	var/list/client_recoil_animation_information = null
 	/// Whether or not this weapon moves the shooter backwards when fired in space.
 	var/space_recoil = 0
 	var/silenced = FALSE
@@ -375,6 +383,20 @@
 		if(screen_shake)
 			spawn()
 				shake_camera(user, screen_shake+1, screen_shake)
+
+		if(LAZYLEN(client_recoil_animation_information))
+			var/skill_modifier = user.get_skill_value(SKILL_WEAPONS) * 0.1
+			var/duration = client_recoil_animation_information["duration"]
+			if (isnull(duration))
+				duration = 1
+			duration = max(duration - skill_modifier, 1)
+			var/strength = client_recoil_animation_information["strength"]
+			if (isnull(strength))
+				strength = 0.5
+			strength = max(strength - skill_modifier, 0.1)
+			var/easing = client_recoil_animation_information["easing"] || CUBIC_EASING|EASE_OUT
+			var/recoil_angle = SIMPLIFY_DEGREES(Get_Angle(target, user) + 90)
+			recoil_camera(user, duration, recoil_angle, strength, easing)
 
 	if(combustion)
 		var/turf/curloc = get_turf(src)

--- a/code/modules/projectiles/guns/projectile.dm
+++ b/code/modules/projectiles/guns/projectile.dm
@@ -6,7 +6,10 @@
 	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 2)
 	w_class = ITEM_SIZE_NORMAL
 	matter = list(MATERIAL_STEEL = 1000)
-	screen_shake = 1
+	client_recoil_animation_information = list(
+		"strength" = 0.35,
+		"duration" = 2,
+	)
 	space_recoil = 1
 	combustion = 1
 

--- a/code/modules/projectiles/guns/projectile/automatic.dm
+++ b/code/modules/projectiles/guns/projectile/automatic.dm
@@ -25,6 +25,10 @@
 		list(mode_name="4-round bursts", burst=4, fire_delay=null, move_delay=4,    one_hand_penalty=1, burst_accuracy=list(0,0,-1,-1),       dispersion=list(0.0, 0.0, 0.5, 0.6)),
 		list(mode_name="long bursts",   burst=8, fire_delay=null, move_delay=4,    one_hand_penalty=2, burst_accuracy=list(0,0,-1,-1,-1,-1,-2,-2), dispersion=list(0.0, 0.0, 0.5, 0.6, 0.8, 1.0, 1.0, 1.2)),
 		)
+	client_recoil_animation_information = list(
+		"strength" = 0.7,
+		"duration" = 2,
+	)
 
 /obj/item/gun/projectile/automatic/machine_pistol
 	name = "machine pistol"
@@ -125,6 +129,10 @@
 		list(mode_name="3-round bursts", burst=3, fire_delay=null, move_delay=6,    one_hand_penalty=9, burst_accuracy=list(0,-1,-1),       dispersion=list(0.0, 0.6, 1.0)),
 		list(mode_name="short bursts",   burst=5, fire_delay=null, move_delay=6,    one_hand_penalty=11, burst_accuracy=list(0,-1,-2,-3,-3), dispersion=list(0.6, 1.0, 1.2, 1.2, 1.5)),
 		)
+	client_recoil_animation_information = list(
+		"strength" = 0.2,
+		"duration" = 2,
+	)
 
 /obj/item/gun/projectile/automatic/assault_rifle/on_update_icon()
 	..()

--- a/code/modules/projectiles/guns/projectile/dartgun.dm
+++ b/code/modules/projectiles/guns/projectile/dartgun.dm
@@ -52,7 +52,7 @@
 	caliber = CALIBER_DART
 	fire_sound = 'sound/weapons/empty.ogg'
 	fire_sound_text = "a metallic click"
-	screen_shake = 0
+	client_recoil_animation_information = null
 	silenced = TRUE
 	load_method = MAGAZINE
 	magazine_type = /obj/item/ammo_magazine/chemdart

--- a/code/modules/projectiles/guns/projectile/pistol.dm
+++ b/code/modules/projectiles/guns/projectile/pistol.dm
@@ -51,7 +51,6 @@
 	force = 9
 	caliber = CALIBER_PISTOL_MAGNUM
 	fire_delay = 12
-	screen_shake = 2
 	magazine_type = /obj/item/ammo_magazine/magnum
 	allowed_magazines = /obj/item/ammo_magazine/magnum
 	mag_insert_sound = 'sound/weapons/guns/interaction/hpistol_magin.ogg'
@@ -61,6 +60,10 @@
 	one_hand_penalty = 2
 	bulk = 3
 	ammo_indicator = TRUE
+	client_recoil_animation_information = list(
+		"strength" = 0.5,
+		"duration" = 2,
+	)
 
 /obj/item/gun/projectile/pistol/throwback
 	name = "pistol"

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -17,6 +17,10 @@
 	accuracy_power = 8
 	one_hand_penalty = 2
 	bulk = 3
+	client_recoil_animation_information = list(
+		"strength" = 0.5,
+		"duration" = 2.5,
+	)
 
 /obj/item/gun/projectile/revolver/AltClick()
 	if(CanPhysicallyInteract(usr))

--- a/code/modules/projectiles/guns/projectile/shotgun.dm
+++ b/code/modules/projectiles/guns/projectile/shotgun.dm
@@ -3,6 +3,10 @@
 	name = "master shotgun object"
 	desc = "You should not see this."
 	fire_sound = 'sound/weapons/gunshot/shotgun.ogg'
+	client_recoil_animation_information = list(
+		"strength" = 1.5,
+		"duration" = 3.5,
+	)
 
 /obj/item/gun/projectile/shotgun/pump
 	name = "shotgun"

--- a/code/modules/projectiles/guns/projectile/sniper.dm
+++ b/code/modules/projectiles/guns/projectile/sniper.dm
@@ -23,6 +23,7 @@
 	wielded_item_state = "heavysniper-wielded" //sort of placeholder
 	load_sound = 'sound/weapons/guns/interaction/rifle_load.ogg'
 	fire_delay = 12
+	client_recoil_animation_information = null
 
 /obj/item/gun/projectile/heavysniper/on_update_icon()
 	..()
@@ -115,6 +116,12 @@
 	scoped_accuracy = 0
 	wielded_item_state = "boltaction-wielded"
 	fire_sound = 'sound/weapons/gunshot/gunshot3.ogg'
+
+/obj/item/gun/projectile/sniper
+	client_recoil_animation_information = list(
+		"strength" = 1,
+		"duration" = 1,
+	)
 
 /obj/item/gun/projectile/sniper/panther //semi-automatic only
 	name = "marksman rifle"

--- a/code/modules/projectiles/guns/projectile/zipgun.dm
+++ b/code/modules/projectiles/guns/projectile/zipgun.dm
@@ -24,6 +24,11 @@
 		/obj/item/ammo_casing/rifle/military,
 		/obj/item/ammo_casing/rifle
 		)
+	// this gun is really shitty to use
+	client_recoil_animation_information = list(
+		"strength" = 3,
+		"duration" = 5,
+	)
 
 /obj/item/gun/projectile/pirate/toggle_safety(mob/user)
 	to_chat(user, SPAN_WARNING("There's no safety on \the [src]!"))


### PR DESCRIPTION
Ported from commit https://gitgud.io/notMatt/septic-fork/-/commit/eb76f56b0d7907594037962f0017c04f67be7f4e 

Screen recoil is influenced by the firers skill level. Higher weapons skill means better recoil control.

🆑 Bam4000
rscadd: Add a screen recoil to projectile weapons.
/:cl:



https://github.com/user-attachments/assets/a75f8afe-f894-4750-b313-184e3324320d


