### PR TITLE
Don't use flow style when generating changelog files from PRs

### DIFF
--- a/tools/changelog/generate_cl.py
+++ b/tools/changelog/generate_cl.py
@@ -86,6 +86,7 @@ for k, v in cl_list:
 if write_cl['changes']:
     with io.StringIO() as cl_contents:
         yaml.indent(sequence=4, offset=2)
+        yaml.default_flow_style = False
         yaml.dump(write_cl, cl_contents)
         cl_contents.seek(0)
 


### PR DESCRIPTION
The compactness from flow style is certainly not needed (despite being a default), and breaks YAML parsing when question marks are dumped.

Fixes #35384

### Explanation
There seems to be a flow [YAML style](https://www.yaml.info/learn/flowstyle.html) which is supposed to be more compact, but ruamel.yaml not handle question marks gracefully with map values in a list. The [ruamel.yaml](https://yaml.dev/doc/ruamel.yaml/) library the changelog generation script uses has the flow style as default.

Minimally reproducible example:
```py
from ruamel import yaml
import sys

test_obj = {"foo": "bar", "baz": [{"thing": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur?-_!@#%#()(*^$"}]}
yaml = yaml.YAML(typ='safe',pure=True)
#yaml.default_flow_style = False
yaml.indent(sequence=4, offset=2)
yaml.dump(test_obj, sys.stdout)
```
will produce:
```yaml
baz:
  - {thing: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
      Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
      eu fugiat nulla pariatur?-_!@#%#()(*^$'}
foo: bar
```
which is invalid YAML. Uncommenting the `default_flow_style` line will instead produce:
```yaml
baz:
  - thing: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam,
      quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
      Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore
      eu fugiat nulla pariatur?-_!@#%#()(*^$
foo: bar
```
which can be parsed without issue, preserving special characters (including the question mark)