### PR TITLE
swap tests from branches to branches-ignore

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ permissions:
 
 on:
   push:
-    branches: [ "dev" ]
+    branches-ignore: [ "gh-pages" ]
   pull_request:
     branches: [ "dev" ]
   workflow_dispatch:


### PR DESCRIPTION
Most of the time, branches on the org repository are for game use: events, live tests, etc. This swaps running test on push from branches to branches-ignore; at the moment the only branch we actually want to ignore is pages/docgen.
