### PR TITLE
add 'allow respawn 2' to the special verbs menu

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -81,6 +81,7 @@ var/global/list/admin_verbs_admin = list(
 	/client/proc/toggle_antagHUD_use,
 	/client/proc/toggle_antagHUD_restrictions,
 	/client/proc/allow_character_respawn,    // Allows a ghost to respawn ,
+	/client/proc/allow_respawn,
 	/client/proc/event_manager_panel,
 	/client/proc/empty_ai_core_toggle_latejoin,
 	/client/proc/empty_ai_core_toggle_latejoin,

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -441,7 +441,7 @@ Ccomp's first proc.
 
 /client/proc/allow_respawn()
 	set category = "Special Verbs"
-	set name = "Allow Respawn"
+	set name = "Allow Respawn 2"
 	set desc = "Allows a ghost or lobby player to bypass respawn timers."
 	if(!check_rights(R_ADMIN))
 		return


### PR DESCRIPTION
:cl:
admin: Added "Allow Respawn 2" to the special verbs menu. This allows admins to allow people to skip the lobby timer while they are in the lobby.
/:cl:
Actually makes #32402 available to use. If it hasn't rotted, the older version can get pulled in another commit.
I've mentioned that I should actually do this every so often [for a long time](https://github.com/Baystation12/Baystation12/issues/32527#issuecomment-1239651873) and never actually remembered to. What a despicable fool

can nix #32527 if this works out