### PR TITLE
Fix legion mobs not being atmosphere immune

### DIFF
--- a/packs/legion/mob/legion_mob.dm
+++ b/packs/legion/mob/legion_mob.dm
@@ -14,9 +14,8 @@
 
 	minbodytemp = 0
 	maxbodytemp = INFINITY
-	min_oxy = 0
-	max_tox = 0
-	max_co2 = 0
+	min_gas = null
+	max_gas = null
 
 	meat_type = null
 	meat_amount = 0


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Legion mobs are now properly immune to atmosphere, as intended.
/:cl: