### PR TITLE
revert test target to 1667 to match live

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,10 +1,10 @@
 name: Run Tests
 
 env:
-  CACHE_PREFIX: "test-1.1.0" # Update when this file is changed
+  CACHE_PREFIX: "test-1.1.1" # Update when this file is changed
   BYOND_SOURCE: "https://indm.dev/byond" # Canonical: "https://www.byond.com/download/build"
   BYOND_MAJOR: "516"
-  BYOND_MINOR: "1669"
+  BYOND_MINOR: "1667"
   SDMM_TARGET: "suite-1.11"
 
 permissions:

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-This repository is built and tested against BYOND version `516.1669` at time of writing. If this version number is at odds with `BYOND_MAJOR`.`BYOND_MINOR` as defined in [`/.github/workflows/test.yml`](/.github/workflows/test.yml), the Actions configuration should be considered authoritative and this document should be noted as out-of-date. Security vulnerabilities or exploits that apply to this version should be reported so that they can be closed.
+This repository is built and tested against BYOND version `516.1667` at time of writing. If this version number is at odds with `BYOND_MAJOR`.`BYOND_MINOR` as defined in [`/.github/workflows/test.yml`](/.github/workflows/test.yml), the Actions configuration should be considered authoritative and this document should be noted as out-of-date. Security vulnerabilities or exploits that apply to this version should be reported so that they can be closed.
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
1668 and 1669 suffer from a world.timeofday platform fail (always 0) - should be resolved in 1670+
