### PR TITLE
Add the ability for GAS to open packages and shellfish barehanded

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks/shellfish.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/shellfish.dm
@@ -40,6 +40,23 @@
 	user.apply_damage(2, DAMAGE_BRUTE, pick(BP_R_HAND, BP_L_HAND), damage_flags = DAMAGE_FLAG_SHARP)
 	return TRUE
 
+/// Allows GAS in hunting mode (and others with can_shred) to open the shellfish with their bare arms.
+/obj/item/shellfish/attack_self(mob/user)
+	if(istype(user,/mob/living/carbon/human))
+		var/mob/living/carbon/human/H = user
+		if(!H.species.can_shred(H,1))
+			return ..()
+		to_chat(user, SPAN_NOTICE("You start to pry open \the [src]."))
+		if(!user.do_skilled(3 SECONDS, SKILL_COOKING, user))
+			return TRUE
+		if (!prob(user.skill_fail_chance(SKILL_COOKING, 80, SKILL_TRAINED)))
+			to_chat(user, SPAN_NOTICE("You carefully clean and open \the [src]."))
+			new snack_path (get_turf(src))
+			qdel(src)
+			return TRUE
+		if(ishuman(user))
+			to_chat(user, SPAN_WARNING("You fail to open \the [src]."))
+			return TRUE
 
 /obj/item/shellfish/clam
 	name = "clam"

--- a/code/modules/reagents/reagent_containers/food/snacks/shellfish.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/shellfish.dm
@@ -41,22 +41,27 @@
 	return TRUE
 
 /// Allows GAS in hunting mode (and others with can_shred) to open the shellfish with their bare arms.
-/obj/item/shellfish/attack_self(mob/user)
+/obj/item/shellfish/attack_self(mob/living/user)
 	if(istype(user,/mob/living/carbon/human))
-		var/mob/living/carbon/human/H = user
-		if(!H.species.can_shred(H,1))
+		var/mob/living/carbon/human/shredder = user
+		if(!shredder.species.can_shred(shredder,1))
 			return ..()
-		to_chat(user, SPAN_NOTICE("You start to pry open \the [src]."))
-		if(!user.do_skilled(3 SECONDS, SKILL_COOKING, user))
+		user.visible_message(
+			SPAN_NOTICE("\The [user] starts to pry-open \the [src]."),
+			SPAN_NOTICE("You start to pry open \the [src].")
+		)
+		if(!user.do_skilled(3 SECONDS, SKILL_COOKING, user) || !user.use_sanity_check(src))
 			return TRUE
-		if (!prob(user.skill_fail_chance(SKILL_COOKING, 80, SKILL_TRAINED)))
-			to_chat(user, SPAN_NOTICE("You carefully clean and open \the [src]."))
-			new snack_path (get_turf(src))
+		if(!prob(user.skill_fail_chance(SKILL_COOKING, 80, SKILL_TRAINED)))
+			var/obj/item/new_snack = new snack_path (get_turf(src))
 			qdel(src)
+			user.put_in_hands(new_snack)
 			return TRUE
 		if(ishuman(user))
 			to_chat(user, SPAN_WARNING("You fail to open \the [src]."))
 			return TRUE
+		return TRUE
+	return ..()
 
 /obj/item/shellfish/clam
 	name = "clam"

--- a/code/modules/reagents/reagent_containers/food/snacks/shellfish.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks/shellfish.dm
@@ -44,20 +44,20 @@
 /obj/item/shellfish/attack_self(mob/living/user)
 	if(istype(user,/mob/living/carbon/human))
 		var/mob/living/carbon/human/shredder = user
-		if(!shredder.species.can_shred(shredder,1))
+		if (!shredder.species.can_shred(shredder, TRUE))
 			return ..()
 		user.visible_message(
 			SPAN_NOTICE("\The [user] starts to pry-open \the [src]."),
 			SPAN_NOTICE("You start to pry open \the [src].")
 		)
-		if(!user.do_skilled(3 SECONDS, SKILL_COOKING, user) || !user.use_sanity_check(src))
+		if (!user.do_skilled(3 SECONDS, SKILL_COOKING, user) || !user.use_sanity_check(src))
 			return TRUE
-		if(!prob(user.skill_fail_chance(SKILL_COOKING, 80, SKILL_TRAINED)))
-			var/obj/item/new_snack = new snack_path (get_turf(src))
+		if (!prob(user.skill_fail_chance(SKILL_COOKING, 80, SKILL_TRAINED)))
+			var/obj/item/new_snack = new snack_path(get_turf(src))
 			qdel(src)
 			user.put_in_hands(new_snack)
 			return TRUE
-		if(ishuman(user))
+		if (ishuman(user))
 			to_chat(user, SPAN_WARNING("You fail to open \the [src]."))
 			return TRUE
 		return TRUE

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -359,18 +359,19 @@
 	to_chat(user, "You need a sharp tool to unwrap \the [src].")
 
 /// Allows GAS in hunting mode (and others with can_shred) to open the packaging wrap with their bare arms.
-/obj/item/smallDelivery/attack_self(mob/user)
+/obj/item/smallDelivery/attack_self(mob/living/user)
 	if(istype(user,/mob/living/carbon/human))
-		var/mob/living/carbon/human/H = user
-		var/datum/pronouns/P = choose_from_pronouns()
-		if(H.species.can_shred(H,1))
-			user.visible_message(
-				SPAN_WARNING("\The [user] shreds \the [src] open with \a [P.his] scythe-like arms!"),
-				SPAN_NOTICE("You shred \the [src] open with your scythe-like arms!")
-			)
-			playsound(src.loc, 'sound/weapons/slash.ogg', 100, 1)
-			unwrap(user)
-			return TRUE
+		var/mob/living/carbon/human/shredder = user
+		var/datum/pronouns/pronouns = choose_from_pronouns()
+		if(!shredder.species.can_shred(shredder,1))
+			return..()
+		user.visible_message(
+			SPAN_WARNING("\The [user] shreds \the [src] open with \a [pronouns.his] scythe-like arms!"),
+			SPAN_NOTICE("You shred \the [src] open with your scythe-like arms!")
+		)
+		playsound(loc, 'sound/weapons/slash.ogg', 100, 1)
+		unwrap(user)
+		return TRUE
 
 /obj/item/smallDelivery/use_tool(obj/item/tool, mob/living/user, list/click_params)
 	if (is_sharp(tool))

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -360,18 +360,20 @@
 
 /// Allows GAS in hunting mode (and others with can_shred) to open the packaging wrap with their bare arms.
 /obj/item/smallDelivery/attack_self(mob/living/user)
-	if(istype(user,/mob/living/carbon/human))
+	if (istype(user, /mob/living/carbon/human))
 		var/mob/living/carbon/human/shredder = user
 		var/datum/pronouns/pronouns = choose_from_pronouns()
-		if(!shredder.species.can_shred(shredder,1))
-			return..()
+		if (!shredder.species.can_shred(shredder, TRUE))
+			return ..()
 		user.visible_message(
-			SPAN_WARNING("\The [user] shreds \the [src] open with \a [pronouns.his] scythe-like arms!"),
+			SPAN_WARNING("\The [user] shreds \the [src] open with [pronouns.his] scythe-like arms!"),
 			SPAN_NOTICE("You shred \the [src] open with your scythe-like arms!")
 		)
-		playsound(loc, 'sound/weapons/slash.ogg', 100, 1)
+		playsound(loc, 'sound/weapons/slash.ogg', 100, TRUE)
 		unwrap(user)
 		return TRUE
+
+	return ..()
 
 /obj/item/smallDelivery/use_tool(obj/item/tool, mob/living/user, list/click_params)
 	if (is_sharp(tool))

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -358,6 +358,20 @@
 /obj/item/smallDelivery/attack_self(mob/user as mob)
 	to_chat(user, "You need a sharp tool to unwrap \the [src].")
 
+/// Allows GAS in hunting mode (and others with can_shred) to open the packaging wrap with their bare arms.
+/obj/item/smallDelivery/attack_self(mob/user)
+	if(istype(user,/mob/living/carbon/human))
+		var/mob/living/carbon/human/H = user
+		var/datum/pronouns/P = choose_from_pronouns()
+		if(H.species.can_shred(H,1))
+			user.visible_message(
+				SPAN_WARNING("\The [user] shreds \the [src] open with \a [P.his] scythe-like arms!"),
+				SPAN_NOTICE("You shred \the [src] open with your scythe-like arms!")
+			)
+			playsound(src.loc, 'sound/weapons/slash.ogg', 100, 1)
+			unwrap(user)
+			return TRUE
+
 /obj/item/smallDelivery/use_tool(obj/item/tool, mob/living/user, list/click_params)
 	if (is_sharp(tool))
 		user.visible_message(


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: Podszywacz
rscadd: Added functionality where GAS in hunting stance can rip-open packages barehanded.
rscadd: Added functionality where GAS in hunting stance can pry-open shellfish barehanded.
/:cl:

GAS have scythe-like arms, so they should be able to use them in order to rip apart paper packages or pry-open shellfish. Crustaceans and your parcels shall be doomed! (Also may work for other mobs with can_shred).