### PR TITLE
Minimum ages for some jobs

### DIFF
--- a/maps/torch/job/security_jobs.dm
+++ b/maps/torch/job/security_jobs.dm
@@ -100,7 +100,7 @@
 	supervisors = "the Chief of Security"
 	economic_power = 4
 	minimal_player_age = 7
-	minimum_character_age = list(SPECIES_HUMAN = 18)
+	minimum_character_age = list(SPECIES_HUMAN = 19) //we don't have trainee MA, so the regular MA title is tied to the "regular" titles of other departments.
 	ideal_character_age = 25
 	alt_titles = list() // This is a hack. Overriding a list var with null does not actually override it due to the particulars of dm list init. Do not "clean up" without testing.
 	outfit_type = /singleton/hierarchy/outfit/job/torch/crew/security/maa

--- a/maps/torch/job/service_jobs.dm
+++ b/maps/torch/job/service_jobs.dm
@@ -79,7 +79,7 @@
 	total_positions = 2
 	spawn_positions = 2
 	supervisors = "the Chief Steward"
-	minimum_character_age = list(SPECIES_HUMAN = 20)
+	minimum_character_age = list(SPECIES_HUMAN = 18)
 	ideal_character_age = 20
 	alt_titles = list(
 		"Custodian",
@@ -114,7 +114,7 @@
 	department_flag = SRV
 	total_positions = 2
 	spawn_positions = 2
-	minimum_character_age = list(SPECIES_HUMAN = 20)
+	minimum_character_age = list(SPECIES_HUMAN = 18)
 	supervisors = "the Chief Steward"
 	alt_titles = list(
 		"Bartender",
@@ -158,7 +158,7 @@
 	total_positions = 5
 	spawn_positions = 5
 	supervisors = "the Chief Steward"
-	minimum_character_age = list(SPECIES_HUMAN = 20)
+	minimum_character_age = list(SPECIES_HUMAN = 18)
 	ideal_character_age = 20
 	outfit_type = /singleton/hierarchy/outfit/job/torch/crew/service/crewman
 	allowed_branches = list(


### PR DESCRIPTION
:cl:
tweak: Minimum ages for junior enlisted personnel were given a sanity check. More available for 18 yo.
/:cl:

Most of it is self-explanatory except for the MA: since we do not have a trainee MA (for OOC reasons, IIRC), its age has been increased to match the other regular (non-trainee) titles in other departments.