### PR TITLE
Fix changelog entry

### DIFF
--- a/html/changelogs/AutoChangeLog-pr-35375.yml
+++ b/html/changelogs/AutoChangeLog-pr-35375.yml
@@ -1,5 +1,5 @@
 author: SierraKomodo
 changes:
-  - {rscdel: Calling ERT no longer blocks the round from ending or server from 
-      restarting (Why was this even a thing?)}
+  - {rscdel: "Calling ERT no longer blocks the round from ending or server from
+      restarting (Why was this even a thing?)"}
 delete-after: true


### PR DESCRIPTION
So apparently the make changelogs action creates yaml that can't be parsed if you put a question mark in a changelog entry. Interesting.