### PR TITLE
Fix shuttles leaving open space turfs

### DIFF
--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -204,13 +204,14 @@
 				AM.shuttle_land_on()
 	var/list/powernets = list()
 	var/list/beacons = list()
+	var/list/roofs_to_clear = list()
 	for(var/area/A in shuttle_area)
-		// if there was a zlevel above our origin, erase our ceiling now we're leaving
+		// if there was a zlevel above our origin, prepare to erase our ceiling now we're leaving. The actual replacement occurs later, to prevent space turfs converting to open space because the shuttle's still there.
 		if(HasAbove(current_location.z))
 			for(var/turf/TO in A.contents)
 				var/turf/TA = GetAbove(TO)
 				if(istype(TA, ceiling_type))
-					TA.ChangeTurf(get_base_turf_by_area(TA), 1, 1)
+					roofs_to_clear += TA
 		if(knockdown)
 			for(var/mob/M in A)
 				spawn(0)
@@ -234,6 +235,9 @@
 
 	translate_turfs(turf_translation, current_location.base_area, current_location.base_turf)
 	current_location = destination
+
+	for (var/turf/roof_turf as anything in roofs_to_clear)
+		roof_turf.ChangeTurf(get_base_turf_by_area(roof_turf), 1, 1)
 
 	// if there's a zlevel above our destination, paint in a ceiling on it so we retain our air
 	if(HasAbove(current_location.z))


### PR DESCRIPTION
Ended up being an order of operations issue:
1. Shuttle starts the launch process
2. Shuttle replaces its roof tiles with space turfs
3. Space turfs notice the tiles below them arent space turfs (Because the shuttle itself hasn't moved its turfs yet)
4. Space turfs convert themselves into open space turfss
5. The shuttle moves
6. You now have open space turfs in the middle of a sea of space, which don't behave the same as space.

This PR simply moves the "Replace roof with space" step to after the shuttle's turfs have been relocated.

## Changelog
:cl: SierraKomodo
bugfix: Shuttles no longer leave outlines in space.
/:cl:

## Bug Fixes
- Fixes #32373 