### PR TITLE
Locks high explosive missiles behind esoteric tech

### DIFF
--- a/code/modules/overmap/projectiles/missiles/equipment/payload/antimissile.dm
+++ b/code/modules/overmap/projectiles/missiles/equipment/payload/antimissile.dm
@@ -4,6 +4,7 @@
 	desc = "An advanced concotion of technology intended to detect and detonate in close proximity of another projectile in order to disable it."
 	icon_state = "antimissile"
 	missile_name_override = "countermeasure missile"
+	origin_tech = list(TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_ALUMINIUM = 4000, MATERIAL_GOLD = 500, MATERIAL_PHORON = 2000)
 	enters_zs = FALSE
 	cooldown = 3

--- a/code/modules/overmap/projectiles/missiles/equipment/payload/diffuser.dm
+++ b/code/modules/overmap/projectiles/missiles/equipment/payload/diffuser.dm
@@ -4,6 +4,7 @@
 	missile_name_override = "diffuser missile"
 	desc = "A one time use device designed to emit a strong, lasting strobe of antiphase EM waves. It can diffuse large shield sections for a long period of time, possibly causing massive damage to them as well."
 	icon_state = "diffuse"
+	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_ALUMINIUM = 4000, MATERIAL_GOLD = 1000, MATERIAL_DIAMOND = 250)
 
 	var/diffuse_range = 10

--- a/code/modules/overmap/projectiles/missiles/equipment/payload/emp.dm
+++ b/code/modules/overmap/projectiles/missiles/equipment/payload/emp.dm
@@ -4,6 +4,7 @@
 	missile_name_override = "emp missile"
 	desc = "Emits a strong electromagnetic pulse when the detonation mechanism of the missile it's fitted in is triggered."
 	icon_state = "ion"
+	origin_tech = list(TECH_COMBAT = 2, TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_ALUMINIUM = 4000, MATERIAL_GOLD = 1000, MATERIAL_URANIUM = 500)
 
 /obj/item/missile_equipment/payload/emp/on_trigger(armed)

--- a/code/modules/overmap/projectiles/missiles/equipment/payload/explosive.dm
+++ b/code/modules/overmap/projectiles/missiles/equipment/payload/explosive.dm
@@ -3,6 +3,7 @@
 	missile_name_override = "\improper HE missile"
 	desc = "An explosive charge. Detonates when the missile is triggered."
 	icon_state = "explosive"
+	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_ESOTERIC = 4)
 	matter = list(MATERIAL_ALUMINIUM = 4000, MATERIAL_GOLD = 1000, MATERIAL_PHORON = 2000)
 
 /obj/item/missile_equipment/payload/explosive/on_trigger(armed, atom/triggerer)

--- a/code/modules/overmap/projectiles/missiles/equipment/thruster/hunter.dm
+++ b/code/modules/overmap/projectiles/missiles/equipment/thruster/hunter.dm
@@ -4,6 +4,7 @@
 	name = "HUNTER warp booster"
 	desc = "An advanced booster specifically designed to plot courses towards and catch up to rapidly moving objects such as other missiles."
 	icon_state = "seeker"
+	origin_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_ALUMINIUM = 4000, MATERIAL_GOLD = 500, MATERIAL_PHORON = 3000)
 	overmap_speed = 1 / (6 SECONDS)
 

--- a/code/modules/overmap/projectiles/missiles/equipment/thruster/planet.dm
+++ b/code/modules/overmap/projectiles/missiles/equipment/thruster/planet.dm
@@ -3,6 +3,7 @@
 	name = "planetary missile booster"
 	desc = "The standard fare missile booster, but with planetary flight capabilities."
 	icon_state = "planet"
+	origin_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_ALUMINIUM = 4000, MATERIAL_PHORON = 3000)
 
 	var/turf/planetary_target

--- a/code/modules/overmap/projectiles/missiles/equipment/thruster/point.dm
+++ b/code/modules/overmap/projectiles/missiles/equipment/thruster/point.dm
@@ -3,6 +3,7 @@
 	name = "pointman missile booster"
 	desc = "A missile booster designed to travel to and rest at a given point. Steers away from structures."
 	icon_state = "dumbfire"
+	origin_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_ALUMINIUM = 4000, MATERIAL_PHORON = 3000)
 
 /obj/item/missile_equipment/thruster/point/preset/Initialize()

--- a/code/modules/overmap/projectiles/missiles/equipment/thruster/thruster.dm
+++ b/code/modules/overmap/projectiles/missiles/equipment/thruster/thruster.dm
@@ -3,6 +3,7 @@
 	name = "missile booster"
 	desc = "A simple but powerful and modular booster that can be fitted in most missiles. This one comes with an embedded targeting computer."
 	icon_state = "target"
+	origin_tech = list(TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
 	matter = list(MATERIAL_ALUMINIUM = 4000, MATERIAL_PHORON = 3000)
 	cooldown = 5
 	slot = MISSILE_PART_THRUSTER

--- a/code/modules/research/designs/designs_weapon.dm
+++ b/code/modules/research/designs/designs_weapon.dm
@@ -219,7 +219,7 @@
 
 /datum/design/item/weapon/missile_payload/explosive
 	id = "high explosive"
-	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_ENGINEERING = 3)
+	req_tech = list(TECH_COMBAT = 3, TECH_MATERIAL = 3, TECH_ENGINEERING = 3, TECH_ESOTERIC = 4)
 	materials = list(MATERIAL_ALUMINIUM = 5000, MATERIAL_GOLD = 2000, MATERIAL_PHORON = 3000)
 	build_path = /obj/item/missile_equipment/payload/explosive
 	sort_string = "TCDAA"


### PR DESCRIPTION
🆑 Cakey
balance: High explosive missile warheads are now locked behind esoteric tech 4.
rscadd: Added destructive tech origin values for missile parts.
/:cl: