### PR TITLE
flaticon results can leak between runs again

### DIFF
--- a/code/modules/goonchat/_helpers.dm
+++ b/code/modules/goonchat/_helpers.dm
@@ -3,12 +3,12 @@ GLOBAL_TYPED_AS(is_http_protocol, /regex, regex("^https?://"))
 
 /// Convert icon to base64-encoded png data. Consider caching heavy use
 /proc/icon2base64(icon/icon)
-	var/static/savefile/temp = new
+	var/static/savefile/converter = new ("data/icon_base64.sav")
 	var/static/regex/newlines = regex(@"\n", "g")
 	if (!isicon(icon))
 		return
-	temp["_"] = icon
-	return replacetext(copytext(splittext(temp.ExportText("_"), "{")[2], 3, -5), newlines, "")
+	converter["_"] = icon
+	return replacetext(copytext(splittext(converter.ExportText("_"), "{")[2], 3, -5), newlines, "")
 
 
 /proc/icon2html(thing, target, icon_state, dir, frame = 1, moving = FALSE, realsize = FALSE, class = null)


### PR DESCRIPTION
(but once, instead of what temp files was doing!)

The alternative was a teeny bit nightmarish.

In theory, no path should result in [temporary files](https://www.byond.com/docs/ref/#/savefile/proc/New) that are cleaned up at shutdown. In practice, it resulted in piles of loose files in the game root that were *not* cleaned up, presumably because of their null-prefixed node names.

By going back to the prior approach, Byond will presumably read and deserialize the cache file before writing out the new one- but that's better than the annoyances of current behavior. Perhaps client.RenderIcon will solve all our problems later.
