### PR TITLE
Email QOL Updates

### DIFF
--- a/code/modules/modular_computers/file_system/programs/generic/email_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/email_client.dm
@@ -451,6 +451,28 @@
 				ui_interact(AM.loc)
 		return TOPIC_HANDLED
 
+	if (href_list["forward"])
+		var/datum/computer_file/data/email_message/message = find_message_by_fuid(href_list["forward"])
+		if (!istype(message))
+			return TOPIC_HANDLED
+		error = null
+		new_message = TRUE
+		msg_recipient = null
+		msg_title = message.title
+		if (copytext_char(msg_title, 1, 4) != "Fw:")
+			msg_title = "Fw: [msg_title]"
+		msg_body = "---\n\[b]FORWARDED MESSAGE:\[/b]\n"
+		msg_body += "\[b]SUBJECT\[b]: [message.title]\n"
+		msg_body += "\[b]FROM\[b]: [message.source]\n"
+		msg_body += "\[b]TO\[b]: [message.recipient]\n"
+		msg_body += "---\n"
+		for (var/line in splittext(message.stored_data, "\n"))
+			msg_body += "> [line]\n"
+		var/atom/movable/movable = host
+		if (istype(movable) && ismob(movable.loc))
+			ui_interact(movable.loc)
+		return TOPIC_HANDLED
+
 	if(href_list["view"])
 		var/datum/computer_file/data/email_message/M = find_message_by_fuid(href_list["view"])
 		if(istype(M))

--- a/code/modules/modular_computers/file_system/programs/generic/email_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/email_client.dm
@@ -442,7 +442,9 @@
 		error = null
 		new_message = TRUE
 		msg_recipient = M.source
-		msg_title = "Re: [M.title]"
+		msg_title = M.title
+		if (copytext_char(msg_title, 1, 4) != "Re:")
+			msg_title = "Re: [msg_title]"
 		var/atom/movable/AM = host
 		if(istype(AM))
 			if(ismob(AM.loc))

--- a/nano/templates/email_client.tmpl
+++ b/nano/templates/email_client.tmpl
@@ -163,10 +163,10 @@
 						<td>{{:value.title}}&nbsp</td>
 						<td>{{:value.timestamp}}&nbsp</td>
 						<td>
-							{{:helper.link('', 'trash', {'delete' : value.uid})}}
-							{{:helper.link('', 'arrowreturnthick-1-w', {'reply' :  value.uid})}}
-							{{:helper.link('', 'arrowreturnthick-1-e', {'forward' : value.uid})}}
-							{{:helper.link('', 'search', {'view' :  value.uid})}}
+							<abbr title="Delete Message">{{:helper.link('', 'trash', {'delete' : value.uid})}}</abbr>
+							<abbr title="Reply To Sender">{{:helper.link('', 'arrowreturnthick-1-w', {'reply' :  value.uid})}}</abbr>
+							<abbr title="Forward Message">{{:helper.link('', 'arrowreturnthick-1-e', {'forward' : value.uid})}}</abbr>
+							<abbr title="Open Message">{{:helper.link('', 'search', {'view' :  value.uid})}}</abbr>
 						</td>
 					</tr>
 				{{/for}}

--- a/nano/templates/email_client.tmpl
+++ b/nano/templates/email_client.tmpl
@@ -134,6 +134,7 @@
 			</div>
 			<div class="itemContent">
 				{{:helper.link('Reply', null, {'reply' : data.cur_uid})}}
+				{{:helper.link('Forward', null, {'forward' : data.cur_uid})}}
 				{{:helper.link('Delete', null, {'delete' : data.cur_uid})}}
 				{{:helper.link('Close', null, {'cancel' : data.cur_uid})}}
 				{{:helper.link('Save to Disk', null, {'save' : data.cur_uid})}}
@@ -154,7 +155,7 @@
 					<th>{{:data.source_label}}</th>
 					<th>Title</th>
 					<th>Received at</th>
-					<th></th>
+					<th style="width: 68px;"></th>
 				</tr>
 				{{for data.messages}}
 					<tr class="candystripe">
@@ -164,6 +165,7 @@
 						<td>
 							{{:helper.link('', 'trash', {'delete' : value.uid})}}
 							{{:helper.link('', 'arrowreturnthick-1-w', {'reply' :  value.uid})}}
+							{{:helper.link('', 'arrowreturnthick-1-e', {'forward' : value.uid})}}
 							{{:helper.link('', 'search', {'view' :  value.uid})}}
 						</td>
 					</tr>


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
tweak: Email reply chains no longer keep prefixing additional 'Re: ' if the prefix already exists. No more 'Re: Re: Re: Re: Re: Re: Re: Re: Re: Re: Re: Re: Re: Re: Re: Re: Re: Re: Re: Re: Re: Re: Re: Re: Re: Re: Re: No Subject' in your inbox!
rscadd: Emails can now be forwarded!
rscadd: Added popup tooltips to the icon buttons on email message listings, describing what each button does. (Delete, Reply, Forward, Open).
/:cl:
