### PR TITLE
Make guitars ITEM_SIZE_HUGE to avoid them fitting in backpacks

### DIFF
--- a/code/modules/synthesized_instruments/real_instruments/Guitar/guitar.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Guitar/guitar.dm
@@ -5,9 +5,9 @@
 	icon_state = "guitar"
 	item_state = "guitar"
 	slot_flags = SLOT_BACK
+	w_class = ITEM_SIZE_HUGE
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/guitar/clean_crisis
-
 
 /obj/item/device/synthesized_instrument/guitar/multi_v
 	name = "Polyguitar Flying V"
@@ -16,6 +16,7 @@
 	icon_state = "eguitar_v"
 	item_state = "eguitar_v"
 	slot_flags = SLOT_BACK
+	w_class = ITEM_SIZE_HUGE
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/guitar
 
@@ -26,6 +27,7 @@
 	icon_state = "eguitar_strato_black"
 	item_state = "eguitar_strato_black"
 	slot_flags = SLOT_BACK
+	w_class = ITEM_SIZE_HUGE
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/guitar
 
@@ -36,6 +38,7 @@
 	icon_state = "eguitar_strato_gradient"
 	item_state = "eguitar_strato_gradient"
 	slot_flags = SLOT_BACK
+	w_class = ITEM_SIZE_HUGE
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/guitar
 
@@ -46,6 +49,7 @@
 	icon_state = "eguitar_strato_red"
 	item_state = "eguitar_strato_red"
 	slot_flags = SLOT_BACK
+	w_class = ITEM_SIZE_HUGE
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/guitar
 
@@ -56,5 +60,6 @@
 	icon_state = "eguitar_strato_purple"
 	item_state = "eguitar_strato_purple"
 	slot_flags = SLOT_BACK
+	w_class = ITEM_SIZE_HUGE
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/guitar


### PR DESCRIPTION
:cl: limelier
tweak: Change guitars to a bigger item size class so that they don't fit in backpacks anymore.
/:cl:

I thought it was weird that a whole-ass guitar only takes up a tiny bit of space and can fit in a normal backpack. I'm changing them to ITEM_SIZE_HUGE so that they don't anymore.