### PR TITLE
Make boxing gloves respect intent

### DIFF
--- a/code/modules/mob/living/carbon/human/human_attackhand.dm
+++ b/code/modules/mob/living/carbon/human/human_attackhand.dm
@@ -36,7 +36,7 @@
 	..()
 	remove_cloaking_source(species)
 
-	if (istype(H.gloves, /obj/item/clothing/gloves/boxing/hologlove))
+	if (istype(H.gloves, /obj/item/clothing/gloves/boxing) && H.a_intent == I_HURT)
 		H.do_attack_animation(src)
 		var/damage = rand(0, 9)
 		var/hit_zone = resolve_hand_attack(damage, H, H.zone_sel.selecting)


### PR DESCRIPTION
:cl:
tweak: Wearing boxing gloves allows for all sorts of CQC moves, including grabs etc. Harm intent required for actually punching people.
bugfix: Non-holo boxing gloves also allow harmless boxing.
/:cl:

Because you need all sorts of maneuers and techniques in the box.