### PR TITLE
Grabbag of more use-in-world interactions

### DIFF
--- a/code/game/objects/items/devices/boombox.dm
+++ b/code/game/objects/items/devices/boombox.dm
@@ -39,6 +39,8 @@
 /obj/item/boombox/MouseDrop(mob/user)
 	jukebox.ui_interact(user)
 
+/obj/item/boombox/use_in_world(mob/user)
+	jukebox.ui_interact(user)
 
 /obj/item/boombox/emp_act(severity)
 	if (GET_FLAGS(boombox_flags, BOOMBOX_BROKEN))

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -61,6 +61,9 @@
 	user.update_action_buttons()
 	return 1
 
+/obj/item/device/flashlight/use_in_world(mob/user)
+	attack_self(user)
+
 /obj/item/device/flashlight/proc/set_flashlight()
 	if(light_wedge)
 		set_dir(pick(NORTH, SOUTH, EAST, WEST))

--- a/code/modules/modular_computers/computers/modular_computer/interaction.dm
+++ b/code/modules/modular_computers/computers/modular_computer/interaction.dm
@@ -233,6 +233,9 @@
 	if(scanner)
 		scanner.do_on_afterattack(user, target, proximity)
 
+/obj/item/modular_computer/use_in_world(mob/user)
+	attack_self(user)
+
 /obj/item/modular_computer/CtrlAltClick(mob/user)
 	if(!CanPhysicallyInteract(user))
 		return FALSE


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: sowelipililimute
rscadd: Desk lamps can now be toggled with use-in-world (F)
rscadd: Modular computers (PDAs, tablets, laptops) can now be activated with use-in-world (F)
rscadd: Boomboxes can now have their UI opened with use-in-world (F)
/:cl:
