### PR TITLE
pAIs now receive a f f e c t i o n when clicked on help intent.

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -303,8 +303,12 @@ GLOBAL_LIST_AS(possible_say_verbs, list(
 
 
 /mob/living/silicon/pai/attack_hand(mob/user as mob)
-	visible_message(SPAN_DANGER("[user] boops [src] on the head."))
-	fold()
+	if (user.a_intent == I_HELP)
+		visible_message(SPAN_NOTICE("[user] gently pets [src]."))
+		playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, TRUE, -1)
+	else
+		visible_message(SPAN_DANGER("[user] boops [src] on the head."))
+		fold()
 
 // No binary for pAIs.
 /mob/living/silicon/pai/binarycheck()


### PR DESCRIPTION
You ever walked up to a pAI, go 'oh my gooooooooooo-' and then rush over to pet it, only to watch it turn from an awesome kitty robot to a flat, dull card? Yes? Well then do I have the thing for you.


:cl: Spacemanspark
tweak: You now use non-help intents to fold a pAI back into card mode. Help intent will instead pet them.
/:cl: