### PR TITLE
Pulling atoms creates hidden prints

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -581,6 +581,7 @@
 
 	src.pulling = AM
 	AM.pulledby = src
+	AM.add_hiddenprint(src)
 
 	if(pullin)
 		pullin.icon_state = "pull1"


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
admin: Pulling objects and mobs via ctrl+click now generates hidden prints.
/:cl: