### PR TITLE
Fix notify wiki on merge embed name template error (Maybe)

### DIFF
--- a/.github/workflows/notify_wiki_on_merge.yml
+++ b/.github/workflows/notify_wiki_on_merge.yml
@@ -17,7 +17,7 @@ jobs:
           webhook-url: ${{ secrets.DISCORD_WIKI_WEBHOOK_URL }}
           username: GitHub
           avatar-url: https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png
-          embed-author-name: ${{ github.event.pull_request.user }}
+          embed-author-name: ${{ github.event.pull_request.user.login }}
           embed-title: ${{ github.event.pull_request.title }}
           embed-url: ${{ github.event.pull_request.url }}
           embed-description: |


### PR DESCRIPTION
I'm not able to figure out how to even test this because github actions are weird and don't want to run at all on my fork, for reasons that are beyond me.

NUFC.