### PR TITLE
prevent runtime spawn/build/create of more invalid types

### DIFF
--- a/code/_helpers/types.dm
+++ b/code/_helpers/types.dm
@@ -38,3 +38,19 @@
 			return list()
 		thing = thing.type
 	return typesof_real(thing) - thing
+
+
+/// Returns a reason if path is something that should not be spawned, build moded, etc.
+/proc/prevent_spawn_reason(path) as text
+	if (!ispath(path, /atom/movable) && !ispath(path, /turf))
+		return "not a turf or movable"
+	var/list/base_types = list(
+		/atom/movable,
+		/turf,
+		/obj,
+		/mob
+	)
+	if (path in base_types)
+		return "is a base type"
+	if (is_abstract(path))
+		return "is abstract"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -1122,7 +1122,10 @@ GLOBAL_VAR_AS(skip_allow_lists, FALSE)
 		chosen = input("Select an atom type", "Spawn Atom", matches[1]) as null|anything in matches
 		if(!chosen)
 			return
-
+	var/reason = prevent_spawn_reason(chosen)
+	if (reason)
+		to_chat(usr, SPAN_WARNING("Cannot create a [chosen] - [reason]"))
+		return
 	if(ispath(chosen,/turf))
 		var/turf/T = get_turf(usr.loc)
 		T.ChangeTurf(chosen)

--- a/code/modules/admin/buildmode/build.dm
+++ b/code/modules/admin/buildmode/build.dm
@@ -18,7 +18,15 @@
 	to_chat(user, help_text)
 
 /datum/build_mode/build/Configurate()
-	build_type = select_subpath(build_type || /obj/item/latexballon)
+	var/selected = select_subpath(build_type || /obj/item/latexballon)
+	if (!selected)
+		return
+	var/reason = prevent_spawn_reason(selected)
+	if (reason)
+		to_chat(user, SPAN_WARNING("Cannot create a [selected] - [reason]"))
+		build_type = null
+		return
+	build_type = selected
 	to_chat(user, "Selected Type [build_type]")
 
 /datum/build_mode/build/OnClick(atom/target, list/parameters)
@@ -50,14 +58,11 @@
 			return
 		if (!location)
 			return
-		else if (ispath(build_type, /turf))
+		if (ispath(build_type, /turf))
 			location.ChangeTurf(build_type)
-		else if (ispath(build_type, /area))
-			to_chat(user, SPAN_WARNING("Do not use this to create or modify areas. Use the Area build mode category instead."))
 			return
-		else
-			var/atom/instance = new build_type (location)
-			instance.set_dir(host.dir)
+		var/atom/instance = new build_type (location)
+		instance.set_dir(host.dir)
 
 /datum/build_mode/build/CanUseTopic(mob/user)
 	if (!isadmin(user))

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1672,25 +1672,10 @@
 
 		for(var/dirty_path in dirty_paths)
 			var/path = text2path(dirty_path)
-			if(!path)
+			if (prevent_spawn_reason(path))
 				removed_paths += dirty_path
-				continue
-			else if(!ispath(path, /obj) && !ispath(path, /turf) && !ispath(path, /mob))
-				removed_paths += dirty_path
-				continue
-			else if(ispath(path, /obj/item/gun/energy/pulse_rifle))
-				if(!check_rights(R_FUN,0))
-					removed_paths += dirty_path
-					continue
-			else if(ispath(path, /obj/item/melee/energy/blade))//Not an item one should be able to spawn./N
-				if(!check_rights(R_FUN,0))
-					removed_paths += dirty_path
-					continue
-			else if(ispath(path, /obj/bhole))
-				if(!check_rights(R_FUN,0))
-					removed_paths += dirty_path
-					continue
-			paths += path
+			else
+				paths += path
 
 		if(!paths)
 			alert("The path list you sent is empty")


### PR DESCRIPTION
:cl:
admin: Build Mode, Spawn, and Game Panel - Create, no longer allow base and abstract types to be instantiated.
/:cl: