### PR TITLE
Fix do_skilled with passed skill list being instant

### DIFF
--- a/code/modules/mob/skills/skillset.dm
+++ b/code/modules/mob/skills/skillset.dm
@@ -135,7 +135,7 @@
 	if (islist(skill_path))
 		for (var/path as anything in skill_path)
 			var/check_delay = skill_delay_mult(path, factor)
-			if (check_delay < final_delay)
+			if (isnull(final_delay) || check_delay < final_delay)
 				final_delay = check_delay
 	else
 		final_delay = skill_delay_mult(skill_path, factor)


### PR DESCRIPTION
Rehash of #35319

:cl: Banditoz
bugfix: Prying open a mech's cockpit is no longer instant.
/:cl: