### PR TITLE
Borgs can use in world

### DIFF
--- a/interface/interface.dm
+++ b/interface/interface.dm
@@ -122,8 +122,7 @@
 \tt = say
 \tx = cycle active modules
 \tz = activate held object (or y)
-\tf = cycle-intents-left
-\tg = cycle-intents-right
+\tf = activate object in world
 \t1 = activate module 1
 \t2 = activate module 2
 \t3 = activate module 3
@@ -138,8 +137,7 @@
 \tCtrl+q = unequip active module
 \tCtrl+x = cycle active modules
 \tCtrl+z = activate held object (or Ctrl+y)
-\tCtrl+f = cycle-intents-left
-\tCtrl+g = cycle-intents-right
+\tCtrl+f = activate object in world
 \tCtrl+1 = activate module 1
 \tCtrl+2 = activate module 2
 \tCtrl+3 = activate module 3

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -103,16 +103,10 @@ macro "borghotkeymode"
 		command = ".moveright"
 	elem
 		name = "F"
-		command = "a-intent left"
+		command = "activate-object-in-world"
 	elem
 		name = "CTRL+F"
-		command = "a-intent left"
-	elem
-		name = "G"
-		command = "a-intent right"
-	elem
-		name = "CTRL+G"
-		command = "a-intent right"
+		command = "activate-object-in-world"
 	elem
 		name = "J"
 		command = "toggle-gun-mode"


### PR DESCRIPTION
## Changelog
:cl: SierraKomodo
bugfix: Borgs can now press `F` to use things in world. For those of you that used `F`/`G` to cycle borg intents - `4` can also do that.
/:cl: