### PR TITLE
Ignite mobs hit by objects that are a flame source

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -392,6 +392,9 @@ meteor_act
 					affecting.embed(I, supplied_wound = created_wound)
 					I.has_embedded()
 
+		if (AM.IsFlameSource())
+			IgniteMob()
+
 		process_momentum(AM, TT)
 
 	else

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -325,6 +325,12 @@ meteor_act
 	if(isobj(AM))
 		var/obj/O = AM
 
+		if(TT.thrower)
+			var/client/assailant = TT.thrower.client
+			if(assailant)
+				var/active_flame = "[O.IsFlameSource() ? "(on fire)" : ""]"
+				admin_attack_log(TT.thrower, src, "Threw \an [O][active_flame] at their victim.", "Had \an [O][active_flame] thrown at them", "threw \an [O][active_flame] at")
+
 		if(in_throw_mode && !get_active_hand() && TT.speed <= THROWFORCE_SPEED_DIVISOR)	//empty active hand and we're in throw mode
 			if(!incapacitated())
 				if(isturf(O.loc))
@@ -367,11 +373,6 @@ meteor_act
 
 		src.visible_message(SPAN_WARNING("\The [src] has been hit in the [hit_area] by \the [O]."))
 		created_wound = apply_damage(throw_damage, dtype, zone, O.damage_flags(), O, O.armor_penetration)
-
-		if(TT.thrower)
-			var/client/assailant = TT.thrower.client
-			if(assailant)
-				admin_attack_log(TT.thrower, src, "Threw \an [O] at their victim.", "Had \an [O] thrown at them", "threw \an [O] at")
 
 		//thrown weapon embedded object code.
 		if (dtype == DAMAGE_BRUTE && istype(O,/obj/item))

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -184,6 +184,9 @@
 		if(O.can_embed() && (throw_damage > 5*O.w_class)) //Handles embedding for non-humans and simple_animals.
 			embed(O)
 
+	if (AM.IsFlameSource())
+		IgniteMob()
+
 	process_momentum(AM, TT)
 
 /mob/living/momentum_power(atom/movable/AM, datum/thrownthing/TT)


### PR DESCRIPTION
:cl: Mucker
tweak: Mobs can be ignited when hit by objects considered to be a flame source.
admin: All throw attempts are now attack logged, even if they miss.
/:cl:

alternate to #35394 that should be much cleaner.

closes #35394