### PR TITLE
fix emergency shield generator doubling power use on activation

### DIFF
--- a/code/modules/shieldgen/emergency_shield.dm
+++ b/code/modules/shieldgen/emergency_shield.dm
@@ -115,6 +115,7 @@
 /obj/machinery/shieldgen/proc/collapse_shields()
 	for(var/obj/machinery/shield/shield_tile in deployed_shields)
 		qdel(shield_tile)
+	deployed_shields.Cut()
 
 /obj/machinery/shieldgen/power_change()
 	. = ..()


### PR DESCRIPTION
:cl: Mucker
bugfix: Fixed the emergency shield generator doubling power usage every time it was turned on. 
/:cl: