### PR TITLE
AI core construction fix

### DIFF
--- a/code/game/machinery/computer/ai_core.dm
+++ b/code/game/machinery/computer/ai_core.dm
@@ -58,7 +58,7 @@ var/global/list/empty_playable_ai_cores = list()
 		if (state < STATE_WIRED)
 			USE_FEEDBACK_FAILURE("\The [src] needs to be wired before you can apply \the [tool].")
 			return TRUE
-		if (state > STATE_WIRED)
+		if (state > STATE_BRAIN)
 			USE_FEEDBACK_FAILURE("\The [src]'s panel needs to be removed before you can apply \the [tool].")
 			return TRUE
 		// Special handling for certain law board
@@ -217,7 +217,7 @@ var/global/list/empty_playable_ai_cores = list()
 		if (brain)
 			USE_FEEDBACK_FAILURE("\The [src] already has \a [brain] installed.")
 			return TRUE
-		if (state > STATE_WIRED)
+		if (state > STATE_BRAIN)
 			USE_FEEDBACK_FAILURE("\The [src]'s panel needs to be removed before you can install \the [tool].")
 			return TRUE
 		var/mob/living/carbon/brain/new_brain
@@ -280,7 +280,7 @@ var/global/list/empty_playable_ai_cores = list()
 		if (state < STATE_WIRED)
 			USE_FEEDBACK_FAILURE("\The [src] needs to be wired before you can install a glass panel.")
 			return TRUE
-		if (state > STATE_WIRED)
+		if (state > STATE_BRAIN)
 			USE_FEEDBACK_FAILURE("\The [src] already has a glass panel.")
 			return TRUE
 		if (!material_stack.use(2))


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Fixes incorrect states for AI core construction. Glass panel is at the STATE_PANEL step, that goes after STATE_BRAIN. There are two ways to construct this AI core - either with brain, or without. And construction with brain is now bugged, since reinf glass can't ever be added to the core. Also fixes the abillity to write laws into the core, once the brain is installed.

:cl: Builder13
bugfix: Fix for AI core construction steps.
/:cl: