### PR TITLE
Fix for group activated cult runes

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -91,7 +91,7 @@
 
 /obj/rune/proc/get_cultists()
 	. = list()
-	for(var/mob/living/M in range(1))
+	for(var/mob/living/M in range(1, src))
 		if(iscultist(M))
 			. += M
 


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Some of the cultist runes require multiple people for their activation. Normally the number of cultists should be gathered from around the rune itself, but right now the number of cultists is counted from the location of usr.

It is not supposed to be this way, because it is implied by both the description of the runes
https://github.com/Baystation12/Baystation12/blob/03d73eb1858502e4c62d53ee0011f6139a74546f/code/game/gamemodes/cult/runes.dm#L441

and by their logic that cultists should gather around the rune, and not around the user of the rune. Some of this group activated runes have a delayed effect, like the tear reality rune and offering rune. Right now you can activate them and just walk off to somewhere else with a group of other cultists, and these runes will contiue to work, even if there is literally no one there near the rune.

Another example of how it can also fail now: one of the cultists initiates a tear veil rune and goes away to battle somewhere outside, thinking that the number of cultists around the rune is already sufficient, only to realize that the rune cast fails without him.

:cl: Builder13
bugfix: Fixed an issue where group activation cult runes counted the number of cultists around the initiator, and not around the rune itself.
/:cl: