### PR TITLE
Fix type paths for shooting boost augments

### DIFF
--- a/code/modules/augment/passive/boost/shooting.dm
+++ b/code/modules/augment/passive/boost/shooting.dm
@@ -5,13 +5,13 @@
 	injury_debuffs = list(SKILL_WEAPONS = -1)
 
 
-/obj/item/organ/internal/augment/boost/reflex/buff()
+/obj/item/organ/internal/augment/boost/shooting/buff()
 	. = ..()
 	if (.)
 		to_chat(owner, SPAN_NOTICE("Notice: AIM-4 finished reboot."))
 
 
-/obj/item/organ/internal/augment/boost/reflex/debuff()
+/obj/item/organ/internal/augment/boost/shooting/debuff()
 	. = ..()
 	if (.)
 		to_chat(owner, SPAN_WARNING("Catastrophic damage detected: AIM-4 shutting down."))


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Gunnery booster augments now properly provide feedback on their status.
/:cl:

## Other Changes
- Fixes #35199