### PR TITLE
Replaces Empty Defib w/ Loaded Defib on Deck 2 Medical Storage

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -2535,11 +2535,11 @@
 /area/assembly/robotics)
 "eS" = (
 /obj/structure/table/rack,
-/obj/item/defibrillator/compact,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/item/defibrillator/compact/loaded,
 /turf/simulated/floor/tiled/techfloor,
 /area/storage/medical)
 "eT" = (


### PR DESCRIPTION
:cl: JebediahTechnic
maptweak: Replaces empty compact defibrillator in D2 medical storage with a loaded one. Be sure to thank your local maintenance drone for their service.
/:cl: