### PR TITLE
Suppress goonchat fail admin log and runtime

### DIFF
--- a/code/modules/goonchat/browserOutput.dm
+++ b/code/modules/goonchat/browserOutput.dm
@@ -54,10 +54,10 @@ For the main html chat area
 	if (!winexists(owner, "browseroutput"))
 		set waitfor = FALSE
 		broken = TRUE
-		message_admins("Couldn't start chat for [key_name_admin(owner)]!")
-		. = FALSE
-		alert(owner.mob, "Updated chat window does not exist. If you are using a custom skin file please allow the game to update.")
-		return
+		log_debug("Couldn't start chat for [key_name_admin(owner)]!")
+		if (owner.mob)
+			alert(owner.mob, "Updated chat window does not exist. If you are using a custom skin file please allow the game to update.")
+		return FALSE
 	if (owner && winget(owner, "browseroutput", "is-visible") == "true")
 		doneLoading()
 	else


### PR DESCRIPTION
I'm not sure this was ever helpful for staff