### PR TITLE
Fixes missile thruster targeting selection

### DIFF
--- a/code/modules/overmap/projectiles/missiles/equipment/thruster/thruster.dm
+++ b/code/modules/overmap/projectiles/missiles/equipment/thruster/thruster.dm
@@ -141,7 +141,7 @@
 		to_chat(user, SPAN_NOTICE("The targeting computer display indicates that there are no valid targets."))
 		return TRUE
 
-	var/selected_target = input("Select a target") as null|obj in possible_targets
+	var/selected_target = input("Select a target") as null|anything in possible_targets
 	if (!selected_target)
 		return TRUE
 


### PR DESCRIPTION
🆑 Cakey
bugfix: Fixed targeting input not working on missile thrusters.
/:cl: