### PR TITLE
fixes escape pod forced launches

### DIFF
--- a/code/modules/shuttles/shuttle_autodock.dm
+++ b/code/modules/shuttles/shuttle_autodock.dm
@@ -140,7 +140,7 @@
 	return (next_location && next_location.is_valid(src) && !current_location.cannot_depart(src) && moving_status == SHUTTLE_IDLE && !in_use)
 
 /datum/shuttle/autodock/proc/can_force()
-	return (next_location && next_location.is_valid(src) && !current_location.cannot_depart(src) && moving_status == SHUTTLE_IDLE && process_state == WAIT_LAUNCH)
+	return (next_location && next_location.is_valid(src) && !current_location.cannot_depart(src) && moving_status == SHUTTLE_IDLE && (process_state == IDLE_STATE || process_state == WAIT_LAUNCH))
 
 /datum/shuttle/autodock/proc/can_cancel()
 	return (moving_status == SHUTTLE_WARMUP || process_state == WAIT_LAUNCH || process_state == FORCE_LAUNCH)

--- a/nano/templates/escape_pod_console.tmpl
+++ b/nano/templates/escape_pod_console.tmpl
@@ -88,8 +88,8 @@
 <div class="item" style="padding-top: 10px">
 	<div class="item">
 		<div class="itemContent" style="padding-top: 2px; width: 100%">
-		{{:helper.link('ARM', 'alert', {'command' : 'manual_arm'}, data.is_armed ? 'disabled' : null, data.is_armed ? 'redButton' : 'yellowButton')}}
-		{{:helper.link('MANUAL EJECT', 'alert', {'command' : 'force_launch'}, data.can_force ? null : 'disabled', data.can_force ? 'yellowButton' : null)}}
+		{{:helper.link('ARM', 'alert', {'manual_arm' : 1}, data.is_armed ? 'disabled' : null, data.is_armed ? 'redButton' : 'yellowButton')}}
+		{{:helper.link('MANUAL EJECT', 'alert', {'force_launch' : 1}, data.can_force ? null : 'disabled', data.can_force ? 'yellowButton' : null)}}
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
🆑 Cakey
bugfix: Escape pods can now be armed and force launched as intended.
/:cl: