### PR TITLE
Removed colliding recipe for meatball spaghetti

### DIFF
--- a/code/modules/cooking/recipes/recipes_pasta.dm
+++ b/code/modules/cooking/recipes/recipes_pasta.dm
@@ -48,19 +48,6 @@
 	cooked_scent = /datum/extension/scent/food/pasta
 
 /singleton/cooking_recipe/meatballspagettiboiled
-	appliance = COOKING_APPLIANCE_POT | COOKING_APPLIANCE_SAUCEPAN | COOKING_APPLIANCE_MICROWAVE
-	consumed_reagents = list(
-		/datum/reagent/water = 10
-	)
-	required_items = list(
-		/obj/item/reagent_containers/food/snacks/boiledspagetti,
-		/obj/item/reagent_containers/food/snacks/meatball,
-		/obj/item/reagent_containers/food/snacks/meatball
-	)
-	result_path = /obj/item/reagent_containers/food/snacks/meatballspagetti
-	cooked_scent = /datum/extension/scent/food/pasta
-
-/singleton/cooking_recipe/meatballspagettiboiled
 	appliance = COOKING_APPLIANCE_POT | COOKING_APPLIANCE_SAUCEPAN
 	required_items = list(
 		/obj/item/reagent_containers/food/snacks/boiledspagetti,


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

:cl: Podszywacz
bugfix: Removed one of spaghetti & meatballs recipe, which caused an alternative recipe not to work.
/:cl:

[SOMEBODY TOUCHA MY SPAGHET!](https://youtu.be/LC8iPoZCEok)

(Also cooking a boiled spaghetti in even more water sounds like a recipe for mush)