### PR TITLE
Fix two pAI bugs

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -79,6 +79,7 @@ GLOBAL_LIST_AS(possible_say_verbs, list(
 	light_wedge = LIGHT_OMNI
 
 	hud_type = /datum/hud/pai
+	status_flags = NO_ANTAG
 
 
 /mob/living/silicon/pai/Destroy()
@@ -89,7 +90,6 @@ GLOBAL_LIST_AS(possible_say_verbs, list(
 
 /mob/living/silicon/pai/Initialize(mapload, obj/item/device/paicard)
 	. = ..()
-	status_flags |= NO_ANTAG
 	add_language(LANGUAGE_HUMAN_EURO, TRUE)
 	verbs -= /mob/living/verb/ghost
 	software = default_pai_software.Copy()
@@ -316,6 +316,8 @@ GLOBAL_LIST_AS(possible_say_verbs, list(
 	if(.)
 		var/obj/item/holder/H = .
 		if(istype(H))
+			if(resting)
+				lay_down()
 			H.item_state = "pai-[icon_state]"
 			grabber.update_inv_l_hand()
 			grabber.update_inv_r_hand()


### PR DESCRIPTION
Fixes both https://github.com/Baystation12/Baystation12/issues/35501 and https://github.com/Baystation12/Baystation12/issues/35483. No more shall pAIs activate their hidden cloaking capabilities, or suffer permanent motor damage.

Thanks spook for helping <3

:cl: Spacemanspark
bugfix: pAIs will no longer be stealth cloaked when picked up while resting.
bugfix: pAIs will no longer be permanently slowed down in certain situations.
/:cl: