### PR TITLE
Unlocks O3/O5 for EC Skrell

### DIFF
--- a/maps/torch/job/torch_jobs.dm
+++ b/maps/torch/job/torch_jobs.dm
@@ -13,7 +13,7 @@
 	species_to_job_blacklist = list(
 		/singleton/species/unathi  = list(HUMAN_ONLY_JOBS, /datum/job/liaison, /datum/job/warden), //Other jobs unavailable via branch restrictions,
 		/singleton/species/unathi/yeosa = list(HUMAN_ONLY_JOBS, /datum/job/liaison, /datum/job/warden),
-		/singleton/species/skrell  = list(HUMAN_ONLY_JOBS),
+		/singleton/species/skrell  = list(/datum/job/captain, /datum/job/representative, /datum/job/sea, /datum/job/pathfinder, /datum/job/rd),
 		/singleton/species/machine = list(HUMAN_ONLY_JOBS, /datum/job/liaison, /datum/job/psychiatrist, /datum/job/bridgeofficer, /datum/job/senior_engineer, /datum/job/warden, /datum/job/qm, /datum/job/senior_scientist, /datum/job/chief_steward),
 		/singleton/species/diona   = list(HUMAN_ONLY_JOBS, /datum/job/officer, /datum/job/liaison, /datum/job/warden, /datum/job/doctor, /datum/job/medical_trainee),	//Other jobs unavailable via branch restrictions,
 	)

--- a/maps/torch/torch_ranks.dm
+++ b/maps/torch/torch_ranks.dm
@@ -84,7 +84,9 @@
 				/datum/mil_rank/ec/e3,
 				/datum/mil_rank/ec/e5,
 				/datum/mil_rank/ec/e7,
-				/datum/mil_rank/ec/o1
+				/datum/mil_rank/ec/o1,
+				/datum/mil_rank/ec/o3,
+				/datum/mil_rank/ec/o5
 			)
 		),
 		/singleton/species/unathi = list(


### PR DESCRIPTION
🆑 Cakey
rscadd: Following the latest change in Expeditionary Corps structuring, SDTF Skrell are now eligible for O3 and O5 rankings via the exchange program. Research command roles remain in Human hands to maintain oversight.
/:cl:

Someone mentioned the other week how sad it is that we can't have a Skif to our Zap Brannigans, which got me thinking that it doesn't seem too unfeasible to have Skrell supporting in heads of staff roles. Seemed like a good opportunity given the ongoing lore happenings to try this PR out and see what loremins think.

I kept CSO and Pathfinder human-only but that was just a gut feeling and can be changed if necessary.