### PR TITLE
Add functionality allowing lit objects to ignite flammable mobs

### DIFF
--- a/code/game/objects/items/weapons/candle/candle.dm
+++ b/code/game/objects/items/weapons/candle/candle.dm
@@ -6,6 +6,7 @@
 	item_state = "candle1"
 	w_class = ITEM_SIZE_TINY
 	light_color = "#e09d37"
+	throwforce = 1
 
 	var/available_colours = list(COLOR_WHITE, COLOR_DARK_GRAY, COLOR_RED, COLOR_ORANGE, COLOR_YELLOW, COLOR_GREEN, COLOR_BLUE, COLOR_INDIGO, COLOR_VIOLET)
 	var/wax
@@ -77,6 +78,85 @@
 		set_light(0)
 		remove_extension(src, /datum/extension/scent)
 
+/// Allows player to light a flammable mob with lit candle.
+/obj/item/flame/candle/use_before(mob/living/fiery, mob/living/carbon/user)
+	. = FALSE
+	if (!istype(fiery))
+		return FALSE
+	if (lit)
+		var/turf/location = get_turf(user)
+		var/mob/living/burn = fiery
+		if(isliving(fiery) && burn.fire_stacks > 0)
+			user.visible_message(
+				SPAN_WARNING("\The [user] sets \the [fiery] on fire with \a [src]!"),
+				SPAN_WARNING("You set \the [fiery] on fire!")
+			)
+			fiery.IgniteMob()
+			/// admin logs
+			if(ismob(user))
+				var/attacker_message = "Ignited using \a [src] (lit)"
+				var/victim_message = "Was ignited with \a [src] (lit)"
+				var/admin_message = "used \a [src] (lit) to ignite"
+				admin_attack_log(user, fiery, attacker_message, victim_message, admin_message)
+			else
+				admin_victim_log(fiery, "was ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
+			if (istype(fiery.wear_mask, /obj/item/clothing/mask/smokable/cigarette) && user.zone_sel.selecting == BP_MOUTH)
+				var/obj/item/clothing/mask/smokable/cigarette/cig = fiery.wear_mask
+				if (fiery == user)
+					cig.use_tool(src, user)
+				else
+					cig.light(SPAN_NOTICE("[user] holds the [name] out for [fiery], and lights the [cig.name]."))
+				return TRUE
+		if(isturf(location))
+			location.hotspot_expose(700)
+	return
+/// Ignites flammable mobs if you throw a lit candle at them
+/obj/item/flame/candle/throw_impact(atom/hit_atom, datum/thrownthing/igniter)
+	if (isliving(hit_atom))
+		var/mob/living/victim = hit_atom
+		var/miss_chance = max(15*(igniter.dist_travelled-2),0)
+		if (!lit)
+			return ..()
+		/// Overwrites the hitby miss outcome, when it's lit.
+		if (prob(miss_chance))
+			visible_message(
+				SPAN_NOTICE("\The [src] misses [victim] narrowly!")
+			)
+			/// admin log when there is intention, but a miss happens
+			if (ismob(igniter.thrower))
+				var/attacker_attempt = "Attempted to ignite using \a [src] (lit)"
+				var/victim_attempt = "Was almost ignited with \a [src] (lit)"
+				var/admin_attempt = "tried to use \a [src] (lit) to ignite"
+				admin_attack_log(igniter.thrower, victim, attacker_attempt, victim_attempt, admin_attempt)
+			else
+				admin_victim_log(victim, "was almost ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
+		else
+			/// make it deal burn damage based on throwforce and speed
+			var/dtype = DAMAGE_BURN
+			var/throw_damage = src.throwforce*(src.throw_speed/THROWFORCE_SPEED_DIVISOR)
+			igniter.thrower.visible_message(
+				SPAN_WARNING("\The [igniter.thrower] throws \a lit [src] at \the [victim]!"),
+				SPAN_WARNING("You throw \a lit [src] at \the [victim]!")
+			)
+			victim.IgniteMob()
+			victim.apply_damage(damage = throw_damage, damagetype = dtype, used_weapon = igniter)
+			/** admin logs
+			* If victim is flammable, they'll be set on fire */
+			if (victim.on_fire)
+				if (ismob(igniter.thrower))
+					var/attacker_ignited = "Ignited using \a [src] (lit)"
+					var/victim_ignited = "Was ignited with \a [src] (lit)"
+					var/admin_ignited = "used \a [src] (lit) to ignite"
+					admin_attack_log(igniter.thrower, victim, attacker_ignited, victim_ignited, admin_ignited)
+				else
+					admin_victim_log(victim, "was ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
+			/// But what if it fails/victim isn't flammable?
+			else
+				if (ismob(igniter.thrower))
+					var/attacker_unblazed = "Failed to be ignited with \a [src] (lit)"
+					var/victim_unblazed = "Was hit with \a [src] (lit) but didn't ignite"
+					var/admin_unblazed = "used \a [src] (lit) to ignite"
+					admin_attack_log(igniter.thrower, victim, attacker_unblazed, victim_unblazed, admin_unblazed)
 /obj/item/storage/candle_box
 	name = "candle pack"
 	desc = "A pack of unscented candles in a variety of colours."

--- a/code/game/objects/items/weapons/flame.dm
+++ b/code/game/objects/items/weapons/flame.dm
@@ -74,3 +74,29 @@
 	if(burnt)
 		icon_state = "match_burnt"
 		item_state = "cigoff"
+
+/obj/item/flame/match/use_before(mob/living/fiery, mob/living/carbon/user)
+	. = FALSE
+	if (!istype(fiery))
+		return FALSE
+
+	if (lit)
+		var/turf/location = get_turf(user)
+		var/mob/living/burn = fiery
+		if(isliving(fiery) && burn.fire_stacks > 0)
+			user.visible_message(
+				SPAN_WARNING("\The [user] sets \the [fiery] on fire with \a [src]!"),
+				SPAN_WARNING("You set \the [fiery] on fire!")
+			)
+			fiery.IgniteMob()
+			/// admin logs
+			if(ismob(user))
+				var/attacker_message = "Ignited using \a [src] (lit)"
+				var/victim_message = "Was ignited with \a [src] (lit)"
+				var/admin_message = "used \a [src] (lit) to ignite"
+				admin_attack_log(user, fiery, attacker_message, victim_message, admin_message)
+			else
+				admin_victim_log(fiery, "was ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
+		if(isturf(location))
+			location.hotspot_expose(700)
+	return

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -125,23 +125,51 @@
 	return
 /// Ignites flammable mobs if you throw a lit lighter at them
 /obj/item/flame/lighter/throw_impact(atom/hit_atom, datum/thrownthing/igniter)
-	..()
-	if(lit)
+	if (isliving(hit_atom))
 		var/mob/living/victim = hit_atom
-		if(isliving(victim) && victim.fire_stacks > 0)
+		var/miss_chance = max(15*(igniter.dist_travelled-2),0)
+		if (!lit)
+			return ..()
+		/// Overwrites the hitby miss outcome, when it's lit.
+		if (prob(miss_chance))
+			visible_message(
+				SPAN_NOTICE("\The [src] misses [victim] narrowly!")
+			)
+			/// admin log when there is intention, but a miss happens
+			if (ismob(igniter.thrower))
+				var/attacker_attempt = "Attempted to ignite using \a [src] (lit)"
+				var/victim_attempt = "Was almost ignited with \a [src] (lit)"
+				var/admin_attempt = "tried to use \a [src] (lit) to ignite"
+				admin_attack_log(igniter.thrower, victim, attacker_attempt, victim_attempt, admin_attempt)
+			else
+				admin_victim_log(victim, "was almost ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
+		else
+			/// make it deal burn damage based on throwforce and speed
+			var/dtype = DAMAGE_BURN
+			var/throw_damage = src.throwforce*(src.throw_speed/THROWFORCE_SPEED_DIVISOR)
 			igniter.thrower.visible_message(
-				SPAN_WARNING("\The [igniter.thrower] sets \the [victim] on fire with \a [src]!"),
-				SPAN_WARNING("You set \the [victim] on fire!")
+				SPAN_WARNING("\The [igniter.thrower] throws \a lit [src] at \the [victim]!"),
+				SPAN_WARNING("You throw \a lit [src] at \the [victim]!")
 			)
 			victim.IgniteMob()
-			/// admin logs
-			if(ismob(igniter.thrower))
-				var/attacker_message = "Ignited using \a [src] (lit)"
-				var/victim_message = "Was ignited with \a [src] (lit)"
-				var/admin_message = "used \a [src] (lit) to ignite"
-				admin_attack_log(igniter.thrower, victim, attacker_message, victim_message, admin_message)
+			victim.apply_damage(damage = throw_damage, damagetype = dtype, used_weapon = igniter)
+			/** admin logs
+			* If victim is flammable, they'll be set on fire */
+			if (victim.on_fire)
+				if (ismob(igniter.thrower))
+					var/attacker_ignited = "Ignited using \a [src] (lit)"
+					var/victim_ignited = "Was ignited with \a [src] (lit)"
+					var/admin_ignited = "used \a [src] (lit) to ignite"
+					admin_attack_log(igniter.thrower, victim, attacker_ignited, victim_ignited, admin_ignited)
+				else
+					admin_victim_log(victim, "was ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
+			/// But what if it fails/victim isn't flammable?
 			else
-				admin_victim_log(victim, "was ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
+				if (ismob(igniter.thrower))
+					var/attacker_unblazed = "Failed to be ignited with \a [src] (lit)"
+					var/victim_unblazed = "Was hit with \a [src] (lit) but didn't ignite"
+					var/admin_unblazed = "used \a [src] (lit) to ignite"
+					admin_attack_log(igniter.thrower, victim, attacker_unblazed, victim_unblazed, admin_unblazed)
 
 /obj/item/flame/lighter/Process()
 	if(!submerged() && reagents.has_reagent(/datum/reagent/fuel))

--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -30,6 +30,7 @@
 	if (fail_light(user))
 		return
 	lit = 1
+	src.damtype = DAMAGE_BURN /// So hitting a target with a lit lighter sets them on fire
 	update_icon()
 	light_effects(user)
 	set_light(2, l_color = COLOR_PALE_ORANGE)
@@ -90,20 +91,57 @@
 	else
 		AddOverlays(overlay_image(icon, "[bis.base_icon_state]_striker", flags=RESET_COLOR))
 
-/obj/item/flame/lighter/use_before(mob/living/M, mob/living/carbon/user)
+/// Allows player to light a flammable mob with lit lighter.
+/obj/item/flame/lighter/use_before(mob/living/fiery, mob/living/carbon/user)
 	. = FALSE
-	if (!istype(M))
+	if (!istype(fiery))
 		return FALSE
-
 	if (lit)
-		M.IgniteMob()
-		if (istype(M.wear_mask, /obj/item/clothing/mask/smokable/cigarette) && user.zone_sel.selecting == BP_MOUTH)
-			var/obj/item/clothing/mask/smokable/cigarette/cig = M.wear_mask
-			if (M == user)
-				cig.use_tool(src, user)
+		var/turf/location = get_turf(user)
+		var/mob/living/burn = fiery
+		if(isliving(fiery) && burn.fire_stacks > 0)
+			user.visible_message(
+				SPAN_WARNING("\The [user] sets \the [fiery] on fire with \a [src]!"),
+				SPAN_WARNING("You set \the [fiery] on fire!")
+			)
+			fiery.IgniteMob()
+			/// admin logs
+			if(ismob(user))
+				var/attacker_message = "Ignited using \a [src] (lit)"
+				var/victim_message = "Was ignited with \a [src] (lit)"
+				var/admin_message = "used \a [src] (lit) to ignite"
+				admin_attack_log(user, fiery, attacker_message, victim_message, admin_message)
 			else
-				cig.light(SPAN_NOTICE("[user] holds the [name] out for [M], and lights the [cig.name]."))
-			return TRUE
+				admin_victim_log(fiery, "was ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
+			if (istype(fiery.wear_mask, /obj/item/clothing/mask/smokable/cigarette) && user.zone_sel.selecting == BP_MOUTH)
+				var/obj/item/clothing/mask/smokable/cigarette/cig = fiery.wear_mask
+				if (fiery == user)
+					cig.use_tool(src, user)
+				else
+					cig.light(SPAN_NOTICE("[user] holds the [name] out for [fiery], and lights the [cig.name]."))
+				return TRUE
+		if(isturf(location))
+			location.hotspot_expose(700)
+	return
+/// Ignites flammable mobs if you throw a lit lighter at them
+/obj/item/flame/lighter/throw_impact(atom/hit_atom, datum/thrownthing/igniter)
+	..()
+	if(lit)
+		var/mob/living/victim = hit_atom
+		if(isliving(victim) && victim.fire_stacks > 0)
+			igniter.thrower.visible_message(
+				SPAN_WARNING("\The [igniter.thrower] sets \the [victim] on fire with \a [src]!"),
+				SPAN_WARNING("You set \the [victim] on fire!")
+			)
+			victim.IgniteMob()
+			/// admin logs
+			if(ismob(igniter.thrower))
+				var/attacker_message = "Ignited using \a [src] (lit)"
+				var/victim_message = "Was ignited with \a [src] (lit)"
+				var/admin_message = "used \a [src] (lit) to ignite"
+				admin_attack_log(igniter.thrower, victim, attacker_message, victim_message, admin_message)
+			else
+				admin_victim_log(victim, "was ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
 
 /obj/item/flame/lighter/Process()
 	if(!submerged() && reagents.has_reagent(/datum/reagent/fuel))

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -153,23 +153,51 @@
 	return
 /// Ignites flammable mobs if you throw a toggled welding tool at them
 /obj/item/weldingtool/throw_impact(atom/hit_atom, datum/thrownthing/igniter)
-	..()
-	if(welding)
+	if (isliving(hit_atom))
 		var/mob/living/victim = hit_atom
-		if(isliving(victim) && victim.fire_stacks > 0)
+		var/miss_chance = max(15*(igniter.dist_travelled-2),0)
+		if (!welding)
+			return ..()
+		/// Overwrites the hitby miss outcome, when it's lit.
+		if (prob(miss_chance))
+			visible_message(
+				SPAN_NOTICE("\The [src] misses [victim] narrowly!")
+			)
+			/// admin log when there is intention, but a miss happens
+			if (ismob(igniter.thrower))
+				var/attacker_attempt = "Attempted to ignite using \a [src] (lit)"
+				var/victim_attempt = "Was almost ignited with \a [src] (lit)"
+				var/admin_attempt = "tried to use \a [src] (lit) to ignite"
+				admin_attack_log(igniter.thrower, victim, attacker_attempt, victim_attempt, admin_attempt)
+			else
+				admin_victim_log(victim, "was almost ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
+		else
+			/// make it deal burn damage based on throwforce and speed
+			var/dtype = DAMAGE_BURN
+			var/throw_damage = src.throwforce*(src.throw_speed/THROWFORCE_SPEED_DIVISOR)
 			igniter.thrower.visible_message(
-				SPAN_WARNING("\The [igniter.thrower] sets \the [victim] on fire with \a [src]!"),
-				SPAN_WARNING("You set \the [victim] on fire!")
+				SPAN_WARNING("\The [igniter.thrower] throws \a lit [src] at \the [victim]!"),
+				SPAN_WARNING("You throw \a lit [src] at \the [victim]!")
 			)
 			victim.IgniteMob()
-			/// admin logs
-			if(ismob(igniter.thrower))
-				var/attacker_message = "Ignited using \a [src] (lit)"
-				var/victim_message = "Was ignited with \a [src] (lit)"
-				var/admin_message = "used \a [src] (lit) to ignite"
-				admin_attack_log(igniter.thrower, victim, attacker_message, victim_message, admin_message)
+			victim.apply_damage(damage = throw_damage, damagetype = dtype, used_weapon = igniter)
+			/** admin logs
+			* If victim is flammable, they'll be set on fire */
+			if (victim.on_fire)
+				if (ismob(igniter.thrower))
+					var/attacker_ignited = "Ignited using \a [src] (lit)"
+					var/victim_ignited = "Was ignited with \a [src] (lit)"
+					var/admin_ignited = "used \a [src] (lit) to ignite"
+					admin_attack_log(igniter.thrower, victim, attacker_ignited, victim_ignited, admin_ignited)
+				else
+					admin_victim_log(victim, "was ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
+			/// But what if it fails/victim isn't flammable?
 			else
-				admin_victim_log(victim, "was ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
+				if (ismob(igniter.thrower))
+					var/attacker_unblazed = "Failed to be ignited with \a [src] (lit)"
+					var/victim_unblazed = "Was hit with \a [src] (lit) but didn't ignite"
+					var/admin_unblazed = "used \a [src] (lit) to ignite"
+					admin_attack_log(igniter.thrower, victim, attacker_unblazed, victim_unblazed, admin_unblazed)
 
 /obj/item/weldingtool/attack_self(mob/user as mob)
 	setWelding(!welding, usr)

--- a/code/game/objects/items/weapons/tools/weldingtool.dm
+++ b/code/game/objects/items/weapons/tools/weldingtool.dm
@@ -128,17 +128,48 @@
 		to_chat(user, SPAN_NOTICE("You refuel \the [tank]."))
 		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
 		return TRUE
-
+	/// Allows player to light a flammable mob with lit welding tool.
 	if(welding)
 		var/turf/location = get_turf(user)
-		if(isliving(O))
-			var/mob/living/L = O
+		var/mob/living/L = O
+		if(isliving(O) && L.fire_stacks > 0)
+			user.visible_message(
+				SPAN_WARNING("\The [user] sets \the [O] on fire with \a [src]!"),
+				SPAN_WARNING("You set \the [O] on fire!")
+			)
 			L.IgniteMob()
+			/// admin logs
+			if(ismob(user))
+				var/attacker_message = "Ignited using \a [src] (lit)"
+				var/victim_message = "Was ignited with \a [src] (lit)"
+				var/admin_message = "used \a [src] (lit) to ignite"
+				admin_attack_log(user, O, attacker_message, victim_message, admin_message)
+			else
+				admin_victim_log(O, "was ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
 		else if(istype(O))
 			O.HandleObjectHeating(src, user, 700)
 		if (isturf(location))
 			location.hotspot_expose(700)
 	return
+/// Ignites flammable mobs if you throw a toggled welding tool at them
+/obj/item/weldingtool/throw_impact(atom/hit_atom, datum/thrownthing/igniter)
+	..()
+	if(welding)
+		var/mob/living/victim = hit_atom
+		if(isliving(victim) && victim.fire_stacks > 0)
+			igniter.thrower.visible_message(
+				SPAN_WARNING("\The [igniter.thrower] sets \the [victim] on fire with \a [src]!"),
+				SPAN_WARNING("You set \the [victim] on fire!")
+			)
+			victim.IgniteMob()
+			/// admin logs
+			if(ismob(igniter.thrower))
+				var/attacker_message = "Ignited using \a [src] (lit)"
+				var/victim_message = "Was ignited with \a [src] (lit)"
+				var/admin_message = "used \a [src] (lit) to ignite"
+				admin_attack_log(igniter.thrower, victim, attacker_message, victim_message, admin_message)
+			else
+				admin_victim_log(victim, "was ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
 
 /obj/item/weldingtool/attack_self(mob/user as mob)
 	setWelding(!welding, usr)

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -192,23 +192,51 @@
 	return
 /// Ignites flammable mobs if you throw a lit cigarette at them
 /obj/item/clothing/mask/smokable/throw_impact(atom/hit_atom, datum/thrownthing/igniter)
-	..()
-	if(lit)
+	if (isliving(hit_atom))
 		var/mob/living/victim = hit_atom
-		if(isliving(victim) && victim.fire_stacks > 0)
+		var/miss_chance = max(15*(igniter.dist_travelled-2),0)
+		if (!lit)
+			return ..()
+		/// Overwrites the hitby miss outcome, when it's lit.
+		if (prob(miss_chance))
+			visible_message(
+				SPAN_NOTICE("\The [src] misses [victim] narrowly!")
+			)
+			/// admin log when there is intention, but a miss happens
+			if (ismob(igniter.thrower))
+				var/attacker_attempt = "Attempted to ignite using \a [src] (lit)"
+				var/victim_attempt = "Was almost ignited with \a [src] (lit)"
+				var/admin_attempt = "tried to use \a [src] (lit) to ignite"
+				admin_attack_log(igniter.thrower, victim, attacker_attempt, victim_attempt, admin_attempt)
+			else
+				admin_victim_log(victim, "was almost ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
+		else
+			/// make it deal burn damage based on throwforce and speed
+			var/dtype = DAMAGE_BURN
+			var/throw_damage = src.throwforce*(src.throw_speed/THROWFORCE_SPEED_DIVISOR)
 			igniter.thrower.visible_message(
-				SPAN_WARNING("\The [igniter.thrower] sets \the [victim] on fire with \a [src]!"),
-				SPAN_WARNING("You set \the [victim] on fire!")
+				SPAN_WARNING("\The [igniter.thrower] throws \a lit [src] at \the [victim]!"),
+				SPAN_WARNING("You throw \a lit [src] at \the [victim]!")
 			)
 			victim.IgniteMob()
-			/// admin logs
-			if(ismob(igniter.thrower))
-				var/attacker_message = "Ignited using \a [src] (lit)"
-				var/victim_message = "Was ignited with \a [src] (lit)"
-				var/admin_message = "used \a [src] (lit) to ignite"
-				admin_attack_log(igniter.thrower, victim, attacker_message, victim_message, admin_message)
+			victim.apply_damage(damage = throw_damage, damagetype = dtype, used_weapon = igniter)
+			/** admin logs
+			* If victim is flammable, they'll be set on fire */
+			if (victim.on_fire)
+				if (ismob(igniter.thrower))
+					var/attacker_ignited = "Ignited using \a [src] (lit)"
+					var/victim_ignited = "Was ignited with \a [src] (lit)"
+					var/admin_ignited = "used \a [src] (lit) to ignite"
+					admin_attack_log(igniter.thrower, victim, attacker_ignited, victim_ignited, admin_ignited)
+				else
+					admin_victim_log(victim, "was ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
+			/// But what if it fails/victim isn't flammable?
 			else
-				admin_victim_log(victim, "was ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
+				if (ismob(igniter.thrower))
+					var/attacker_unblazed = "Failed to be ignited with \a [src] (lit)"
+					var/victim_unblazed = "Was hit with \a [src] (lit) but didn't ignite"
+					var/admin_unblazed = "used \a [src] (lit) to ignite"
+					admin_attack_log(igniter.thrower, victim, attacker_unblazed, victim_unblazed, admin_unblazed)
 
 /obj/item/clothing/mask/smokable/IsFlameSource()
 	return lit

--- a/code/modules/clothing/masks/smokable.dm
+++ b/code/modules/clothing/masks/smokable.dm
@@ -3,6 +3,7 @@
 	desc = "You're not sure what this is. You should probably ahelp it."
 	body_parts_covered = 0
 	waterproof = FALSE
+	throwforce = 1
 
 	var/lit = 0
 	var/icon_on
@@ -161,13 +162,53 @@
 		light(text)
 	return ..()
 
-/obj/item/clothing/mask/smokable/use_before(mob/living/M, mob/living/user)
+/obj/item/clothing/mask/smokable/use_before(mob/living/fiery, mob/living/user)
 	. = FALSE
-	if (istype(M) && M.on_fire)
-		user.do_attack_animation(M)
-		light(SPAN_NOTICE("\The [user] coldly lights the \the [src] with the burning body of \the [M]."))
+	if (istype(fiery) && fiery.on_fire)
+		user.do_attack_animation(fiery)
+		light(SPAN_NOTICE("\The [user] coldly lights the \the [src] with the burning body of \the [fiery]."))
 		return TRUE
+	/// Allows player to light a flammable mob with lit cigarette.
+	if(lit)
+		var/turf/location = get_turf(user)
+		var/mob/living/burn = fiery
+		if(isliving(fiery) && burn.fire_stacks > 0)
+			user.visible_message(
+				SPAN_WARNING("\The [user] sets \the [fiery] on fire with \a [src]!"),
+				SPAN_WARNING("You set \the [fiery] on fire!")
+			)
+			burn.IgniteMob()
+			/// admin logs
+			if(ismob(user))
+				var/attacker_message = "Ignited using \a [src] (lit)"
+				var/victim_message = "Was ignited with \a [src] (lit)"
+				var/admin_message = "used \a [src] (lit) to ignite"
 
+				admin_attack_log(user, fiery, attacker_message, victim_message, admin_message)
+			else
+				admin_victim_log(fiery, "was ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
+		if (isturf(location))
+			location.hotspot_expose(700)
+	return
+/// Ignites flammable mobs if you throw a lit cigarette at them
+/obj/item/clothing/mask/smokable/throw_impact(atom/hit_atom, datum/thrownthing/igniter)
+	..()
+	if(lit)
+		var/mob/living/victim = hit_atom
+		if(isliving(victim) && victim.fire_stacks > 0)
+			igniter.thrower.visible_message(
+				SPAN_WARNING("\The [igniter.thrower] sets \the [victim] on fire with \a [src]!"),
+				SPAN_WARNING("You set \the [victim] on fire!")
+			)
+			victim.IgniteMob()
+			/// admin logs
+			if(ismob(igniter.thrower))
+				var/attacker_message = "Ignited using \a [src] (lit)"
+				var/victim_message = "Was ignited with \a [src] (lit)"
+				var/admin_message = "used \a [src] (lit) to ignite"
+				admin_attack_log(igniter.thrower, victim, attacker_message, victim_message, admin_message)
+			else
+				admin_victim_log(victim, "was ignited by an <b> UNKNOWN SUBJECT (No longer exists)</b> using \a [src]")
 
 /obj/item/clothing/mask/smokable/IsFlameSource()
 	return lit


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: Podszywacz
rscadd: Added functionality allowing lit objects like lighters, matches, cigarettes, welding tools and candles to set flammable mobs ablaze via directly clicking or throwing at them such lit item.
admin: Added attack logs when someone is set on fire with lit flame sources.
/:cl:

Pouring welding fuel and setting someone ablaze couldn't be any easier!
Become even more baleful to your local GAS!
Become pyroman from TF2!

~~Despite throwables missing a target "[item] misses [target] narrowly!", the target is still ignited. Until this gets fixed or I get a green light to add it like that, this PR is a draft.~~