### PR TITLE
Revert "Make guitars ITEM_SIZE_HUGE to avoid them fitting in backpacks"

### DIFF
--- a/code/modules/synthesized_instruments/real_instruments/Guitar/guitar.dm
+++ b/code/modules/synthesized_instruments/real_instruments/Guitar/guitar.dm
@@ -5,9 +5,9 @@
 	icon_state = "guitar"
 	item_state = "guitar"
 	slot_flags = SLOT_BACK
-	w_class = ITEM_SIZE_HUGE
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/guitar/clean_crisis
+
 
 /obj/item/device/synthesized_instrument/guitar/multi_v
 	name = "Polyguitar Flying V"
@@ -16,7 +16,6 @@
 	icon_state = "eguitar_v"
 	item_state = "eguitar_v"
 	slot_flags = SLOT_BACK
-	w_class = ITEM_SIZE_HUGE
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/guitar
 
@@ -27,7 +26,6 @@
 	icon_state = "eguitar_strato_black"
 	item_state = "eguitar_strato_black"
 	slot_flags = SLOT_BACK
-	w_class = ITEM_SIZE_HUGE
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/guitar
 
@@ -38,7 +36,6 @@
 	icon_state = "eguitar_strato_gradient"
 	item_state = "eguitar_strato_gradient"
 	slot_flags = SLOT_BACK
-	w_class = ITEM_SIZE_HUGE
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/guitar
 
@@ -49,7 +46,6 @@
 	icon_state = "eguitar_strato_red"
 	item_state = "eguitar_strato_red"
 	slot_flags = SLOT_BACK
-	w_class = ITEM_SIZE_HUGE
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/guitar
 
@@ -60,6 +56,5 @@
 	icon_state = "eguitar_strato_purple"
 	item_state = "eguitar_strato_purple"
 	slot_flags = SLOT_BACK
-	w_class = ITEM_SIZE_HUGE
 	sound_player = /datum/sound_player/synthesizer
 	path = /datum/instrument/guitar


### PR DESCRIPTION
This makes a fluff item way too cumbersome to carry around relative to the impact on the game it has. This discourages players from scenes featuring them by requiring them to dedicate a back slot or a hand to keeping the instrument on their person. The net result is that players that aren't explicitly passengers will have to choose between "carrying equipment" or "carrying a roleplay tool" rather than being able to have both, making it that much harder to fill the time between mechanical demands with this aspect of fluff.

Reverts Baystation12/Baystation12#35551

🆑 sowelipililimute
tweak: Guitars can now fit in backpacks again
/:cl: