### PR TITLE
fix merchant guest IDs

### DIFF
--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -736,3 +736,8 @@ var/global/const/NO_EMAG_ACT = -50
 	access = list(access_merchant)
 	color = COLOR_OFF_WHITE
 	detail_color = COLOR_BEIGE
+
+/obj/item/card/id/merchant/guest
+	name = "guest card"
+	desc = "A card providing guest access to the facilities of a merchant station."
+	detail_color = COLOR_GREEN_GRAY

--- a/maps/torch/z1_admin.dmm
+++ b/maps/torch/z1_admin.dmm
@@ -8922,24 +8922,9 @@
 "aQo" = (
 /obj/structure/table/rack,
 /obj/floor_decal/industrial/outline/grey,
-/obj/item/card/id{
-	access = list(301);
-	desc = "A visitor's access card, this one is for the Merchant's Station.";
-	icon_state = "guest";
-	name = "Visitor's Card - Merchant's Station"
-	},
-/obj/item/card/id{
-	access = list(301);
-	desc = "A visitor's access card, this one is for the Merchant's Station.";
-	icon_state = "guest";
-	name = "Visitor's Card - Merchant's Station"
-	},
-/obj/item/card/id{
-	access = list(301);
-	desc = "A visitor's access card, this one is for the Merchant's Station.";
-	icon_state = "guest";
-	name = "Visitor's Card - Merchant's Station"
-	},
+/obj/item/card/id/merchant/guest,
+/obj/item/card/id/merchant/guest,
+/obj/item/card/id/merchant/guest,
 /turf/simulated/floor/tiled/dark,
 /area/merchant_station)
 "aQp" = (


### PR DESCRIPTION
:cl:
bugfix: Merchant guest IDs have sprites again.
/:cl:
fixes this 
<img width="294" height="185" alt="dreamseeker_TRG64V5pdR" src="https://github.com/user-attachments/assets/d1a7be26-6924-4c70-b0aa-0121f517d287" />
