### PR TITLE
add vote assertiveness preferences

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -220,6 +220,8 @@
 
 #define FONT_GIANT(X) SPAN_SIZE("24px", "[X]")
 
+#define SPAN_SYSTEM(X) SPAN_COLOR("purple", "[X]")
+
 #define TO_HEX_DIGIT(n) ascii2text((n&15) + ((n&15)<10 ? 48 : 87))
 
 

--- a/code/datums/vote/transfer.dm
+++ b/code/datums/vote/transfer.dm
@@ -83,6 +83,15 @@
 	if(isadmin(user))
 		config.allow_vote_restart = !config.allow_vote_restart
 
+
+/datum/vote/transfer/get_allowed_voters()
+	return GLOB.living_players.Copy()
+
+
+/datum/vote/transfer/get_disallowed_reason()
+	return "You are not a living player."
+
+
 #undef CHOICE_TRANSFER
 #undef CHOICE_EXTEND
 #undef CHOICE_ADD_ANTAG

--- a/code/datums/vote/vote.dm
+++ b/code/datums/vote/vote.dm
@@ -40,7 +40,7 @@
 
 //Performs functions relating to setting up the question and choices, if relevant.
 /datum/vote/proc/setup_vote(mob/creator, automatic)
-	initiator = (!automatic && istype(creator)) ? creator.ckey : "the server"
+	initiator = (!automatic && istype(creator)) ? creator.ckey : "The game"
 	for(var/choice in choices)
 		display_choices[choice] = choice // Default behavior is that the choice name is displayed directly.
 
@@ -48,15 +48,7 @@
 	start_time = world.time
 	status = VOTE_STATUS_ACTIVE
 	time_remaining = round(config.vote_period/10)
-
-	var/text = get_start_text()
-
-	log_vote(text)
-	to_world(SPAN_COLOR("purple", "<b>[text]</b>\nType <b>vote</b> or click <a href='byond://?src=\ref[SSvote];vote_panel=1'>here</a> to place your votes.\nYou have [config.vote_period/10] seconds to vote."))
-	sound_to(world, sound('sound/ui/vote-notify.ogg', repeat = 0, wait = 0, volume = 33, channel = GLOB.vote_sound_channel))
-
-/datum/vote/proc/get_start_text()
-	return "[capitalize(name)] vote started by [initiator]."
+	log_vote("[capitalize(name)] vote started by [initiator].")
 
 //Modifies the vote totals based on non-voting mobs.
 /datum/vote/proc/handle_default_votes()
@@ -240,3 +232,11 @@
 		return
 
 	submit_vote(user, choice)
+
+
+/datum/vote/proc/get_allowed_voters()
+	return GLOB.player_list.Copy()
+
+
+/datum/vote/proc/get_disallowed_reason()
+	return

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -317,6 +317,36 @@ var/global/list/_client_preferences_by_type
 	options = list(GLOB.PREF_HIDE, GLOB.PREF_SHOW)
 	default_value = GLOB.PREF_HIDE
 
+
+GLOBAL_CONST(PREF_VA_NOTIFY, "Start Notify")
+GLOBAL_CONST(PREF_VA_POPUP, "Start Popup")
+GLOBAL_CONST(PREF_VA_HALF_NOTIFY, "Reminder Notify")
+GLOBAL_CONST(PREF_VA_HALF_POPUP, "Reminder Popup")
+
+/datum/client_preference/vote_assertiveness
+	description = "Vote Assertiveness"
+	key = "VOTE_ASSERTIVENESS"
+	options = list(
+		GLOB.PREF_VA_HALF_NOTIFY,
+		GLOB.PREF_VA_HALF_POPUP,
+		GLOB.PREF_VA_POPUP,
+		GLOB.PREF_VA_NOTIFY
+	)
+
+/datum/client_preference/vote_assertiveness/changed(mob/mob, new_value)
+	switch (new_value)
+		if (GLOB.PREF_VA_HALF_NOTIFY)
+			to_chat(mob, "[description]: When a vote starts, you will be notified. If you have not voted by half time, you will be notified again.")
+		if (GLOB.PREF_VA_HALF_POPUP)
+			to_chat(mob, "[description]:When a vote starts, you will be notified. If you have not voted by half time, it will pop up.")
+		if (GLOB.PREF_VA_POPUP)
+			to_chat(mob, "[description]:When a vote starts, it will pop up.")
+		if (GLOB.PREF_VA_NOTIFY)
+			to_chat(mob, "[description]:When a vote starts, you will be notified.")
+		else
+			to_chat(mob, {"[description]: "[new_value]" is unexpected. Please report this."})
+
+
 /********************
 * General Staff Preferences *
 ********************/

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -34,7 +34,7 @@ exactly 2 "/datum text paths" '"/datum'
 exactly 2 "/mob text paths" '"/mob'
 exactly 10 "/obj text paths" '"/obj'
 exactly 8 "/turf text paths" '"/turf'
-exactly 117 "to_world uses" '\sto_world\('
+exactly 116 "to_world uses" '\sto_world\('
 exactly 0 "globals with leading /" '^/var' -P
 exactly 0 "globals without global sugar" '^var/(?!global/)' -P
 exactly 0 "apparent paths with trailing /" '\w/[,\)\n]' -P


### PR DESCRIPTION
:cl:
tweak: Added Vote Assertiveness preference. Cycle it to see what it does, or see <a href="https://github.com/Baystation12/Baystation12/pull/35391">PR 35391</a>!
/:cl:

Vote Assertiveness determines how pushy you want the vote system to be with you when a vote has been called.

"**Start Notify**" is equivalent to prior behavior - voters will be notified once at the start of the vote and not reminded.

"**Start Popup**" will do the same as start notify, but also open the vote window automatically.

"**Reminder Notify**" will notify the voter a second time *if* half the vote time has passed and they have not voted.

"**Reminder Popup**" will do the same as reminder notify, but also open the vote window automatically.

This new preference defaults to **Reminder Notify**.

----

Also, explains to inelligible voters why they can't vote if the vote in question will not allow it. Implements this for transfer votes.

---

also, closes #35378 -- this implements the same behavior as the reminder notify option.