### PR TITLE
Custom events are less HTML-y

### DIFF
--- a/code/modules/admin/verbs/custom_event.dm
+++ b/code/modules/admin/verbs/custom_event.dm
@@ -7,7 +7,7 @@
 		to_chat(src, "Only administrators may use this command.")
 		return
 
-	var/input = sanitize(input(usr, "Enter the description of the event. Be descriptive. To cancel the event, make this blank or hit cancel.", "Event", config.event) as message|null, MAX_BOOK_MESSAGE_LEN, extra = 0)
+	var/input = sanitize(input(usr, "Enter the description of the event. Be descriptive. To cancel the event, make this blank or hit cancel.", "Event", html_decode(config.event)) as message|null, MAX_BOOK_MESSAGE_LEN, extra = 0)
 	if(isnull(input))
 		config.event = ""
 		log_admin("[usr.key] has cleared the event text.")

--- a/code/modules/webhooks/webhook_custom_event.dm
+++ b/code/modules/webhooks/webhook_custom_event.dm
@@ -6,6 +6,6 @@
 	. = ..()
 	.["embeds"] = list(list(
 		"title" = "An event is beginning.",
-		"description" = (data && data["text"]) || "undefined",
+		"description" = (data && html_decode(data["text"])) || "undefined",
 		"color" = COLOR_WEBHOOK_DEFAULT
 	))


### PR DESCRIPTION
This spot feels a _bit_ kludgy but HTML handling in byond is crazy

:cl: Banditoz
admin: Custom events are less HTML-y when modifying existing and their webhooks render in Discord correctly.
/:cl:

<img width="975" height="382" alt="dreamseeker_kXzwvwNSlY" src="https://github.com/user-attachments/assets/5856c679-920d-43d5-a3fd-bda63391de7f" />
