### PR TITLE
Fix resin not brittling prosthetics

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -382,11 +382,11 @@
 				for (var/i = 1 to rand(1,3))
 					new /obj/item/material/shard(get_turf(affecting), MATERIAL_STEEL)
 				affecting.take_external_damage(rand(20,40), 0)
-			if(prob(30))
-				if (!M.isSynthetic())
-					M.emote("scream")
-					M.Weaken(2)
-				affecting.status |= ORGAN_BRITTLE // 30% chance to brittle your limb/organ, and if you're organic, you get weakened.
+		if(prob(30))
+			if (!M.isSynthetic())
+				M.emote("scream")
+				M.Weaken(2)
+			affecting.status |= ORGAN_BRITTLE // 30% chance to brittle your limb/organ, and if you're organic, you get weakened.
 		affecting.heal_damage(heal_brute, heal_burn, robo_repair = TRUE)
 		user.setClickCooldown(DEFAULT_ATTACK_COOLDOWN)
 		return TRUE


### PR DESCRIPTION
Funny what one extra level of indentation can do.

## Changelog
:cl: SierraKomodo
bugfix: Resin now has a chance to make prosthetic and robotic limbs brittle when used on them, as was originally intended.
/:cl: