### PR TITLE
Fixes and tweaks to ISV Crab

### DIFF
--- a/code/modules/shuttles/shuttle.dm
+++ b/code/modules/shuttles/shuttle.dm
@@ -53,7 +53,7 @@
 			CRASH("Shuttle \"[name]\" couldn't locate area [area_type].")
 		areas += located_area
 
-		for (var/turf/area_turf in area_type)
+		for (var/turf/area_turf in located_area.contents)
 			if (should_inherit_turf(area_turf))
 				var/relative_x = area_turf.x - current_location.x
 				var/relative_y = area_turf.y - current_location.y

--- a/maps/away/salvage_shuttle/code/shuttle.dm
+++ b/maps/away/salvage_shuttle/code/shuttle.dm
@@ -58,6 +58,7 @@
 /obj/shuttle_landmark/nav_salvage_shuttle/torch/d4
 	name = "SEV Torch ISV Crab EVA Dock"
 	landmark_tag = "nav_salvage_shuttle_torch_eva_dock"
+	docking_controller = "eva_airlock"
 
 /obj/machinery/computer/shuttle_control/explore/crab
 	name = "crab control console"

--- a/maps/away/salvage_shuttle/salvage_shuttle.dmm
+++ b/maps/away/salvage_shuttle/salvage_shuttle.dmm
@@ -52,7 +52,6 @@
 	},
 /obj/item/device/radio/intercom/map_preset/salvage_shuttle{
 	dir = 8;
-	name = "Intercom (Crab)";
 	pixel_x = 24
 	},
 /turf/simulated/floor/tiled/techfloor,
@@ -123,7 +122,6 @@
 /obj/paint/brown,
 /obj/machinery/door/blast/regular/open{
 	density = 0;
-	icon_state = "pdoor0";
 	id_tag = "crab_shutters";
 	name = "Protective Shutters";
 	opacity = 0
@@ -146,7 +144,7 @@
 	pixel_x = 24;
 	pixel_y = -8
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/salvage_shuttle/net)
 "bX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -416,8 +414,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/hologram/holopad/longrange,
-/obj/floor_decal/industrial/outline/yellow,
 /obj/submap_landmark/spawnpoint/independent_salvager,
 /turf/simulated/floor/lino,
 /area/salvage_shuttle/lounge)
@@ -505,6 +501,9 @@
 /area/salvage_shuttle/cargo)
 "fX" = (
 /obj/floor_decal/industrial/outline/orange,
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide/engine_setup{
+	start_pressure = 7498
+	},
 /turf/simulated/floor/plating,
 /area/derelict_cargo_ship/maintenance)
 "gb" = (
@@ -926,7 +925,7 @@
 	pixel_x = 24;
 	pixel_y = -10
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/salvage_shuttle/net)
 "ma" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/fuel,
@@ -992,7 +991,15 @@
 /obj/machinery/atmospherics/pipe/manifold/hidden{
 	dir = 8
 	},
-/turf/simulated/floor/plating,
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	master_tag = "crab_cargo";
+	name = "exterior access button";
+	pixel_x = 22;
+	pixel_y = 38;
+	frequency = 1331
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/salvage_shuttle/net)
 "nm" = (
 /obj/structure/closet/emcloset,
@@ -1024,7 +1031,7 @@
 /area/derelict_cargo_ship/maintenance)
 "nv" = (
 /obj/floor_decal/industrial/warning,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/salvage_shuttle/net)
 "nw" = (
 /obj/shuttle_landmark/nav_salvage_shuttle/nav1,
@@ -1068,8 +1075,7 @@
 	dir = 1
 	},
 /obj/item/device/radio/intercom/map_preset/salvage_shuttle{
-	pixel_y = 23;
-	name = "Intercom (Crab)"
+	pixel_y = 23
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/salvage_shuttle/airlock)
@@ -1201,7 +1207,7 @@
 	pixel_y = 24
 	},
 /obj/structure/handrail,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/salvage_shuttle/net)
 "qi" = (
 /obj/machinery/computer/ship/sensors{
@@ -1306,7 +1312,6 @@
 	},
 /obj/machinery/door/blast/regular/open{
 	dir = 2;
-	icon_state = "pdoor0";
 	id_tag = "crab_cargo_hatch";
 	name = "Storage Hatch"
 	},
@@ -1653,7 +1658,6 @@
 /obj/paint/brown,
 /obj/machinery/door/blast/regular/open{
 	density = 0;
-	icon_state = "pdoor0";
 	id_tag = "crab_shutters";
 	name = "Protective Shutters";
 	opacity = 0;
@@ -1898,7 +1902,6 @@
 /obj/paint/brown,
 /obj/machinery/door/blast/regular/open{
 	density = 0;
-	icon_state = "pdoor0";
 	id_tag = "crab_shutters";
 	name = "Protective Shutters";
 	opacity = 0;
@@ -1985,7 +1988,7 @@
 /obj/structure/handrail{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/salvage_shuttle/net)
 "Bm" = (
 /obj/structure/bed/chair/padded/black{
@@ -2124,8 +2127,7 @@
 "DD" = (
 /obj/item/device/radio/intercom/map_preset/salvage_shuttle{
 	dir = 1;
-	pixel_y = -32;
-	name = "Intercom (Crab)"
+	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
@@ -2334,7 +2336,6 @@
 /obj/paint/brown,
 /obj/machinery/door/blast/regular/open{
 	density = 0;
-	icon_state = "pdoor0";
 	id_tag = "crab_shutters";
 	name = "Protective Shutters";
 	opacity = 0
@@ -2741,6 +2742,8 @@
 	dir = 1;
 	pixel_y = -26
 	},
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide,
 /turf/simulated/floor/plating,
 /area/derelict_cargo_ship/cargo)
 "LG" = (
@@ -2802,6 +2805,9 @@
 /obj/machinery/atmospherics/pipe/simple/visible/fuel{
 	dir = 10
 	},
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/simulated/floor/plating,
 /area/salvage_shuttle/maintenance)
 "Nk" = (
@@ -2816,8 +2822,8 @@
 	command = "cycle_interior";
 	master_tag = "crab_cargo";
 	name = "interior access button";
-	pixel_x = 24;
-	pixel_y = 6;
+	pixel_x = 23;
+	pixel_y = 3;
 	frequency = 1331
 	},
 /obj/floor_decal/techfloor{
@@ -2825,6 +2831,14 @@
 	},
 /obj/floor_decal/techfloor/corner{
 	dir = 1
+	},
+/obj/machinery/access_button{
+	command = "cycle_exterior";
+	master_tag = "crab_cargo";
+	name = "exterior cycle button";
+	pixel_x = 23;
+	pixel_y = 11;
+	frequency = 1331
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/salvage_shuttle/cargo)
@@ -2865,7 +2879,7 @@
 /obj/machinery/nav_light/ventral{
 	pixel_x = 22
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/salvage_shuttle/net)
 "NX" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -3029,7 +3043,7 @@
 	dir = 4;
 	id_tag = "crab_airlock_pump_out_external"
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/salvage_shuttle/net)
 "Qr" = (
 /turf/space,
@@ -3085,7 +3099,6 @@
 /obj/structure/grille,
 /obj/machinery/door/blast/regular/open{
 	density = 0;
-	icon_state = "pdoor0";
 	id_tag = "crab_shutters";
 	name = "Protective Shutters";
 	opacity = 0;
@@ -3100,7 +3113,6 @@
 "Rb" = (
 /obj/machinery/door/blast/regular/open{
 	density = 0;
-	icon_state = "pdoor0";
 	id_tag = "crab_shutters";
 	name = "Protective Shutters";
 	opacity = 0;
@@ -3140,7 +3152,7 @@
 /obj/floor_decal/industrial/warning{
 	dir = 1
 	},
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/techfloor/grid,
 /area/salvage_shuttle/net)
 "RJ" = (
 /obj/paint/green,
@@ -3159,6 +3171,7 @@
 /obj/item/storage/belt/utility/full,
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/gloves/insulated,
+/obj/item/tape_roll,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/salvage_shuttle/cargo)
 "Sh" = (
@@ -3442,6 +3455,8 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/floor_decal/industrial/outline/yellow,
+/obj/machinery/hologram/holopad/longrange,
 /turf/simulated/floor/tiled,
 /area/salvage_shuttle/cockpit)
 "VC" = (
@@ -3487,8 +3502,7 @@
 "WD" = (
 /obj/item/device/radio/intercom/map_preset/salvage_shuttle{
 	dir = 1;
-	pixel_y = -32;
-	name = "Intercom (Crab)"
+	pixel_y = -32
 	},
 /obj/floor_decal/industrial/outline/yellow,
 /obj/floor_decal/industrial/warning{
@@ -3499,6 +3513,7 @@
 /obj/item/storage/belt/utility/full,
 /obj/item/clothing/glasses/welding,
 /obj/item/clothing/gloves/insulated,
+/obj/item/tape_roll,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/salvage_shuttle/cargo)
 "WI" = (
@@ -3728,7 +3743,6 @@
 "YK" = (
 /obj/machinery/door/blast/regular/open{
 	density = 0;
-	icon_state = "pdoor0";
 	id_tag = "crab_shutters";
 	name = "Protective Shutters";
 	opacity = 0;

--- a/maps/torch/torch2_deck4.dmm
+++ b/maps/torch/torch2_deck4.dmm
@@ -7599,7 +7599,7 @@
 /obj/floor_decal/techfloor{
 	dir = 1
 	},
-/obj/machinery/embedded_controller/radio/airlock/airlock_controller{
+/obj/machinery/embedded_controller/radio/airlock/docking_port{
 	frequency = 1380;
 	id_tag = "eva_airlock";
 	pixel_y = 20;

--- a/maps/torch/torch_overmap.dm
+++ b/maps/torch/torch_overmap.dm
@@ -25,7 +25,8 @@
 		"Cyclopes" = list("nav_merc_dock"),
 		"ICGNV Hound" = list("nav_hound_dock"),
 		"SFV Arbiter" = list("nav_sfv_arbiter_dock"),
-		"FTV Cubkitten" = list("nav_hangar_cubkitten_torch")
+		"FTV Cubkitten" = list("nav_hangar_cubkitten_torch"),
+		"ISV Crab" = list("nav_salvage_shuttle_torch_eva_dock")
 	)
 
 	initial_generic_waypoints = list(

--- a/nano/templates/shuttle_control_console_antag.tmpl
+++ b/nano/templates/shuttle_control_console_antag.tmpl
@@ -70,6 +70,12 @@
 					<span class="bad">ERROR</span>
 				{{/if}}
 			</div>
+			<div class="itemLabel">
+				Docking Codes:
+			</div>
+			<div class="itemContent">
+				{{:helper.link(data.docking_codes ? data.docking_codes : 'Not set', null, {'set_codes' : '1'}, null , null)}}
+			</div>
 		</div>
 	</div>
 {{/if}}

--- a/nano/templates/shuttle_control_console_exploration.tmpl
+++ b/nano/templates/shuttle_control_console_exploration.tmpl
@@ -67,6 +67,12 @@
 					<span class="bad">ERROR</span>
 				{{/if}}
 			</div>
+			<div class="itemLabel">
+				Docking Codes:
+			</div>
+			<div class="itemContent">
+				{{:helper.link(data.docking_codes ? data.docking_codes : 'Not set', null, {'set_codes' : '1'}, null , null)}}
+			</div>
 		</div>
 	</div>
 {{/if}}


### PR DESCRIPTION
🆑 Cakey
bugfix: The ISV Crab will no longer land with space tiles on planets.
maptweak: The deck 4 EVA airlock is now a docking controller and can dock with several ships.
maptweak: Added tape rolls to the ISV Crab.
maptweak: Added starting jetpacks for the ISV crab Crab crew to salvage from their starting sector.
maptweak: Moved the ISV Crab's holopad to the cockpit.
maptweak: The ISV Crab now has additional buttons for cycling the cargo bay out and in.
/:cl: