### PR TITLE
Fix smart AIs crashing while their target is in space

### DIFF
--- a/code/modules/ai/ai_holder_combat_unseen.dm
+++ b/code/modules/ai/ai_holder_combat_unseen.dm
@@ -14,9 +14,13 @@
 			if (can_violently_breakthrough())
 				if(!breakthrough(target_last_seen_turf))
 					var/list/turf/search_turf_candidates = list()
-					for (var/turf/simulated/floor/search_turf in (range(vision_range, holder) + get_area_turfs(get_area(target_last_seen_turf))))
+					var/list/search_space = range(vision_range, holder)
+					if (!isspace(get_area(target_last_seen_turf)))
+						search_space += get_area_turfs(get_area(target_last_seen_turf))
+					for (var/turf/simulated/floor/search_turf in search_space)
 						search_turf_candidates += search_turf
-
+					if (!length(search_turf_candidates))
+						return
 					var/picked_turf = pick(search_turf_candidates)
 					ai_log("engage_unseen_enemy() : Searching for enemy at : [picked_turf]", AI_LOG_TRACE)
 					give_destination(picked_turf, 1, TRUE)


### PR DESCRIPTION
Think the crash issue is searching for target in all space turfs, wihch blows out memory/processing time.

Includes fleet armsman AIs

:cl: Banditoz
bugfix: Certain AIs should no longer crash the server while their target is in space.
/:cl: