### PR TITLE
pAI radio range reduced

### DIFF
--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -6,7 +6,7 @@
 	w_class = ITEM_SIZE_SMALL
 	slot_flags = SLOT_BELT
 	origin_tech = list(TECH_DATA = 2)
-	var/radio = /obj/item/device/radio/infinite
+	var/radio = /obj/item/device/radio/infinite/pai
 	var/looking_for_personality = FALSE
 	var/mob/living/silicon/pai/pai
 

--- a/code/game/objects/items/devices/radio/radio.dm
+++ b/code/game/objects/items/devices/radio/radio.dm
@@ -50,6 +50,8 @@
 	on = TRUE
 	power_usage = 0
 
+/obj/item/device/radio/infinite/pai
+	canhear_range = 0
 
 /obj/item/device/radio/proc/set_frequency(new_frequency)
 	radio_controller.remove_object(src, frequency)


### PR DESCRIPTION
I've almost accidentally screwed over a few antagonists because of the radio's range, so I've made a custom radio for pAIs with reduced range (it'll only broadcast to the same tile the pAI itself is on, much like a headset).

:cl: Spacemanspark
tweak: pAI radio system broadcast range reduced to the tile they're standing on.
/:cl: