### PR TITLE
Add option to work around WINE rendering issues for goonchat

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -8,9 +8,10 @@ html, body {
 	margin: 0;
 	height: 100%;
 	color: #a4bad6;
+	background-color: #171717;
 }
 body {
-	background: #171717;
+	background-color: #171717;
 	font-family: Verdana, sans-serif;
 	font-size: 13px;
 	color: #a4bad6;
@@ -22,7 +23,17 @@ body {
 	scrollbar-track-color:#171717;
 	scrollbar-highlight-color:#171717;
 }
-
+.renderingWorkaround, .renderingWorkaround .entry {
+	animation: renderingWorkaround 1s infinite linear;
+}
+@keyframes renderingWorkaround {
+  0% {
+    background-color: #171717;
+  }
+  100% {
+    background-color: #161717;
+  }
+}
 em {
 	font-style: normal;
 	font-weight: bold;

--- a/code/modules/goonchat/browserassets/css/browserOutput_white.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput_white.css
@@ -8,15 +8,29 @@ html, body {
 	margin: 0;
 	height: 100%;
 	color: #000000;
+	background-color: #fff;
 }
 body {
-	background: #fff;
+	background-color: #fff;
 	font-family: Verdana, sans-serif;
 	font-size: 13px;
 	line-height: 1.2;
 	overflow-x: hidden;
 	overflow-y: scroll;
 	word-wrap: break-word;
+}
+
+.renderingWorkaround, .renderingWorkaround .entry {
+	animation: renderingWorkaround 1s infinite linear;
+}
+
+@keyframes renderingWorkaround {
+  0% {
+    background-color: #fcffff;
+  }
+  100% {
+    background-color: #ffffff;
+  }
 }
 
 em {

--- a/code/modules/goonchat/browserassets/html/browserOutput.html
+++ b/code/modules/goonchat/browserassets/html/browserOutput.html
@@ -58,6 +58,7 @@
 			<a href="#" class="subCell highlightTerm" id="highlightTerm"><span>Highlight string</span> <i class="fas fa-tag"></i></a>
 			<a href="#" class="subCell saveLog" id="saveLog"><span>Save chat log</span> <i class="fas fa-save"></i></a>
 			<a href="#" class="subCell toggleCombine" id="toggleCombine"><span>Toggle line combining</span> <i class="fas fa-filter"></i></a>
+			<a href="#" class="subCell" id="renderingWorkaround"><span>Toggle WINE workaround</span></a>
 			<a href="#" class="subCell clearMessages" id="clearMessages"><span>Clear all messages</span> <i class="fas fa-eraser"></i></a>
 		</div>
 		<div class="sub" id="subFont">

--- a/code/modules/goonchat/browserassets/js/browserOutput.js
+++ b/code/modules/goonchat/browserassets/js/browserOutput.js
@@ -62,7 +62,8 @@ var opts = {
 	'clientData': [],
 
 	'font': 'Arial',
-	'messageCombining': true
+	'messageCombining': true,
+	'renderingWorkaround': false
 
 };
 var replaceRegexes = {};
@@ -701,6 +702,7 @@ $(function() {
 		'shighlightColor': getCookie('highlightcolor'),
 		'sfont': getCookie('font'),
 		'smessagecombining': getCookie('messagecombining'),
+		'srenderingWorkaround': getCookie('renderingWorkaround'),
 		'stheme': getCookie('theme')
 	};
 
@@ -757,6 +759,12 @@ $(function() {
 			opts.messageCombining = true;
 		}
 	}
+	if (savedConfig.srenderingWorkaround == 'true') {
+		opts.renderingWorkaround = false;
+	} else if (savedConfig.srenderingWorkaround == 'false') {
+		opts.renderingWorkaround = true;
+	}
+	$('body').toggleClass('renderingWorkaround', opts.renderingWorkaround);
 	(function() {
 		var dataCookie = getCookie('connData');
 		if (dataCookie) {
@@ -1111,6 +1119,13 @@ $(function() {
 	$('#toggleCombine').click(function(e) {
 		opts.messageCombining = !opts.messageCombining;
 		setCookie('messagecombining', (opts.messageCombining ? 'true' : 'false'), 365);
+	});
+
+	$('#renderingWorkaround').click(function(e) {
+		opts.renderingWorkaround = !opts.renderingWorkaround;
+		$('body').toggleClass('renderingWorkaround', opts.renderingWorkaround);
+		setCookie('renderingWorkaround', (opts.renderingWorkaround ? 'true' : 'false'), 36);
+		internalOutput('<span class="internal boldnshit">WINE (Linux/macOS) rendering workaround set to '+opts.renderingWorkaround+'</span>', 'internal');
 	});
 
 	$('img.icon').error(iconError);


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
- chat blanks out a lot on baystation but not as much on paradise/tgstation
- including when byond loses/regains focus
- dive into tgui setup to find out why this is
- it's not how the interface skin is set up
- notice that the top status panel in tgui has same issue but only the actively updating area is fixing itself
- wait
- oh my god something in tgui is causing this to rerender on every frame
- well i can make baystation do that but with css instead of god knows what's going on in tgui :godo:
- add a knob to turn this on
- approximating bad behaviours that happen to be bad in a way that fixes things
- i hate this but it technically works to cause goonchat to redraw itself every frame to recover from when it blanks out and only shows the legacy output xd