### PR TITLE
Adds a usable shuttle to the Bearcat map

### DIFF
--- a/maps/away/bearcat/bearcat-2.dmm
+++ b/maps/away/bearcat/bearcat-2.dmm
@@ -1039,6 +1039,15 @@
 "ca" = (
 /turf/simulated/floor/tiled,
 /area/ship/scrap/crew/hallway/port)
+"cb" = (
+/obj/paint/silver,
+/obj/paint/brown,
+/obj/wallframe_spawn/reinforced/titanium,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 10
+	},
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
 "cc" = (
 /obj/machinery/door/blast/regular{
 	density = 0;
@@ -5417,10 +5426,25 @@
 	},
 /turf/simulated/floor/tiled,
 /area/ship/scrap/crew/toilets)
+"kd" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/floor/tiled,
+/area/ship/scrap/shuttle/cubkitten)
 "km" = (
 /obj/paint/brown,
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/crew/toilets)
+"lb" = (
+/obj/structure/inflatable/wall,
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
 "lC" = (
 /turf/simulated/floor/reinforced{
 	map_airless = 1
@@ -5431,6 +5455,15 @@
 /obj/structure/lattice,
 /turf/space,
 /area/ship/scrap/maintenance/power)
+"mI" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/floor_decal/corner/yellow{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/scrap/shuttle/cubkitten)
 "nS" = (
 /obj/paint/brown,
 /turf/simulated/wall/r_wall,
@@ -5447,6 +5480,22 @@
 /obj/paint/brown,
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/crew/hallway/port)
+"pP" = (
+/obj/machinery/computer/ship/sensors/spacer,
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
+"qT" = (
+/turf/simulated/floor/tiled/dark,
+/area/ship/scrap/shuttle/cubkitten)
+"rc" = (
+/obj/structure/fuel_port{
+	pixel_x = 30
+	},
+/obj/structure/handrail{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/scrap/shuttle/cubkitten)
 "so" = (
 /obj/paint/brown,
 /turf/simulated/wall/r_wall,
@@ -5455,6 +5504,29 @@
 /obj/structure/lattice,
 /turf/simulated/floor,
 /area/ship/scrap/maintenance/atmos)
+"sQ" = (
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/item/device/radio/intercom/map_preset/bearcat{
+	pixel_x = -23;
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ship/scrap/shuttle/cubkitten)
+"tr" = (
+/obj/structure/cable{
+	d2 = 2;
+	icon_state = "0-2"
+	},
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1;
+	sheets = 25
+	},
+/turf/simulated/floor/tiled,
+/area/ship/scrap/shuttle/cubkitten)
 "ts" = (
 /obj/structure/lattice,
 /turf/space,
@@ -5476,6 +5548,16 @@
 /obj/paint/brown,
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/maintenance/atmos)
+"vw" = (
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/power/smes/buildable/preset/scavver/smes{
+	charge = 10000
+	},
+/turf/simulated/floor/tiled,
+/area/ship/scrap/shuttle/cubkitten)
 "vN" = (
 /obj/paint/red,
 /turf/simulated/wall/r_wall,
@@ -5484,10 +5566,31 @@
 /obj/paint/brown,
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/maintenance/atmos)
+"wI" = (
+/obj/machinery/computer/ship/helm,
+/obj/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled,
+/area/ship/scrap/shuttle/cubkitten)
+"xL" = (
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
 "xU" = (
 /obj/paint/brown,
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/maintenance/power)
+"xY" = (
+/obj/wallframe_spawn/reinforced/titanium,
+/obj/paint/brown,
+/turf/simulated/floor/plating,
+/area/ship/scrap/shuttle/cubkitten)
+"yq" = (
+/obj/machinery/atmospherics/valve,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
 "zT" = (
 /obj/floor_decal/corner/blue/diagonal{
 	dir = 4
@@ -5495,11 +5598,48 @@
 /obj/floor_decal/corner/blue/diagonal,
 /turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/atmos)
+"AL" = (
+/obj/machinery/button/alternate/door/bolts{
+	id_tag = "cubkitten_door";
+	name = "Cubkitten Exterior Bolts";
+	pixel_y = 24
+	},
+/obj/machinery/door/airlock/external/bolted{
+	id_tag = "cubkitten_door"
+	},
+/obj/shuttle_landmark/cubkitten,
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
+"AW" = (
+/obj/machinery/atmospherics/portables_connector,
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
+"Bb" = (
+/obj/machinery/atmospherics/unary/engine{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
 "Cs" = (
 /obj/floor_decal/industrial/warning,
 /obj/paint/red,
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/maintenance/engine/port)
+"Cy" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 6
+	},
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
+"Dm" = (
+/obj/structure/lattice,
+/turf/space,
+/area/ship/scrap/shuttle/cubkitten)
 "Dr" = (
 /obj/structure/closet/secure_closet/engineering_electrical/bearcat,
 /obj/item/cell/device/standard,
@@ -5536,6 +5676,32 @@
 /obj/structure/lattice,
 /turf/space,
 /area/ship/scrap/maintenance/atmos)
+"Ex" = (
+/obj/structure/bed/chair/shuttle/white{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/scrap/shuttle/cubkitten)
+"EP" = (
+/obj/paint/brown,
+/turf/simulated/wall/titanium,
+/area/ship/scrap/shuttle/cubkitten)
+"FG" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "east bump";
+	pixel_x = 24;
+	req_access = list()
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
 "FI" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/simulated/floor,
@@ -5548,10 +5714,47 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/space,
 /area/space)
+"Hn" = (
+/obj/paint/silver,
+/obj/machinery/atmospherics/pipe/manifold/visible/fuel{
+	dir = 8
+	},
+/obj/wallframe_spawn/reinforced/titanium,
+/obj/paint/brown,
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
+"Ho" = (
+/obj/structure/bed/chair/shuttle/white{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
+"Hx" = (
+/obj/floor_decal/corner/yellow{
+	dir = 5
+	},
+/obj/machinery/atmospherics/portables_connector{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark,
+/area/ship/scrap/shuttle/cubkitten)
 "HQ" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/atmos)
+"HV" = (
+/obj/machinery/shipsensors{
+	use_power = 0
+	},
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
+"Is" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
 "IG" = (
 /obj/item/material/shard,
 /obj/machinery/atmospherics/unary/outlet_injector{
@@ -5609,11 +5812,40 @@
 "JH" = (
 /turf/simulated/floor/reinforced,
 /area/ship/scrap/maintenance/power)
+"JR" = (
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
+	},
+/obj/structure/closet/crate,
+/obj/item/stack/material/phoron/fifty,
+/obj/item/tank/hydrogen,
+/turf/simulated/floor/tiled,
+/area/ship/scrap/shuttle/cubkitten)
+"JX" = (
+/obj/overmap/visitable/ship/landable/cubkitten,
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ship/scrap/shuttle/cubkitten)
 "Kj" = (
 /turf/simulated/floor/reinforced{
 	map_airless = 1
 	},
 /area/ship/scrap/crew/cryo)
+"La" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden{
+	dir = 4
+	},
+/turf/simulated/floor/tiled,
+/area/ship/scrap/shuttle/cubkitten)
 "Lp" = (
 /turf/simulated/floor/reinforced{
 	map_airless = 1
@@ -5662,6 +5894,13 @@
 /obj/paint/red,
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/maintenance/engine/starboard)
+"Ot" = (
+/obj/machinery/atmospherics/pipe/simple/visible/fuel,
+/obj/structure/bed/chair/shuttle/white{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
 "OB" = (
 /obj/structure/lattice,
 /obj/structure/cable/green{
@@ -5722,6 +5961,11 @@
 /obj/structure/lattice,
 /turf/space,
 /area/ship/scrap/maintenance/engine/starboard)
+"Sf" = (
+/obj/wallframe_spawn/reinforced/titanium,
+/obj/paint/brown,
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
 "Sm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
 /obj/decal/cleanable/molten_item,
@@ -5735,18 +5979,55 @@
 	},
 /turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
+"Ss" = (
+/obj/floor_decal/corner/grey/border{
+	dir = 1
+	},
+/obj/machinery/computer/shuttle_control/explore/cubkitten,
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
+"TB" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/valve,
+/turf/simulated/floor/tiled,
+/area/ship/scrap/shuttle/cubkitten)
 "Ul" = (
 /obj/paint/brown,
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/crew/cryo)
+"Uq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden{
+	dir = 10
+	},
+/turf/simulated/floor/tiled,
+/area/ship/scrap/shuttle/cubkitten)
 "Ur" = (
 /obj/paint/brown,
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/crew/wash)
+"UA" = (
+/obj/paint/silver,
+/obj/wallframe_spawn/reinforced/titanium,
+/obj/machinery/atmospherics/pipe/simple/visible/fuel{
+	dir = 4
+	},
+/obj/paint/brown,
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
 "Va" = (
 /obj/paint/brown,
 /turf/simulated/wall/r_wall,
 /area/ship/scrap/hidden)
+"Vc" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
 "VA" = (
 /obj/wallframe_spawn/reinforced,
 /obj/machinery/door/blast/regular{
@@ -5763,10 +6044,21 @@
 /obj/paint/brown,
 /turf/simulated/floor,
 /area/ship/scrap/comms)
+"VJ" = (
+/obj/paint/brown,
+/obj/structure/inflatable/wall,
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
 "Wu" = (
 /obj/decal/cleanable/molten_item,
 /turf/simulated/floor,
 /area/ship/scrap/maintenance/engine/aft)
+"XS" = (
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/simulated/floor,
+/area/ship/scrap/shuttle/cubkitten)
 "XU" = (
 /obj/structure/sign/redcross,
 /obj/paint/brown,
@@ -5783,6 +6075,36 @@
 /obj/decal/cleanable/ash,
 /turf/simulated/floor/tiled,
 /area/ship/scrap/maintenance/atmos)
+"YV" = (
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/bed/chair/shuttle/white{
+	dir = 1
+	},
+/obj/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled,
+/area/ship/scrap/shuttle/cubkitten)
+"YW" = (
+/obj/machinery/power/terminal{
+	dir = 1
+	},
+/obj/structure/cable{
+	d2 = 4;
+	icon_state = "0-4"
+	},
+/obj/machinery/computer/ship/engines{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/obj/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled,
+/area/ship/scrap/shuttle/cubkitten)
 
 (1,1,1) = {"
 aa
@@ -10720,7 +11042,7 @@ aa
 aa
 aa
 aa
-aa
+jB
 aa
 aa
 aa
@@ -10839,11 +11161,11 @@ aa
 aa
 aa
 aa
+jB
+bY
 aa
 aa
-aa
-aa
-aa
+bY
 aa
 aa
 aa
@@ -10962,8 +11284,8 @@ aa
 aa
 aa
 aa
-aa
-aa
+jB
+bY
 aa
 aa
 aa
@@ -11078,15 +11400,15 @@ aa
 aa
 aa
 aa
+EP
+EP
+EP
+EP
+Sf
+lb
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+jB
 aa
 aa
 aa
@@ -11198,17 +11520,17 @@ aa
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-bg
-aa
-aa
-aa
-aa
-aa
-aa
+EP
+xY
+EP
+vw
+YW
+Vc
+xL
+lb
+lb
+lb
+Dm
 aa
 aa
 aa
@@ -11316,21 +11638,21 @@ aa
 aa
 aa
 aa
+jB
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+EP
+wI
+sQ
+Cy
+TB
+Hx
+AW
+yq
+Ot
+Hn
+Bb
 aa
 aa
 aa
@@ -11440,19 +11762,19 @@ aa
 aa
 aa
 aa
+bY
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+VJ
+Ss
+YV
+JX
+kd
+mI
+qT
+qT
+Ho
+UA
+HV
 aa
 aa
 aa
@@ -11561,20 +11883,20 @@ aa
 aa
 aa
 aa
+bY
+jB
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+VJ
+pP
+FG
+Uq
+La
+XS
+xL
+rc
+Ex
+cb
+Bb
 aa
 aa
 aa
@@ -11684,19 +12006,19 @@ aa
 aa
 aa
 aa
+jB
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+VJ
+xY
+EP
+tr
+JR
+Is
+qT
+EP
+EP
+EP
+EP
 aa
 km
 km
@@ -11804,18 +12126,18 @@ aa
 aa
 aa
 aa
+bY
+aa
+bY
 aa
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+EP
+xY
+Sf
+EP
+AL
+EP
 aa
 aa
 aa
@@ -14617,7 +14939,7 @@ aa
 aa
 aa
 aa
-bg
+aa
 aa
 aa
 aa

--- a/maps/away/bearcat/bearcat.dm
+++ b/maps/away/bearcat/bearcat.dm
@@ -2,6 +2,7 @@
 #include "bearcat_jobs.dm"
 #include "bearcat_access.dm"
 #include "bearcat_radio.dm"
+#include "bearcat_shuttles.dm"
 
 /obj/submap_landmark/joinable_submap/bearcat
 	name = "FTV Bearcat"
@@ -21,6 +22,9 @@
 	vessel_mass = 20000
 	max_speed = 1/(10 SECONDS)
 	burn_delay = 10 SECONDS
+	initial_restricted_waypoints = list(
+		"FTV Cubkitten" = list("nav_hangar_cubkitten")
+	)
 
 /obj/overmap/visitable/ship/bearcat/New()
 	name = "[pick("FTV","ITV","IEV")] [pick("Bearcat", "Firebug", "Defiant", "Unsinkable","Horizon","Vagrant")]"
@@ -37,7 +41,10 @@
 	suffixes = list("bearcat/bearcat-1.dmm", "bearcat/bearcat-2.dmm")
 	spawn_cost = 1
 	player_cost = 4
-	shuttles_to_initialise = list(/datum/shuttle/autodock/ferry/lift)
+	shuttles_to_initialise = list(
+		/datum/shuttle/autodock/ferry/lift,
+		/datum/shuttle/autodock/overmap/cubkitten
+	)
 	area_usage_test_exempted_root_areas = list(/area/ship)
 	apc_test_exempt_areas = list(
 		/area/ship/scrap/maintenance/engine/port = NO_SCRUBBER|NO_VENT,
@@ -50,7 +57,8 @@
 		/area/ship/scrap/escape_port = NO_SCRUBBER|NO_VENT,
 		/area/ship/scrap/escape_star = NO_SCRUBBER|NO_VENT,
 		/area/ship/scrap/shuttle/lift = NO_SCRUBBER|NO_VENT|NO_APC,
-		/area/ship/scrap/command/hallway = NO_SCRUBBER|NO_VENT
+		/area/ship/scrap/command/hallway = NO_SCRUBBER|NO_VENT,
+		/area/ship/scrap/shuttle/cubkitten = NO_SCRUBBER
 	)
 	spawn_weight = 0.67
 

--- a/maps/away/bearcat/bearcat_areas.dm
+++ b/maps/away/bearcat/bearcat_areas.dm
@@ -171,6 +171,11 @@
 	ambience = list('sound/ambience/ambigen3.ogg','sound/ambience/ambigen4.ogg','sound/ambience/signal.ogg','sound/ambience/sonar.ogg')
 
 /area/ship/scrap/shuttle/lift
-  name = "Cargo Lift"
-  icon_state = "shuttle3"
-  base_turf = /turf/simulated/open
+	name = "Cargo Lift"
+	icon_state = "shuttle3"
+	base_turf = /turf/simulated/open
+
+/area/ship/scrap/shuttle/cubkitten
+	name = "\improper FTV Cubkitten"
+	icon_state = "shuttle3"
+	area_flags = AREA_FLAG_RAD_SHIELDED

--- a/maps/away/bearcat/bearcat_shuttles.dm
+++ b/maps/away/bearcat/bearcat_shuttles.dm
@@ -1,0 +1,39 @@
+/obj/overmap/visitable/ship/landable/cubkitten
+	name = "FTV Cubkitten"
+	shuttle = "FTV Cubkitten"
+	desc = "Sensor array detects a tiny vessel claiming to be the 'FTV Cubkitten'. It appears to be a standard civilian utility pod - however, rudimentary scans indicate that severe damage was sustained by the hull quite recently."
+	fore_dir = NORTH
+	skill_needed = SKILL_BASIC
+	vessel_size = SHIP_SIZE_TINY
+	max_speed = 1/(4 SECONDS)
+	burn_delay = 2.5 SECONDS
+	vessel_mass = 3500
+
+/obj/machinery/computer/shuttle_control/explore/cubkitten
+	name = "landing control console"
+	shuttle_tag = "FTV Cubkitten"
+
+/datum/shuttle/autodock/overmap/cubkitten
+	name = "FTV Cubkitten"
+	warmup_time = 5
+	move_time = 35
+	shuttle_area = list(/area/ship/scrap/shuttle/cubkitten)
+	current_location = "nav_hangar_cubkitten"
+	landmark_transition = "nav_transit_cubkitten"
+	range = 1
+	fuel_consumption = 3
+	ceiling_type = /turf/simulated/floor/shuttle_ceiling
+	flags = SHUTTLE_FLAGS_PROCESS
+	defer_initialisation = TRUE
+
+/obj/shuttle_landmark/cubkitten
+	name = "FTV Cubkitten Dock"
+	landmark_tag = "nav_hangar_cubkitten"
+
+/obj/shuttle_landmark/transit/cubkitten
+	name = "In transit"
+	landmark_tag = "nav_transit_cubkitten"
+
+/obj/shuttle_landmark/cubkitten/torch
+	name = "SEV Torch FTV Cubkitten Dock"
+	landmark_tag = "nav_hangar_cubkitten_torch"

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -14848,6 +14848,10 @@
 /obj/structure/catwalk,
 /turf/simulated/floor/plating,
 /area/maintenance/fourthdeck/forestarboard)
+"Xu" = (
+/obj/shuttle_landmark/cubkitten/torch,
+/turf/space,
+/area/space)
 "Xv" = (
 /obj/floor_decal/corner/brown{
 	dir = 10
@@ -23859,7 +23863,7 @@ aa
 aa
 aa
 aa
-aa
+Xu
 aa
 aa
 aa

--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -24,7 +24,8 @@
 		"SRV Venerable Catfish" = list("nav_verne_5"), //docking location for verne shuttle
 		"Cyclopes" = list("nav_merc_dock"),
 		"ICGNV Hound" = list("nav_hound_dock"),
-		"SFV Arbiter" = list("nav_sfv_arbiter_dock")
+		"SFV Arbiter" = list("nav_sfv_arbiter_dock"),
+		"FTV Cubkitten" = list("nav_hangar_cubkitten_torch")
 	)
 
 	initial_generic_waypoints = list(


### PR DESCRIPTION
###  Changelog

🆑 genessee
add: The FTV Cubkitten, a small utility pod attached to the FTV Bearcat that can be used to dock to other vessels or planets
add: A spare oxygen and CO2 canister and some extra plasma fuel on the Bearcat intended to be used to power and propulse the Cubkitten
tweak: The Vulcan dock on the Torch is now also used by the Cubkitten

### Description & Reasoning

Adds a small shuttle to the Bearcat that, while damaged, works roundstart. It can be used to dock to the Torch, exoplanets, ruins, and anything else that accepts shuttle docks. The shuttle itself is a somewhat modified Vulcan.

I've played the Bearcat a few times, and it kind of sucks as-is -- from what I understand, it's intended to be a 'fix your own ship and use it' type beat, but without a shuttle, you can't really do much once it's working and you can't get more supplies if you mess up (or just want more supplies for other projects that you might undertake), leading to many crews either ghosting or resorting to the radio transmitter to call for help, which defeats the gimmick of the map.

Adding a shuttle allows the Bearcat crew to actually act as an independent crew trying to repair their ship via going out and looking for materials and supplies rather than being yet another 'turn on radio transmitter and wait for rescue' offship role.

###  Images

Strong.DMM (Areas)
<img width="383" height="578" alt="image" src="https://github.com/user-attachments/assets/d4dc1da9-c5d1-4bef-be17-e15e8a135063" />

Strong.DMM (No Areas)
<img width="376" height="608" alt="image" src="https://github.com/user-attachments/assets/daacdced-ff6b-4e38-b684-75e90cb4c44b" />

