### PR TITLE
Fixes the Radio Interceptor

### DIFF
--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -61,7 +61,10 @@
 	wires = new(src)
 	if(ispath(cell))
 		cell = new cell(src)
-	internal_channels = GLOB.using_map.default_internal_channels()
+	if (intercept)
+		internal_channels = GLOB.using_map.intercept_internal_channels()
+	else
+		internal_channels = GLOB.using_map.default_internal_channels()
 	GLOB.listening_objects += src
 
 	if(frequency < RADIO_LOW_FREQ || frequency > RADIO_HIGH_FREQ)
@@ -161,6 +164,8 @@
 /obj/item/device/radio/proc/list_internal_channels(mob/user)
 	var/dat[0]
 	for(var/internal_chan in internal_channels)
+		if (!syndie && (text2num(internal_chan) == SYND_FREQ)) //Only traitor shortwaves should be able to see the traitor frequency
+			continue
 		if(has_channel_access(user, internal_chan))
 			dat.Add(list(list("chan" = internal_chan, "display_name" = get_frequency_default_name(text2num(internal_chan)), "chan_span" = frequency_span_class(text2num(internal_chan)))))
 
@@ -965,9 +970,10 @@
 	name = "bulky radio"
 	desc = "A large radio fitted with several military-grade communication interception circuits."
 	icon_state = "radio"
-	intercept = 1
+	intercept = TRUE
+	syndie = TRUE
 	w_class = ITEM_SIZE_NORMAL
-
+	default_frequency = SYND_FREQ
 
 //The exosuit  radio subtype. It allows pilots to interact and consumes exosuit power
 

--- a/maps/mapsystem/maps.dm
+++ b/maps/mapsystem/maps.dm
@@ -534,6 +534,25 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 		num2text(HAIL_FREQ)  = list(),
 	)
 
+/datum/map/proc/intercept_internal_channels()
+	return list(
+		num2text(PUB_FREQ)   = list(),
+		num2text(AI_FREQ)    = list(access_synth),
+		num2text(ENT_FREQ)   = list(),
+		num2text(ERT_FREQ)   = list(access_cent_specops),
+		num2text(COMM_FREQ)  = list(access_bridge),
+		num2text(ENG_FREQ)   = list(access_engine_equip, access_atmospherics),
+		num2text(MED_FREQ)   = list(access_medical_equip),
+		num2text(MED_I_FREQ) = list(access_medical_equip),
+		num2text(SEC_FREQ)   = list(access_brig),
+		num2text(SEC_I_FREQ) = list(access_brig),
+		num2text(SCI_FREQ)   = list(access_tox,access_robotics,access_xenobiology),
+		num2text(SUP_FREQ)   = list(access_cargo),
+		num2text(SRV_FREQ)   = list(access_janitor, access_hydroponics),
+		num2text(HAIL_FREQ)  = list(),
+		num2text(SYND_FREQ)  = list()
+	)
+
 /datum/map/proc/show_titlescreen(client/C)
 	winset(C, "lobbybrowser", "is-disabled=false;is-visible=true")
 

--- a/maps/torch/torch_presets.dm
+++ b/maps/torch/torch_presets.dm
@@ -190,8 +190,29 @@ var/global/const/NETWORK_ENGINEERING_OUTPOST = "Engineering Outpost"
 		num2text(SUP_FREQ)   = list(access_radio_sup),
 		num2text(SRV_FREQ)   = list(access_radio_serv),
 		num2text(EXP_FREQ)   = list(access_radio_exp),
-		num2text(HAIL_FREQ)  = list(),
+		num2text(HAIL_FREQ)  = list()
 	)
+
+/datum/map/torch/intercept_internal_channels()
+	return list(
+		num2text(PUB_FREQ)   = list(),
+		num2text(AI_FREQ)    = list(access_synth),
+		num2text(ENT_FREQ)   = list(),
+		num2text(ERT_FREQ)   = list(access_cent_specops),
+		num2text(COMM_FREQ)  = list(access_radio_comm),
+		num2text(ENG_FREQ)   = list(access_radio_eng),
+		num2text(MED_FREQ)   = list(access_radio_med),
+		num2text(MED_I_FREQ) = list(access_radio_med),
+		num2text(SEC_FREQ)   = list(access_radio_sec),
+		num2text(SEC_I_FREQ) = list(access_radio_sec),
+		num2text(SCI_FREQ)   = list(access_radio_sci),
+		num2text(SUP_FREQ)   = list(access_radio_sup),
+		num2text(SRV_FREQ)   = list(access_radio_serv),
+		num2text(EXP_FREQ)   = list(access_radio_exp),
+		num2text(HAIL_FREQ)  = list(),
+		num2text(SYND_FREQ)  = list()
+	)
+
 
 /singleton/stock_part_preset/radio/receiver/vent_pump/guppy
 	frequency = 1431


### PR DESCRIPTION
:cl: Karl Johansson
bugfix: The radio interceptor is now fixed. You can use it to intercept secure radio transmissions by tuning into the traitor frequency.
rscadd: The radio interceptor can also be used to speak and listen on the traitor frequency.
/:cl:

<img width="542" height="50" alt="image" src="https://github.com/user-attachments/assets/48e677ba-04a3-4d30-9d29-cecfbe70d207" />

The addition of the ability to speak and listen on the traitor frequency was required to make it work. The alternative would've been gutting radio code and basically starting fresh. It was probably intended functionality anyway, and for 30TC you might as well.