### PR TITLE
throw_at now unbuckles mobs

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -358,6 +358,8 @@
 /**
  * Throws the atom at a given target.
  *
+ * If this is a mob, they will be unbuckled.
+ *
  * Initializes a `/datum/thrownthing` handling this atom and adds it to `SSthrowing`.
  *
  * **Parameters**:
@@ -374,6 +376,10 @@
 	. = TRUE
 	if (!target || speed <= 0 || QDELETED(src) || (target.z != src.z))
 		return FALSE
+
+	var/mob/mob = src
+	if (istype(mob) && mob.buckled)
+		mob.buckled.unbuckle_mob()
 
 	if (pulledby)
 		pulledby.stop_pulling()
@@ -561,7 +567,7 @@
  */
 /atom/movable/proc/post_movement(turf/old_turf, turf/new_turf)
 	return
-	
+
 /atom/movable/get_affecting_weather()
 	var/turf/my_turf = get_turf(src)
 	if(!istype(my_turf))


### PR DESCRIPTION
:cl: Banditoz
bugfix: Fixes some cases where a mob is phantom buckled to something, making unbuckling near impossible.
/:cl:

This fix is mostly a hunch, in a round, a player was buckled to a chair but was shifted to another chair when a meteor struck them.

Meteors [call](https://github.com/Baystation12/Baystation12/blob/6d6273a826acaad436c85b818856016410945f17/code/game/gamemodes/meteor/meteors.dm#L189-L192) `ex_act()` with either `EX_ACT_DEVASTATING` or `EX_ACT_HEAVY`, depending on the meteor type,
and humans can react to explosions by being [thrown around](https://github.com/Baystation12/Baystation12/blob/a9dd1337ce7c50e2f5353d2b2fb881a74ca3f565/code/modules/mob/living/carbon/human/human.dm#L102-L107). I couldn't find a "if buckled, then unbuckle" check there,
so I added it to the `throw_at` proc to potentially pre-emptively fix other bugs related to force-throwing buckled mobs.