### PR TITLE
Borgs can use ctrl+alt click interactions

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -107,9 +107,6 @@
 	cycle_modules()
 	return TRUE
 
-/mob/living/silicon/robot/CtrlAltClickOn(atom/A)
-	return pointed(A)
-
 /atom/proc/BorgMiddleClick(mob/living/silicon/robot/user)
 	return FALSE
 


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Borgs can now use Ctrl+Alt+Click interactions, such as opening computer terminals, quick-ejecting beakers, etc.
/:cl: