### PR TITLE
give all food 1 nutriment minimum

### DIFF
--- a/code/modules/reagents/reagent_containers/food/snacks.dm
+++ b/code/modules/reagents/reagent_containers/food/snacks.dm
@@ -9,7 +9,7 @@
 	var/slices_num
 	var/dried_type = null
 	var/dry = 0
-	var/nutriment_amt = 0
+	var/nutriment_amt = 1
 	var/list/nutriment_desc = list("food" = 1)
 	var/list/eat_sound = 'sound/items/eatfood.ogg'
 	var/obj/item/trash


### PR DESCRIPTION
:cl: Mucker
bugfix: All food items now have at least 1 unit of nutriment when spawned in by means other than cooking.
/:cl: