### PR TITLE
Add more fax machines

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -8,7 +8,9 @@
 /area/space)
 "ac" = (
 /obj/structure/table/steel,
-/obj/item/pen/fancy,
+/obj/machinery/photocopier/faxmachine{
+	department = "Torch - Pilots Lounge"
+	},
 /turf/simulated/floor/lino,
 /area/command/pilot)
 "ad" = (
@@ -3683,6 +3685,7 @@
 	},
 /obj/item/material/folder/blue,
 /obj/item/material/folder/envelope,
+/obj/item/pen/fancy,
 /turf/simulated/floor/lino,
 /area/command/pilot)
 "iL" = (

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -2808,6 +2808,9 @@
 "fF" = (
 /obj/structure/table/steel,
 /obj/machinery/light,
+/obj/machinery/photocopier/faxmachine{
+	department = "Torch - Robotics"
+	},
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "fG" = (
@@ -10752,13 +10755,15 @@
 	dir = 4
 	},
 /obj/structure/table/steel,
-/obj/item/stack/material/wood/fifty,
 /obj/floor_decal/industrial/warning{
 	dir = 4;
 	icon_state = "warning"
 	},
 /obj/machinery/camera/network/engineering{
 	c_tag = "Engineering - Lobby"
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "Torch - Engineering"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_bay)
@@ -16558,6 +16563,7 @@
 /obj/floor_decal/industrial/warning{
 	dir = 6
 	},
+/obj/item/stack/material/wood/fifty,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_bay)
 "SD" = (

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -4032,9 +4032,6 @@
 /turf/simulated/floor/plating,
 /area/medical/counselor/therapy)
 "ahf" = (
-/obj/structure/bookcase,
-/obj/item/book/manual/medical_diagnostics_manual,
-/obj/item/book/manual/military_law,
 /obj/floor_decal/corner/paleblue/mono,
 /obj/machinery/light_switch{
 	pixel_x = 6;
@@ -4045,6 +4042,10 @@
 	pixel_x = -2;
 	pixel_y = 24
 	},
+/obj/machinery/photocopier/faxmachine{
+	department = "Torch - Counselor"
+	},
+/obj/structure/table/standard,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/counselor)
 "ahg" = (
@@ -4153,6 +4154,19 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/structure/filingcabinet/chestdrawer{
+	dir = 1
+	},
+/obj/item/material/folder/blue,
+/obj/item/material/folder/red,
+/obj/item/material/folder,
+/obj/item/material/folder/nt,
+/obj/item/material/folder/yellow,
+/obj/item/material/folder/white,
+/obj/item/material/folder/white,
+/obj/item/material/folder/white,
+/obj/item/material/folder/envelope,
+/obj/item/material/folder/envelope,
 /turf/simulated/floor/tiled/white,
 /area/medical/counselor)
 "ahr" = (
@@ -4464,17 +4478,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
 "ahU" = (
-/obj/structure/filingcabinet/chestdrawer{
-	dir = 1
-	},
-/obj/item/material/folder/blue,
-/obj/item/material/folder/red,
-/obj/item/material/folder,
-/obj/item/material/folder/nt,
-/obj/item/material/folder/yellow,
-/obj/item/material/folder/white,
-/obj/item/material/folder/white,
-/obj/item/material/folder/white,
 /obj/floor_decal/corner/paleblue/mono,
 /obj/machinery/button/alternate/door{
 	id_tag = "counselor";
@@ -4488,8 +4491,9 @@
 	pixel_x = -24;
 	pixel_y = -5
 	},
-/obj/item/material/folder/envelope,
-/obj/item/material/folder/envelope,
+/obj/structure/bookcase,
+/obj/item/book/manual/medical_diagnostics_manual,
+/obj/item/book/manual/military_law,
 /turf/simulated/floor/tiled/white/monotile,
 /area/medical/counselor)
 "ahV" = (
@@ -16355,17 +16359,15 @@
 /area/medical/sleeper)
 "dZx" = (
 /obj/structure/table/steel,
-/obj/item/stack/package_wrap/cargo_wrap,
-/obj/item/hand_labeler,
-/obj/item/device/destTagger{
-	pixel_y = 13
-	},
 /obj/floor_decal/corner/red/mono,
 /obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/recharger/wallcharger{
 	dir = 4;
 	pixel_x = -23;
 	pixel_y = -3
+	},
+/obj/machinery/photocopier/faxmachine{
+	department = "Torch - Security"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/security/locker)
@@ -16500,6 +16502,7 @@
 	pixel_y = -3
 	},
 /obj/item/sticky_pad/random,
+/obj/item/hand_labeler,
 /turf/simulated/floor/tiled/monotile,
 /area/security/locker)
 "eim" = (
@@ -20582,6 +20585,10 @@
 	},
 /obj/item/book/manual/sol_sop,
 /obj/random_multi/single_item/memo_security,
+/obj/item/device/destTagger{
+	pixel_y = 13
+	},
+/obj/item/stack/package_wrap/cargo_wrap,
 /turf/simulated/floor/tiled/monotile,
 /area/security/locker)
 "kku" = (


### PR DESCRIPTION
Why?

For the glory of Nar'sie, of course.

Also because more accessible fax machines outside of the computer room is probably good for antag play.

## Changelog
:cl: SierraKomodo
maptweak: Added fax machines to: Security Locker Room, Robotics Lab, Counselor's Office, Chaplain's Office, Engineering Bay, Pilot's Lounge.
/:cl: