### PR TITLE
Quick >=516.1670 compatibility fix

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -316,7 +316,7 @@
 	var/static/expected_round_length = 2 HOURS
 
 	/// Whether the first delay per level has a custom start time
-	var/static/list/event_first_run = list(
+	var/static/list/event_first_run = alist(
 		EVENT_LEVEL_MUNDANE = null,
 		EVENT_LEVEL_MODERATE = null,
 		EVENT_LEVEL_MAJOR = list(
@@ -330,7 +330,7 @@
 	)
 
 	/// The lowest delay until next event
-	var/static/list/event_delay_lower = list(
+	var/static/list/event_delay_lower = alist(
 		EVENT_LEVEL_MUNDANE = 10 MINUTES,
 		EVENT_LEVEL_MODERATE = 30 MINUTES,
 		EVENT_LEVEL_MAJOR = 50 MINUTES,
@@ -338,7 +338,7 @@
 	)
 
 	/// The upper delay until next event
-	var/static/list/event_delay_upper = list(
+	var/static/list/event_delay_upper = alist(
 		EVENT_LEVEL_MUNDANE = 15 MINUTES,
 		EVENT_LEVEL_MODERATE = 45 MINUTES,
 		EVENT_LEVEL_MAJOR = 70 MINUTES,

--- a/code/controllers/subsystems/event.dm
+++ b/code/controllers/subsystems/event.dm
@@ -29,7 +29,7 @@ SUBSYSTEM_DEF(event)
 	if(!all_events)
 		all_events = subtypesof(/datum/event)
 	if(!event_containers)
-		event_containers = list(
+		event_containers = alist(
 				EVENT_LEVEL_MUNDANE 	= new/datum/event_container/mundane,
 				EVENT_LEVEL_MODERATE	= new/datum/event_container/moderate,
 				EVENT_LEVEL_MAJOR 		= new/datum/event_container/major,

--- a/code/modules/admin/verbs/atmosdebug.dm
+++ b/code/modules/admin/verbs/atmosdebug.dm
@@ -29,7 +29,7 @@
 	next_turf:
 		for(var/turf/T)
 			for(var/dir in GLOB.cardinal)
-				var/list/connect_types = list(1 = 0, 2 = 0, 3 = 0)
+				var/list/connect_types = alist(1 = 0, 2 = 0, 3 = 0)
 				for(var/obj/machinery/atmospherics/pipe in T)
 					if(dir & pipe.initialize_directions)
 						for(var/connect_type in pipe.connect_types)

--- a/code/modules/events/event_container.dm
+++ b/code/modules/events/event_container.dm
@@ -8,7 +8,7 @@
 #define ASSIGNMENT_SCIENTIST "Scientist"
 #define ASSIGNMENT_SECURITY "Security"
 
-var/global/list/severity_to_string = list(EVENT_LEVEL_MUNDANE = "Mundane", EVENT_LEVEL_MODERATE = "Moderate", EVENT_LEVEL_MAJOR = "Major", EVENT_LEVEL_EXO = "Exoplanet")
+var/global/list/severity_to_string = alist(EVENT_LEVEL_MUNDANE = "Mundane", EVENT_LEVEL_MODERATE = "Moderate", EVENT_LEVEL_MAJOR = "Major", EVENT_LEVEL_EXO = "Exoplanet")
 
 /datum/event_container
 	var/severity = -1

--- a/maps/mapsystem/maps.dm
+++ b/maps/mapsystem/maps.dm
@@ -231,7 +231,7 @@ var/global/const/MAP_HAS_RANK = 2		//Rank system, also togglable
 		TAG_RELIGION =  RELIGION_AGNOSTICISM
 	)
 
-	var/access_modify_region = list(
+	var/access_modify_region = alist(
 		ACCESS_REGION_SECURITY = list(access_hos, access_change_ids),
 		ACCESS_REGION_MEDBAY = list(access_cmo, access_change_ids),
 		ACCESS_REGION_RESEARCH = list(access_rd, access_change_ids),

--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -36,7 +36,7 @@
 		/datum/job/merchant
 	)
 
-	access_modify_region = list(
+	access_modify_region = alist(
 		ACCESS_REGION_SECURITY = list(access_change_ids),
 		ACCESS_REGION_MEDBAY = list(access_change_ids),
 		ACCESS_REGION_RESEARCH = list(access_change_ids),


### PR DESCRIPTION
1670 no longer accepts numeric keys in list() in an associative manner, alist() has to be used instead