### PR TITLE
Extreme spider implant nerfs

### DIFF
--- a/code/_global_vars/lists/mobs.dm
+++ b/code/_global_vars/lists/mobs.dm
@@ -13,3 +13,17 @@ GLOBAL_LIST_AS(spider_castes, list(
 	/mob/living/simple_animal/hostile/giant_spider/spitter = 2,
 	/mob/living/simple_animal/hostile/giant_spider/hunter = 1
 ))
+
+GLOBAL_LIST_AS(implant_spider_castes, list(
+	/mob/living/simple_animal/hostile/giant_spider/lurker = 0.1,
+	/mob/living/simple_animal/hostile/giant_spider/tunneler = 0.2,
+	/mob/living/simple_animal/hostile/giant_spider/pepper = 0.5,
+	/mob/living/simple_animal/hostile/giant_spider/webslinger = 1,
+	/mob/living/simple_animal/hostile/giant_spider/electric = 0.5,
+	/mob/living/simple_animal/hostile/giant_spider/thermic = 0.5,
+	/mob/living/simple_animal/hostile/giant_spider/frost = 0.5,
+	/mob/living/simple_animal/hostile/giant_spider = 2,
+	/mob/living/simple_animal/hostile/giant_spider/guard = 2,
+	/mob/living/simple_animal/hostile/giant_spider/spitter = 2,
+	/mob/living/simple_animal/hostile/giant_spider/hunter = 1
+))

--- a/code/game/objects/items/weapons/implants/mobspawner/mobspawner.dm
+++ b/code/game/objects/items/weapons/implants/mobspawner/mobspawner.dm
@@ -3,22 +3,32 @@
 	origin_tech = list(TECH_MATERIAL = 1, TECH_BIO = 2, TECH_BLUESPACE = 4)
 	/// Next minimum world.time to spawn a mob.
 	var/process_next_ds = 0
-	/// Base mob type of what this is spawning. Used for limiting
+	/// Base mob type of what this is spawning. Used for limiting mob types around the implantee as not to overwhelm them.
 	var/base_mob_type = /mob
 
 	// adminbus vars
-	/// Average wait time, in deciseocnds, to spawn a mob.
-	var/wait_ds = 600
-	/// Variation added or subtracted to wait_ds on when to spwan a mob.
-	var/wait_variation_ds = 150
-	/// Limit of mobs nearby the implantee.
+	/// Average wait time to spawn a mob.
+	var/wait_time = 60 SECONDS
+	/// Variation added or subtracted to wait_time on when to spawn a mob.
+	var/wait_variation = 15 SECONDS
+	// Limit of mobs that may be nearby the implantee
 	var/mob_limit = 10
+	/// Lower random limit of mobs spawned from this implant until it expires. Has no runtime effects.
+	var/max_spawned_rand_lower_bound = 5
+	/// Upper random limit of mobs spawned from this implant until it expires. Has no runtime effects.
+	var/max_spawned_rand_uppser_bound = 7
+	/// Number of remaining spawns until it expires.
+	var/spawns_remaining
+
+/obj/item/implant/processing/mobspawner/New(loc, ...)
+	. = ..()
+	spawns_remaining = rand(max_spawned_rand_lower_bound, max_spawned_rand_uppser_bound)
 
 /obj/item/implant/processing/mobspawner/get_data()
 	return {"
 	<b>Implant Specifications:</b><br>
 	This implant will materialize creatures near the implantee.
-	First creature will materialize on average every [wait_ds / 10] seconds, varied by [wait_variation_ds / 10] seconds.<br>
+	First creature will materialize on average every [wait_time / 10] seconds, varied by [wait_variation / 10] seconds.<br>
 	"}
 
 /// Returns an exact mob type to spawn. Be sure to override this.
@@ -31,11 +41,17 @@
 		return
 	if (process_next_ds > world.time)
 		return
+	if (imp_in.stat == DEAD)
+		return PROCESS_KILL
 	set_next_process_time()
 
 	var/list/around_us = oview(7, get_turf(imp_in))
 	var/list/mob_types_around = filter_list(around_us, base_mob_type)
-	if (length(mob_types_around) >= mob_limit)
+	var/mobs_around = 0
+	for (var/mob/mob_around in mob_types_around)
+		if (mob_around.stat == CONSCIOUS)
+			mobs_around++
+	if (mobs_around >= mob_limit)
 		return // cool off a bit
 
 	var/list/floor_list_near_us = filter_list(around_us, /turf/simulated/floor)
@@ -43,19 +59,22 @@
 		return
 	var/turf/simulated/floor/floor = pick(floor_list_near_us)
 	playsound(floor, 'sound/effects/phasein.ogg', 100, TRUE)
-	to_chat(imp_in, SPAN_DANGER("Something inside of you crackles. It feels unpleasant."))
+	to_chat(imp_in, FONT_LARGE(SPAN_DANGER("Something inside of you crackles. It feels unpleasant.")))
 
 	var/spawned_type = get_mob_type()
 	var/mob/spawned_mob = new spawned_type()
 	spawned_mob.loc = floor
 	phase_in_anim(spawned_mob)
 
+	if (!spawns_remaining--)
+		return PROCESS_KILL
+
 /obj/item/implant/processing/mobspawner/implanted(mob/source)
 	. = ..()
 	set_next_process_time()
 
 /obj/item/implant/processing/mobspawner/proc/set_next_process_time()
-	process_next_ds = world.time + (wait_ds + rand(wait_variation_ds * -1, wait_variation_ds))
+	process_next_ds = world.time + (wait_time + rand(wait_variation * -1, wait_variation))
 
 /obj/item/implant/processing/mobspawner/proc/phase_in_anim(mob/mob)
 	return

--- a/code/game/objects/items/weapons/implants/mobspawner/spider.dm
+++ b/code/game/objects/items/weapons/implants/mobspawner/spider.dm
@@ -2,9 +2,12 @@
 	name = "spider beacon implant"
 	desc = "An implant with small spiders etched along the metal."
 	base_mob_type = /mob/living/simple_animal/hostile/giant_spider
+	wait_time = 180 SECONDS
+	wait_variation = 60 SECONDS
+	mob_limit = 2
 
 /obj/item/implant/processing/mobspawner/get_mob_type()
-	return pickweight(GLOB.spider_castes)
+	return pickweight(GLOB.implant_spider_castes)
 
 /obj/item/implant/processing/mobspawner/spider/get_data()
 	return ..() + "This implant materializes creatures of the <b>large spider</b> family.<br>"


### PR DESCRIPTION
Presented as an alternative to #35514. Take only one!
Major change between mine and Mucker's is mine is a harder nerf; it limits the spider implant to 5-7 spiders.

:cl: Banditoz & Mucker
balance: Spider implants no longer spawn nursing spiders.
balance: Spider implants only can spawn around 5 to 7 spiders before they stop working.
balance: Spider implants no longer spawn spiders if the implantee is dead.
balance: Spider implants now only allow up to 2 spiders to be alive at once near the implantee.
balance: Tweaked the spider implant to only spawn a spider once every 180 seconds (up from 60 seconds), variance of 60 seconds.
/:cl: