### PR TITLE
[HOTFIX] Removes leftover references to alarm_red.ogg

### DIFF
--- a/maps/antag_spawn/ert/ert_ship.dm
+++ b/maps/antag_spawn/ert/ert_ship.dm
@@ -19,15 +19,6 @@
 	else
 		crash_with("[GLOB.ert_announcer.type] was unable to be relocated to the ERT shuttle.")
 
-	spawn(1 MINUTE)
-		silence_alarms()
-
-/datum/map_template/ruin/antag_spawn/ert/proc/silence_alarms()
-	for(var/obj/machinery/rotating_alarm/start_on/ert/alarm in SSmachines.machinery)
-		if(!alarm.sound_loop)
-			continue
-		QDEL_NULL(alarm.sound_loop)
-
 /obj/overmap/visitable/sector/ert_ship
 	name = "SFV Trident"
 	desc = "An Orca-Class Escort Carrier, broadcasting SCGF codes.\n<span class='bad'>Its weapons systems appears to be active.</span>"
@@ -132,7 +123,6 @@
 	desc = "A rotating alarm light."
 	icon_state = "code red"
 	alarm_light_color = COLOR_RED
-	sound_file = 'sound/obj/machinery/rotating_alarm/alert_red.ogg'
 
 // Turfs & Paints
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

File removed in #35358 but this reference was leftover due to PR conflicts.

Will solve some runtimes.