### PR TITLE
Fix for loadout preview

### DIFF
--- a/code/modules/client/preference_setup/loadout/loadout.dm
+++ b/code/modules/client/preference_setup/loadout/loadout.dm
@@ -408,7 +408,7 @@ var/global/list/gear_datums = list()
 
 /datum/gear/proc/spawn_on_mob(mob/living/carbon/human/H, metadata)
 	var/obj/item/item = spawn_item(H, H, metadata)
-	if(H.equip_to_slot_if_possible(item, slot, TRYEQUIP_REDRAW | TRYEQUIP_DESTROY | TRYEQUIP_FORCE))
+	if(H.equip_to_slot_if_possible(item, slot, TRYEQUIP_REDRAW | TRYEQUIP_DESTROY | TRYEQUIP_FORCE | TRYEQUIP_INSTANT))
 		. = item
 
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Some items, like armor, have a delay before they can be equipped. The same delay works for the mannequin in a preview screen of the character setup, and this causes a delay before this window can be loaded.

Example:
1. Get a high preference for any security role for your character
2. Choose 'black plate carrier' in Loadout->Tactical Equipment
3. Go back to Physical tab - and immediately get a delay before this window can be loaded
4. Click Cycle background in character preview to see the same delay again

:cl: Builder13
bugfix: Equip delay of loadout items no longer delays character setup window.
/:cl: