### PR TITLE
Move items between hands via drag+drop

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -381,3 +381,16 @@
 				usr.update_inv_l_hand(0)
 				usr.update_inv_r_hand(0)
 	return 1
+
+/obj/screen/inventory/Adjacent(atom/neighbor)
+	return neighbor == usr
+
+/obj/screen/inventory/MouseDrop_T(atom/dropped, mob/living/user)
+	// Hands - Transfer items to between hands with drag+drop.
+	if (name == BP_R_HAND && user.l_hand == dropped)
+		return user.put_in_r_hand(dropped)
+
+	if (name == BP_L_HAND && user.r_hand == dropped)
+		return user.put_in_l_hand(dropped)
+
+	return ..()


### PR DESCRIPTION
https://github.com/user-attachments/assets/6d055921-c25a-41d1-a5f3-2e04f6ff25ef

## Changelog
:cl: SierraKomodo
rscadd: Things in your hands can be swapped to your other hand by drag+dropping the item from one hand to the other. Only works if the target hand is empty. Why? Try clicking a loaded handgun with your empty hand.
/:cl:

## Other Changes
- Added an `Adjacent()` override to `/obj/screen/inventory` that returns `TRUE` if the passed neighbor is the user. `MouseDrop_T()` wouldn't proc without this.