### PR TITLE
replaced uses of text() proc, added a test against more

### DIFF
--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -375,7 +375,7 @@
 
 /proc/ScreenText(obj/O, maptext="", screen_loc="CENTER-7,CENTER-7", maptext_height=480, maptext_width=480)
 	RETURN_TYPE(/obj/screen)
-	if(!isobj(O))	O = new /obj/screen/text()
+	if(!isobj(O))	O = new /obj/screen/text
 	O.maptext = maptext
 	O.maptext_height = maptext_height
 	O.maptext_width = maptext_width

--- a/code/_helpers/text.dm
+++ b/code/_helpers/text.dm
@@ -532,34 +532,34 @@
 	switch(macro)
 		//prefixes/agnostic
 		if("the")
-			rest = text("\the []", rest)
+			rest = "\the [rest]"
 		if("a")
-			rest = text("\a []", rest)
+			rest = "\a [rest]"
 		if("an")
-			rest = text("\an []", rest)
+			rest = "\an [rest]"
 		if("proper")
-			rest = text("\proper []", rest)
+			rest = "\proper [rest]"
 		if("improper")
-			rest = text("\improper []", rest)
+			rest = "\improper [rest]"
 		if("roman")
-			rest = text("\roman []", rest)
+			rest = "\roman [rest]"
 		//postfixes
 		if("th")
-			base = text("[]\th", rest)
+			base = "[rest]\th"
 		if("s")
-			base = text("[]\s", rest)
+			base = "[rest]\s"
 		if("he")
-			base = text("[]\he", rest)
+			base = "[rest]\he"
 		if("she")
-			base = text("[]\she", rest)
+			base = "[rest]\she"
 		if("his")
-			base = text("[]\his", rest)
+			base = "[rest]\his"
 		if("himself")
-			base = text("[]\himself", rest)
+			base = "[rest]\himself"
 		if("herself")
-			base = text("[]\herself", rest)
+			base = "[rest]\herself"
 		if("hers")
-			base = text("[]\hers", rest)
+			base = "[rest]\hers"
 
 	. = base
 	if(rest)

--- a/code/datums/wires/airlock.dm
+++ b/code/datums/wires/airlock.dm
@@ -50,17 +50,16 @@ var/global/const/AIRLOCK_WIRE_LIGHT = 2048
 /datum/wires/airlock/GetInteractWindow(mob/user)
 	var/obj/machinery/door/airlock/A = holder
 	var/haspower = A.arePowerSystemsOn() //If there's no power, then no lights will be on.
-
 	. += ..()
-	. += text("<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]<br>\n[]",
-	(A.locked ? "The door bolts have fallen!" : "The door bolts look up."),
-	((A.lights && haspower) ? "The door bolt lights are on." : "The door bolt lights are off!"),
-	((haspower) ? "The test light is on." : "The test light is off!"),
-	((A.backup_power_lost_until) ? "The backup power light is off!" : "The backup power light is on."),
-	((!A.ai_control_disabled && !A.emagged && haspower)? "The 'AI control allowed' light is on." : "The 'AI control allowed' light is off."),
-	((!A.safe && haspower)? "The 'Check Wiring' light is on." : "The 'Check Wiring' light is off."),
-	((!A.normalspeed && haspower)? "The 'Check Timing Mechanism' light is on." : "The 'Check Timing Mechanism' light is off."),
-	((!A.aiDisabledIdScanner && haspower)? "The IDScan light is on." : "The IDScan light is off."))
+	. += "<br>\n[A.locked ? "The door bolts have fallen!" : "The door bolts look up."]"
+	. += "<br>\n[(A.lights && haspower) ? "The door bolt lights are on." : "The door bolt lights are off!"]"
+	. += "<br>\n[haspower ? "The test light is on." : "The test light is off!"]"
+	. += "<br>\n[A.backup_power_lost_until ? "The backup power light is off!" : "The backup power light is on."]"
+	. += "<br>\n[(!A.ai_control_disabled && !A.emagged && haspower) ? "The 'AI control allowed' light is on." : "The 'AI control allowed' light is off."]"
+	. += "<br>\n[(!A.safe && haspower) ? "The 'Check Wiring' light is on." : "The 'Check Wiring' light is off."]"
+	. += "<br>\n[(!A.normalspeed && haspower) ? "The 'Check Timing Mechanism' light is on." : "The 'Check Timing Mechanism' light is off."]"
+	. += "<br>\n[(!A.aiDisabledIdScanner && haspower) ? "The IDScan light is on." : "The IDScan light is off."]"
+
 
 /datum/wires/airlock/UpdateCut(index, mended)
 

--- a/code/datums/wires/alarm.dm
+++ b/code/datums/wires/alarm.dm
@@ -25,12 +25,12 @@ var/global/const/AALARM_WIRE_AALARM = 16
 /datum/wires/alarm/GetInteractWindow(mob/user)
 	var/obj/machinery/alarm/A = holder
 	. += ..()
-	. += text({"
+	. += {"
 		<br>
 		[(A.locked ? "The Air Alarm is locked." : "The Air Alarm is unlocked.")]<br>
 		[((A.shorted || A.inoperable()) ? "The Air Alarm is offline." : "The Air Alarm is working properly!")]<br>
 		[(A.aidisabled ? "The 'AI control allowed' light is off." : "The 'AI control allowed' light is on.")]
-	"})
+	"}
 
 /datum/wires/alarm/UpdateCut(index, mended)
 	var/obj/machinery/alarm/A = holder

--- a/code/datums/wires/apc.dm
+++ b/code/datums/wires/apc.dm
@@ -16,7 +16,7 @@
 /datum/wires/apc/GetInteractWindow(mob/user)
 	var/obj/machinery/power/apc/A = holder
 	. += ..()
-	. += text("<br>\n[(A.locked ? "The APC is locked." : "The APC is unlocked.")]<br>\n[(A.shorted ? "The APCs power has been shorted." : "The APC is working properly!")]<br>\n[(A.aidisabled ? "The 'AI control allowed' light is off." : "The 'AI control allowed' light is on.")]")
+	. += "<br>\n[(A.locked ? "The APC is locked." : "The APC is unlocked.")]<br>\n[(A.shorted ? "The APCs power has been shorted." : "The APC is working properly!")]<br>\n[(A.aidisabled ? "The 'AI control allowed' light is off." : "The 'AI control allowed' light is on.")]"
 
 
 /datum/wires/apc/CanUse(mob/living/L)

--- a/code/datums/wires/robot.dm
+++ b/code/datums/wires/robot.dm
@@ -18,9 +18,9 @@ var/global/const/BORG_WIRE_AI_CONTROL = 8
 
 	. = ..()
 	var/mob/living/silicon/robot/R = holder
-	. += text("<br>\n[(R.lawupdate ? "The LawSync light is on." : "The LawSync light is off.")]")
-	. += text("<br>\n[(R.connected_ai ? "The AI link light is on." : "The AI link light is off.")]")
-	. += text("<br>\n[(R.lockcharge ? "The lockdown light is on." : "The lockdown light is off.")]")
+	. += "<br>\n[R.lawupdate ? "The LawSync light is on." : "The LawSync light is off."]"
+	. += "<br>\n[R.connected_ai ? "The AI link light is on." : "The AI link light is off."]"
+	. += "<br>\n[R.lockcharge ? "The lockdown light is on." : "The lockdown light is off."]"
 	return .
 
 /datum/wires/robot/UpdateCut(index, mended)

--- a/code/game/gamemodes/malfunction/newmalf_ability_trees/HELPERS.dm
+++ b/code/game/gamemodes/malfunction/newmalf_ability_trees/HELPERS.dm
@@ -206,9 +206,9 @@
 /proc/log_ability_use(mob/living/silicon/ai/A, ability_name, atom/target = null, notify_admins = 1)
 	var/message
 	if(target)
-		message = text("used malf ability/function: [ability_name] on [target] ([target.x], [target.y], [target.z])")
+		message = "used malf ability/function: [ability_name] on [target] ([target.x], [target.y], [target.z])"
 	else
-		message = text("used malf ability/function: [ability_name].")
+		message = "used malf ability/function: [ability_name]."
 	admin_attack_log(A, null, message, null, message)
 
 /proc/check_for_interception()

--- a/code/game/machinery/alarm.dm
+++ b/code/game/machinery/alarm.dm
@@ -1102,29 +1102,29 @@ FIRE ALARM
 		A = A.loc
 
 		if (A.fire)
-			d1 = text("<A href='byond://?src=\ref[];reset=1'>Reset - Lockdown</A>", src)
+			d1 = "<A href='byond://?src=\ref[src];reset=1'>Reset - Lockdown</A>"
 		else
-			d1 = text("<A href='byond://?src=\ref[];alarm=1'>Alarm - Lockdown</A>", src)
+			d1 = "<A href='byond://?src=\ref[src];alarm=1'>Alarm - Lockdown</A>"
 		if (src.timing)
-			d2 = text("<A href='byond://?src=\ref[];time=0'>Stop Time Lock</A>", src)
+			d2 = "<A href='byond://?src=\ref[src];time=0'>Stop Time Lock</A>"
 		else
-			d2 = text("<A href='byond://?src=\ref[];time=1'>Initiate Time Lock</A>", src)
+			d2 = "<A href='byond://?src=\ref[src];time=1'>Initiate Time Lock</A>"
 		var/second = round(src.time) % 60
 		var/minute = (round(src.time) - second) / 60
 		popup.set_content("[d1]\n<HR>The current alert level is <b>[security_state.current_security_level.name]</b><br><br>\nTimer System: [d2]<BR>\nTime Left: [(minute ? "[minute]:" : null)][second] <A href='byond://?src=\ref[src];tp=-30'>-</A> <A href='byond://?src=\ref[src];tp=-1'>-</A> <A href='byond://?src=\ref[src];tp=1'>+</A> <A href='byond://?src=\ref[src];tp=30'>+</A>")
 	else
 		A = A.loc
 		if (A.fire)
-			d1 = text("<A href='byond://?src=\ref[];reset=1'>[]</A>", src, stars("Reset - Lockdown"))
+			d1 = "<A href='byond://?src=\ref[src];reset=1'>[stars("Reset - Lockdown")]</A>"
 		else
-			d1 = text("<A href='byond://?src=\ref[];alarm=1'>[]</A>", src, stars("Alarm - Lockdown"))
+			d1 = "<A href='byond://?src=\ref[src];alarm=1'>[stars("Alarm - Lockdown")]</A>"
 		if (src.timing)
-			d2 = text("<A href='byond://?src=\ref[];time=0'>[]</A>", src, stars("Stop Time Lock"))
+			d2 = "<A href='byond://?src=\ref[src];time=0'>[stars("Stop Time Lock")]</A>"
 		else
-			d2 = text("<A href='byond://?src=\ref[];time=1'>[]</A>", src, stars("Initiate Time Lock"))
+			d2 = "<A href='byond://?src=\ref[src];time=1'>[stars("Initiate Time Lock")]</A>"
 		var/second = round(src.time) % 60
 		var/minute = (round(src.time) - second) / 60
-		popup.set_content("[d1]\n<HR>The current security level is <b>[security_state.current_security_level.name]</b><br><br>\nTimer System: [d2]<BR>\nTime Left: [(minute ? text("[]:", minute) : null)][second] <A href='byond://?src=\ref[src];tp=-30'>-</A> <A href='byond://?src=\ref[src];tp=-1'>-</A> <A href='byond://?src=\ref[src];tp=1'>+</A> <A href='byond://?src=\ref[src];tp=30'>+</A>\n")
+		popup.set_content("[d1]\n<HR>The current security level is <b>[security_state.current_security_level.name]</b><br><br>\nTimer System: [d2]<BR>\nTime Left: [(minute ? "[minute]:" : null)][second] <A href='byond://?src=\ref[src];tp=-30'>-</A> <A href='byond://?src=\ref[src];tp=-1'>-</A> <A href='byond://?src=\ref[src];tp=1'>+</A> <A href='byond://?src=\ref[src];tp=30'>+</A>\n")
 	popup.open()
 	return
 
@@ -1234,28 +1234,28 @@ Just a object used in constructing fire alarms
 	if (istype(user, /mob/living/carbon/human) || istype(user, /mob/living/silicon/ai))
 
 		if (A.party)
-			d1 = text("<A href='byond://?src=\ref[];reset=1'>No Party :(</A>", src)
+			d1 = "<A href='byond://?src=\ref[src];reset=1'>No Party :(</A>"
 		else
-			d1 = text("<A href='byond://?src=\ref[];alarm=1'>PARTY!!!</A>", src)
+			d1 = "<A href='byond://?src=\ref[src];alarm=1'>PARTY!!!</A>"
 		if (timing)
-			d2 = text("<A href='byond://?src=\ref[];time=0'>Stop Time Lock</A>", src)
+			d2 = "<A href='byond://?src=\ref[src];time=0'>Stop Time Lock</A>"
 		else
-			d2 = text("<A href='byond://?src=\ref[];time=1'>Initiate Time Lock</A>", src)
+			d2 = "<A href='byond://?src=\ref[src];time=1'>Initiate Time Lock</A>"
 		var/second = time % 60
 		var/minute = (time - second) / 60
-		popup.set_content(text("<TT><B>Party Button</B> []\n<HR>\nTimer System: []<BR>\nTime Left: [][] <A href='byond://?src=\ref[];tp=-30'>-</A> <A href='byond://?src=\ref[];tp=-1'>-</A> <A href='byond://?src=\ref[];tp=1'>+</A> <A href='byond://?src=\ref[];tp=30'>+</A>\n</TT>", d1, d2, (minute ? text("[]:", minute) : null), second, src, src, src, src))
+		popup.set_content("<TT><B>Party Button</B> [d1]\n<HR>\nTimer System: [d2]<BR>\nTime Left: [minute ? "[minute]:" : null][second] <A href='byond://?src=\ref[src];tp=-30'>-</A> <A href='byond://?src=\ref[src];tp=-1'>-</A> <A href='byond://?src=\ref[src];tp=1'>+</A> <A href='byond://?src=\ref[src];tp=30'>+</A>\n</TT>")
 	else
 		if (A.fire)
-			d1 = text("<A href='byond://?src=\ref[];reset=1'>[]</A>", src, stars("No Party :("))
+			d1 = "<A href='byond://?src=\ref[src];reset=1'>[stars("No Party :(")]</A>"
 		else
-			d1 = text("<A href='byond://?src=\ref[];alarm=1'>[]</A>", src, stars("PARTY!!!"))
+			d1 = "<A href='byond://?src=\ref[src];alarm=1'>[stars("PARTY!!!")]</A>"
 		if (timing)
-			d2 = text("<A href='byond://?src=\ref[];time=0'>[]</A>", src, stars("Stop Time Lock"))
+			d2 = "<A href='byond://?src=\ref[src];time=0'>[stars("Stop Time Lock")]</A>"
 		else
-			d2 = text("<A href='byond://?src=\ref[];time=1'>[]</A>", src, stars("Initiate Time Lock"))
+			d2 = "<A href='byond://?src=\ref[src];time=1'>[stars("Initiate Time Lock")]</A>"
 		var/second = time % 60
 		var/minute = (time - second) / 60
-		popup.set_content(text("<TT><B>[]</B> []\n<HR>\nTimer System: []<BR>\nTime Left: [][] <A href='byond://?src=\ref[];tp=-30'>-</A> <A href='byond://?src=\ref[];tp=-1'>-</A> <A href='byond://?src=\ref[];tp=1'>+</A> <A href='byond://?src=\ref[];tp=30'>+</A>\n</TT>", stars("Party Button"), d1, d2, (minute ? text("[]:", minute) : null), second, src, src, src, src))
+		popup.set_content("<TT><B>[stars("Party Button")]</B> [d1]\n<HR>\nTimer System: [d2]<BR>\nTime Left: [minute ? "[minute]:" : null][second] <A href='byond://?src=\ref[src];tp=-30'>-</A> <A href='byond://?src=\ref[src];tp=-1'>-</A> <A href='byond://?src=\ref[src];tp=1'>+</A> <A href='byond://?src=\ref[src];tp=30'>+</A>\n</TT>")
 	popup.open()
 	return
 

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -212,7 +212,7 @@
 			if(!O.client) continue
 			if(U.name == "Unknown") to_chat(O, "<b>[U]</b> holds \a [itemname] up to one of your cameras ...")
 			else to_chat(O, "<b><a href='byond://?src=\ref[O];track2=\ref[O];track=\ref[U];trackname=[U.name]'>[U]</a></b> holds \a [itemname] up to one of your cameras ...")
-			show_browser(O, text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", itemname, info), text("window=[]", itemname))
+			show_browser(O, "<HTML><HEAD><TITLE>[itemname]</TITLE></HEAD><BODY><TT>[info]</TT></BODY></HTML>", "window=[itemname]")
 		return TRUE
 
 	return ..()

--- a/code/game/machinery/camera/tracking.dm
+++ b/code/game/machinery/camera/tracking.dm
@@ -16,7 +16,7 @@
 	for (var/obj/machinery/camera/C in cameranet.cameras)
 		var/list/tempnetwork = C.network&src.network
 		if (length(tempnetwork))
-			T[text("[][]", C.c_tag, (C.can_use() ? null : " (Deactivated)"))] = C
+			T["[C.c_tag][C.can_use() ? null : " (Deactivated)"]"] = C
 
 	track = new()
 	track.cameras = T
@@ -113,7 +113,7 @@
 		var/name = M.name
 		if (name in TB.names)
 			TB.namecounts[name]++
-			name = text("[] ([])", name, TB.namecounts[name])
+			name = "[name] ([TB.namecounts[name]])"
 		else
 			TB.names.Add(name)
 			TB.namecounts[name] = 1

--- a/code/game/machinery/computer/shuttle.dm
+++ b/code/game/machinery/computer/shuttle.dm
@@ -34,7 +34,7 @@
 			to_chat(user, "The access level of [W:registered_name]\'s card is not high enough. ")
 			return TRUE
 
-		var/choice = alert(user, text("Would you like to (un)authorize a shortened launch time? [] authorization\s are still needed. Use abort to cancel all authorizations.", src.auth_need - length(src.authorized)), "Shuttle Launch", "Authorize", "Repeal", "Abort")
+		var/choice = alert(user, "Would you like to (un)authorize a shortened launch time? [auth_need - length(authorized)] authorization\s are still needed. Use abort to cancel all authorizations.", "Shuttle Launch", "Authorize", "Repeal", "Abort")
 		if(evacuation_controller.is_prepared() && user.get_active_hand() != W)
 			return TRUE
 		switch(choice)

--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -551,21 +551,21 @@ About the new airlock wires panel:
 /obj/machinery/door/airlock/proc/electrify(duration, feedback = 0)
 	var/message = ""
 	if(src.isWireCut(AIRLOCK_WIRE_ELECTRIFY) && arePowerSystemsOn())
-		message = text("The electrification wire is cut - Door permanently electrified.")
+		message = "The electrification wire is cut - Door permanently electrified."
 		src.electrified_until = -1
 		. = 1
 	else if(duration && !arePowerSystemsOn())
-		message = text("The door is unpowered - Cannot electrify the door.")
+		message = "The door is unpowered - Cannot electrify the door."
 		src.electrified_until = 0
 	else if(!duration && electrified_until != 0)
 		message = "The door is now un-electrified."
 		src.electrified_until = 0
 	else if(duration)	//electrify door for the given duration seconds
 		if(usr)
-			shockedby += text("\[[time_stamp()]\] - [key_name(usr)]")
+			shockedby += "\[[time_stamp()]\] - [key_name(usr)]"
 			admin_attacker_log(usr, "electrified \the [name] [duration == -1 ? "permanently" : "for [duration] second\s"]")
 		else
-			shockedby += text("\[[time_stamp()]\] - EMP)")
+			shockedby += "\[[time_stamp()]\] - EMP)"
 		message = "The door is now electrified [duration == -1 ? "permanently" : "for [duration] second\s"]."
 		src.electrified_until = duration == -1 ? -1 : world.time + SecondsToTicks(duration)
 		. = 1
@@ -593,7 +593,7 @@ About the new airlock wires panel:
 	var/message = ""
 	// Safeties!  We don't need no stinking safeties!
 	if (src.isWireCut(AIRLOCK_WIRE_SAFETY))
-		message = text("The safety wire is cut - Cannot enable safeties.")
+		message = "The safety wire is cut - Cannot enable safeties."
 	else if (!activate && src.safe)
 		safe = FALSE
 	else if (activate && !src.safe)
@@ -887,9 +887,9 @@ About the new airlock wires panel:
 			electrify(-1 * activate, 1)
 		if("open")
 			if(src.welded)
-				to_chat(usr, text("The airlock has been welded shut!"))
+				to_chat(usr, "The airlock has been welded shut!")
 			else if(src.locked)
-				to_chat(usr, text("The door bolts are down!"))
+				to_chat(usr, "The door bolts are down!")
 			else if(activate && density)
 				open()
 			else if(!activate && !density)
@@ -899,7 +899,7 @@ About the new airlock wires panel:
 		if("timing")
 			// Door speed control
 			if(src.isWireCut(AIRLOCK_WIRE_SPEED))
-				to_chat(usr, text("The timing wire is cut - Cannot alter timing."))
+				to_chat(usr, "The timing wire is cut - Cannot alter timing.")
 			else if (activate && src.normalspeed)
 				normalspeed = FALSE
 			else if (!activate && !src.normalspeed)

--- a/code/game/machinery/doors/windowdoor.dm
+++ b/code/game/machinery/doors/windowdoor.dm
@@ -134,7 +134,7 @@
 	if (src.operating)
 		return 0
 	operating = DOOR_OPERATING_YES
-	flick(text("[]closing", src.base_state), src)
+	flick("[base_state]closing", src)
 	playsound(src.loc, 'sound/machines/windowdoor.ogg', 100, 1)
 	set_density(1)
 	update_icon()
@@ -233,7 +233,7 @@
 		return TRUE
 
 	else if (density)
-		flick(text("[]deny", src.base_state), src)
+		flick("[base_state]deny", src)
 		return TRUE
 
 /obj/machinery/door/window/create_electronics(electronics_type = /obj/item/airlock_electronics)

--- a/code/game/machinery/newscaster.dm
+++ b/code/game/machinery/newscaster.dm
@@ -235,7 +235,7 @@ var/global/list/obj/machinery/newscaster/allCasters = list() //Global list that 
 	if(istype(user, /mob/living/carbon/human) || istype(user,/mob/living/silicon) )
 		var/mob/living/human_or_robot_user = user
 		var/dat
-		dat = text("<HEAD><TITLE>Newscaster</TITLE></HEAD><H3>Newscaster Unit #[src.unit_no]</H3>")
+		dat = "<HEAD><TITLE>Newscaster</TITLE></HEAD><H3>Newscaster Unit #[unit_no]</H3>"
 
 		src.scan_user(human_or_robot_user) //Newscaster scans you
 

--- a/code/game/machinery/nuclear_bomb.dm
+++ b/code/game/machinery/nuclear_bomb.dm
@@ -271,7 +271,7 @@ var/global/bomb_set
 					yes_code = 0
 					code = null
 				else
-					lastentered = text("[]", href_list["type"])
+					lastentered = "[href_list["type"]]"
 					if(isnull(text2num_or_default(lastentered)))
 						log_and_message_admins("tried to exploit a nuclear bomb by entering non-numerical codes")
 					else

--- a/code/game/machinery/requests_console.dm
+++ b/code/game/machinery/requests_console.dm
@@ -165,7 +165,7 @@ var/global/list/obj/machinery/requests_console/allConsoles = list()
 				screen = RCS_SENTPASS
 				message_log += "<B>Message sent to [recipient]</B><BR>[message]"
 		else
-			audible_message(text("[icon2html(src, viewers(get_turf(src)))] *The Requests Console beeps: 'NOTICE: No server detected!'"),,4)
+			audible_message("[icon2html(src, viewers(get_turf(src)))] *The Requests Console beeps: 'NOTICE: No server detected!'",,4)
 		return TOPIC_REFRESH
 
 	//Handle screen switching
@@ -194,7 +194,7 @@ var/global/list/obj/machinery/requests_console/allConsoles = list()
 		if(inoperable() || GET_FLAGS(stat, MACHINE_STAT_MAINT)) return FALSE
 		if(screen == RCS_MESSAUTH)
 			var/obj/item/card/id/T = O
-			msgVerified = text(SPAN_COLOR("green", "<b>Verified by [T.registered_name] ([T.assignment])</b>"))
+			msgVerified = SPAN_COLOR("green", "<b>Verified by [T.registered_name] ([T.assignment])</b>")
 			SSnano.update_uis(src)
 		if(screen == RCS_ANNOUNCE)
 			var/obj/item/card/id/ID = O
@@ -211,7 +211,7 @@ var/global/list/obj/machinery/requests_console/allConsoles = list()
 		if(inoperable() || GET_FLAGS(stat, MACHINE_STAT_MAINT)) return FALSE
 		if(screen == RCS_MESSAUTH)
 			var/obj/item/stamp/T = O
-			msgStamped = text(SPAN_COLOR("blue", "<b>Stamped with the [T.name]</b>"))
+			msgStamped = SPAN_COLOR("blue", "<b>Stamped with the [T.name]</b>")
 			SSnano.update_uis(src)
 		return TRUE
 

--- a/code/game/objects/effects/manifest.dm
+++ b/code/game/objects/effects/manifest.dm
@@ -11,7 +11,7 @@
 /obj/manifest/proc/manifest()
 	var/dat = "<B>Crew Manifest</B>:<BR>"
 	for(var/mob/living/carbon/human/M in SSmobs.mob_list)
-		dat += text("    <B>[]</B> -  []<BR>", M.name, M.get_assignment())
+		dat += "    <B>[M.name]</B> -  [M.get_assignment()]<BR>"
 	var/obj/item/paper/P = new /obj/item/paper( src.loc )
 	P.info = dat
 	P.SetName("paper- 'Crew Manifest'")

--- a/code/game/objects/effects/spawners/bombspawner.dm
+++ b/code/game/objects/effects/spawners/bombspawner.dm
@@ -63,7 +63,7 @@
 
 			if(src.active)
 				R.part1.secured = 1
-				R.part1.icon_state = text("motion[]", 1)
+				R.part1.icon_state = "motion1"
 				R.c_state(1, src)
 
 		// timer

--- a/code/game/objects/items/weapons/AI_modules.dm
+++ b/code/game/objects/items/weapons/AI_modules.dm
@@ -91,7 +91,7 @@ AI MODULES
 	..()
 	var/targName = sanitize(input("Please enter the name of the person to safeguard.", "Safeguard who?", user.name))
 	targetName = targName
-	desc = text("A 'safeguard' AI module: 'Safeguard []. Anyone threatening or attempting to harm [] is no longer to be considered a crew member, and is a threat which must be neutralized.'.", targetName, targetName)
+	desc = "A 'safeguard' AI module: 'Safeguard [targetName]. Anyone threatening or attempting to harm [targetName] is no longer to be considered a crew member, and is a threat which must be neutralized.'."
 
 /obj/item/aiModule/safeguard/install(obj/machinery/computer/C, mob/user)
 	if(!targetName)
@@ -100,7 +100,7 @@ AI MODULES
 	..()
 
 /obj/item/aiModule/safeguard/addAdditionalLaws(mob/living/silicon/ai/target, mob/sender)
-	var/law = text("Safeguard []. Anyone threatening or attempting to harm [] is no longer to be considered a crew member, and is a threat which must be neutralized.", targetName, targetName)
+	var/law = "Safeguard [targetName]. Anyone threatening or attempting to harm [targetName] is no longer to be considered a crew member, and is a threat which must be neutralized."
 	target.add_supplied_law(9, law)
 	GLOB.lawchanges.Add("The law specified [targetName]")
 
@@ -116,8 +116,7 @@ AI MODULES
 /obj/item/aiModule/oneHuman/attack_self(mob/user as mob)
 	..()
 	var/targName = sanitize(input("Please enter the name of the person who is the only crew member.", "Who?", user.real_name))
-	targetName = targName
-	desc = text("A 'one crew member' AI module: 'Only [] is a crew member.'.", targetName)
+	desc = "A 'one crew member' AI module: 'Only [targName] is a crew member.'."
 
 /obj/item/aiModule/oneHuman/install(obj/machinery/computer/C, mob/user)
 	if(!targetName)

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -368,19 +368,19 @@ var/global/const/NO_EMAG_ACT = -50
 
 /obj/item/card/id/proc/dat()
 	var/list/dat = list("<table><tr><td>")
-	dat += text("Name: []</A><BR>", "[formal_name_prefix][registered_name][formal_name_suffix]")
-	dat += text("Pronouns: []</A><BR>\n", sex)
-	dat += text("Age: []</A><BR>\n", age)
+	dat += "Name: [formal_name_prefix][registered_name][formal_name_suffix]</A><BR>"
+	dat += "Pronouns: [sex]</A><BR>\n"
+	dat += "Age: [age]</A><BR>\n"
 
 	if(GLOB.using_map.flags & MAP_HAS_BRANCH)
-		dat += text("Branch: []</A><BR>\n", military_branch ? military_branch.name : "\[UNSET\]")
+		dat += "Branch: [military_branch ? military_branch.name : "\[UNSET\]"]</A><BR>\n"
 	if(GLOB.using_map.flags & MAP_HAS_RANK)
-		dat += text("Rank: []</A><BR>\n", military_rank ? military_rank.name : "\[UNSET\]")
+		dat += "Rank: [military_rank ? military_rank.name : "\[UNSET\]"]</A><BR>\n"
 
-	dat += text("Assignment: []</A><BR>\n", assignment)
-	dat += text("Fingerprint: []</A><BR>\n", fingerprint_hash)
-	dat += text("Blood Type: []<BR>\n", blood_type)
-	dat += text("DNA Hash: []<BR><BR>\n", dna_hash)
+	dat += "Assignment: [assignment]</A><BR>\n"
+	dat += "Fingerprint: [fingerprint_hash]</A><BR>\n"
+	dat += "Blood Type: [blood_type]<BR>\n"
+	dat += "DNA Hash: [dna_hash]<BR><BR>\n"
 	if(front && side)
 		dat +="<td align = center valign = top>Photo:<br><img src=front.png height=80 width=80 border=4><img src=side.png height=80 width=80 border=4></td>"
 	dat += "</tr></table>"
@@ -404,7 +404,7 @@ var/global/const/NO_EMAG_ACT = -50
 	set category = "Object"
 	set src in usr
 
-	to_chat(usr, text("[icon2html(src, usr)] []: The current assignment on the card is [].", src.name, src.assignment))
+	to_chat(usr, "[icon2html(src, usr)] [name]: The current assignment on the card is [assignment].")
 	to_chat(usr, "The blood type on the card is [blood_type].")
 	to_chat(usr, "The DNA hash on the card is [dna_hash].")
 	to_chat(usr, "The fingerprint hash on the card is [fingerprint_hash].")

--- a/code/game/objects/items/weapons/extinguisher.dm
+++ b/code/game/objects/items/weapons/extinguisher.dm
@@ -54,7 +54,7 @@
 /obj/item/extinguisher/examine(mob/user, distance)
 	. = ..()
 	if(distance <= 0)
-		to_chat(user, text("[icon2html(src, viewers(get_turf(src)))] [] contains [] units of fluid left!", src, src.reagents.total_volume))
+		to_chat(user, "[icon2html(src, viewers(get_turf(src)))] [src] contains [reagents.total_volume] units of fluid left!")
 
 /obj/item/extinguisher/attack_self(mob/user as mob)
 	safety = !safety

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -65,18 +65,18 @@
 
 /obj/item/storage/secure/attack_self(mob/user)
 	user.set_machine(src)
-	var/dat = text("<TT><B>[]</B><BR>\n\nLock Status: []",src, (locked ? "LOCKED" : "UNLOCKED"))
+	var/dat = "<TT><B>[src]</B><BR>\n\nLock Status: [locked ? "LOCKED" : "UNLOCKED"]"
 	var/message = "Code"
 	if ((l_set == 0) && (!emagged) && (!l_setshort))
-		dat += text("<p>\n<b>5-DIGIT PASSCODE NOT SET.<br>ENTER NEW PASSCODE.</b>")
+		dat += "<p>\n<b>5-DIGIT PASSCODE NOT SET.<br>ENTER NEW PASSCODE.</b>"
 	if (emagged)
-		dat += text("<p>\n[SPAN_COLOR("red", "<b>LOCKING SYSTEM ERROR - 1701</b>")]")
+		dat += "<p>\n[SPAN_COLOR("red", "<b>LOCKING SYSTEM ERROR - 1701</b>")]"
 	if (l_setshort)
-		dat += text("<p>\n[SPAN_COLOR("red", "<b>ALERT: MEMORY SYSTEM ERROR - 6040 201</b>")]")
-	message = text("[]", src.code)
+		dat += "<p>\n[SPAN_COLOR("red", "<b>ALERT: MEMORY SYSTEM ERROR - 6040 201</b>")]"
+	message = "[code]"
 	if (!locked)
 		message = "*****"
-	dat += text("<HR>\n>[]<BR>\n<A href='byond://?src=\ref[];type=1'>1</A>-<A href='byond://?src=\ref[];type=2'>2</A>-<A href='byond://?src=\ref[];type=3'>3</A><BR>\n<A href='byond://?src=\ref[];type=4'>4</A>-<A href='byond://?src=\ref[];type=5'>5</A>-<A href='byond://?src=\ref[];type=6'>6</A><BR>\n<A href='byond://?src=\ref[];type=7'>7</A>-<A href='byond://?src=\ref[];type=8'>8</A>-<A href='byond://?src=\ref[];type=9'>9</A><BR>\n<A href='byond://?src=\ref[];type=R'>R</A>-<A href='byond://?src=\ref[];type=0'>0</A>-<A href='byond://?src=\ref[];type=E'>E</A><BR>\n</TT>", message, src, src, src, src, src, src, src, src, src, src, src, src)
+	dat += "<HR>\n>[message]<BR>\n<A href='byond://?src=\ref[src];type=1'>1</A>-<A href='byond://?src=\ref[src];type=2'>2</A>-<A href='byond://?src=\ref[src];type=3'>3</A><BR>\n<A href='byond://?src=\ref[src];type=4'>4</A>-<A href='byond://?src=\ref[src];type=5'>5</A>-<A href='byond://?src=\ref[src];type=6'>6</A><BR>\n<A href='byond://?src=\ref[src];type=7'>7</A>-<A href='byond://?src=\ref[src];type=8'>8</A>-<A href='byond://?src=\ref[src];type=9'>9</A><BR>\n<A href='byond://?src=\ref[src];type=R'>R</A>-<A href='byond://?src=\ref[src];type=0'>0</A>-<A href='byond://?src=\ref[src];type=E'>E</A><BR>\n</TT>"
 	show_browser(user, dat, "window=caselock;size=300x280")
 
 
@@ -103,7 +103,7 @@
 				code = null
 				close(usr)
 			else
-				src.code += text("[]", href_list["type"])
+				src.code += "[href_list["type"]]"
 				if (length(src.code) > 5)
 					src.code = "ERROR"
 		for (var/mob/M in viewers(1, loc))
@@ -115,7 +115,7 @@
 /obj/item/storage/secure/examine(mob/user, distance)
 	. = ..()
 	if(distance <= 1)
-		to_chat(user, text("The service panel is [src.open ? "open" : "closed"]."))
+		to_chat(user, "The service panel is [open ? "open" : "closed"].")
 
 
 /obj/item/storage/secure/emag_act(remaining_charges, mob/user, feedback)

--- a/code/game/objects/items/weapons/weldbackpack.dm
+++ b/code/game/objects/items/weapons/weldbackpack.dm
@@ -73,4 +73,4 @@
 
 /obj/item/storage/backpack/weldpack/examine(mob/user)
 	. = ..()
-	to_chat(user, text("[icon2html(src, user)] [] units of fuel left!", src.reagents.total_volume))
+	to_chat(user, "[icon2html(src, user)] [reagents.total_volume] units of fuel left!")

--- a/code/game/objects/structures/displaycase.dm
+++ b/code/game/objects/structures/displaycase.dm
@@ -67,6 +67,6 @@
 /obj/structure/displaycase/attack_hand(mob/user as mob)
 	add_fingerprint(user)
 	if(!health_dead())
-		to_chat(usr, text(SPAN_WARNING("You kick the display case.")))
+		to_chat(usr, SPAN_WARNING("You kick the display case."))
 		visible_message(SPAN_WARNING("[usr] kicks the display case."))
 		damage_health(2, DAMAGE_BRUTE)

--- a/code/modules/admin/NewBan.dm
+++ b/code/modules/admin/NewBan.dm
@@ -186,7 +186,7 @@ var/global/savefile/Banlist
 			if(!expiry)		expiry = "Removal Pending"
 		else				expiry = "Permaban"
 
-		dat += text("<tr><td><A href='byond://?src=[ref];unbanf=[key][id]'>(U)</A><A href='byond://?src=[ref];unbane=[key][id]'>(E)</A> Key: <B>[key]</B></td><td>ComputerID: <B>[id]</B></td><td>IP: <B>[ip]</B></td><td> [expiry]</td><td>(By: [by])</td><td>(Reason: [reason])</td></tr>")
+		dat += "<tr><td><A href='byond://?src=[ref];unbanf=[key][id]'>(U)</A><A href='byond://?src=[ref];unbane=[key][id]'>(E)</A> Key: <B>[key]</B></td><td>ComputerID: <B>[id]</B></td><td>IP: <B>[ip]</B></td><td> [expiry]</td><td>(By: [by])</td><td>(Reason: [reason])</td></tr>"
 
 	dat += "</table>"
 	dat = "<HR><B>Bans:</B> [SPAN_COLOR("blue", "(U) = Unban , (E) = Edit Ban")] - [SPAN_COLOR("green", "([count] Bans)")]<HR><table border=1 rules=all frame=void cellspacing=0 cellpadding=3 >[dat]"

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -412,8 +412,7 @@ var/global/floorIsLava = 0
 
 	var/datum/feed_network/torch_network = news_network[1] //temp change until the UI can be updated to support switching networks.
 
-	var/dat
-	dat = text("<HEAD><TITLE>Admin Newscaster</TITLE></HEAD><H3>Admin Newscaster Unit</H3>")
+	var/dat = "<HEAD><TITLE>Admin Newscaster</TITLE></HEAD><H3>Admin Newscaster Unit</H3>"
 
 	switch(admincaster_screen)
 		if(0)
@@ -657,7 +656,7 @@ var/global/floorIsLava = 0
 		var/r = t
 		if( findtext(r,"##") )
 			r = copytext( r, 1, findtext(r,"##") )//removes the description
-		dat += text("<tr><td>[t] (<A href='byond://?src=\ref[src];removejobban=[r]'>unban</A>)</td></tr>")
+		dat += "<tr><td>[t] (<A href='byond://?src=\ref[src];removejobban=[r]'>unban</A>)</td></tr>"
 	dat += "</table>"
 	show_browser(usr, dat, "window=ban;size=400x400")
 

--- a/code/modules/admin/admin_attack_log.dm
+++ b/code/modules/admin/admin_attack_log.dm
@@ -54,16 +54,16 @@
 		if (attacker.zone_sel?.selecting)
 			zone_sel = "(ZONE_SEL: [uppertext(attacker.zone_sel.selecting)])"
 		if(victim)
-			attacker.attack_logs_ += text("\[[time_stamp()]\] [SPAN_COLOR("red", "[key_name(victim)] - [attacker_message] [intent] [zone_sel]")]")
+			attacker.attack_logs_ += "\[[time_stamp()]\] [SPAN_COLOR("red", "[key_name(victim)] - [attacker_message] [intent] [zone_sel]")]"
 		else
-			attacker.attack_logs_ += text("\[[time_stamp()]\] [SPAN_COLOR("red", "[attacker_message] [intent] [zone_sel]")]")
+			attacker.attack_logs_ += "\[[time_stamp()]\] [SPAN_COLOR("red", "[attacker_message] [intent] [zone_sel]")]"
 		attacker.last_attacked_ = mob_repository.get_lite_mob(victim)
 		attack_location = get_turf(attacker)
 	if(victim)
 		if(attacker)
-			victim.attack_logs_ += text("\[[time_stamp()]\] [SPAN_COLOR("orange", "[key_name(attacker)] - [victim_message] [intent] [zone_sel]")]")
+			victim.attack_logs_ += "\[[time_stamp()]\] [SPAN_COLOR("orange", "[key_name(attacker)] - [victim_message] [intent] [zone_sel]")]"
 		else
-			victim.attack_logs_ += text("\[[time_stamp()]\] [SPAN_COLOR("orange", "[victim_message]")]")
+			victim.attack_logs_ += "\[[time_stamp()]\] [SPAN_COLOR("orange", "[victim_message]")]"
 		victim.last_attacker_ = mob_repository.get_lite_mob(attacker)
 		if(!attack_location)
 			attack_location = get_turf(victim)

--- a/code/modules/admin/banjob.dm
+++ b/code/modules/admin/banjob.dm
@@ -9,12 +9,12 @@ var/global/list/jobban_keylist = list()		//to store the keys & ranks
 	var/last_ckey = LAST_CKEY(M)
 	if(!last_ckey)
 		return
-	jobban_keylist.Add(text("[last_ckey] - [rank] ## [reason]"))
+	jobban_keylist.Add("[last_ckey] - [rank] ## [reason]")
 	jobban_savebanfile()
 
 /proc/jobban_client_fullban(ckey, rank)
 	if (!ckey || !rank) return
-	jobban_keylist.Add(text("[ckey] - [rank]"))
+	jobban_keylist.Add("[ckey] - [rank]")
 	jobban_savebanfile()
 
 //returns a reason if M is banned from rank, returns 0 otherwise

--- a/code/modules/admin/secrets/admin_secrets/bombing_list.dm
+++ b/code/modules/admin/secrets/admin_secrets/bombing_list.dm
@@ -8,5 +8,5 @@
 
 	var/dat = "<B>Bombing List</B>"
 	for(var/l in GLOB.bombers)
-		dat += text("[l]<BR>")
+		dat += "[l]<BR>"
 	show_browser(user, dat, "window=bombers")

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -413,7 +413,7 @@
 
 	var/dat = display_medical_data(H.get_raw_medical_data(mutations = TRUE), SKILL_MAX)
 
-	dat += text("<A href='byond://?src=\ref[];mach_close=scanconsole'>Close</A>", usr)
+	dat += "<A href='byond://?src=\ref[usr];mach_close=scanconsole'>Close</A>"
 	send_rsc(usr, 'html/browser/common.css', "common.css")
 	show_browser(usr, html_page_common("Health Data: [H]", dat), "window=scanconsole;size=600x900")
 

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -151,7 +151,7 @@
 			return
 
 	if (!message)
-		message = input("Message:", text("Enter the text you wish to appear to your target:")) as null|text
+		message = input("Message:", "Enter the text you wish to appear to your target:") as null|text
 		if (style != "unsafe")
 			message = sanitize(message)
 	if (!message)
@@ -702,9 +702,9 @@ Ccomp's first proc.
 
 	if(!check_rights(R_DEBUG|R_FUN))	return
 
-	var/heavy = input("Range of heavy pulse.", text("Input"))  as num|null
+	var/heavy = input("Range of heavy pulse.", "Input")  as num|null
 	if(isnull(heavy)) return
-	var/light = input("Range of light pulse.", text("Input"))  as num|null
+	var/light = input("Range of light pulse.", "Input")  as num|null
 	if(isnull(light)) return
 
 	if (heavy || light)

--- a/code/modules/assembly/infrared.dm
+++ b/code/modules/assembly/infrared.dm
@@ -64,11 +64,21 @@
 		return
 
 	user.set_machine(src)
-	var/dat = list()
-	dat += text("<TT><B>Infrared Laser</B>\n<B>Status</B>: []<BR>\n<B>Visibility</B>: []<BR>\n</TT>", (on ? text("<A href='byond://?src=\ref[];state=0'>On</A>", src) : text("<A href='byond://?src=\ref[];state=1'>Off</A>", src)), (src.visible ? text("<A href='byond://?src=\ref[];visible=0'>Visible</A>", src) : text("<A href='byond://?src=\ref[];visible=1'>Invisible</A>", src)))
+	var/dat
+	var/onoff
+	if (on)
+		onoff = "<A href='byond://?src=\ref[src];state=0'>On</A>"
+	else
+		onoff = "<A href='byond://?src=\ref[src];state=1'>Off</A>"
+	var/visibility
+	if (visible)
+		visibility = "<A href='byond://?src=\ref[src];visible=0'>Visible</A>"
+	else
+		visibility = "<A href='byond://?src=\ref[src];visible=1'>Invisible</A>"
+	dat = "<TT><B>Infrared Laser</B>\n<B>Status</B>: [onoff]<BR>\n<B>Visibility</B>: [visibility]<BR>\n</TT>"
 	dat += "<BR><BR><A href='byond://?src=\ref[src];refresh=1'>Refresh</A>"
 	dat += "<BR><BR><A href='byond://?src=\ref[src];close=1'>Close</A>"
-	show_browser(user, jointext(dat,null), "window=infra")
+	show_browser(user, dat, "window=infra")
 	onclose(user, "infra")
 
 /obj/item/device/assembly/infra/Topic(href, href_list, state = GLOB.physical_state)

--- a/code/modules/assembly/proximity.dm
+++ b/code/modules/assembly/proximity.dm
@@ -120,8 +120,13 @@
 		return 0
 	var/second = time % 60
 	var/minute = (time - second) / 60
-	var/dat = text("<TT><B>Proximity Sensor</B>\n[] []:[]\n<A href='byond://?src=\ref[];tp=-30'>-</A> <A href='byond://?src=\ref[];tp=-1'>-</A> <A href='byond://?src=\ref[];tp=1'>+</A> <A href='byond://?src=\ref[];tp=30'>+</A>\n</TT>", (timing ? text("<A href='byond://?src=\ref[];time=0'>Arming</A>", src) : text("<A href='byond://?src=\ref[];time=1'>Not Arming</A>", src)), minute, second, src, src, src, src)
-	dat += text("<BR>Range: <A href='byond://?src=\ref[];range=-1'>-</A> [] <A href='byond://?src=\ref[];range=1'>+</A>", src, range, src)
+	var/dat
+	if (timing)
+		dat = "<A href='byond://?src=\ref[src];time=0'>Arming</A>"
+	else
+		dat = "<A href='byond://?src=\ref[src];time=1'>Not Arming</A>"
+	dat = "<TT><B>Proximity Sensor</B>\n[dat] [minute]:[second]\n<A href='byond://?src=\ref[src];tp=-30'>-</A> <A href='byond://?src=\ref[src];tp=-1'>-</A> <A href='byond://?src=\ref[src];tp=1'>+</A> <A href='byond://?src=\ref[src];tp=30'>+</A>\n</TT>"
+	dat += "<BR>Range: <A href='byond://?src=\ref[src];range=-1'>-</A> [range] <A href='byond://?src=\ref[src];range=1'>+</A>"
 	dat += "<BR><A href='byond://?src=\ref[src];scanning=1'>[scanning?"Armed":"Unarmed"]</A> (Movement sensor active when armed!)"
 	dat += "<BR><BR><A href='byond://?src=\ref[src];refresh=1'>Refresh</A>"
 	dat += "<BR><BR><A href='byond://?src=\ref[src];close=1'>Close</A>"

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -133,7 +133,7 @@
 
 	if(!holder)
 		for(var/mob/O in hearers(1, src.loc))
-			O.show_message(text("[icon2html(src, O)] *beep* *beep*"), 3, "*beep* *beep*", 2)
+			O.show_message("[icon2html(src, O)] *beep* *beep*", 3, "*beep* *beep*", 2)
 	return
 
 

--- a/code/modules/assembly/timer.dm
+++ b/code/modules/assembly/timer.dm
@@ -74,7 +74,12 @@
 		return 0
 	var/second = time % 60
 	var/minute = (time - second) / 60
-	var/dat = text("<TT><B>Timing Unit</B>\n[] []:[]\n<A href='byond://?src=\ref[];tp=-30'>-</A> <A href='byond://?src=\ref[];tp=-1'>-</A> <A href='byond://?src=\ref[];tp=1'>+</A> <A href='byond://?src=\ref[];tp=30'>+</A>\n</TT>", (timing ? text("<A href='byond://?src=\ref[];time=0'>Timing</A>", src) : text("<A href='byond://?src=\ref[];time=1'>Not Timing</A>", src)), minute, second, src, src, src, src)
+	var/dat
+	if (timing)
+		dat = "<A href='byond://?src=\ref[src];time=0'>Timing</A>"
+	else
+		dat = "<A href='byond://?src=\ref[src];time=1'>Not Timing</A>"
+	dat = "<TT><B>Timing Unit</B>\n[dat] [minute]:[second]\n<A href='byond://?src=\ref[src];tp=-30'>-</A> <A href='byond://?src=\ref[src];tp=-1'>-</A> <A href='byond://?src=\ref[src];tp=1'>+</A> <A href='byond://?src=\ref[src];tp=30'>+</A>\n</TT>"
 	dat += "<BR><BR><A href='byond://?src=\ref[src];refresh=1'>Refresh</A>"
 	dat += "<BR><BR><A href='byond://?src=\ref[src];close=1'>Close</A>"
 	show_browser(user, dat, "window=timer")

--- a/code/modules/economy/Accounts_DB.dm
+++ b/code/modules/economy/Accounts_DB.dm
@@ -54,7 +54,7 @@
 	var/data = list()
 	data["src"] = "\ref[src]"
 	data["id_inserted"] = !!held_card
-	data["id_card"] = held_card ? text("[held_card.registered_name], [held_card.assignment]") : "-----"
+	data["id_card"] = held_card ? "[held_card.registered_name], [held_card.assignment]" : "-----"
 	data["access_level"] = has_access(needed_access, held_card && held_card.GetAccess())
 	data["machine_id"] = machine_id
 	data["creating_new_account"] = creating_new_account

--- a/code/modules/holodeck/HolodeckObjects.dm
+++ b/code/modules/holodeck/HolodeckObjects.dm
@@ -182,7 +182,7 @@
 			close()
 
 	else if (density)
-		flick(text("[]deny", base_state), src)
+		flick("[base_state]deny", src)
 		return TRUE
 
 	return ..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -435,8 +435,8 @@
 	<BR><B>Head(Mask):</B> <A href='byond://?src=\ref[src];item=mask'>[(wear_mask ? wear_mask : "Nothing")]</A>
 	<BR><B>Left Hand:</B> <A href='byond://?src=\ref[src];item=l_hand'>[(l_hand ? l_hand  : "Nothing")]</A>
 	<BR><B>Right Hand:</B> <A href='byond://?src=\ref[src];item=r_hand'>[(r_hand ? r_hand : "Nothing")]</A>
-	<BR><B>Back:</B> <A href='byond://?src=\ref[src];item=back'>[(back ? back : "Nothing")]</A> [((istype(wear_mask, /obj/item/clothing/mask) && istype(back, /obj/item/tank) && !( internal )) ? text(" <A href='byond://?src=\ref[];item=internal'>Set Internal</A>", src) : "")]
-	<BR>[(internal ? text("<A href='byond://?src=\ref[src];item=internal'>Remove Internal</A>") : "")]
+	<BR><B>Back:</B> <A href='byond://?src=\ref[src];item=back'>[(back ? back : "Nothing")]</A> [(istype(wear_mask, /obj/item/clothing/mask) && istype(back, /obj/item/tank) && !internal) ? " <A href='byond://?src=\ref[src];item=internal'>Set Internal</A>" : ""]
+	<BR>[internal ? "<A href='byond://?src=\ref[src];item=internal'>Remove Internal</A>" : ""]
 	<BR><A href='byond://?src=\ref[src];item=pockets'>Empty Pockets</A>
 	<BR><A href='byond://?src=\ref[user];refresh=1'>Refresh</A>
 	<BR>"}

--- a/code/modules/mob/living/carbon/xenobiological/powers.dm
+++ b/code/modules/mob/living/carbon/xenobiological/powers.dm
@@ -137,7 +137,7 @@
 			maxHealth = 200
 			amount_grown = 0
 			regenerate_icons()
-			SetName(text("[colour] [is_adult ? "adult" : "baby"] slime ([number])"))
+			SetName("[colour] [is_adult ? "adult" : "baby"] slime ([number])")
 		else
 			to_chat(src, SPAN_NOTICE("I am not ready to evolve yet..."))
 	else

--- a/code/modules/mob/living/silicon/robot/analyzer.dm
+++ b/code/modules/mob/living/silicon/robot/analyzer.dm
@@ -19,11 +19,11 @@
 
 /proc/roboscan(mob/living/M, mob/living/user)
 	if((MUTATION_CLUMSY in user.mutations) && prob(50))
-		to_chat(user, text(SPAN_WARNING("You try to analyze the floor's vitals!")))
+		to_chat(user, SPAN_WARNING("You try to analyze the floor's vitals!"))
 		for(var/mob/O in viewers(M, null))
-			O.show_message(text(SPAN_WARNING("[user] has analyzed the floor's vitals!")), 1)
-		user.show_message(text(SPAN_NOTICE("Analyzing Results for The floor:\n\t Overall Status: Healthy")), 1)
-		user.show_message(text(SPAN_NOTICE("\t Damage Specifics: \[0\]-\[0\]-\[0\]-\[0\]")), 1)
+			O.show_message(SPAN_WARNING("[user] has analyzed the floor's vitals!"), 1)
+		user.show_message(SPAN_NOTICE("Analyzing Results for The floor:\n\t Overall Status: Healthy"), 1)
+		user.show_message(SPAN_NOTICE("\t Damage Specifics: \[0\]-\[0\]-\[0\]-\[0\]"), 1)
 		user.show_message(SPAN_NOTICE("Key: Suffocation/Toxin/Burns/Brute"), 1)
 		user.show_message(SPAN_NOTICE("Body Temperature: ???"), 1)
 		return

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -455,11 +455,11 @@
 // this function displays the cyborgs current cell charge in the stat panel
 /mob/living/silicon/robot/proc/show_cell_power()
 	if(cell)
-		stat(null, text("Charge Left: [round(cell.percent())]%"))
-		stat(null, text("Cell Rating: [round(cell.maxcharge)]")) // Round just in case we somehow get crazy values
-		stat(null, text("Power Cell Load: [round(used_power_this_tick)]W"))
+		stat(null, "Charge Left: [round(cell.percent())]%")
+		stat(null, "Cell Rating: [round(cell.maxcharge)]") // Round just in case we somehow get crazy value
+		stat(null, "Power Cell Load: [round(used_power_this_tick)]W")
 	else
-		stat(null, text("No Cell Inserted!"))
+		stat(null, "No Cell Inserted!")
 
 
 // update the status screen display
@@ -468,7 +468,7 @@
 	if (statpanel("Status"))
 		show_cell_power()
 		show_jetpack_pressure()
-		stat(null, text("Lights: [lights_on ? "ON" : "OFF"]"))
+		stat(null, "Lights: [lights_on ? "ON" : "OFF"]")
 		if(module)
 			for(var/datum/matter_synth/ms in module.synths)
 				stat("[ms.name]: [ms.energy]/[ms.max_energy_multiplied]")
@@ -949,11 +949,11 @@
 
 	for (var/obj in module.equipment)
 		if (!obj)
-			dat += text("<B>Resource depleted</B><BR>")
+			dat += "<B>Resource depleted</B><BR>"
 		else if (IsHolding(obj))
-			dat += text("[obj]: <B>Activated</B><BR>")
+			dat += "[obj]: <B>Activated</B><BR>"
 		else
-			dat += text("[obj]: <A HREF='byond://?src=\ref[src];act=\ref[obj]'>Activate</A><BR>")
+			dat += "[obj]: <A HREF='byond://?src=\ref[src];act=\ref[obj]'>Activate</A><BR>"
 
 	show_browser(src, dat, "window=robotmod")
 

--- a/code/modules/mob/living/silicon/robot/robot_items.dm
+++ b/code/modules/mob/living/silicon/robot/robot_items.dm
@@ -89,7 +89,7 @@
 	I.forceMove(src)
 	loaded_item = I
 	for(var/mob/M in viewers())
-		M.show_message(text(SPAN_NOTICE("[user] adds the [I] to the [src].")), 1)
+		M.show_message(SPAN_NOTICE("[user] adds the [I] to the [src]."), 1)
 	desc = initial(desc) + "<br>It is holding \the [loaded_item]."
 	flick("portable_analyzer_load", src)
 	icon_state = "portable_analyzer_full"
@@ -242,7 +242,7 @@
 
 	//n_name = copytext(n_name, 1, 32)
 	if(( get_dist(user,paper) <= 1  && user.stat == 0))
-		paper.SetName("paper[(n_name ? text("- '[n_name]'") : null)]")
+		paper.SetName("paper[(n_name ? "- '[n_name]'" : null)]")
 		paper.last_modified_ckey = user.ckey
 	add_fingerprint(user)
 	return

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -149,9 +149,9 @@
 // this function shows the health of the AI in the Status panel
 /mob/living/silicon/proc/show_system_integrity()
 	if(!src.stat)
-		stat(null, text("System integrity: [round((health/maxHealth)*100)]%"))
+		stat(null, "System integrity: [round((health/maxHealth)*100)]%")
 	else
-		stat(null, text("Systems nonfunctional"))
+		stat(null, "Systems nonfunctional")
 
 
 // This is a pure virtual function, it should be overwritten by all subclasses

--- a/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/retaliate/parrot.dm
@@ -151,7 +151,7 @@
 	else
 		dat +=	"<br><b>Headset:</b> <a href='byond://?src=\ref[src];add_inv=ears'>Nothing</a>"
 
-	show_browser(user, dat, text("window=mob[];size=325x500", name))
+	show_browser(user, dat, "window=mob[name];size=325x500")
 	onclose(user, "mob[real_name]")
 	return
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -458,7 +458,7 @@
 /mob/proc/OnSelfTopic(href_list, topic_status)
 	if (topic_status == STATUS_INTERACTIVE)
 		if(href_list["mach_close"])
-			var/t1 = text("window=[href_list["mach_close"]]")
+			var/t1 = "window=[href_list["mach_close"]]"
 			unset_machine()
 			show_browser(src, null, t1)
 			return TOPIC_HANDLED

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -262,16 +262,16 @@ var/global/list/organ_rel_size = list(
 		var/n_letter = copytext_char(te, p, p + 1)//copies text from a certain distance. In this case, only one letter at a time.
 		if (prob(80) && (ckey(n_letter) in list("b","c","d","f","g","h","j","k","l","m","n","p","q","r","s","t","v","w","x","y","z")))
 			if (prob(10))
-				n_letter = text("[n_letter]-[n_letter]-[n_letter]-[n_letter]")//replaces the current letter with this instead.
+				n_letter = "[n_letter]-[n_letter]-[n_letter]-[n_letter]" //replaces the current letter with this instead.
 			else
 				if (prob(20))
-					n_letter = text("[n_letter]-[n_letter]-[n_letter]")
+					n_letter = "[n_letter]-[n_letter]-[n_letter]"
 				else
 					if (prob(5))
 						n_letter = null
 					else
-						n_letter = text("[n_letter]-[n_letter]")
-		t = text("[t][n_letter]")//since the above is ran through for each letter, the text just adds up back to the original word.
+						n_letter = "[n_letter]-[n_letter]"
+		t = "[t][n_letter]" //since the above is ran through for each letter, the text just adds up back to the original word.
 		p++//for each letter p is increased to find where the next letter will be.
 	return sanitize(t)
 

--- a/code/modules/modular_computers/NTNet/emails/email_message.dm
+++ b/code/modules/modular_computers/NTNet/emails/email_message.dm
@@ -21,7 +21,7 @@
 
 // Turns /email_message/ file into regular /data/ file.
 /datum/computer_file/data/email_message/proc/export()
-	var/datum/computer_file/data/dat = new/datum/computer_file/data/text()
+	var/datum/computer_file/data/dat = new/datum/computer_file/data/text
 	dat.stored_data =  "Received from [source] at [timestamp]."
 	dat.stored_data += "\[b\][title]\[/b\]"
 	dat.stored_data += stored_data

--- a/code/modules/modular_computers/file_system/programs/command/card.dm
+++ b/code/modules/modular_computers/file_system/programs/command/card.dm
@@ -321,7 +321,7 @@
 								id_card.access += access_type
 							break
 	if(id_card)
-		id_card.SetName(text("[id_card.registered_name]'s ID Card ([id_card.assignment])"))
+		id_card.SetName("[id_card.registered_name]'s ID Card ([id_card.assignment])")
 
 	SSnano.update_uis(NM)
 	return 1

--- a/code/modules/paperwork/paper_bundle.dm
+++ b/code/modules/paperwork/paper_bundle.dm
@@ -188,7 +188,7 @@
 
 	var/n_name = sanitizeSafe(input(usr, "What would you like to label the bundle?", "Bundle Labelling", null)  as text, MAX_NAME_LEN)
 	if((loc == usr || loc.loc && loc.loc == usr) && usr.stat == 0)
-		SetName("[(n_name ? text("[n_name]") : "paper")]")
+		SetName("[n_name ? "[n_name]" : "paper"]")
 	add_fingerprint(usr)
 	return
 

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -96,7 +96,7 @@ var/global/photo_count = 0
 	//loc.loc check is for making possible renaming photos in clipboards
 	if(!n_name || !CanInteract(usr, GLOB.deep_inventory_state))
 		return
-	SetName("[(n_name ? text("[n_name]") : "photo")]")
+	SetName("[n_name ? "[n_name]" : "photo"]")
 	add_fingerprint(usr)
 	return
 

--- a/code/modules/power/breaker_box.dm
+++ b/code/modules/power/breaker_box.dm
@@ -68,7 +68,7 @@
 
 	busy = 1
 	for(var/mob/O in viewers(user))
-		O.show_message(text(SPAN_WARNING("\The [user] started reprogramming \the [src]!")), 1)
+		O.show_message(SPAN_WARNING("\The [user] started reprogramming \the [src]!"), 1)
 
 	if(do_after(user, 5 SECONDS, src, DO_PUBLIC_UNIQUE))
 		set_state(!on)

--- a/code/modules/power/port_gen.dm
+++ b/code/modules/power/port_gen.dm
@@ -372,16 +372,16 @@
 
 	user.set_machine(src)
 
-	var/dat = text("<b>[name]</b><br>")
+	var/dat = "<b>[name]</b><br>"
 	if (active)
-		dat += text("Generator: <A href='byond://?src=\ref[src];action=disable'>On</A><br>")
+		dat += "Generator: <A href='byond://?src=\ref[src];action=disable'>On</A><br>"
 	else
-		dat += text("Generator: <A href='byond://?src=\ref[src];action=enable'>Off</A><br>")
-	dat += text("[capitalize(sheet_name)]: [sheets] - <A href='byond://?src=\ref[src];action=eject'>Eject</A><br>")
+		dat += "Generator: <A href='byond://?src=\ref[src];action=enable'>Off</A><br>"
+	dat += "[capitalize(sheet_name)]: [sheets] - <A href='byond://?src=\ref[src];action=eject'>Eject</A><br>"
 	var/stack_percent = round(sheet_left * 100, 1)
-	dat += text("Current stack: [stack_percent]% <br>")
-	dat += text("Power output: <A href='byond://?src=\ref[src];action=lower_power'>-</A> [power_gen * power_output] Watts<A href='byond://?src=\ref[src];action=higher_power'>+</A><br>")
-	dat += text("Power current: [(isnull(powernet) ? "Unconnected" : "[avail()]")]<br>")
+	dat += "Current stack: [stack_percent]% <br>"
+	dat += "Power output: <A href='byond://?src=\ref[src];action=lower_power'>-</A> [power_gen * power_output] Watts<A href='byond://?src=\ref[src];action=higher_power'>+</A><br>"
+	dat += "Power current: [(isnull(powernet) ? "Unconnected" : "[avail()]")]<br>"
 
 	var/tempstr = "Temperature: [temperature]&deg;C<br>"
 	dat += (overheating)? SPAN_DANGER("[tempstr]") : tempstr

--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -297,7 +297,7 @@
 
 		if (target != user && H.get_blocked_ratio(target_zone, DAMAGE_BRUTE, damage_flags=DAMAGE_FLAG_SHARP) > 0.1 && prob(50))
 			for(var/mob/O in viewers(world.view, user))
-				O.show_message(text(SPAN_DANGER("[user] tries to stab [target] in \the [hit_area] with [src.name], but the attack is deflected by armor!")), 1)
+				O.show_message(SPAN_DANGER("[user] tries to stab [target] in \the [hit_area] with [src.name], but the attack is deflected by armor!"), 1)
 			qdel(src)
 
 			admin_attack_log(user, target, "Attacked using \a [src]", "Was attacked with \a [src]", "used \a [src] to attack")

--- a/code/modules/spells/spell_code.dm
+++ b/code/modules/spells/spell_code.dm
@@ -191,7 +191,7 @@ var/global/list/spells = typesof(/spell) //needed for the badmin verb for now
 	for(var/atom/target in targets)
 		var/location = get_turf(target)
 		if(istype(target,/mob/living) && message)
-			to_chat(target, text("[message]"))
+			to_chat(target, "[message]")
 		if(sparks_spread)
 			var/datum/effect/spark_spread/sparks = new /datum/effect/spark_spread()
 			sparks.set_up(sparks_amt, 0, location) //no idea what the 0 is

--- a/code/modules/synthesized_instruments/real_instruments.dm
+++ b/code/modules/synthesized_instruments/real_instruments.dm
@@ -44,7 +44,7 @@
 		if ("import")
 			var/t = ""
 			do
-				t = html_encode(input(user, "Please paste the entire song, formatted:", text("[]", owner.name), t)  as message)
+				t = html_encode(input(user, "Please paste the entire song, formatted:", "[owner.name]", t)  as message)
 				if(!CanInteractWith(user, owner, GLOB.physical_state))
 					return
 

--- a/test/check-paths.sh
+++ b/test/check-paths.sh
@@ -70,6 +70,7 @@ exactly 0 "istype /list where islist should be used" 'istype\(.*?,\s*/list\s*\)'
 exactly 0 "istype /atom where isloc should be used" 'istype\(.*?,\s*/atom\s*\)' -P
 exactly 0 "istype atom/movable where ismovable should be used" 'istype\(.*?,\s*/atom/movable\s*\)' -P
 exactly 0 "callback proc/ or verb/ where PROC_REF, VERB_REF, etc should be used" 'Callback\([\w/]*,\s*[\w\./]*proc' -P # Callback(src, .proc/foo) should be Callback(src, PROC_REF(foo)), or equivalent. See code\__defines\procs.dm
+exactly 0 "uses of deprecated text proc" '\btext\(' -P
 # If you increase any of these numbers you're probably doing it wrong
 
 num=`find ./html/changelogs -not -name "*.yml" | wc -l`


### PR DESCRIPTION
using \btext\( to match, changes uses of `text("[]", foo)` to `"[foo]"` and adds a test to prevent adding new uses

late as this is, follows (undocumented) guidance on deprecation:
https://www.byond.com/forum/post/2872285#comment26519139