### PR TITLE
Fix projectile guns in space not moving you

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -392,7 +392,7 @@
 		var/old_dir = user.dir
 		var/mob/living/carbon/human/H = user
 		var/obj/item/tank/jetpack/jetpack = H.get_jetpack()
-		if(jetpack && !jetpack.stabilization_on)
+		if(!(jetpack && jetpack.on && jetpack.stabilization_on))
 			user.inertia_ignore = projectile
 			step(user,get_dir(target,user))
 			user.set_dir(old_dir)


### PR DESCRIPTION
Fixes #35440

:cl: Banditoz
bugfix: Fix projectile weapons not propelling you the opposite direction when fired in space.
/:cl:

https://github.com/user-attachments/assets/340f6c08-a967-4a30-97a3-aa3934f6cdd1