### PR TITLE
Projector fix

### DIFF
--- a/code/game/objects/items/devices/slide_projector.dm
+++ b/code/game/objects/items/devices/slide_projector.dm
@@ -187,7 +187,7 @@
 	if(!istype(slide))
 		qdel(src)
 		return
-	return slide.examine(user, 0, FALSE)
+	return slide.examine(user, 0, TRUE)
 
 /obj/projection/photo
 	alpha = 170


### PR DESCRIPTION
Dirty fix but it works so w/e.

Technically needs visibility stuff tied to the projection, not the paper (which is how it is now).

:cl: Sbotkin
bugfix: Fixed projector requiring you to be next to the projector to properly examine what it is projecting.
/:cl:

Thanks to Mucker and [git blame](https://github.com/Baystation12/Baystation12/pull/34473).