### PR TITLE
Show dead crew count in roundend Discord message

### DIFF
--- a/code/modules/webhooks/webhook_roundend.dm
+++ b/code/modules/webhooks/webhook_roundend.dm
@@ -6,7 +6,7 @@
 	. = ..()
 	var/desc = "A round of **[SSticker.mode ? SSticker.mode.name : "Unknown"]** has ended.\n"
 	if(data)
-
+		var/dead_count = GLOB.crew_death_count
 		if(data["surviving_total"] > 0)
 
 			var/s_was =      "was"
@@ -16,9 +16,9 @@
 				s_was = "were"
 				s_survivor = "survivors"
 
-			desc += "There [s_was] **[data["surviving_total"]] [s_survivor] ([data["escaped_total"]] escaped)** and **[data["ghosts"]] ghosts.**"
+			desc += "There [s_was] **[data["surviving_total"]] [s_survivor], [dead_count] dead ([data["escaped_total"]] escaped)** and **[data["ghosts"]] ghosts.**"
 		else
-			desc += "There were **no survivors** ([data["ghosts"]] ghosts)."
+			desc += "There were **no survivors** ([dead_count] dead and [data["ghosts"]] ghosts)."
 
 	.["embeds"] = list(list(
 		"title" = "Round [game_id] is ending.",


### PR DESCRIPTION
:cl: Banditoz
spellcheck: Roundend Discord message now shows crew death count.
/:cl:

<img width="423" height="383" alt="image" src="https://github.com/user-attachments/assets/3e1d2281-a47f-40eb-9959-d06d841cfd0d" />