### PR TITLE
Fix for cooking recipes

### DIFF
--- a/code/modules/cooking/_appliance.dm
+++ b/code/modules/cooking/_appliance.dm
@@ -376,7 +376,8 @@
 		recipe = select_recipe(container, appliance = appliance)
 
 	if (recipe)
-		var/list/results = recipe.CreateResult(container)
+		var/list/results = list()
+		results += recipe.CreateResult(container)
 
 		var/obj/temp = new /obj(src) //To prevent infinite loops, all results will be moved into a temporary location so they're not considered as inputs for other recipes
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Current problem: this variable is supposed to be a list the entire time
https://github.com/Baystation12/Baystation12/blob/2d140734eca91284aa838f65371b705cb7b3a586/code/modules/cooking/_appliance.dm#L379

But in the way it is initialized, it can actually turn into object under specific result overrides, example of a such override:
https://github.com/Baystation12/Baystation12/blob/2d140734eca91284aa838f65371b705cb7b3a586/code/modules/cooking/recipes/recipes_oven.dm#L217-L220

How to reproduce the issue:
Add a donk pocket into microwave and turn it on.

After a little while, this donk pocket disappears and we have a runtime:
`
[22:02:31] Runtime in code/modules/cooking/_appliance.dm,392: type mismatch: the hot protein donk-pocket (/obj/item/reagent_containers/food/snacks/donkpocket/protein) += /list (/list)
  proc name: finish cooking (/obj/machinery/appliance/proc/finish_cooking)
  src: the microwave (/obj/machinery/appliance/cooker/microwave)
  src.loc: the deck (79,114,3) (/turf/simulated/floor/tiled/white)
  call stack:
  the microwave (/obj/machinery/appliance/cooker/microwave): finish cooking(/datum/cooking_item (/datum/cooking_item))
  the microwave (/obj/machinery/appliance/cooker/microwave): do cooking tick(/datum/cooking_item (/datum/cooking_item))
  the microwave (/obj/machinery/appliance/cooker/microwave): Process(20)
  the microwave (/obj/machinery/appliance/cooker/microwave): Process(20)
  Machines (/datum/controller/subsystem/machines): process machinery(1, null)
  Machines (/datum/controller/subsystem/machines): fire(1, null)
  Machines (/datum/controller/subsystem/machines): ignite(1)
  Main (/datum/controller/master): RunQueue()
  Main (/datum/controller/master): Loop()
  Main (/datum/controller/master): StartProcessing(0)
`
Should also fix all the other recipes that had a CreateResult override.

:cl: Builder13
bugfix: Fix for certain cooking recipes that had a result override (donk pockets)
/:cl: