### PR TITLE
Add instruments to loadout

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/utility.dm
+++ b/code/modules/client/preference_setup/loadout/lists/utility.dm
@@ -121,3 +121,26 @@ Pouches and kits
 	display_name = "pencil case"
 	path = /obj/item/storage/fancy/pencilcase
 	cost = 2
+
+/****************
+Instruments
+****************/
+
+/datum/gear/utility/musical_instruments
+	display_name = "musical instruments"
+	path = /obj/item/device/synthesized_instrument
+	cost = 6
+
+/datum/gear/utility/musical_instruments/New()
+	..()
+	var/musical_instruments = list()
+	musical_instruments["acoustic guitar"] = /obj/item/device/synthesized_instrument/guitar
+	musical_instruments["polyguitar flying V"] = /obj/item/device/synthesized_instrument/guitar/multi_v
+	musical_instruments["polyguitar strato black"] = /obj/item/device/synthesized_instrument/guitar/multi_strato_black
+	musical_instruments["polyguitar strato gradient"] = /obj/item/device/synthesized_instrument/guitar/multi_strato_gradient
+	musical_instruments["polyguitar strato red"] = /obj/item/device/synthesized_instrument/guitar/multi_strato_red
+	musical_instruments["polyguitar strato purple"] = /obj/item/device/synthesized_instrument/guitar/multi_strato_purple
+	musical_instruments["synthesizer"] = /obj/item/device/synthesized_instrument/synthesizer
+	musical_instruments["trumpet"] = /obj/item/device/synthesized_instrument/trumpet
+	musical_instruments["violin"] = /obj/item/device/synthesized_instrument/violin
+	gear_tweaks += new/datum/gear_tweak/path(musical_instruments)

--- a/maps/torch/loadout/loadout_utility.dm
+++ b/maps/torch/loadout/loadout_utility.dm
@@ -1,0 +1,3 @@
+/datum/gear/utility/musical_instruments
+	allowed_roles = CASUAL_ROLES
+	allowed_branches = CIVILIAN_BRANCHES

--- a/maps/torch/torch.dm
+++ b/maps/torch/torch.dm
@@ -155,6 +155,7 @@
 	#include "loadout/loadout_shoes.dm"
 	#include "loadout/loadout_suit.dm"
 	#include "loadout/loadout_uniform.dm"
+	#include "loadout/loadout_utility.dm"
 	#include "loadout/loadout_xeno.dm"
 	#include "loadout/~defines.dm"
 


### PR DESCRIPTION
:cl: limelier
rscadd: Musical instruments are now available in the loadout under the "utility" tab
/:cl:

Adds handheld instruments to loadout, grouped under one item (so only one can be equipped at a time). They are gated behind CIVILIAN + CASUAL roles, so only civilian roles with no dress code will be able to equip them.