### PR TITLE
remove short list init format

### DIFF
--- a/code/__defines/misc.dm
+++ b/code/__defines/misc.dm
@@ -218,7 +218,7 @@
 
 #define RADIATION_THRESHOLD_CUTOFF 0.1	// Radiation will not affect a tile when below this value.
 
-#define LEGACY_RECORD_STRUCTURE(X, Y) GLOBAL_LIST_EMPTY(##X);/datum/computer_file/data/##Y/var/list/fields[0];/datum/computer_file/data/##Y/New(){..();GLOB.##X.Add(src);}/datum/computer_file/data/##Y/Destroy(){. = ..();GLOB.##X.Remove(src);}
+#define LEGACY_RECORD_STRUCTURE(X, Y) GLOBAL_LIST_EMPTY(##X);/datum/computer_file/data/##Y/var/list/fields=list();/datum/computer_file/data/##Y/New(){..();GLOB.##X.Add(src);}/datum/computer_file/data/##Y/Destroy(){. = ..();GLOB.##X.Remove(src);}
 
 #define SUPPLY_SECURITY_ELEVATED 1
 #define SUPPLY_SECURITY_HIGH 2

--- a/code/_helpers/global_lists.dm
+++ b/code/_helpers/global_lists.dm
@@ -18,13 +18,13 @@ var/global/list/landmarks_list = list()				//list of all landmarks created
 //Languages/species/whitelist.
 
 var/global/list/datum/language/all_languages = list()
-var/global/list/language_keys[0]					// Table of say codes for all languages
+var/global/list/language_keys = list()					// Table of say codes for all languages
 
 GLOBAL_LIST_EMPTY(all_particles)
 
 // Grabs
-var/global/list/all_grabstates[0]
-var/global/list/all_grabobjects[0]
+var/global/list/all_grabstates = list()
+var/global/list/all_grabobjects = list()
 
 // Uplinks
 var/global/list/obj/item/device/uplink/world_uplinks = list()

--- a/code/_helpers/names.dm
+++ b/code/_helpers/names.dm
@@ -74,12 +74,12 @@
 		25; 5
 	)
 
-	var/safety[] = list(1,2,3)//Tells the proc which options to remove later on.
-	var/nouns[] = list("love","hate","anger","peace","pride","sympathy","bravery","loyalty","honesty","integrity","compassion","charity","success","courage","deceit","skill","beauty","brilliance","pain","misery","beliefs","dreams","justice","truth","faith","liberty","knowledge","thought","information","culture","trust","dedication","progress","education","hospitality","leisure","trouble","friendships", "relaxation")
-	var/drinks[] = list("vodka and tonic","gin fizz","bahama mama","manhattan","black Russian","whiskey soda","long island tea","margarita","Irish coffee"," manly dwarf","Irish cream","doctor's delight","Beepksy Smash","tequilla sunrise","brave bull","gargle blaster","bloody mary","whiskey cola","white Russian","vodka martini","martini","Cuba libre","kahlua","vodka","wine","moonshine")
-	var/locations[] = length(stationlocs) ? stationlocs : drinks//if null, defaults to drinks instead.
+	var/safety = list(1,2,3)//Tells the proc which options to remove later on.
+	var/nouns = list("love","hate","anger","peace","pride","sympathy","bravery","loyalty","honesty","integrity","compassion","charity","success","courage","deceit","skill","beauty","brilliance","pain","misery","beliefs","dreams","justice","truth","faith","liberty","knowledge","thought","information","culture","trust","dedication","progress","education","hospitality","leisure","trouble","friendships", "relaxation")
+	var/drinks = list("vodka and tonic","gin fizz","bahama mama","manhattan","black Russian","whiskey soda","long island tea","margarita","Irish coffee"," manly dwarf","Irish cream","doctor's delight","Beepksy Smash","tequilla sunrise","brave bull","gargle blaster","bloody mary","whiskey cola","white Russian","vodka martini","martini","Cuba libre","kahlua","vodka","wine","moonshine")
+	var/locations = length(stationlocs) ? stationlocs : drinks//if null, defaults to drinks instead.
 
-	var/names[] = list()
+	var/names = list()
 	for(var/datum/computer_file/report/crew_record/t in GLOB.all_crew_records)//Picks from crew manifest.
 		names += t.get_name()
 

--- a/code/_helpers/unsorted.dm
+++ b/code/_helpers/unsorted.dm
@@ -54,7 +54,7 @@
 	RETURN_TYPE(/list)
 	var/px=M.x		//starting x
 	var/py=M.y
-	var/line[] = list(locate(px,py,M.z))
+	var/line = list(locate(px,py,M.z))
 	var/dx=N.x-px	//x distance
 	var/dy=N.y-py
 	var/dxabs=abs(dx)//Absolute value of x distance

--- a/code/controllers/subsystems/vote.dm
+++ b/code/controllers/subsystems/vote.dm
@@ -178,7 +178,7 @@ SUBSYSTEM_DEF(vote)
 		to_chat(mob, notify_message)
 
 
-/datum/controller/subsystem/vote/Topic(href,href_list[],hsrc)
+/datum/controller/subsystem/vote/Topic(href, list/href_list, hsrc)
 	if(!usr || !usr.client)
 		return	//not necessary but meh...just in-case somebody does something stupid
 

--- a/code/datums/extensions/chameleon.dm
+++ b/code/datums/extensions/chameleon.dm
@@ -321,8 +321,8 @@
 	)
 
 /datum/extension/chameleon/emag/GetItemDisguiseType(singleton/hierarchy/outfit/outfit)
-	if (length(outfit.id_types) > 0)
-		var/id_path = outfit.id_types[0]
+	if (length(outfit.id_types))
+		var/id_path = outfit.id_types[1]
 		if (ispath(id_path, expected_type))
 			return id_path
 

--- a/code/datums/managed_browsers/changelingevolution.dm
+++ b/code/datums/managed_browsers/changelingevolution.dm
@@ -43,7 +43,7 @@
 
 	return dat.Join()
 
-/datum/managed_browser/changelingevolution/Topic(href, href_list[])
+/datum/managed_browser/changelingevolution/Topic(href, list/href_list)
 	if(!my_client)
 		return FALSE
 

--- a/code/datums/mind/mind.dm
+++ b/code/datums/mind/mind.dm
@@ -315,7 +315,7 @@
 						possible_targets += possible_target.current
 
 				var/mob/def_target = null
-				var/objective_list[] = list(/datum/objective/assassinate, /datum/objective/protect, /datum/objective/debrain)
+				var/objective_list = list(/datum/objective/assassinate, /datum/objective/protect, /datum/objective/debrain)
 				if (objective&&(objective.type in objective_list) && objective:target)
 					def_target = objective.target?.current
 

--- a/code/game/dna/dna2.dm
+++ b/code/game/dna/dna2.dm
@@ -49,7 +49,7 @@ var/global/list/dna_activity_bounds[DNA_SE_LENGTH]
 // Used to determine what each block means
 var/global/list/assigned_blocks[DNA_SE_LENGTH]
 
-var/global/list/datum/dna/gene/dna_genes[0]
+var/global/list/datum/dna/gene/dna_genes = list()
 
 /////////////////
 // GENE DEFINES

--- a/code/game/gamemodes/changeling/changeling_powers.dm
+++ b/code/game/gamemodes/changeling/changeling_powers.dm
@@ -211,7 +211,7 @@ var/global/list/possible_changeling_IDs = list("Alpha","Beta","Gamma","Delta","E
 		/mob
 	)
 
-	var/L[] = new()
+	var/list/L = list()
 	for(var/turf/simulated/t in oview(src,1))
 		var/add = 1
 		if(t.density)

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -55,7 +55,7 @@ var/global/list/additional_antag_types = list()
 	else if(!round_autoantag && length(latejoin_antag_tags))
 		round_autoantag = TRUE
 
-/datum/game_mode/Topic(href, href_list[])
+/datum/game_mode/Topic(href, list/href_list)
 	if(..())
 		return
 	if(href_list["toggle"])
@@ -389,7 +389,7 @@ var/global/list/additional_antag_types = list()
 		if(P.client && P.ready)
 			. ++
 
-/datum/game_mode/proc/check_antagonists_topic(href, href_list[])
+/datum/game_mode/proc/check_antagonists_topic(href, list/href_list)
 	return 0
 
 /datum/game_mode/proc/create_antagonists()

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -218,7 +218,7 @@ var/global/list/all_objectives = list()
 	var/obj/item/steal_target
 	var/target_name
 
-	var/static/possible_items[] = list(
+	var/static/possible_items = list(
 		"the captain's antique laser gun" = /obj/item/gun/energy/captain,
 		"a bluespace rift generator" = /obj/item/integrated_circuit/manipulation/bluespace_rift,
 		"an RCD" = /obj/item/rcd,
@@ -241,7 +241,7 @@ var/global/list/all_objectives = list()
 		"an ablative armor vest" = /obj/item/clothing/suit/armor/laserproof,
 	)
 
-	var/static/possible_items_special[] = list(
+	var/static/possible_items_special = list(
 		/*"nuclear authentication disk" = /obj/item/disk/nuclear,*///Broken with the change to nuke disk making it respawn on z level change.
 		"nuclear gun" = /obj/item/gun/energy/gun/nuclear,
 		"diamond drill" = /obj/item/pickaxe/diamonddrill,

--- a/code/game/gamemodes/setupgame.dm
+++ b/code/game/gamemodes/setupgame.dm
@@ -76,7 +76,7 @@
 			if(G.block in blocks_assigned)
 				warning("DNA2: Gene [G.name] trying to use already-assigned block [G.block] (used by [english_list(blocks_assigned[G.block])])")
 			dna_genes.Add(G)
-			var/list/assignedToBlock[0]
+			var/list/assignedToBlock = list()
 			if(blocks_assigned[G.block])
 				assignedToBlock=blocks_assigned[G.block]
 			assignedToBlock.Add(G.name)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -97,7 +97,7 @@
 	return TRUE
 
 /obj/machinery/sleeper/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/topic_state/state = GLOB.outside_state)
-	var/data[0]
+	var/data = list()
 
 	data["power"] = inoperable() ? 0 : 1
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -428,7 +428,6 @@
 	signal.data["status"] = TRUE
 
 	radio_connection.post_signal(src, signal, RADIO_FROM_AIRALARM)
-//			log_debug(text("Signal [] Broadcasted to []", command, target))
 
 	return 1
 

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -562,7 +562,7 @@
 		if(AALARM_SCREEN_MAIN)
 			data["mode"] = mode
 		if(AALARM_SCREEN_VENT)
-			var/vents = list()
+			var/list/vents = list()
 			for(var/id_tag in alarm_area.air_vent_names)
 				var/long_name = alarm_area.air_vent_names[id_tag]
 				var/list/info = alarm_area.air_vent_info[id_tag]
@@ -578,7 +578,7 @@
 					)
 			data["vents"] = vents
 		if(AALARM_SCREEN_SCRUB)
-			var/scrubbers = list()
+			var/list/scrubbers = list()
 			for(var/id_tag in alarm_area.air_scrub_names)
 				var/long_name = alarm_area.air_scrub_names[id_tag]
 				var/list/info = alarm_area.air_scrub_info[id_tag]
@@ -604,7 +604,7 @@
 
 			data["scrubbers"] = scrubbers
 		if(AALARM_SCREEN_MODE)
-			var/modes = list()
+			var/list/modes = list()
 			modes[LIST_PRE_INC(modes)] = list("name" = "Filtering - Scrubs out contaminants", 			"mode" = AALARM_MODE_SCRUBBING,		"selected" = mode == AALARM_MODE_SCRUBBING, 	"danger" = 0)
 			modes[LIST_PRE_INC(modes)] = list("name" = "Replace Air - Siphons out air while replacing", "mode" = AALARM_MODE_REPLACEMENT,	"selected" = mode == AALARM_MODE_REPLACEMENT,	"danger" = 0)
 			modes[LIST_PRE_INC(modes)] = list("name" = "Panic - Siphons air out of the room", 			"mode" = AALARM_MODE_PANIC,			"selected" = mode == AALARM_MODE_PANIC, 		"danger" = 1)
@@ -615,7 +615,7 @@
 			data["mode"] = mode
 		if(AALARM_SCREEN_SENSORS)
 			var/list/selected
-			var/thresholds = list()
+			var/list/thresholds = list()
 
 			var/breach_data = list("selected" = breach_pressure)
 			data["breach_data"] = breach_data

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -502,7 +502,7 @@
 	return TRUE
 
 /obj/machinery/alarm/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, master_ui = null, datum/topic_state/state = GLOB.default_state)
-	var/data[0]
+	var/data = list()
 	var/remote_connection = 0
 	var/remote_access = 0
 	if(state)
@@ -563,7 +563,7 @@
 		if(AALARM_SCREEN_MAIN)
 			data["mode"] = mode
 		if(AALARM_SCREEN_VENT)
-			var/vents[0]
+			var/vents = list()
 			for(var/id_tag in alarm_area.air_vent_names)
 				var/long_name = alarm_area.air_vent_names[id_tag]
 				var/list/info = alarm_area.air_vent_info[id_tag]
@@ -579,7 +579,7 @@
 					)
 			data["vents"] = vents
 		if(AALARM_SCREEN_SCRUB)
-			var/scrubbers[0]
+			var/scrubbers = list()
 			for(var/id_tag in alarm_area.air_scrub_names)
 				var/long_name = alarm_area.air_scrub_names[id_tag]
 				var/list/info = alarm_area.air_scrub_info[id_tag]
@@ -605,7 +605,7 @@
 
 			data["scrubbers"] = scrubbers
 		if(AALARM_SCREEN_MODE)
-			var/modes[0]
+			var/modes = list()
 			modes[LIST_PRE_INC(modes)] = list("name" = "Filtering - Scrubs out contaminants", 			"mode" = AALARM_MODE_SCRUBBING,		"selected" = mode == AALARM_MODE_SCRUBBING, 	"danger" = 0)
 			modes[LIST_PRE_INC(modes)] = list("name" = "Replace Air - Siphons out air while replacing", "mode" = AALARM_MODE_REPLACEMENT,	"selected" = mode == AALARM_MODE_REPLACEMENT,	"danger" = 0)
 			modes[LIST_PRE_INC(modes)] = list("name" = "Panic - Siphons air out of the room", 			"mode" = AALARM_MODE_PANIC,			"selected" = mode == AALARM_MODE_PANIC, 		"danger" = 1)
@@ -616,7 +616,7 @@
 			data["mode"] = mode
 		if(AALARM_SCREEN_SENSORS)
 			var/list/selected
-			var/thresholds[0]
+			var/thresholds = list()
 
 			var/breach_data = list("selected" = breach_pressure)
 			data["breach_data"] = breach_data

--- a/code/game/machinery/atmoalter/canister.dm
+++ b/code/game/machinery/atmoalter/canister.dm
@@ -229,7 +229,7 @@
 
 /obj/machinery/portable_atmospherics/canister/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
 	// this is the data which will be sent to the ui
-	var/data[0]
+	var/data = list()
 	data["name"] = name
 	data["canLabel"] = can_label ? 1 : 0
 	data["portConnected"] = connected_port ? 1 : 0

--- a/code/game/machinery/atmoalter/pump.dm
+++ b/code/game/machinery/atmoalter/pump.dm
@@ -111,7 +111,7 @@
 	return TRUE
 
 /obj/machinery/portable_atmospherics/powered/pump/ui_interact(mob/user, ui_key = "rcon", datum/nanoui/ui=null, force_open=1)
-	var/list/data[0]
+	var/list/data = list()
 	var/obj/item/cell/cell = get_cell()
 	data["portConnected"] = connected_port ? 1 : 0
 	data["tankPressure"] = round(air_contents.return_pressure() > 0 ? air_contents.return_pressure() : 0)

--- a/code/game/machinery/atmoalter/scrubber.dm
+++ b/code/game/machinery/atmoalter/scrubber.dm
@@ -95,7 +95,7 @@
 	return TRUE
 
 /obj/machinery/portable_atmospherics/powered/scrubber/ui_interact(mob/user, ui_key = "rcon", datum/nanoui/ui=null, force_open=1)
-	var/list/data[0]
+	var/list/data = list()
 	var/obj/item/cell/cell = get_cell()
 	data["portConnected"] = connected_port ? 1 : 0
 	data["tankPressure"] = round(air_contents.return_pressure() > 0 ? air_contents.return_pressure() : 0)

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -432,7 +432,7 @@
 		update_coverage(1)
 
 /obj/machinery/camera/proc/nano_structure()
-	var/cam[0]
+	var/cam = list()
 	cam["name"] = sanitize(c_tag)
 	cam["deact"] = !can_use()
 	cam["camera"] = "\ref[src]"

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -3,7 +3,7 @@
 #define TRACKING_TERMINATE 2
 
 /mob/living/silicon/ai/var/max_locations = 10
-/mob/living/silicon/ai/var/stored_locations[0]
+/mob/living/silicon/ai/var/stored_locations = list()
 
 /proc/InvalidPlayerTurf(turf/T as turf)
 	return !(T && (T.z in GLOB.using_map.player_levels))

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -3,7 +3,7 @@
 #define TRACKING_TERMINATE 2
 
 /mob/living/silicon/ai/var/max_locations = 10
-/mob/living/silicon/ai/var/stored_locations = list()
+/mob/living/silicon/ai/var/list/stored_locations = list()
 
 /proc/InvalidPlayerTurf(turf/T as turf)
 	return !(T && (T.z in GLOB.using_map.player_levels))

--- a/code/game/machinery/computer/atmos_alert.dm
+++ b/code/game/machinery/computer/atmos_alert.dm
@@ -26,9 +26,9 @@ var/global/list/minor_air_alarms = list()
 	return TRUE
 
 /obj/machinery/computer/atmos_alert/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
-	var/major_alarms[0]
-	var/minor_alarms[0]
+	var/data = list()
+	var/major_alarms = list()
+	var/minor_alarms = list()
 
 	for(var/datum/alarm/alarm in GLOB.atmosphere_alarm.major_alarms(get_z(src)))
 		major_alarms[LIST_PRE_INC(major_alarms)] = list("name" = sanitize(alarm.alarm_name()), "ref" = "\ref[alarm]")

--- a/code/game/machinery/computer/atmos_alert.dm
+++ b/code/game/machinery/computer/atmos_alert.dm
@@ -26,9 +26,9 @@ var/global/list/minor_air_alarms = list()
 	return TRUE
 
 /obj/machinery/computer/atmos_alert/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data = list()
-	var/major_alarms = list()
-	var/minor_alarms = list()
+	var/list/data = list()
+	var/list/major_alarms = list()
+	var/list/minor_alarms = list()
 
 	for(var/datum/alarm/alarm in GLOB.atmosphere_alarm.major_alarms(get_z(src)))
 		major_alarms[LIST_PRE_INC(major_alarms)] = list("name" = sanitize(alarm.alarm_name()), "ref" = "\ref[alarm]")

--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -14,7 +14,7 @@
 	return TRUE
 
 /obj/machinery/computer/robotics/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
+	var/data = list()
 	data["robots"] = get_cyborgs(user)
 	data["is_ai"] = issilicon(user)
 

--- a/code/game/machinery/cryo.dm
+++ b/code/game/machinery/cryo.dm
@@ -121,7 +121,7 @@
 		return
 
 	// this is the data which will be sent to the ui
-	var/data[0]
+	var/data = list()
 	data["isOperating"] = on
 	data["hasOccupant"] = occupant ? 1 : 0
 

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -797,14 +797,14 @@ About the new airlock wires panel:
 	ui_interact(user)
 
 /obj/machinery/door/airlock/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/topic_state/state = GLOB.default_state)
-	var/data = list()
+	var/list/data = list()
 
 	data["main_power_loss"]		= round(main_power_lost_until 	> 0 ? max(main_power_lost_until - world.time,	0) / 10 : main_power_lost_until,	1)
 	data["backup_power_loss"]	= round(backup_power_lost_until	> 0 ? max(backup_power_lost_until - world.time,	0) / 10 : backup_power_lost_until,	1)
 	data["electrified"] 		= round(electrified_until		> 0 ? max(electrified_until - world.time, 	0) / 10 	: electrified_until,		1)
 	data["open"] = !density
 
-	var/commands = list()
+	var/list/commands = list()
 	commands[LIST_PRE_INC(commands)] = list("name" = "IdScan",					"command"= "idscan",				"active" = !aiDisabledIdScanner,	"enabled" = "Enabled",	"disabled" = "Disable",		"danger" = 0, "act" = 1)
 	commands[LIST_PRE_INC(commands)] = list("name" = "Bolts",					"command"= "bolts",					"active" = !locked,					"enabled" = "Raised ",	"disabled" = "Dropped",		"danger" = 0, "act" = 0)
 	commands[LIST_PRE_INC(commands)] = list("name" = "Lights",					"command"= "lights",				"active" = lights,					"enabled" = "Enabled",	"disabled" = "Disable",		"danger" = 0, "act" = 1)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -797,14 +797,14 @@ About the new airlock wires panel:
 	ui_interact(user)
 
 /obj/machinery/door/airlock/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/topic_state/state = GLOB.default_state)
-	var/data[0]
+	var/data = list()
 
 	data["main_power_loss"]		= round(main_power_lost_until 	> 0 ? max(main_power_lost_until - world.time,	0) / 10 : main_power_lost_until,	1)
 	data["backup_power_loss"]	= round(backup_power_lost_until	> 0 ? max(backup_power_lost_until - world.time,	0) / 10 : backup_power_lost_until,	1)
 	data["electrified"] 		= round(electrified_until		> 0 ? max(electrified_until - world.time, 	0) / 10 	: electrified_until,		1)
 	data["open"] = !density
 
-	var/commands[0]
+	var/commands = list()
 	commands[LIST_PRE_INC(commands)] = list("name" = "IdScan",					"command"= "idscan",				"active" = !aiDisabledIdScanner,	"enabled" = "Enabled",	"disabled" = "Disable",		"danger" = 0, "act" = 1)
 	commands[LIST_PRE_INC(commands)] = list("name" = "Bolts",					"command"= "bolts",					"active" = !locked,					"enabled" = "Raised ",	"disabled" = "Dropped",		"danger" = 0, "act" = 0)
 	commands[LIST_PRE_INC(commands)] = list("name" = "Lights",					"command"= "lights",				"active" = lights,					"enabled" = "Enabled",	"disabled" = "Disable",		"danger" = 0, "act" = 1)

--- a/code/game/machinery/embedded_controller/airlock_controllers.dm
+++ b/code/game/machinery/embedded_controller/airlock_controllers.dm
@@ -35,7 +35,7 @@
 	name = "advanced airlock controller"
 
 /obj/machinery/embedded_controller/radio/airlock/advanced_airlock_controller/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/nanoui/master_ui = null, datum/topic_state/state = GLOB.default_state)
-	var/data[0]
+	var/data = list()
 
 	data = list(
 		"chamber_pressure" = round(program.memory["chamber_sensor_pressure"]),
@@ -59,7 +59,7 @@
 	tag_secure = 1
 
 /obj/machinery/embedded_controller/radio/airlock/airlock_controller/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/nanoui/master_ui = null, datum/topic_state/state = GLOB.default_state)
-	var/data[0]
+	var/data = list()
 
 	data = list(
 		"chamber_pressure" = round(program.memory["chamber_sensor_pressure"]),
@@ -82,7 +82,7 @@
 	tag_secure = 1
 
 /obj/machinery/embedded_controller/radio/airlock/access_controller/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/nanoui/master_ui = null, datum/topic_state/state = GLOB.default_state)
-	var/data[0]
+	var/data = list()
 
 	data = list(
 		"exterior_status" = program.memory["exterior_status"],

--- a/code/game/machinery/embedded_controller/airlock_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/airlock_docking_controller.dm
@@ -25,7 +25,7 @@
 	return ..()
 
 /obj/machinery/embedded_controller/radio/airlock/docking_port/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/nanoui/master_ui = null, datum/topic_state/state = GLOB.default_state)
-	var/data[0]
+	var/data = list()
 	var/datum/computer/file/embedded_program/docking/airlock/docking_program = program
 	var/datum/computer/file/embedded_program/airlock/docking/airlock_program = docking_program.airlock_program
 

--- a/code/game/machinery/embedded_controller/airlock_docking_controller_multi.dm
+++ b/code/game/machinery/embedded_controller/airlock_docking_controller_multi.dm
@@ -16,7 +16,7 @@
 			child_names[tags[i]] = names[i]
 
 /obj/machinery/embedded_controller/radio/docking_port_multi/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/nanoui/master_ui = null, datum/topic_state/state = GLOB.default_state)
-	var/data[0]
+	var/data = list()
 	var/datum/computer/file/embedded_program/docking/multi/docking_program = program
 
 	var/list/airlocks[length(child_names)]
@@ -50,7 +50,7 @@
 	tag_secure = 1
 
 /obj/machinery/embedded_controller/radio/airlock/docking_port_multi/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/nanoui/master_ui = null, datum/topic_state/state = GLOB.default_state)
-	var/data[0]
+	var/data = list()
 	var/datum/computer/file/embedded_program/airlock/multi_docking/airlock_program
 
 	data = list(

--- a/code/game/machinery/embedded_controller/simple_docking_controller.dm
+++ b/code/game/machinery/embedded_controller/simple_docking_controller.dm
@@ -5,7 +5,7 @@
 	var/tag_door
 
 /obj/machinery/embedded_controller/radio/simple_docking_controller/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/nanoui/master_ui = null, datum/topic_state/state = GLOB.default_state)
-	var/data[0]
+	var/data = list()
 	var/datum/computer/file/embedded_program/docking/simple/docking_program = program
 
 	data = list(

--- a/code/game/machinery/kitchen/smartfridge.dm
+++ b/code/game/machinery/kitchen/smartfridge.dm
@@ -373,14 +373,14 @@
 /obj/machinery/smartfridge/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
 	user.set_machine(src)
 
-	var/data[0]
+	var/data = list()
 	data["contents"] = null
 	data["electrified"] = seconds_electrified > 0
 	data["shoot_inventory"] = shoot_inventory
 	data["locked"] = locked
 	data["secure"] = is_secure
 
-	var/list/items[0]
+	var/list/items = list()
 	for (var/i=1 to length(item_records))
 		var/datum/stored_items/I = item_records[i]
 		var/count = I.get_amount()

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -272,13 +272,13 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 						else
 							dat+="<B><A href='byond://?src=\ref[src];show_channel=\ref[CHANNEL]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? (SPAN_COLOR("red", "***")) : null ]<BR></B>"
 				dat+="<BR><HR><A href='byond://?src=\ref[src];refresh=1'>Refresh</A>"
-				dat+="<BR><A href='byond://?src=\ref[src];setScreen=[0]'>Back</A>"
+				dat+="<BR><A href='byond://?src=\ref[src];setScreen=0'>Back</A>"
 			if(2)
 				dat+="Creating new Feed Channel..."
 				dat+="<HR><B><A href='byond://?src=\ref[src];set_channel_name=1'>Channel Name</A>:</B> [src.channel_name]<BR>"
 				dat+="<B>Channel Author:</B> [SPAN_COLOR("green", src.scanned_user)]<BR>"
 				dat+="<B><A href='byond://?src=\ref[src];set_channel_lock=1'>Will Accept Public Feeds</A>:</B> [(src.c_locked) ? ("NO") : ("YES")]<BR><BR>"
-				dat+="<BR><A href='byond://?src=\ref[src];submit_new_channel=1'>Submit</A><BR><BR><A href='byond://?src=\ref[src];setScreen=[0]'>Cancel</A><BR>"
+				dat+="<BR><A href='byond://?src=\ref[src];submit_new_channel=1'>Submit</A><BR><BR><A href='byond://?src=\ref[src];setScreen=0'>Cancel</A><BR>"
 			if(3)
 				dat+="Creating new Feed Message..."
 				dat+="<HR><B><A href='byond://?src=\ref[src];set_channel_receiving=1'>Receiving Channel</A>:</B> [src.channel_name]<BR>" //MARK
@@ -291,13 +291,13 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 					dat+="<BR><B><A href='byond://?src=\ref[src];set_attachment=1'>Delete Photo</A></B></BR>"
 				else
 					dat+="<A href='byond://?src=\ref[src];set_attachment=1'>Attach Photo</A>"
-				dat+="<BR><BR><A href='byond://?src=\ref[src];submit_new_message=1'>Submit</A><BR><BR><A href='byond://?src=\ref[src];setScreen=[0]'>Cancel</A><BR>"
+				dat+="<BR><BR><A href='byond://?src=\ref[src];submit_new_message=1'>Submit</A><BR><BR><A href='byond://?src=\ref[src];setScreen=0'>Cancel</A><BR>"
 			if(4)
 				dat+="Feed story successfully submitted to [src.channel_name].<BR><BR>"
-				dat+="<BR><A href='byond://?src=\ref[src];setScreen=[0]'>Return</A><BR>"
+				dat+="<BR><A href='byond://?src=\ref[src];setScreen=0'>Return</A><BR>"
 			if(5)
 				dat+="Feed Channel [src.channel_name] created successfully.<BR><BR>"
-				dat+="<BR><A href='byond://?src=\ref[src];setScreen=[0]'>Return</A><BR>"
+				dat+="<BR><A href='byond://?src=\ref[src];setScreen=0'>Return</A><BR>"
 			if(6)
 				dat+="[SPAN_COLOR("maroon", "<B>ERROR: Could not submit Feed story to Network.</B>")]<HR><BR>"
 				if(src.channel_name=="")
@@ -341,8 +341,8 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 						active_num--
 				dat+="Network currently serves a total of [total_num] Feed channels, [active_num] of which are active, and a total of [message_num] Feed Stories." //TODO: CONTINUE
 				dat+="<BR><BR><B>Liquid Paper remaining:</B> [(src.paper_remaining) *100 ] cm^3"
-				dat+="<BR><BR><A href='byond://?src=\ref[src];print_paper=[0]'>Print Paper</A>"
-				dat+="<BR><A href='byond://?src=\ref[src];setScreen=[0]'>Cancel</A>"
+				dat+="<BR><BR><A href='byond://?src=\ref[src];print_paper=0'>Print Paper</A>"
+				dat+="<BR><A href='byond://?src=\ref[src];setScreen=0'>Cancel</A>"
 			if(9)
 				dat+="<B>[src.viewing_channel.channel_name]: </B>[FONT_SMALL("\[created by: [SPAN_COLOR("maroon", src.viewing_channel.author)]\] \[views: [SPAN_COLOR("maroon", ++src.viewing_channel.views)]\]")]<HR>"
 				if(src.viewing_channel.censored)
@@ -376,7 +376,7 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 				else
 					for(var/datum/feed_channel/CHANNEL in connected_group.network_channels)
 						dat+="<A href='byond://?src=\ref[src];pick_censor_channel=\ref[CHANNEL]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? (SPAN_COLOR("red", "***")) : null ]<BR>"
-				dat+="<BR><A href='byond://?src=\ref[src];setScreen=[0]'>Cancel</A>"
+				dat+="<BR><A href='byond://?src=\ref[src];setScreen=0'>Cancel</A>"
 			if(11)
 				dat+="<B>[GLOB.using_map.company_name] D-Notice Handler</B><HR>"
 				dat+="[FONT_SMALL("A D-Notice is to be bestowed upon the channel if the handling Authority deems it as harmful for the [station_name()]'s \
@@ -388,7 +388,7 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 					for(var/datum/feed_channel/CHANNEL in connected_group.network_channels)
 						dat+="<A href='byond://?src=\ref[src];pick_d_notice=\ref[CHANNEL]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? (SPAN_COLOR("red", "***")) : null ]<BR>"
 
-				dat+="<BR><A href='byond://?src=\ref[src];setScreen=[0]'>Back</A>"
+				dat+="<BR><A href='byond://?src=\ref[src];setScreen=0'>Back</A>"
 			if(12)
 				dat+="<B>[src.viewing_channel.channel_name]: </B>[FONT_SMALL("\[ created by: [SPAN_COLOR("maroon", src.viewing_channel.author)] \]")]<BR>"
 				dat+="[FONT_NORMAL("<A href='byond://?src=\ref[src];censor_channel_author=\ref[src.viewing_channel]'>[(src.viewing_channel.author=="\[REDACTED\]") ? ("Undo Author censorship") : ("Censor channel Author")]</A>")]<HR>"
@@ -442,10 +442,10 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 				dat+="<BR><A href='byond://?src=\ref[src];submit_wanted=[end_param]'>[(wanted_already) ? ("Edit Issue") : ("Submit")]</A>"
 				if(wanted_already)
 					dat+="<BR><A href='byond://?src=\ref[src];cancel_wanted=1'>Take down Issue</A>"
-				dat+="<BR><A href='byond://?src=\ref[src];setScreen=[0]'>Cancel</A>"
+				dat+="<BR><A href='byond://?src=\ref[src];setScreen=0'>Cancel</A>"
 			if(15)
 				dat+="[SPAN_COLOR("green", "Wanted issue for [src.channel_name] is now in Network Circulation.")]<BR><BR>"
-				dat+="<BR><A href='byond://?src=\ref[src];setScreen=[0]'>Return</A><BR>"
+				dat+="<BR><A href='byond://?src=\ref[src];setScreen=0'>Return</A><BR>"
 			if(16)
 				dat+="[SPAN_COLOR("maroon", "<B>ERROR: Wanted Issue rejected by Network.</B>")]<HR><BR>"
 				if(src.channel_name=="" || src.channel_name == "\[REDACTED\]")
@@ -454,10 +454,10 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 					dat+="[SPAN_COLOR("maroon", "Issue author unverified.")]<BR>"
 				if(src.msg == "" || src.msg == "\[REDACTED\]")
 					dat+="[SPAN_COLOR("maroon", "Invalid description.")]<BR>"
-				dat+="<BR><A href='byond://?src=\ref[src];setScreen=[0]'>Return</A><BR>"
+				dat+="<BR><A href='byond://?src=\ref[src];setScreen=0'>Return</A><BR>"
 			if(17)
 				dat+="<B>Wanted Issue successfully deleted from Circulation</B><BR>"
-				dat+="<BR><A href='byond://?src=\ref[src];setScreen=[0]'>Return</A><BR>"
+				dat+="<BR><A href='byond://?src=\ref[src];setScreen=0'>Return</A><BR>"
 			if(18)
 				dat+="[SPAN_COLOR("maroon", "<B>-- STATIONWIDE WANTED ISSUE --</B>")]<BR>[FONT_NORMAL("\[Submitted by: [SPAN_COLOR("green", connected_group.wanted_issue.backup_author)]\]")]<HR>"
 				dat+="<B>Criminal</B>: [connected_group.wanted_issue.author]<BR>"
@@ -468,16 +468,16 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 					dat+="<BR><img src='tmp_photow.png' width = '180'>"
 				else
 					dat+="None"
-				dat+="<BR><BR><A href='byond://?src=\ref[src];setScreen=[0]'>Back</A><BR>"
+				dat+="<BR><BR><A href='byond://?src=\ref[src];setScreen=0'>Back</A><BR>"
 			if(19)
 				dat+="[SPAN_COLOR("green", "Wanted issue for [src.channel_name] successfully edited.")]<BR><BR>"
-				dat+="<BR><A href='byond://?src=\ref[src];setScreen=[0]'>Return</A><BR>"
+				dat+="<BR><A href='byond://?src=\ref[src];setScreen=0'>Return</A><BR>"
 			if(20)
 				dat+="[SPAN_COLOR("green", "Printing successful. Please receive your newspaper from the bottom of the machine.")]<BR><BR>"
-				dat+="<A href='byond://?src=\ref[src];setScreen=[0]'>Return</A>"
+				dat+="<A href='byond://?src=\ref[src];setScreen=0'>Return</A>"
 			if(21)
 				dat+="[SPAN_COLOR("maroon", "Unable to print newspaper. Insufficient paper. Please notify maintenance personnel to refill machine storage.")]<BR><BR>"
-				dat+="<A href='byond://?src=\ref[src];setScreen=[0]'>Return</A>"
+				dat+="<A href='byond://?src=\ref[src];setScreen=0'>Return</A>"
 			else
 				dat+="I'm sorry to break your immersion. This shit's bugged. Report this bug to Agouri, polyxenitopalidou@gmail.com"
 

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -185,7 +185,7 @@ var/global/bomb_set
 		return TRUE
 
 /obj/machinery/nuclearbomb/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
+	var/data = list()
 	data["evacuate"] = evacuate
 	data["hacking"] = 0
 	data["auth"] = is_auth(user)

--- a/code/game/machinery/oxygen_pump.dm
+++ b/code/game/machinery/oxygen_pump.dm
@@ -200,7 +200,7 @@
 
 //GUI Tank Setup
 /obj/machinery/oxygen_pump/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
+	var/data = list()
 	if(!tank)
 		to_chat(usr, SPAN_WARNING("It is missing a tank!"))
 		data["tankPressure"] = 0

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -196,7 +196,7 @@ var/global/list/turret_icons
 	return TRUE
 
 /obj/machinery/porta_turret/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
+	var/data = list()
 	data["access"] = !isLocked(user)
 	data["locked"] = locked
 	data["enabled"] = enabled
@@ -204,7 +204,7 @@ var/global/list/turret_icons
 	data["lethal"] = lethal
 
 	if(data["access"])
-		var/settings[0]
+		var/settings = list()
 		settings[LIST_PRE_INC(settings)] = list("category" = "Neutralize All Non-Synthetics", "setting" = "check_synth", "value" = check_synth)
 		settings[LIST_PRE_INC(settings)] = list("category" = "Check Weapon Authorization", "setting" = "check_weapons", "value" = check_weapons)
 		settings[LIST_PRE_INC(settings)] = list("category" = "Check Security Records", "setting" = "check_records", "value" = check_records)

--- a/code/game/machinery/portable_turret.dm
+++ b/code/game/machinery/portable_turret.dm
@@ -196,7 +196,7 @@ var/global/list/turret_icons
 	return TRUE
 
 /obj/machinery/porta_turret/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data = list()
+	var/list/data = list()
 	data["access"] = !isLocked(user)
 	data["locked"] = locked
 	data["enabled"] = enabled
@@ -204,7 +204,7 @@ var/global/list/turret_icons
 	data["lethal"] = lethal
 
 	if(data["access"])
-		var/settings = list()
+		var/list/settings = list()
 		settings[LIST_PRE_INC(settings)] = list("category" = "Neutralize All Non-Synthetics", "setting" = "check_synth", "value" = check_synth)
 		settings[LIST_PRE_INC(settings)] = list("category" = "Check Weapon Authorization", "setting" = "check_weapons", "value" = check_weapons)
 		settings[LIST_PRE_INC(settings)] = list("category" = "Check Security Records", "setting" = "check_records", "value" = check_records)

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -100,7 +100,7 @@ var/global/list/obj/machinery/requests_console/allConsoles = list()
 	return TRUE
 
 /obj/machinery/requests_console/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
+	var/data = list()
 
 	data["department"] = department
 	data["screen"] = screen

--- a/code/game/machinery/robotics_fabricator.dm
+++ b/code/game/machinery/robotics_fabricator.dm
@@ -79,7 +79,7 @@
 	return TRUE
 
 /obj/machinery/robotics_fabricator/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
+	var/data = list()
 
 	var/datum/design/current = length(queue) ? queue[1] : null
 	if(current)

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -597,7 +597,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 // Simple log entry datum
 
 /datum/comm_log_entry
-	var/parameters = list() // carbon-copy to signal.data[]
+	var/parameters = list() // carbon-copy to signal.data
 	var/name = "data packet (#)"
 	var/garbage_collector = 1 // if set to 0, will not be garbage collected
 	var/input_type = "Speech File"

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -114,7 +114,7 @@
 	return TRUE
 
 /obj/machinery/turretid/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
+	var/data = list()
 	data["access"] = !isLocked(user)
 	data["locked"] = locked
 	data["enabled"] = enabled
@@ -122,7 +122,7 @@
 	data["lethal"] = lethal
 
 	if(data["access"])
-		var/settings[0]
+		var/settings = list()
 		settings[LIST_PRE_INC(settings)] = list("category" = "Neutralize All Non-Synthetics", "setting" = "check_synth", "value" = check_synth)
 		settings[LIST_PRE_INC(settings)] = list("category" = "Check Weapon Authorization", "setting" = "check_weapons", "value" = check_weapons)
 		settings[LIST_PRE_INC(settings)] = list("category" = "Check Security Records", "setting" = "check_records", "value" = check_records)

--- a/code/game/machinery/turret_control.dm
+++ b/code/game/machinery/turret_control.dm
@@ -114,7 +114,7 @@
 	return TRUE
 
 /obj/machinery/turretid/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data = list()
+	var/list/data = list()
 	data["access"] = !isLocked(user)
 	data["locked"] = locked
 	data["enabled"] = enabled
@@ -122,7 +122,7 @@
 	data["lethal"] = lethal
 
 	if(data["access"])
-		var/settings = list()
+		var/list/settings = list()
 		settings[LIST_PRE_INC(settings)] = list("category" = "Neutralize All Non-Synthetics", "setting" = "check_synth", "value" = check_synth)
 		settings[LIST_PRE_INC(settings)] = list("category" = "Check Weapon Authorization", "setting" = "check_weapons", "value" = check_weapons)
 		settings[LIST_PRE_INC(settings)] = list("category" = "Check Security Records", "setting" = "check_records", "value" = check_records)

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -15,7 +15,7 @@
 	ui_interact(user)
 
 /obj/item/aicard/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/topic_state/state = GLOB.inventory_state)
-	var/data[0]
+	var/data = list()
 	data["has_ai"] = carded_ai != null
 	if(carded_ai)
 		data["name"] = carded_ai.name
@@ -26,7 +26,7 @@
 		data["operational"] = !carded_ai.is_dead()
 		data["flushing"] = flush
 
-		var/laws[0]
+		var/laws = list()
 		for(var/datum/ai_law/AL in carded_ai.laws.all_laws())
 			laws[LIST_PRE_INC(laws)] = list("index" = AL.get_index(), "law" = sanitize(AL.law))
 		data["laws"] = laws

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -15,7 +15,7 @@
 	ui_interact(user)
 
 /obj/item/aicard/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/topic_state/state = GLOB.inventory_state)
-	var/data = list()
+	var/list/data = list()
 	data["has_ai"] = carded_ai != null
 	if(carded_ai)
 		data["name"] = carded_ai.name
@@ -26,7 +26,7 @@
 		data["operational"] = !carded_ai.is_dead()
 		data["flushing"] = flush
 
-		var/laws = list()
+		var/list/laws = list()
 		for(var/datum/ai_law/AL in carded_ai.laws.all_laws())
 			laws[LIST_PRE_INC(laws)] = list("index" = AL.get_index(), "law" = sanitize(AL.law))
 		data["laws"] = laws

--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -237,7 +237,7 @@ var/global/list/all_gps_units = list()
 		if(G == src || !can_track(G, z_level_detection))
 			continue
 
-		var/gps_data[0]
+		var/gps_data = list()
 		var/gps_ref = "\ref[G]"
 		gps_data["gps_ref"] = gps_ref
 		gps_data["gps_tag"] = G.gps_tag

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -151,7 +151,7 @@
 	return list_internal_channels(user)
 
 /obj/item/device/radio/proc/list_secure_channels(mob/user)
-	var/dat = list()
+	var/list/dat = list()
 
 	for(var/ch_name in channels)
 		var/chan_stat = channels[ch_name]
@@ -162,7 +162,7 @@
 	return dat
 
 /obj/item/device/radio/proc/list_internal_channels(mob/user)
-	var/dat = list()
+	var/list/dat = list()
 	for(var/internal_chan in internal_channels)
 		if (!syndie && (text2num(internal_chan) == SYND_FREQ)) //Only traitor shortwaves should be able to see the traitor frequency
 			continue

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -117,7 +117,7 @@
 		ui_interact(user)
 
 /obj/item/device/radio/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/nanoui/master_ui = null, datum/topic_state/state = GLOB.default_state)
-	var/data[0]
+	var/data = list()
 
 	if (power_usage > 0)
 		data["power"] = on
@@ -151,7 +151,7 @@
 	return list_internal_channels(user)
 
 /obj/item/device/radio/proc/list_secure_channels(mob/user)
-	var/dat[0]
+	var/dat = list()
 
 	for(var/ch_name in channels)
 		var/chan_stat = channels[ch_name]
@@ -162,7 +162,7 @@
 	return dat
 
 /obj/item/device/radio/proc/list_internal_channels(mob/user)
-	var/dat[0]
+	var/dat = list()
 	for(var/internal_chan in internal_channels)
 		if (!syndie && (text2num(internal_chan) == SYND_FREQ)) //Only traitor shortwaves should be able to see the traitor frequency
 			continue
@@ -853,7 +853,7 @@
 	. = ..()
 
 /obj/item/device/radio/borg/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
+	var/data = list()
 
 	data["mic_status"] = broadcasting
 	data["speaker"] = listening

--- a/code/game/objects/items/devices/scanners/health.dm
+++ b/code/game/objects/items/devices/scanners/health.dm
@@ -249,7 +249,7 @@
 	var/print_reagent_default_message = TRUE
 	if(H.reagents.total_volume)
 		var/unknown = 0
-		var/reagentdata[0]
+		var/reagentdata = list()
 		for(var/A in H.reagents.reagent_list)
 			var/datum/reagent/R = A
 			if(R.scannable)

--- a/code/game/objects/items/devices/transfer_valve.dm
+++ b/code/game/objects/items/devices/transfer_valve.dm
@@ -115,7 +115,7 @@
 /obj/item/device/transfer_valve/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
 
 	// this is the data which will be sent to the ui
-	var/data[0]
+	var/data = list()
 	data["attachmentOne"] = tank_one ? tank_one.name : null
 	data["attachmentTwo"] = tank_two ? tank_two.name : null
 	data["valveAttachment"] = attached_device ? attached_device.name : null

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -116,7 +116,7 @@
 */
 /obj/item/device/uplink/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, uistate = GLOB.inventory_state)
 	var/title = "Remote Uplink"
-	var/data[0]
+	var/data = list()
 
 	data["welcome"] = welcome
 	data["crystals"] = uses
@@ -174,13 +174,13 @@
 
 /obj/item/device/uplink/proc/update_nano_data()
 	if(nanoui_menu == 0)
-		var/categories[0]
+		var/categories = list()
 		for(var/datum/uplink_category/category in uplink.categories)
 			if(category.can_view(src))
 				categories[LIST_PRE_INC(categories)] = list("name" = category.name, "ref" = "\ref[category]")
 		nanoui_data["categories"] = categories
 	else if(nanoui_menu == 1)
-		var/items[0]
+		var/items = list()
 		for(var/datum/uplink_item/item in category.items)
 			if(item.can_view(src))
 				var/cost = item.cost(uses, src)
@@ -188,7 +188,7 @@
 				items[LIST_PRE_INC(items)] = list("name" = item.name(), "description" = replacetext(item.description(), "\n", "<br>"), "can_buy" = item.can_buy(src), "cost" = cost, "ref" = "\ref[item]")
 		nanoui_data["items"] = items
 	else if(nanoui_menu == 2)
-		var/permanentData[0]
+		var/permanentData = list()
 		for(var/datum/computer_file/report/crew_record/L in GLOB.all_crew_records)
 			permanentData[LIST_PRE_INC(permanentData)] = list(Name = L.get_name(),"id" = L.uid, "exploit" = length(L.get_antagRecord()))
 		nanoui_data["exploit_records"] = permanentData

--- a/code/game/objects/items/devices/uplink.dm
+++ b/code/game/objects/items/devices/uplink.dm
@@ -174,13 +174,13 @@
 
 /obj/item/device/uplink/proc/update_nano_data()
 	if(nanoui_menu == 0)
-		var/categories = list()
+		var/list/categories = list()
 		for(var/datum/uplink_category/category in uplink.categories)
 			if(category.can_view(src))
 				categories[LIST_PRE_INC(categories)] = list("name" = category.name, "ref" = "\ref[category]")
 		nanoui_data["categories"] = categories
 	else if(nanoui_menu == 1)
-		var/items = list()
+		var/list/items = list()
 		for(var/datum/uplink_item/item in category.items)
 			if(item.can_view(src))
 				var/cost = item.cost(uses, src)
@@ -188,7 +188,7 @@
 				items[LIST_PRE_INC(items)] = list("name" = item.name(), "description" = replacetext(item.description(), "\n", "<br>"), "can_buy" = item.can_buy(src), "cost" = cost, "ref" = "\ref[item]")
 		nanoui_data["items"] = items
 	else if(nanoui_menu == 2)
-		var/permanentData = list()
+		var/list/permanentData = list()
 		for(var/datum/computer_file/report/crew_record/L in GLOB.all_crew_records)
 			permanentData[LIST_PRE_INC(permanentData)] = list(Name = L.get_name(),"id" = L.uid, "exploit" = length(L.get_antagRecord()))
 		nanoui_data["exploit_records"] = permanentData

--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -43,8 +43,8 @@
 		..()
 
 /obj/item/card/id/syndicate/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
-	var/entries[0]
+	var/data = list()
+	var/entries = list()
 	entries[LIST_PRE_INC(entries)] = list("name" = "Age", 				"value" = age)
 	entries[LIST_PRE_INC(entries)] = list("name" = "Prefix", 			"value" = formal_name_prefix)
 	entries[LIST_PRE_INC(entries)] = list("name" = "Suffix", 			"value" = formal_name_suffix)

--- a/code/game/objects/items/weapons/cards_ids_syndicate.dm
+++ b/code/game/objects/items/weapons/cards_ids_syndicate.dm
@@ -43,8 +43,8 @@
 		..()
 
 /obj/item/card/id/syndicate/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data = list()
-	var/entries = list()
+	var/list/data = list()
+	var/list/entries = list()
 	entries[LIST_PRE_INC(entries)] = list("name" = "Age", 				"value" = age)
 	entries[LIST_PRE_INC(entries)] = list("name" = "Prefix", 			"value" = formal_name_prefix)
 	entries[LIST_PRE_INC(entries)] = list("name" = "Suffix", 			"value" = formal_name_suffix)

--- a/code/game/objects/items/weapons/tanks/tanks.dm
+++ b/code/game/objects/items/weapons/tanks/tanks.dm
@@ -260,7 +260,7 @@ var/global/list/tank_gauge_cache = list()
 			using_internal = 1
 
 	// this is the data which will be sent to the ui
-	var/data[0]
+	var/data = list()
 	data["tankPressure"] = round(air_contents && air_contents.return_pressure() ? air_contents.return_pressure() : 0)
 	data["releasePressure"] = round(distribute_pressure ? distribute_pressure : 0)
 	data["defaultReleasePressure"] = round(initial(distribute_pressure))

--- a/code/game/objects/structures/janicart.dm
+++ b/code/game/objects/structures/janicart.dm
@@ -145,7 +145,7 @@
 	return
 
 /obj/structure/janitorialcart/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
+	var/data = list()
 	data["name"] = capitalize(name)
 	data["bag"] = mybag ? capitalize(mybag.name) : null
 	data["mop"] = mymop ? capitalize(mymop.name) : null

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -304,7 +304,7 @@ var/global/const/enterloopsanity = 100
 		return get_dist(src,t)
 
 /turf/proc/AdjacentTurfsSpace()
-	var/L[] = new()
+	var/list/L = list()
 	for(var/turf/t in oview(src,1))
 		if(!t.density)
 			if(!LinkBlocked(src, t) && !TurfBlockedNonWindow(t))

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -153,7 +153,7 @@ GLOBAL_VAR_AS(world_topic_last, world.timeofday)
 		return n
 
 	else if (copytext(T,1,7) == "status")
-		var/input[] = params2list(T)
+		var/input = params2list(T)
 		var/list/s = list()
 		s["version"] = config.game_version
 		s["mode"] = PUBLIC_GAME_MODE
@@ -234,7 +234,7 @@ GLOBAL_VAR_AS(world_topic_last, world.timeofday)
 	* * * * * * * */
 
 	if(copytext(T,1,14) == "placepermaban")
-		var/input[] = params2list(T)
+		var/input = params2list(T)
 		if(!config.ban_comms_password)
 			SET_THROTTLE(10 SECONDS, "Bans Not Enabled")
 			return "Not Enabled"
@@ -270,7 +270,7 @@ GLOBAL_VAR_AS(world_topic_last, world.timeofday)
 		return "Not enabled"
 
 	else if(copytext(T,1,5) == "laws")
-		var/input[] = params2list(T)
+		var/input = params2list(T)
 		if(input["key"] != config.comms_password)
 			SET_THROTTLE(30 SECONDS, "Bad Comms Key")
 			return "Bad Key"
@@ -317,7 +317,7 @@ GLOBAL_VAR_AS(world_topic_last, world.timeofday)
 			return list2params(ret)
 
 	else if(copytext(T,1,5) == "info")
-		var/input[] = params2list(T)
+		var/input = params2list(T)
 		if(input["key"] != config.comms_password)
 			SET_THROTTLE(30 SECONDS, "Bad Comms Key")
 			return "Bad Key"
@@ -377,7 +377,7 @@ GLOBAL_VAR_AS(world_topic_last, world.timeofday)
 		*/
 
 
-		var/input[] = params2list(T)
+		var/input = params2list(T)
 		if(input["key"] != config.comms_password)
 			SET_THROTTLE(30 SECONDS, "Bad Comms Key")
 			return "Bad Key"
@@ -418,14 +418,14 @@ GLOBAL_VAR_AS(world_topic_last, world.timeofday)
 				1. notes = ckey of person the notes lookup is for
 				2. validationkey = the key the bot has, it should match the gameservers commspassword in it's configuration.
 		*/
-		var/input[] = params2list(T)
+		var/input = params2list(T)
 		if(input["key"] != config.comms_password)
 			SET_THROTTLE(30 SECONDS, "Bad Comms Key")
 			return "Bad Key"
 		return show_player_info_irc(ckey(input["notes"]))
 
 	else if(copytext(T,1,4) == "age")
-		var/input[] = params2list(T)
+		var/input = params2list(T)
 		if(input["key"] != config.comms_password)
 			SET_THROTTLE(30 SECONDS, "Bad Comms Key")
 			return "Bad Key"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -451,7 +451,7 @@ var/global/floorIsLava = 0
 					else
 						dat+="<B><A href='byond://?src=\ref[src];ac_show_channel=\ref[CHANNEL]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? (SPAN_COLOR("red", "***")) : null ]<BR></B>"
 			dat+={"<BR><HR><A href='byond://?src=\ref[src];ac_refresh=1'>Refresh</A>
-				<BR><A href='byond://?src=\ref[src];ac_setScreen=[0]'>Back</A>
+				<BR><A href='byond://?src=\ref[src];ac_setScreen=0'>Back</A>
 			"}
 
 		if(2)
@@ -460,7 +460,7 @@ var/global/floorIsLava = 0
 				<HR><B><A href='byond://?src=\ref[src];ac_set_channel_name=1'>Channel Name</A>:</B> [src.admincaster_feed_channel.channel_name]<BR>
 				<B><A href='byond://?src=\ref[src];ac_set_signature=1'>Channel Author</A>:</B> [SPAN_COLOR("green", src.admincaster_signature)]<BR>
 				<B><A href='byond://?src=\ref[src];ac_set_channel_lock=1'>Will Accept Public Feeds</A>:</B> [(src.admincaster_feed_channel.locked) ? ("NO") : ("YES")]<BR><BR>
-				<BR><A href='byond://?src=\ref[src];ac_submit_new_channel=1'>Submit</A><BR><BR><A href='byond://?src=\ref[src];ac_setScreen=[0]'>Cancel</A><BR>
+				<BR><A href='byond://?src=\ref[src];ac_submit_new_channel=1'>Submit</A><BR><BR><A href='byond://?src=\ref[src];ac_setScreen=0'>Cancel</A><BR>
 			"}
 		if(3)
 			dat+={"
@@ -468,17 +468,17 @@ var/global/floorIsLava = 0
 				<HR><B><A href='byond://?src=\ref[src];ac_set_channel_receiving=1'>Receiving Channel</A>:</B> [src.admincaster_feed_channel.channel_name]<BR>" //MARK
 				<B>Message Author:</B> [SPAN_COLOR("green", src.admincaster_signature)]<BR>
 				<B><A href='byond://?src=\ref[src];ac_set_new_message=1'>Message Body</A>:</B> [src.admincaster_feed_message.body] <BR>
-				<BR><A href='byond://?src=\ref[src];ac_submit_new_message=1'>Submit</A><BR><BR><A href='byond://?src=\ref[src];ac_setScreen=[0]'>Cancel</A><BR>
+				<BR><A href='byond://?src=\ref[src];ac_submit_new_message=1'>Submit</A><BR><BR><A href='byond://?src=\ref[src];ac_setScreen=0'>Cancel</A><BR>
 			"}
 		if(4)
 			dat+={"
 					Feed story successfully submitted to [src.admincaster_feed_channel.channel_name].<BR><BR>
-					<BR><A href='byond://?src=\ref[src];ac_setScreen=[0]'>Return</A><BR>
+					<BR><A href='byond://?src=\ref[src];ac_setScreen=0'>Return</A><BR>
 				"}
 		if(5)
 			dat+={"
 				Feed Channel [src.admincaster_feed_channel.channel_name] created successfully.<BR><BR>
-				<BR><A href='byond://?src=\ref[src];ac_setScreen=[0]'>Return</A><BR>
+				<BR><A href='byond://?src=\ref[src];ac_setScreen=0'>Return</A><BR>
 			"}
 		if(6)
 			dat+="<B>[SPAN_COLOR("maroon", "ERROR: Could not submit Feed story to Network.</B>")]<HR><BR>"
@@ -534,7 +534,7 @@ var/global/floorIsLava = 0
 			else
 				for(var/datum/feed_channel/CHANNEL in torch_network.network_channels)
 					dat+="<A href='byond://?src=\ref[src];ac_pick_censor_channel=\ref[CHANNEL]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? (SPAN_COLOR("red", "***")) : null ]<BR>"
-			dat+="<BR><A href='byond://?src=\ref[src];ac_setScreen=[0]'>Cancel</A>"
+			dat+="<BR><A href='byond://?src=\ref[src];ac_setScreen=0'>Cancel</A>"
 		if(11)
 			dat+={"
 				<B>[GLOB.using_map.company_name] D-Notice Handler</B><HR>
@@ -548,7 +548,7 @@ var/global/floorIsLava = 0
 				for(var/datum/feed_channel/CHANNEL in torch_network.network_channels)
 					dat+="<A href='byond://?src=\ref[src];ac_pick_d_notice=\ref[CHANNEL]'>[CHANNEL.channel_name]</A> [(CHANNEL.censored) ? (SPAN_COLOR("red", "***")) : null ]<BR>"
 
-			dat+="<BR><A href='byond://?src=\ref[src];ac_setScreen=[0]'>Back</A>"
+			dat+="<BR><A href='byond://?src=\ref[src];ac_setScreen=0'>Back</A>"
 		if(12)
 			dat+={"
 				<B>[src.admincaster_feed_channel.channel_name]: </B>[FONT_SMALL("\[ created by: [SPAN_COLOR("maroon", src.admincaster_feed_channel.author)] \]")]<BR>
@@ -602,11 +602,11 @@ var/global/floorIsLava = 0
 			dat+="<BR><A href='byond://?src=\ref[src];ac_submit_wanted=[end_param]'>[(wanted_already) ? ("Edit Issue") : ("Submit")]</A>"
 			if(wanted_already)
 				dat+="<BR><A href='byond://?src=\ref[src];ac_cancel_wanted=1'>Take down Issue</A>"
-			dat+="<BR><A href='byond://?src=\ref[src];ac_setScreen=[0]'>Cancel</A>"
+			dat+="<BR><A href='byond://?src=\ref[src];ac_setScreen=0'>Cancel</A>"
 		if(15)
 			dat+={"
 				[SPAN_COLOR("green", "Wanted issue for [src.admincaster_feed_message.author] is now in Network Circulation.")]<BR><BR>
-				<BR><A href='byond://?src=\ref[src];ac_setScreen=[0]'>Return</A><BR>
+				<BR><A href='byond://?src=\ref[src];ac_setScreen=0'>Return</A><BR>
 			"}
 		if(16)
 			dat+="<B>[SPAN_COLOR("maroon", "ERROR: Wanted Issue rejected by Network.</B>")]<HR><BR>"
@@ -614,11 +614,11 @@ var/global/floorIsLava = 0
 				dat+="[SPAN_COLOR("maroon", "Invalid name for person wanted.")]<BR>"
 			if(src.admincaster_feed_message.body == "" || src.admincaster_feed_message.body == "\[REDACTED\]")
 				dat+="[SPAN_COLOR("maroon", "Invalid description.")]<BR>"
-			dat+="<BR><A href='byond://?src=\ref[src];ac_setScreen=[0]'>Return</A><BR>"
+			dat+="<BR><A href='byond://?src=\ref[src];ac_setScreen=0'>Return</A><BR>"
 		if(17)
 			dat+={"
 				<B>Wanted Issue successfully deleted from Circulation</B><BR>
-				<BR><A href='byond://?src=\ref[src];ac_setScreen=[0]'>Return</A><BR>
+				<BR><A href='byond://?src=\ref[src];ac_setScreen=0'>Return</A><BR>
 			"}
 		if(18)
 			dat+={"
@@ -632,11 +632,11 @@ var/global/floorIsLava = 0
 				dat+="<BR><img src='tmp_photow.png' width = '180'>"
 			else
 				dat+="None"
-			dat+="<BR><A href='byond://?src=\ref[src];ac_setScreen=[0]'>Back</A><BR>"
+			dat+="<BR><A href='byond://?src=\ref[src];ac_setScreen=0'>Back</A><BR>"
 		if(19)
 			dat+={"
 				[SPAN_COLOR("green", "Wanted issue for [src.admincaster_feed_message.author] successfully edited.")]<BR><BR>
-				<BR><A href='byond://?src=\ref[src];ac_setScreen=[0]'>Return</A><BR>
+				<BR><A href='byond://?src=\ref[src];ac_setScreen=0'>Return</A><BR>
 			"}
 		else
 			dat+="I'm sorry to break your immersion. This shit's bugged. Report this bug to Agouri, polyxenitopalidou@gmail.com"

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -1,7 +1,7 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:32
 
 var/global/jobban_runonce			// Updates legacy bans with new info
-var/global/jobban_keylist = list()		//to store the keys & ranks
+var/global/list/jobban_keylist = list()		//to store the keys & ranks
 
 /proc/jobban_fullban(mob/M, rank, reason)
 	if(!M)

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -1,7 +1,7 @@
 //This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:32
 
 var/global/jobban_runonce			// Updates legacy bans with new info
-var/global/jobban_keylist[0]		//to store the keys & ranks
+var/global/jobban_keylist = list()		//to store the keys & ranks
 
 /proc/jobban_fullban(mob/M, rank, reason)
 	if(!M)
@@ -46,7 +46,7 @@ var/global/jobban_keylist[0]		//to store the keys & ranks
 /proc/jobban_loadbanfile()
 	if(config.ban_legacy_system)
 		var/savefile/S=new("data/job_full.ban")
-		from_save(S["keys[0]"],  jobban_keylist)
+		from_save(S["keys0"],  jobban_keylist)
 		log_admin("Loading jobban_rank")
 		from_save(S["runonce"], jobban_runonce)
 
@@ -83,7 +83,7 @@ var/global/jobban_keylist[0]		//to store the keys & ranks
 
 /proc/jobban_savebanfile()
 	var/savefile/S=new("data/job_full.ban")
-	to_save(S["keys[0]"], jobban_keylist)
+	to_save(S["keys0"], jobban_keylist)
 
 /proc/jobban_unban(mob/M, rank)
 	jobban_remove("[M.ckey] - [rank]")

--- a/code/modules/admin/buildmode/atmosphere.dm
+++ b/code/modules/admin/buildmode/atmosphere.dm
@@ -31,7 +31,7 @@
 /datum/build_mode/atmosphere/ui_interact(mob/user, ui_key = "atmosphere_editor", datum/nanoui/ui = null, force_open = 1, master_ui = null, datum/topic_state/state = GLOB.default_state)
 	. = ..()
 
-	var/data[0]
+	var/data = list()
 	data["total_moles"] = enviroment.total_moles
 	data["temperature"] = enviroment.temperature
 	data["volume_total"] = enviroment.volume

--- a/code/modules/admin/buildmode/mob_spawning.dm
+++ b/code/modules/admin/buildmode/mob_spawning.dm
@@ -66,7 +66,7 @@ GLOBAL_LIST_EMPTY(mob_spawners)
 			ui.close()
 		return
 
-	var/data[0]
+	var/data = list()
 	data["area"] = current_area
 	data["area_name"] = current_area.name
 	data["mobs"] = spawner.mobs

--- a/code/modules/admin/buildmode/turret.dm
+++ b/code/modules/admin/buildmode/turret.dm
@@ -30,7 +30,7 @@
 /datum/build_mode/turret/ui_interact(mob/user, ui_key = "turret_editor", datum/nanoui/ui = null, force_open = 1, master_ui = null, datum/topic_state/state = GLOB.default_state)
 	. = ..()
 
-	var/data[0]
+	var/data = list()
 	data["health"] = settings["health"]
 	data["repair"] = settings["repair"]
 	data["weapon"] = settings["weapon"]

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -761,7 +761,6 @@
 						ban_unban_log_save("[key_name(usr)] temp-jobbanned [key_name(M)] from [job] for [mins_readable]. reason: [reason]")
 						log_admin("[key_name(usr)] temp-jobbanned [key_name(M)] from [job] for [mins_readable]")
 						DB_ban_record(BANTYPE_JOB_TEMP, M, mins, reason, job)
-						jobban_fullban(M, job, "[reason]; By [usr.ckey] on [time2text(world.realtime)]") //Legacy banning does not support temporary jobbans.
 						if(!msg)
 							msg = job
 						else
@@ -782,7 +781,6 @@
 							ban_unban_log_save("[key_name(usr)] perma-jobbanned [key_name(M)] from [job]. reason: [reason]")
 							log_admin("[key_name(usr)] perma-banned [key_name(M)] from [job]")
 							DB_ban_record(BANTYPE_JOB_PERMA, M, -1, reason, job)
-							jobban_fullban(M, job, "[reason]; By [usr.ckey] on [time2text(world.realtime)]")
 							if(!msg)	msg = job
 							else		msg += ", [job]"
 						notes_add(LAST_CKEY(M), "Banned  from [msg] - [reason]", usr)

--- a/code/modules/admin/verbs/adminpm.dm
+++ b/code/modules/admin/verbs/adminpm.dm
@@ -15,7 +15,7 @@
 	if(!holder)
 		to_chat(src, SPAN_WARNING("Error: Admin-PM-Panel: Only administrators may use this command."))
 		return
-	var/list/client/targets[0]
+	var/list/client/targets = list()
 	for(var/client/T)
 		if(T.mob)
 			if(isnewplayer(T.mob))

--- a/code/modules/atmospherics/_atmos_setup.dm
+++ b/code/modules/atmospherics/_atmos_setup.dm
@@ -34,16 +34,11 @@ var/global/list/pipe_colors = list(
 //--------------------------------------------
 
 /datum/pipe_icon_manager
-	var/list/pipe_icons[]
-	var/list/manifold_icons[]
-	var/list/device_icons[]
-	var/list/underlays[]
-	//var/list/underlays_down[]
-	//var/list/underlays_exposed[]
-	//var/list/underlays_intact[]
-	//var/list/pipe_underlays_exposed[]
-	//var/list/pipe_underlays_intact[]
-	var/list/omni_icons[]
+	var/list/pipe_icons = list()
+	var/list/manifold_icons = list()
+	var/list/device_icons = list()
+	var/list/underlays = list()
+	var/list/omni_icons = list()
 
 /datum/pipe_icon_manager/New()
 	check_icons()

--- a/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
+++ b/code/modules/atmospherics/components/binary_devices/oxyregenerator.dm
@@ -174,7 +174,7 @@
 	return TRUE
 
 /obj/machinery/atmospherics/binary/oxyregenerator/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
+	var/data = list()
 	data["on"] = use_power ? 1 : 0
 	data["powerSetting"] = power_setting
 	data["gasProcessed"] = last_flow_rate

--- a/code/modules/atmospherics/components/binary_devices/passive_gate.dm
+++ b/code/modules/atmospherics/components/binary_devices/passive_gate.dm
@@ -176,7 +176,7 @@
 
 /obj/machinery/atmospherics/binary/passive_gate/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
 	// this is the data which will be sent to the ui
-	var/data[0]
+	var/data = list()
 
 	data = list(
 		"on" = unlocked,

--- a/code/modules/atmospherics/components/binary_devices/pump.dm
+++ b/code/modules/atmospherics/components/binary_devices/pump.dm
@@ -120,7 +120,7 @@ Thus, the two variables affect pump operation are set in New():
 		return
 
 	// this is the data which will be sent to the ui
-	var/data[0]
+	var/data = list()
 
 	data = list(
 		"on" = use_power,

--- a/code/modules/atmospherics/components/omni_devices/filter.dm
+++ b/code/modules/atmospherics/components/omni_devices/filter.dm
@@ -148,12 +148,12 @@ GLOBAL_LIST_AS(filter_mode_to_gas_id, list(
 		ui.open()
 
 /obj/machinery/atmospherics/omni/filter/proc/build_uidata()
-	var/list/data = new()
+	var/list/data = list()
 
 	data["power"] = use_power
 	data["config"] = configuring
 
-	var/portData = list()
+	var/list/portData = list()
 	for(var/datum/omni_port/P in ports)
 		if(!configuring && P.mode == 0)
 			continue

--- a/code/modules/atmospherics/components/omni_devices/filter.dm
+++ b/code/modules/atmospherics/components/omni_devices/filter.dm
@@ -153,7 +153,7 @@ GLOBAL_LIST_AS(filter_mode_to_gas_id, list(
 	data["power"] = use_power
 	data["config"] = configuring
 
-	var/portData[0]
+	var/portData = list()
 	for(var/datum/omni_port/P in ports)
 		if(!configuring && P.mode == 0)
 			continue

--- a/code/modules/atmospherics/components/omni_devices/mixer.dm
+++ b/code/modules/atmospherics/components/omni_devices/mixer.dm
@@ -146,12 +146,12 @@
 		ui.open()
 
 /obj/machinery/atmospherics/omni/mixer/proc/build_uidata()
-	var/list/data = new()
+	var/list/data = list()
 
 	data["power"] = use_power
 	data["config"] = configuring
 
-	var/portData = list()
+	var/list/portData = list()
 	for(var/datum/omni_port/P in ports)
 		if(!configuring && P.mode == 0)
 			continue

--- a/code/modules/atmospherics/components/omni_devices/mixer.dm
+++ b/code/modules/atmospherics/components/omni_devices/mixer.dm
@@ -151,7 +151,7 @@
 	data["power"] = use_power
 	data["config"] = configuring
 
-	var/portData[0]
+	var/portData = list()
 	for(var/datum/omni_port/P in ports)
 		if(!configuring && P.mode == 0)
 			continue

--- a/code/modules/atmospherics/components/unary/cold_sink.dm
+++ b/code/modules/atmospherics/components/unary/cold_sink.dm
@@ -70,7 +70,7 @@
 
 /obj/machinery/atmospherics/unary/freezer/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
 	// this is the data which will be sent to the ui
-	var/data[0]
+	var/data = list()
 	data["on"] = use_power ? 1 : 0
 	data["gasPressure"] = round(air_contents.return_pressure())
 	data["gasTemperature"] = round(air_contents.temperature)

--- a/code/modules/atmospherics/components/unary/gas_extractor.dm
+++ b/code/modules/atmospherics/components/unary/gas_extractor.dm
@@ -61,8 +61,8 @@
 /obj/machinery/atmospherics/unary/gas_extractor/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
 	if(inoperable())
 		return
-		
-	var/data[0]
+
+	var/data = list()
 
 	data = list(
 		"on" = use_power,
@@ -86,17 +86,17 @@
 	if(href_list["power"])
 		update_use_power(!use_power)
 		. = 1
-		
+
 	if(href_list["settag"])
 		var/t = sanitizeSafe(input(usr, "Enter the ID tag for [src.name]", src.name, id), MAX_NAME_LEN)
 		id = t
 		. = 1
-		
+
 	if(href_list["toggle_mode"])
 		external_mode = !external_mode
 		update_use_power(POWER_USE_OFF)  // Stop when switching modes without new pressure data
 		. = 1
-		
+
 	if(href_list["setfreq"])
 		var/freq = input(usr, "Enter the Frequency for [src.name]. Decimal will automatically be inserted", src.name, frequency) as num|null
 		set_frequency(freq)
@@ -113,7 +113,7 @@
 
 	if(.)
 		src.update_icon()
-		
+
 /obj/machinery/atmospherics/unary/gas_extractor/interface_interact(mob/user)
 	ui_interact(user)
 	return TRUE

--- a/code/modules/atmospherics/components/unary/heat_source.dm
+++ b/code/modules/atmospherics/components/unary/heat_source.dm
@@ -92,7 +92,7 @@
 
 /obj/machinery/atmospherics/unary/heater/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
 	// this is the data which will be sent to the ui
-	var/data[0]
+	var/data = list()
 	data["on"] = use_power ? 1 : 0
 	data["gasPressure"] = round(air_contents.return_pressure())
 	data["gasTemperature"] = round(air_contents.temperature)

--- a/code/modules/atmospherics/components/unary/outlet_injector.dm
+++ b/code/modules/atmospherics/components/unary/outlet_injector.dm
@@ -65,7 +65,7 @@
 	if(inoperable())
 		return
 
-	var/data[0]
+	var/data = list()
 
 	data = list(
 		"on" = use_power,

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -72,7 +72,7 @@
 	off_state = "securityhud_off"
 	hud_type = HUD_SECURITY
 	body_parts_covered = 0
-	var/static/list/jobs[0]
+	var/static/list/jobs = list()
 	req_access = list(access_brig)
 
 /obj/item/clothing/glasses/hud/security/prescription

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -524,7 +524,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 	if(destination)//If there is a destination.
 		if(errorx||errory)//If errorx or y were specified.
-			var/destination_list = list() = list()//To add turfs to list.
+			var/list/destination_list = list()//To add turfs to list.
 			//destination_list = new()
 			/*This will draw a block around the target turf, given what the error is.
 			Specifying the values above will basically draw a different sort of block.

--- a/code/modules/clothing/spacesuits/rig/modules/ninja.dm
+++ b/code/modules/clothing/spacesuits/rig/modules/ninja.dm
@@ -524,7 +524,7 @@ Turf and target are seperate in case you want to teleport some distance from a t
 
 	if(destination)//If there is a destination.
 		if(errorx||errory)//If errorx or y were specified.
-			var/destination_list[] = list()//To add turfs to list.
+			var/destination_list = list() = list()//To add turfs to list.
 			//destination_list = new()
 			/*This will draw a block around the target turf, given what the error is.
 			Specifying the values above will basically draw a different sort of block.

--- a/code/modules/economy/Accounts_DB.dm
+++ b/code/modules/economy/Accounts_DB.dm
@@ -51,7 +51,7 @@
 /obj/machinery/computer/account_database/ui_interact(mob/user, ui_key="main", datum/nanoui/ui = null, force_open = 1)
 	user.set_machine(src)
 
-	var/data[0]
+	var/data = list()
 	data["src"] = "\ref[src]"
 	data["id_inserted"] = !!held_card
 	data["id_card"] = held_card ? text("[held_card.registered_name], [held_card.assignment]") : "-----"
@@ -69,7 +69,7 @@
 		data["money"] = detailed_account_view.money
 		data["suspended"] = detailed_account_view.suspended
 
-		var/list/trx[0]
+		var/list/trx = list()
 		for (var/datum/transaction/T in detailed_account_view.transaction_log)
 			trx.Add(list(list(\
 				"date" = T.date, \
@@ -82,7 +82,7 @@
 		if (length(trx) > 0)
 			data["transactions"] = trx
 
-	var/list/accounts[0]
+	var/list/accounts = list()
 	for(var/i=1, i<=length(all_money_accounts), i++)
 		var/datum/money_account/D = all_money_accounts[i]
 		accounts.Add(list(list(\

--- a/code/modules/ext_scripts/irc.dm
+++ b/code/modules/ext_scripts/irc.dm
@@ -21,7 +21,7 @@
 
 /proc/adminmsg2adminirc(client/source, client/target, msg)
 	if(config.admin_irc)
-		var/list/params[0]
+		var/list/params = list()
 
 		params["pwd"] = config.comms_password
 		params["chan"] = config.admin_irc
@@ -51,7 +51,7 @@
 
 /proc/send_to_admin_discord(type, message)
 	if(config.admin_discord && config.excom_address)
-		var/list/params[0]
+		var/list/params = list()
 
 		params["pwd"] = config.comms_password
 		params["chan"] = config.admin_discord

--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -399,7 +399,7 @@
 // Returns the surrounding cardinal turfs with open links
 // Including through doors openable with the ID
 /turf/proc/CardinalTurfsWithAccess(obj/item/card/id/ID)
-	var/L[] = new()
+	var/list/L = list()
 
 	//	for(var/turf/simulated/t in oview(src,1))
 

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -264,7 +264,7 @@
 			var/list/embedlist = wound.embedded_objects
 			if(LAZYLEN(embedlist))
 				shown_objects += embedlist
-				var/parsedembed[0]
+				var/parsedembed = list()
 				for(var/obj/embedded in embedlist)
 					if(!length(parsedembed) || (!parsedembed.Find(embedded.name) && !parsedembed.Find("multiple [embedded.name]")))
 						parsedembed.Add(embedded.name)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -264,7 +264,7 @@
 			var/list/embedlist = wound.embedded_objects
 			if(LAZYLEN(embedlist))
 				shown_objects += embedlist
-				var/parsedembed = list()
+				var/list/parsedembed = list()
 				for(var/obj/embedded in embedlist)
 					if(!length(parsedembed) || (!parsedembed.Find(embedded.name) && !parsedembed.Find("multiple [embedded.name]")))
 						parsedembed.Add(embedded.name)

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -538,7 +538,7 @@ var/global/list/ai_verbs_default = list(
 	var/input
 	if(alert("Would you like to select a hologram based on a crew member or switch to unique avatar?",,"Crew Member","Unique")=="Crew Member")
 
-		var/personnel_list = list() = list()
+		var/list/personnel_list = list()
 
 		for(var/datum/computer_file/report/crew_record/t in GLOB.all_crew_records)//Look in data core locked.
 			personnel_list["[t.get_name()]: [t.get_rank()]"] = t.photo_front//Pull names, rank, and image.

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -538,7 +538,7 @@ var/global/list/ai_verbs_default = list(
 	var/input
 	if(alert("Would you like to select a hologram based on a crew member or switch to unique avatar?",,"Crew Member","Unique")=="Crew Member")
 
-		var/personnel_list[] = list()
+		var/personnel_list = list() = list()
 
 		for(var/datum/computer_file/report/crew_record/t in GLOB.all_crew_records)//Look in data core locked.
 			personnel_list["[t.get_name()]: [t.get_rank()]"] = t.photo_front//Pull names, rank, and image.

--- a/code/modules/mob/living/silicon/pai/recruit.dm
+++ b/code/modules/mob/living/silicon/pai/recruit.dm
@@ -27,7 +27,7 @@ var/global/datum/paiController/paiController			// Global handler for pAI candida
 
 	var/askDelay = 10 * 60 * 1	// One minute [ms * sec * min]
 
-/datum/paiController/Topic(href, href_list[])
+/datum/paiController/Topic(href, list/href_list)
 	if(href_list["download"])
 		var/datum/paiCandidate/candidate = locate(href_list["candidate"])
 		var/obj/item/device/paicard/card = locate(href_list["device"])

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -50,16 +50,16 @@ var/global/list/default_pai_software = list()
 			if(ui) ui.set_status(STATUS_CLOSE, 0)
 		return
 
-	var/data[0]
+	var/data = list()
 
 	// Software we have bought
-	var/bought_software[0]
+	var/bought_software = list()
 	// Software we have not bought
-	var/not_bought_software[0]
+	var/not_bought_software = list()
 
 	for(var/key in pai_software_by_key)
 		var/datum/pai_software/S = pai_software_by_key[key]
-		var/software_data[0]
+		var/software_data = list()
 		software_data["name"] = S.name
 		software_data["id"] = S.id
 		if(key in software)
@@ -74,9 +74,9 @@ var/global/list/default_pai_software = list()
 	data["available_ram"] = ram
 
 	// Emotions
-	var/emotions[0]
+	var/emotions = list()
 	for(var/name in pai_emotions)
-		var/emote[0]
+		var/emote = list()
 		emote["name"] = name
 		emote["id"] = pai_emotions[name]
 		emotions[LIST_PRE_INC(emotions)] = emote

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -50,16 +50,16 @@ var/global/list/default_pai_software = list()
 			if(ui) ui.set_status(STATUS_CLOSE, 0)
 		return
 
-	var/data = list()
+	var/list/data = list()
 
 	// Software we have bought
-	var/bought_software = list()
+	var/list/bought_software = list()
 	// Software we have not bought
-	var/not_bought_software = list()
+	var/list/not_bought_software = list()
 
 	for(var/key in pai_software_by_key)
 		var/datum/pai_software/S = pai_software_by_key[key]
-		var/software_data = list()
+		var/list/software_data = list()
 		software_data["name"] = S.name
 		software_data["id"] = S.id
 		if(key in software)
@@ -74,9 +74,9 @@ var/global/list/default_pai_software = list()
 	data["available_ram"] = ram
 
 	// Emotions
-	var/emotions = list()
+	var/list/emotions = list()
 	for(var/name in pai_emotions)
-		var/emote = list()
+		var/list/emote = list()
 		emote["name"] = name
 		emote["id"] = pai_emotions[name]
 		emotions[LIST_PRE_INC(emotions)] = emote

--- a/code/modules/mob/living/silicon/pai/software_modules.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules.dm
@@ -198,7 +198,7 @@
 
 
 /datum/pai_software/atmosphere_sensor/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui, force_open = TRUE)
-	var/data = list()
+	var/list/data = list()
 	var/turf/T = get_turf(user.loc)
 	if (!T)
 		data["reading"] = 0
@@ -214,9 +214,9 @@
 		data["temperature"] = round(env.temperature)
 		data["temperatureC"] = round(env.temperature-T0C)
 		var/t_moles = env.total_moles
-		var/gases = list()
+		var/list/gases = list()
 		for (var/g in env.gas)
-			var/gas = list()
+			var/list/gas = list()
 			gas["name"] = gas_data.name[g]
 			gas["percent"] = round((env.gas[g] / t_moles) * 100)
 			gases[LIST_PRE_INC(gases)] = gas

--- a/code/modules/mob/living/silicon/pai/software_modules.dm
+++ b/code/modules/mob/living/silicon/pai/software_modules.dm
@@ -40,7 +40,7 @@
 
 
 /datum/pai_software/directives/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui, force_open = TRUE)
-	var/data[0]
+	var/data = list()
 	data["master"] = user.master
 	data["dna"] = user.master_dna
 	data["prime"] = user.pai_law0
@@ -103,7 +103,7 @@
 
 
 /datum/pai_software/crew_manifest/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui, force_open = TRUE)
-	var/data[0]
+	var/data = list()
 	data["crew_manifest"] = html_crew_manifest()
 	ui = SSnano.try_update_ui(user, user, id, ui, data, force_open)
 	if (!ui)
@@ -121,7 +121,7 @@
 
 
 /datum/pai_software/door_jack/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui, force_open = TRUE)
-	var/data[0]
+	var/data = list()
 	data["cable"] = user.cable != null
 	data["machine"] = user.cable && (user.cable.machine != null)
 	data["inprogress"] = user.hackdoor != null
@@ -198,7 +198,7 @@
 
 
 /datum/pai_software/atmosphere_sensor/on_ui_interact(mob/living/silicon/pai/user, datum/nanoui/ui, force_open = TRUE)
-	var/data[0]
+	var/data = list()
 	var/turf/T = get_turf(user.loc)
 	if (!T)
 		data["reading"] = 0
@@ -214,9 +214,9 @@
 		data["temperature"] = round(env.temperature)
 		data["temperatureC"] = round(env.temperature-T0C)
 		var/t_moles = env.total_moles
-		var/gases[0]
+		var/gases = list()
 		for (var/g in env.gas)
-			var/gas[0]
+			var/gas = list()
 			gas["name"] = gas_data.name[g]
 			gas["percent"] = round((env.gas[g] / t_moles) * 100)
 			gases[LIST_PRE_INC(gases)] = gas

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -23,7 +23,7 @@
 		for(var/mob/O in viewers(M, null))
 			O.show_message(text(SPAN_WARNING("[user] has analyzed the floor's vitals!")), 1)
 		user.show_message(text(SPAN_NOTICE("Analyzing Results for The floor:\n\t Overall Status: Healthy")), 1)
-		user.show_message(text(SPAN_NOTICE("\t Damage Specifics: [0]-[0]-[0]-[0]")), 1)
+		user.show_message(text(SPAN_NOTICE("\t Damage Specifics: \[0\]-\[0\]-\[0\]-\[0\]")), 1)
 		user.show_message(SPAN_NOTICE("Key: Suffocation/Toxin/Burns/Brute"), 1)
 		user.show_message(SPAN_NOTICE("Body Temperature: ???"), 1)
 		return

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -32,7 +32,7 @@
 
 	var/static/list/eye_overlays
 	var/icontype 				//Persistent icontype tracking allows for cleaner icon updates
-	var/module_sprites[0] 		//Used to store the associations between sprite names and sprite index.
+	var/module_sprites = list() 		//Used to store the associations between sprite names and sprite index.
 	var/icon_selected = 1		//If icon selection has been completed yet
 	var/icon_selection_tries = 0//Remaining attempts to select icon before a selection is forced
 

--- a/code/modules/modular_computers/file_system/programs/antagonist/access_decrypter.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/access_decrypter.dm
@@ -128,7 +128,7 @@
 
 		// Stolen from DOS traffic generator, generates strings of 1s and 0s
 		var/percentage = (PRG.progress / PRG.target_progress) * 100
-		var/list/strings[0]
+		var/list/strings = list()
 		for(var/j, j<10, j++)
 			var/string = ""
 			for(var/i, i<20, i++)

--- a/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
+++ b/code/modules/modular_computers/file_system/programs/antagonist/dos.dm
@@ -54,7 +54,7 @@
 		// Probability of 1 is equal of completion percentage of DoS attack on this relay.
 		// Combined with UI updates this adds quite nice effect to the UI
 		var/percentage = PRG.target.dos_overload * 100 / PRG.target.dos_capacity
-		var/list/strings[0]
+		var/list/strings = list()
 		for(var/j, j<10, j++)
 			var/string = ""
 			for(var/i, i<20, i++)
@@ -62,7 +62,7 @@
 			strings.Add(string)
 		data["dos_strings"] = strings
 	else
-		var/list/relays[0]
+		var/list/relays = list()
 		for(var/obj/machinery/ntnet_relay/R in ntnet_global.relays)
 			relays.Add(R.uid)
 		data["relays"] = relays

--- a/code/modules/modular_computers/file_system/programs/engineering/alarm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/alarm_monitor.dm
@@ -106,13 +106,13 @@
 /datum/nano_module/alarm_monitor/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/topic_state/state = GLOB.default_state)
 	var/list/data = host.initial_data()
 
-	var/categories = list()
+	var/list/categories = list()
 	for(var/datum/alarm_handler/AH in alarm_handlers)
 		categories[LIST_PRE_INC(categories)] = list("category" = AH.category, "alarms" = list())
 		for(var/datum/alarm/A in AH.major_alarms(get_host_z()))
 
-			var/cameras = list()
-			var/lost_sources = list()
+			var/list/cameras = list()
+			var/list/lost_sources = list()
 
 			if(isAI(user))
 				for(var/obj/machinery/camera/C in A.cameras())

--- a/code/modules/modular_computers/file_system/programs/engineering/alarm_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/alarm_monitor.dm
@@ -106,13 +106,13 @@
 /datum/nano_module/alarm_monitor/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/topic_state/state = GLOB.default_state)
 	var/list/data = host.initial_data()
 
-	var/categories[0]
+	var/categories = list()
 	for(var/datum/alarm_handler/AH in alarm_handlers)
 		categories[LIST_PRE_INC(categories)] = list("category" = AH.category, "alarms" = list())
 		for(var/datum/alarm/A in AH.major_alarms(get_host_z()))
 
-			var/cameras[0]
-			var/lost_sources[0]
+			var/cameras = list()
+			var/lost_sources = list()
 
 			if(isAI(user))
 				for(var/obj/machinery/camera/C in A.cameras())

--- a/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
@@ -50,9 +50,9 @@
 
 /datum/nano_module/atmos_control/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, master_ui = null, datum/topic_state/state = GLOB.default_state)
 	var/list/data = host.initial_data()
-	var/alarms = list()
-	var/alarmsAlert = list()
-	var/alarmsDanger = list()
+	var/list/alarms = list()
+	var/list/alarmsAlert = list()
+	var/list/alarmsDanger = list()
 
 	// TODO: Move these to a cache, similar to cameras
 	for(var/obj/machinery/alarm/alarm in (length(monitored_alarms) ? monitored_alarms : SSmachines.machinery))

--- a/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
@@ -50,9 +50,9 @@
 
 /datum/nano_module/atmos_control/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, master_ui = null, datum/topic_state/state = GLOB.default_state)
 	var/list/data = host.initial_data()
-	var/alarms[0]
-	var/alarmsAlert[0]
-	var/alarmsDanger[0]
+	var/alarms = list()
+	var/alarmsAlert = list()
+	var/alarmsDanger = list()
 
 	// TODO: Move these to a cache, similar to cameras
 	for(var/obj/machinery/alarm/alarm in (length(monitored_alarms) ? monitored_alarms : SSmachines.machinery))

--- a/code/modules/modular_computers/file_system/programs/engineering/rcon_console.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/rcon_console.dm
@@ -28,7 +28,7 @@
 	var/list/data = host.initial_data()
 
 	// SMES DATA (simplified view)
-	var/list/smeslist[0]
+	var/list/smeslist = list()
 	for(var/obj/machinery/power/smes/buildable/SMES in known_SMESs)
 		smeslist.Add(list(list(
 		"charge" = round(SMES.Percentage()),
@@ -44,7 +44,7 @@
 	data["smes_info"] = sortByKey(smeslist, "RCON_tag")
 
 	// BREAKER DATA (simplified view)
-	var/list/breakerlist[0]
+	var/list/breakerlist = list()
 	for(var/obj/machinery/power/breakerbox/BR in known_breakers)
 		breakerlist.Add(list(list(
 		"RCON_tag" = BR.RCon_tag,

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -55,7 +55,7 @@
 	data["current_camera"] = current_camera ? current_camera.nano_structure() : null
 	data["current_network"] = current_network
 
-	var/list/all_networks[0]
+	var/list/all_networks = list()
 	for(var/network in GLOB.using_map.station_networks)
 		all_networks.Add(list(list(
 							"tag" = network,

--- a/code/modules/modular_computers/file_system/programs/generic/configurator.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/configurator.dm
@@ -40,7 +40,7 @@
 	var/obj/item/stock_parts/computer/nano_printer/nano_printer = program.computer.get_component(/obj/item/stock_parts/computer/nano_printer)
 	data["print_language"] = nano_printer ? nano_printer.print_language : null
 
-	var/list/all_entries[0]
+	var/list/all_entries = list()
 	var/list/hardware = program.computer.get_all_components()
 	for(var/obj/item/stock_parts/computer/H in hardware)
 		all_entries.Add(list(list(

--- a/code/modules/modular_computers/file_system/programs/generic/file_browser.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/file_browser.dm
@@ -116,7 +116,7 @@
 		if(!PRG.computer || !PRG.computer.has_component(PART_HDD))
 			data["error"] = "I/O ERROR: Unable to access hard drive."
 		else
-			var/list/files[0]
+			var/list/files = list()
 			for(var/datum/computer_file/F in PRG.computer.get_all_files())
 				files.Add(list(list(
 					"name" = F.filename,
@@ -128,7 +128,7 @@
 			var/obj/item/stock_parts/computer/hard_drive/portable/RHDD = PRG.computer.get_component(PART_DRIVE)
 			if(RHDD)
 				data["usbconnected"] = TRUE
-				var/list/usbfiles[0]
+				var/list/usbfiles = list()
 				for(var/datum/computer_file/F in PRG.computer.get_all_files(disk = RHDD))
 					usbfiles.Add(list(list(
 						"name" = F.filename,

--- a/code/modules/modular_computers/file_system/programs/generic/library.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/library.dm
@@ -34,7 +34,7 @@ The answer was five and a half years -ZeroBits
 	else if(current_book)
 		data["current_book"] = current_book
 	else
-		var/list/all_entries[0]
+		var/list/all_entries = list()
 		establish_old_db_connection()
 		if(!dbcon_old.IsConnected())
 			error_message = "Unable to contact External Archive. Please contact your system administrator for assistance."

--- a/code/modules/modular_computers/file_system/programs/generic/ntdownloader.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntdownloader.dm
@@ -20,7 +20,7 @@
 	var/download_completion = 0
 	var/download_netspeed = 0
 	var/downloaderror = ""
-	var/list/downloads_queue[0]
+	var/list/downloads_queue = list()
 	/// For logging, can be faked by antags.
 	var/file_info
 	var/server
@@ -155,9 +155,9 @@
 
 	data["disk_size"] = program.computer.max_disk_capacity()
 	data["disk_used"] = program.computer.used_disk_capacity()
-	var/list/all_entries[0]
+	var/list/all_entries = list()
 	for(var/category in ntnet_global.available_software_by_category)
-		var/list/category_list[0]
+		var/list/category_list = list()
 		for(var/datum/computer_file/program/P in ntnet_global.available_software_by_category[category])
 			// Only those programs our user can run will show in the list
 			if(!P.can_run(user) && P.requires_access_to_download)
@@ -176,7 +176,7 @@
 
 	data["hackedavailable"] = FALSE
 	if(prog.computer.emagged()) // If we are running on emagged computer we have access to some "bonus" software
-		var/list/hacked_programs[0]
+		var/list/hacked_programs = list()
 		for(var/datum/computer_file/program/P in ntnet_global.available_antag_software)
 			data["hackedavailable"] = TRUE
 			hacked_programs.Add(list(list(

--- a/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/ntnrc_client.dm
@@ -229,13 +229,13 @@
 	data["adminmode"] = C.netadmin_mode
 	if(C.channel)
 		data["title"] = C.channel.title
-		var/list/messages[0]
+		var/list/messages = list()
 		for(var/M in C.channel.messages)
 			messages.Add(list(list(
 				"msg" = M
 			)))
 		data["messages"] = messages
-		var/list/clients[0]
+		var/list/clients = list()
 		for(var/datum/computer_file/program/chatclient/cl in C.channel.clients)
 			clients.Add(list(list(
 				"name" = cl.username
@@ -245,7 +245,7 @@
 		data["is_operator"] = C.operator_mode || C.netadmin_mode
 
 	else // Channel selection screen
-		var/list/all_channels[0]
+		var/list/all_channels = list()
 		var/turf/turf = get_turf(C.computer.get_physical_host())
 		var/list/connected_zs = GetConnectedZlevels(turf.z)
 		for(var/datum/ntnet_conversation/conv in ntnet_global.chat_channels)

--- a/code/modules/modular_computers/file_system/programs/generic/nttransfer.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/nttransfer.dm
@@ -120,7 +120,7 @@ var/global/nttransfer_uid = 0
 		data["upload_haspassword"] = PRG.server_password ? TRUE : FALSE
 		data["upload_filename"] = "[PRG.provided_file.filename].[PRG.provided_file.filetype]"
 	else if (PRG.upload_menu)
-		var/list/all_files[0]
+		var/list/all_files = list()
 		for(var/datum/computer_file/F in PRG.computer.get_all_files())
 			all_files.Add(list(list(
 				"uid" = F.uid,
@@ -129,7 +129,7 @@ var/global/nttransfer_uid = 0
 			)))
 		data["upload_filelist"] = all_files
 	else
-		var/list/all_servers[0]
+		var/list/all_servers = list()
 		for(var/datum/computer_file/program/nttransfer/P in ntnet_global.fileservers)
 			if(!P.provided_file)
 				continue

--- a/code/modules/modular_computers/file_system/programs/generic/supply.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/supply.dm
@@ -95,9 +95,9 @@
 
 		if(4)// Order processing
 			if(is_admin) // No bother sending all of this if the user can't see it.
-				var/list/cart[0]
-				var/list/requests[0]
-				var/list/done[0]
+				var/list/cart = list()
+				var/list/requests = list()
+				var/list/done = list()
 				for(var/datum/supply_order/SO in SSsupply.shoppinglist)
 					cart.Add(order_to_nanoui(SO, SUPPLY_LIST_ID_CART))
 				for(var/datum/supply_order/SO in SSsupply.requestlist)
@@ -320,7 +320,7 @@
 		if(!sp.is_category())
 			continue // No children
 		category_names.Add(sp.name)
-		var/list/category[0]
+		var/list/category = list()
 		for(var/singleton/hierarchy/supply_pack/spc in sp.get_descendents())
 			if((spc.hidden || spc.contraband || !spc.sec_available()) && !emagged)
 				continue

--- a/code/modules/modular_computers/file_system/programs/generic/wordprocessor.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/wordprocessor.dm
@@ -146,7 +146,7 @@
 		if(!PRG.computer || !PRG.computer.has_component(PART_HDD))
 			data["error"] = "I/O ERROR: Unable to access hard drive."
 		else
-			var/list/files[0]
+			var/list/files = list()
 			for(var/datum/computer_file/F in PRG.computer.get_all_files())
 				if(F.filetype == "TXT")
 					files.Add(list(list(
@@ -158,7 +158,7 @@
 			var/obj/item/stock_parts/computer/hard_drive/portable/RHDD = PRG.computer.get_component(PART_DRIVE)
 			if(RHDD)
 				data["usbconnected"] = TRUE
-				var/list/usbfiles[0]
+				var/list/usbfiles = list()
 				for(var/datum/computer_file/F in PRG.computer.get_all_files(disk = RHDD))
 					if(F.filetype == "TXT")
 						usbfiles.Add(list(list(

--- a/code/modules/modular_computers/file_system/programs/research/ai_restorer.dm
+++ b/code/modules/modular_computers/file_system/programs/research/ai_restorer.dm
@@ -112,7 +112,7 @@
 		data["ai_isdamaged"] = (A.hardware_integrity() < 100) || (A.backup_capacitor() < 100)
 		data["ai_isdead"] = (A.is_dead())
 
-		var/list/all_laws[0]
+		var/list/all_laws = list()
 		for(var/datum/ai_law/L in A.laws.all_laws())
 			all_laws.Add(list(list(
 			"index" = L.index,

--- a/code/modules/modular_computers/laptop_vendor.dm
+++ b/code/modules/modular_computers/laptop_vendor.dm
@@ -246,7 +246,7 @@
 			ui.close()
 		return 0
 
-	var/list/data[0]
+	var/list/data = list()
 	data["state"] = state
 	if(state == 1)
 		data["devtype"] = devtype

--- a/code/modules/nano/modules/law_manager.dm
+++ b/code/modules/nano/modules/law_manager.dm
@@ -148,7 +148,7 @@
 	return 0
 
 /datum/nano_module/law_manager/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/topic_state/state = GLOB.default_state)
-	var/data = list()
+	var/list/data = list()
 	owner.lawsync()
 
 	data["ion_law_nr"] = ionnum()
@@ -169,7 +169,7 @@
 	data["isAdmin"] = isadmin(user)
 	data["view"] = current_view
 
-	var/channels = list()
+	var/list/channels = list()
 	for (var/ch_name in owner.law_channels())
 		channels[LIST_PRE_INC(channels)] = list("channel" = ch_name)
 	data["channel"] = owner.lawchannel
@@ -184,14 +184,14 @@
 		ui.set_auto_update(1)
 
 /datum/nano_module/law_manager/proc/package_laws(list/data, field, list/datum/ai_law/laws)
-	var/packaged_laws = list()
+	var/list/packaged_laws = list()
 	for(var/datum/ai_law/AL in laws)
 		packaged_laws[LIST_PRE_INC(packaged_laws)] = list("law" = AL.law, "index" = AL.get_index(), "state" = owner.laws.get_state_law(AL), "ref" = "\ref[AL]")
 	data[field] = packaged_laws
 	data["has_[field]"] = length(packaged_laws)
 
 /datum/nano_module/law_manager/proc/package_multiple_laws(list/datum/ai_laws/laws)
-	var/law_sets = list()
+	var/list/law_sets = list()
 	for(var/datum/ai_laws/ALs in laws)
 		var/packaged_laws = list()
 		package_laws(packaged_laws, "zeroth_laws", list(ALs.zeroth_law, ALs.zeroth_law_borg))

--- a/code/modules/nano/modules/law_manager.dm
+++ b/code/modules/nano/modules/law_manager.dm
@@ -148,7 +148,7 @@
 	return 0
 
 /datum/nano_module/law_manager/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/topic_state/state = GLOB.default_state)
-	var/data[0]
+	var/data = list()
 	owner.lawsync()
 
 	data["ion_law_nr"] = ionnum()
@@ -169,7 +169,7 @@
 	data["isAdmin"] = isadmin(user)
 	data["view"] = current_view
 
-	var/channels[0]
+	var/channels = list()
 	for (var/ch_name in owner.law_channels())
 		channels[LIST_PRE_INC(channels)] = list("channel" = ch_name)
 	data["channel"] = owner.lawchannel
@@ -184,16 +184,16 @@
 		ui.set_auto_update(1)
 
 /datum/nano_module/law_manager/proc/package_laws(list/data, field, list/datum/ai_law/laws)
-	var/packaged_laws[0]
+	var/packaged_laws = list()
 	for(var/datum/ai_law/AL in laws)
 		packaged_laws[LIST_PRE_INC(packaged_laws)] = list("law" = AL.law, "index" = AL.get_index(), "state" = owner.laws.get_state_law(AL), "ref" = "\ref[AL]")
 	data[field] = packaged_laws
 	data["has_[field]"] = length(packaged_laws)
 
 /datum/nano_module/law_manager/proc/package_multiple_laws(list/datum/ai_laws/laws)
-	var/law_sets[0]
+	var/law_sets = list()
 	for(var/datum/ai_laws/ALs in laws)
-		var/packaged_laws[0]
+		var/packaged_laws = list()
 		package_laws(packaged_laws, "zeroth_laws", list(ALs.zeroth_law, ALs.zeroth_law_borg))
 		package_laws(packaged_laws, "ion_laws", ALs.ion_laws)
 		package_laws(packaged_laws, "inherent_laws", ALs.inherent_laws)

--- a/code/modules/nano/nanoui.dm
+++ b/code/modules/nano/nanoui.dm
@@ -32,7 +32,7 @@ nanoui is used to open and update nano browser uis
 	// the list of javascript scripts to use for this ui
 	var/list/scripts = list()
 	// a list of templates which can be used with this ui
-	var/templates[0]
+	var/templates = list()
 	// the layout key for this ui (this is used on the frontend, leave it as "default" unless you know what you're doing)
 	var/layout_key = "default"
 	// optional layout key for additional ui header content to include
@@ -48,7 +48,7 @@ nanoui is used to open and update nano browser uis
 	// the map z level to display
 	var/map_z_level = 1
 	// initial data, containing the full data structure, must be sent to the ui (the data structure cannot be extended later on)
-	var/list/initial_data[0]
+	var/list/initial_data = list()
 	// set to 1 to update the ui automatically every master_controller tick
 	var/is_auto_updating = 0
 	// the current status/visibility of the ui

--- a/code/modules/overmap/disperser/disperser_console.dm
+++ b/code/modules/overmap/disperser/disperser_console.dm
@@ -154,7 +154,7 @@
 		display_reconnect_dialog(user, "disperser synchronization")
 		return
 
-	var/data[0]
+	var/data = list()
 
 	if (!link_parts())
 		data["faillink"] = TRUE

--- a/code/modules/overmap/ships/computers/engine_control.dm
+++ b/code/modules/overmap/ships/computers/engine_control.dm
@@ -13,15 +13,15 @@
 		display_reconnect_dialog(user, "ship control systems")
 		return
 
-	var/data[0]
+	var/data = list()
 	data["state"] = display_state
 	data["global_state"] = linked.engines_state
 	data["global_limit"] = round(linked.thrust_limit*100)
 	var/total_thrust = 0
 
-	var/list/enginfo[0]
+	var/list/enginfo = list()
 	for(var/datum/ship_engine/E in linked.engines)
-		var/list/rdata[0]
+		var/list/rdata = list()
 		rdata["eng_type"] = E.name
 		rdata["eng_on"] = E.is_on()
 		rdata["eng_thrust"] = E.get_thrust()

--- a/code/modules/overmap/ships/computers/helm.dm
+++ b/code/modules/overmap/ships/computers/helm.dm
@@ -92,7 +92,7 @@ GLOBAL_LIST_EMPTY(overmap_helm_computers)
 		return 1
 
 /obj/machinery/computer/ship/helm/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
+	var/data = list()
 
 	if(!linked)
 		display_reconnect_dialog(user, "helm")
@@ -131,10 +131,10 @@ GLOBAL_LIST_EMPTY(overmap_helm_computers)
 		else
 			data["ETAnext"] = "N/A"
 
-		var/list/locations[0]
+		var/list/locations = list()
 		for (var/key in known_sectors)
 			var/datum/computer_file/data/waypoint/R = known_sectors[key]
-			var/list/rdata[0]
+			var/list/rdata = list()
 			rdata["name"] = R.fields["name"]
 			rdata["x"] = R.fields["x"]
 			rdata["y"] = R.fields["y"]
@@ -340,7 +340,7 @@ GLOBAL_LIST_EMPTY(overmap_helm_computers)
 		display_reconnect_dialog(user, "Navigation")
 		return
 
-	var/data[0]
+	var/data = list()
 
 
 	var/turf/T = get_turf(linked)

--- a/code/modules/overmap/ships/computers/sensors.dm
+++ b/code/modules/overmap/ships/computers/sensors.dm
@@ -104,7 +104,7 @@
 		display_reconnect_dialog(user, "sensors")
 		return
 
-	var/data[0]
+	var/data = list()
 
 	var/obj/machinery/shipsensors/sensors = get_sensors()
 	data["viewing"] = viewing_overmap(user)

--- a/code/modules/paperwork/pen/chameleon_pen.dm
+++ b/code/modules/paperwork/pen/chameleon_pen.dm
@@ -2,17 +2,6 @@
 	var/signature = ""
 
 /obj/item/pen/chameleon/attack_self(mob/user as mob)
-	/*
-	// Limit signatures to official crew members
-	var/personnel_list[] = list()
-	for(var/datum/data/record/t in data_core.locked) //Look in data core locked.
-		personnel_list.Add(t.fields["name"])
-	personnel_list.Add("Anonymous")
-
-	var/new_signature = input("Enter new signature pattern.", "New Signature") as null|anything in personnel_list
-	if(new_signature)
-		signature = new_signature
-	*/
 	signature = sanitize(input("Enter new signature. Leave blank for 'Anonymous'", "New Signature", signature))
 
 /obj/item/pen/proc/get_signature(mob/user)

--- a/code/modules/power/cell_rack.dm
+++ b/code/modules/power/cell_rack.dm
@@ -197,7 +197,7 @@
 		least.give(most.use(celldiff))
 
 /obj/machinery/power/smes/batteryrack/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
+	var/data = list()
 
 	data["mode"] = mode
 	data["transfer_max"] = max_transfer_rate
@@ -210,14 +210,14 @@
 	var/list/cells = list()
 	var/cell_index = 1
 	for(var/obj/item/cell/C in internal_cells)
-		var/list/cell[0]
+		var/list/cell = list()
 		cell["slot"] = cell_index
 		cell["used"] = 1
 		cell["percentage"] = round(C.percent(), 0.01)
 		cell_index++
 		cells += list(cell)
 	while(cell_index <= PSU_MAXCELLS)
-		var/list/cell[0]
+		var/list/cell = list()
 		cell["slot"] = cell_index
 		cell["used"] = 0
 		cell_index++

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -178,7 +178,7 @@
 	if (dir == NORTH || dir == SOUTH)
 		vertical = 1
 
-	var/data[0]
+	var/data = list()
 	data["totalOutput"] = effective_gen/1000
 	data["maxTotalOutput"] = max_power/1000
 	data["thermalOutput"] = last_thermal_gen/1000

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -325,7 +325,7 @@
 	if(IsBroken())
 		return
 
-	var/data[0]
+	var/data = list()
 	data["active"] = active
 	if(istype(user, /mob/living/silicon/ai))
 		data["is_ai"] = 1

--- a/code/modules/power/smes.dm
+++ b/code/modules/power/smes.dm
@@ -263,7 +263,7 @@
 
 /obj/machinery/power/smes/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
 	// this is the data which will be sent to the ui
-	var/data[0]
+	var/data = list()
 	data["nameTag"] = name_tag
 	data["storedCapacity"] = Percentage()
 	data["storedCapacityAbs"] = round(charge/1000, 0.1)

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -119,11 +119,11 @@
 
 /obj/machinery/chemical_dispenser/ui_interact(mob/user, ui_key = "main",datum/nanoui/ui = null, force_open = 1)
 	// this is the data which will be sent to the ui
-	var/data[0]
+	var/data = list()
 	data["amount"] = amount
 	data["isBeakerLoaded"] = container ? 1 : 0
 	data["glass"] = accept_drinking
-	var beakerD[0]
+	var beakerD = list()
 	if(container && container.reagents && length(container.reagents.reagent_list))
 		for(var/datum/reagent/R in container.reagents.reagent_list)
 			beakerD[LIST_PRE_INC(beakerD)] = list("name" = R.name, "volume" = R.volume)
@@ -136,7 +136,7 @@
 		data["beakerCurrentVolume"] = null
 		data["beakerMaxVolume"] = null
 
-	var chemicals[0]
+	var chemicals = list()
 	for(var/label in cartridges)
 		var/obj/item/reagent_containers/chem_disp_cartridge/C = cartridges[label]
 		chemicals[LIST_PRE_INC(chemicals)] = list("label" = label, "amount" = C.reagents.total_volume)

--- a/code/modules/reagents/dispenser/dispenser2.dm
+++ b/code/modules/reagents/dispenser/dispenser2.dm
@@ -119,11 +119,11 @@
 
 /obj/machinery/chemical_dispenser/ui_interact(mob/user, ui_key = "main",datum/nanoui/ui = null, force_open = 1)
 	// this is the data which will be sent to the ui
-	var/data = list()
+	var/list/data = list()
 	data["amount"] = amount
 	data["isBeakerLoaded"] = container ? 1 : 0
 	data["glass"] = accept_drinking
-	var beakerD = list()
+	var/list/beakerD = list()
 	if(container && container.reagents && length(container.reagents.reagent_list))
 		for(var/datum/reagent/R in container.reagents.reagent_list)
 			beakerD[LIST_PRE_INC(beakerD)] = list("name" = R.name, "volume" = R.volume)
@@ -136,7 +136,7 @@
 		data["beakerCurrentVolume"] = null
 		data["beakerMaxVolume"] = null
 
-	var chemicals = list()
+	var/list/chemicals = list()
 	for(var/label in cartridges)
 		var/obj/item/reagent_containers/chem_disp_cartridge/C = cartridges[label]
 		chemicals[LIST_PRE_INC(chemicals)] = list("label" = label, "amount" = C.reagents.total_volume)

--- a/code/modules/shield_generators/shield_generator.dm
+++ b/code/modules/shield_generators/shield_generator.dm
@@ -243,7 +243,7 @@
 		spinup_counter = round(spinup_delay / idle_multiplier)
 
 /obj/machinery/power/shield_generator/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
+	var/data = list()
 
 	data["running"] = running
 	data["modes"] = get_flag_descriptions()

--- a/code/modules/shuttles/escape_pods.dm
+++ b/code/modules/shuttles/escape_pods.dm
@@ -54,7 +54,7 @@ var/global/list/escape_pods_by_name = list()
 	var/tag_pump
 
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
+	var/data = list()
 	var/datum/computer/file/embedded_program/docking/simple/docking_program = program
 
 	data = list(
@@ -92,7 +92,7 @@ var/global/list/escape_pods_by_name = list()
 	program = /datum/computer/file/embedded_program/docking/simple/escape_pod_berth
 
 /obj/machinery/embedded_controller/radio/simple_docking_controller/escape_pod_berth/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
+	var/data = list()
 	var/datum/computer/file/embedded_program/docking/simple/docking_program = program
 
 	var/armed = null

--- a/code/modules/shuttles/shuttle_emergency.dm
+++ b/code/modules/shuttles/shuttle_emergency.dm
@@ -171,7 +171,7 @@
 	return ..()
 
 /obj/machinery/computer/shuttle_control/emergency/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
+	var/data = list()
 	var/datum/shuttle/autodock/ferry/emergency/shuttle = SSshuttle.shuttles[shuttle_tag]
 	if (!istype(shuttle))
 		return

--- a/code/modules/shuttles/shuttle_specops.dm
+++ b/code/modules/shuttles/shuttle_specops.dm
@@ -104,7 +104,7 @@
 	return ..()
 
 /datum/shuttle/autodock/ferry/specops/proc/sleep_until_launch()
-	var/message_tracker[] = list(0,1,2,3,5,10,30,45)//Create a a list with potential time values.
+	var/list/message_tracker = list(0,1,2,3,5,10,30,45)//Create a a list with potential time values.
 
 	var/launch_time = world.time + specops_countdown_time
 	var/time_until_launch
@@ -151,7 +151,7 @@
 
 		sleep(10)
 
-		var/spawn_marauder[] = new()
+		var/list/spawn_marauder = list()
 		for(var/obj/landmark/L in world)
 			if(L.name == "Marauder Entry")
 				spawn_marauder.Add(L)

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -486,7 +486,7 @@
 
 // This is purely informational UI that may be accessed by AIs or robots
 /obj/machinery/power/supermatter/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1)
-	var/data[0]
+	var/data = list()
 
 	data["integrity_percentage"] = round(get_integrity())
 	var/datum/gas_mixture/env = null

--- a/code/modules/xenoarcheaology/tools/geosample_scanner.dm
+++ b/code/modules/xenoarcheaology/tools/geosample_scanner.dm
@@ -131,7 +131,7 @@
 		return
 
 	// this is the data which will be sent to the ui
-	var/data[0]
+	var/data = list()
 	data["scanned_item"] = (scanned_item ? scanned_item.name : "")
 	data["scanned_item_desc"] = (scanned_item ? (scanned_item.desc ? scanned_item.desc : "No information on record.") : "")
 	data["last_scan_data"] = last_scan_data

--- a/code/procs/dbcore.dm
+++ b/code/procs/dbcore.dm
@@ -88,7 +88,7 @@
 	var/default_cursor
 	var/list/columns //list of DB Columns populated by Columns()
 	var/list/conversions
-	var/list/item[0]  //list of data values populated by NextRow()
+	var/list/item = list()  //list of data values populated by NextRow()
 
 	var/DBConnection/db_connection
 	var/_db_query


### PR DESCRIPTION
nufc - just some further work on style consistency

here, I'm removing uses of the `var/blah[]` (equivalent to `var/list/blah`) and `var/blah[0]` (equivalent to `var/list/blah = new(0)`) forms to declare list vars. These provide hinting invisibly, and should be avoided as less clear than the full type form. I haven't touched anywhere there are `[N]` (rather than 0) initializations - mostly because I forgot to before opening the PR ;B

Will be squashing once it's 👌
