### PR TITLE
exam room windows don't have grilles

### DIFF
--- a/code/game/objects/structures/wallframe_spawner.dm
+++ b/code/game/objects/structures/wallframe_spawner.dm
@@ -156,10 +156,6 @@
 	name = "polarized reinforced wall frame window spawner (no grille)"
 	grille_path = null
 
-/obj/wallframe_spawn/reinforced/polarized/full//wtf it's the same as the other one, not gonna touch this cause I don't wanna remap a million things
-	name = "polarized reinforced wall frame window spawner - full tile"
-	win_path = /obj/structure/window/reinforced/polarized/full
-
 /obj/wallframe_spawn/reinforced/polarized/no_grille/regular
 	name = "polarized wall frame window spawner (no grille) (non reinforced)"
 	win_path = /obj/structure/window/basic/full/polarized

--- a/maps/antag_spawn/ert/ert_ship.dmm
+++ b/maps/antag_spawn/ert/ert_ship.dmm
@@ -870,7 +870,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/ert/ship/hangar)
 "fA" = (
-/obj/wallframe_spawn/reinforced/polarized/full{
+/obj/wallframe_spawn/reinforced/polarized{
 	id = "ert_co_windows"
 	},
 /obj/paint/fleet,
@@ -1619,7 +1619,7 @@
 "kg" = (
 /obj/paint/fleet,
 /obj/machinery/door/firedoor/ert,
-/obj/wallframe_spawn/reinforced/polarized/full{
+/obj/wallframe_spawn/reinforced/polarized{
 	id = "ert_co_windows"
 	},
 /obj/machinery/door/blast/regular/open{

--- a/maps/event/sfv_arbiter/sfv_arbiter.dmm
+++ b/maps/event/sfv_arbiter/sfv_arbiter.dmm
@@ -102,7 +102,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/wallframe_spawn/reinforced/polarized/full{
+/obj/wallframe_spawn/reinforced/polarized{
 	color = "#4c535b"
 	},
 /obj/paint/iccgn,
@@ -632,7 +632,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wallframe_spawn/reinforced/polarized/full{
+/obj/wallframe_spawn/reinforced/polarized{
 	color = "#4c535b"
 	},
 /obj/paint/iccgn,
@@ -718,7 +718,7 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/obj/wallframe_spawn/reinforced/polarized/full{
+/obj/wallframe_spawn/reinforced/polarized{
 	color = "#4c535b"
 	},
 /obj/paint/iccgn,
@@ -1036,7 +1036,7 @@
 	dir = 1;
 	icon_state = "0-2"
 	},
-/obj/wallframe_spawn/reinforced/polarized/full{
+/obj/wallframe_spawn/reinforced/polarized{
 	color = "#4c535b"
 	},
 /obj/paint/iccgn,

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -1332,7 +1332,7 @@
 /turf/simulated/wall/prepainted,
 /area/maintenance/firstdeck/centralstarboard)
 "acE" = (
-/obj/wallframe_spawn/reinforced/polarized/full{
+/obj/wallframe_spawn/reinforced/polarized{
 	id = "roboticlab_window"
 	},
 /obj/machinery/door/blast/shutters{
@@ -18050,7 +18050,7 @@
 /turf/simulated/floor/tiled/monotile,
 /area/assembly/chargebay)
 "gXb" = (
-/obj/wallframe_spawn/reinforced/polarized/full{
+/obj/wallframe_spawn/reinforced/polarized/no_grille{
 	id = "exam_windows"
 	},
 /obj/machinery/door/blast/shutters{
@@ -25615,7 +25615,7 @@
 /turf/simulated/floor/tiled/white,
 /area/medical/surgery)
 "qqb" = (
-/obj/wallframe_spawn/reinforced/polarized/full{
+/obj/wallframe_spawn/reinforced/polarized{
 	id = "sci_office"
 	},
 /turf/simulated/floor/plating,


### PR DESCRIPTION
:cl:
maptweak: Medical exam room exterior windows no longer have grilles.
/:cl:

also removes duplicate definition for full polarized window spawner (it was no longer a million things)