### PR TITLE
Spider implant balancing

### DIFF
--- a/code/game/objects/items/weapons/implants/mobspawner/mobspawner.dm
+++ b/code/game/objects/items/weapons/implants/mobspawner/mobspawner.dm
@@ -7,10 +7,10 @@
 	var/base_mob_type = /mob
 
 	// adminbus vars
-	/// Average wait time, in deciseocnds, to spawn a mob.
-	var/wait_ds = 600
-	/// Variation added or subtracted to wait_ds on when to spwan a mob.
-	var/wait_variation_ds = 150
+	/// Average wait time to spawn a mob.
+	var/wait_time = 60 SECONDS
+	/// Variation added or subtracted to wait_time on when to spawn a mob.
+	var/wait_variation = 15 SECONDS
 	/// Limit of mobs nearby the implantee.
 	var/mob_limit = 10
 
@@ -18,7 +18,7 @@
 	return {"
 	<b>Implant Specifications:</b><br>
 	This implant will materialize creatures near the implantee.
-	First creature will materialize on average every [wait_ds / 10] seconds, varied by [wait_variation_ds / 10] seconds.<br>
+	First creature will materialize on average every [wait_time / 10] seconds, varied by [wait_variation / 10] seconds.<br>
 	"}
 
 /// Returns an exact mob type to spawn. Be sure to override this.
@@ -55,7 +55,7 @@
 	set_next_process_time()
 
 /obj/item/implant/processing/mobspawner/proc/set_next_process_time()
-	process_next_ds = world.time + (wait_ds + rand(wait_variation_ds * -1, wait_variation_ds))
+	process_next_ds = world.time + (wait_time + rand(wait_variation * -1, wait_variation))
 
 /obj/item/implant/processing/mobspawner/proc/phase_in_anim(mob/mob)
 	return

--- a/code/game/objects/items/weapons/implants/mobspawner/spider.dm
+++ b/code/game/objects/items/weapons/implants/mobspawner/spider.dm
@@ -2,6 +2,9 @@
 	name = "spider beacon implant"
 	desc = "An implant with small spiders etched along the metal."
 	base_mob_type = /mob/living/simple_animal/hostile/giant_spider
+	wait_time = 180 SECONDS
+	wait_variation = 60 SECONDS
+	mob_limit = 2
 
 /obj/item/implant/processing/mobspawner/get_mob_type()
 	return pickweight(GLOB.spider_castes)


### PR DESCRIPTION
:cl: Mucker
balance: Tweaked the spider implant to only spawn a spider once every 180 seconds (up from 60 seconds), variance of 60 seconds.
balance: Spider implant now only allows up to 2 spiders to be alive at once near the implantee.
/:cl:

Also slightly changed the wait vars to make them nicer to read.