### PR TITLE
Make older event posters contraband

### DIFF
--- a/maps/torch/structures/posters.dm
+++ b/maps/torch/structures/posters.dm
@@ -15,12 +15,12 @@
 	name = "Wholesome Poster"
 	desc = "A wholesome, mass-fabricated poster that states \"Live Laugh Love\". There's tons of small hearts plastered around the text. The dot above the \"i\" has been drawn in the shape of a heart. Supposed to lift your mood... somehow?"
 
-/singleton/poster/torch/event1
+/singleton/poster/contraband_only/torch/event1
 	icon_state="bsposter_event1"
 	name = "Justice for Joe"
 	desc = "A hand-written poster demanding the release of one SCPO Joseph Tornakov from Fleet Intelligence custody. It's somewhat faded, and someone's drawn an impressive moustache on Tornakov in permanent marker. Someone has also written general anti-government statements written around the poster's fringes."
 
-/singleton/poster/torch/event2
+/singleton/poster/contraband_only/torch/event2
 	icon_state="bsposter_event2"
 	name = "Captain for Senate"
 	desc = "A poster loudly advertising the SEV Torch's captain's upcoming bid for SCG Senate. The fine print lightly suggests that failing to vote in their favor will result in an NJP."


### PR DESCRIPTION
I have nothing against these posters. I just think they're better suited as contraband rather than plastered on the wall most rounds.
:cl: 10sc
tweak: "Justice for Joe" and "Captain for Senate" posters are now contraband.
/:cl: