### PR TITLE
add t2 engineering toolset aug

### DIFF
--- a/code/modules/augment/active/tool/engineering.dm
+++ b/code/modules/augment/active/tool/engineering.dm
@@ -88,3 +88,51 @@
 	icon_state = "multitool_finger"
 	icon = 'icons/obj/augment_tools.dmi'
 	canremove = FALSE
+
+
+/obj/item/organ/internal/augment/active/polytool/engineer/advanced
+	name = "advanced engineering toolset"
+	action_button_name = "Deploy Engineering Tool"
+	desc = "A lightweight augmentation for the engineer on-the-go. This one comes with a series of upgraded tools."
+	paths = list(
+		/obj/item/swapper/power_drill/finger,
+		/obj/item/weldingtool/electric/finger,
+		/obj/item/swapper/jaws_of_life/finger,
+		/obj/item/device/multitool/finger
+	)
+
+
+/obj/item/swapper/power_drill/finger
+	name = "digital drill"
+	desc = "A nifty powertool at your literal fingertips."
+	icon_state = "screwdriver_finger"
+	icon = 'icons/obj/augment_tools.dmi'
+	canremove = FALSE
+
+
+/obj/item/swapper/power_drill/finger/on_update_icon()
+	icon_state = (active_tool == BOLT_HEAD) ? "wrench_finger" : "screwdriver_finger"
+
+
+/obj/item/swapper/jaws_of_life/finger
+	name = "digital prytool"
+	desc = "A hydraulic prying/cutting tool. Much less awkward."
+	icon_state = "prybar_finger"
+	icon = 'icons/obj/augment_tools.dmi'
+	canremove = FALSE
+
+
+/obj/item/swapper/jaws_of_life/finger/on_update_icon()
+	icon_state = (active_tool == CUTTER_HEAD) ? "wirecutter_finger" : "prybar_finger"
+
+
+/obj/item/weldingtool/electric/finger
+	name = "digital arc welder"
+	desc = "A precise, high quality welding tool. No fuel tank required!"
+	icon_state = "welder_finger"
+	icon = 'icons/obj/augment_tools.dmi'
+	canremove = FALSE
+
+
+/obj/item/weldingtool/electric/finger/on_update_icon()
+	icon_state = welding ? "welder_finger_on" : "welder_finger"

--- a/code/modules/augment/implanter.dm
+++ b/code/modules/augment/implanter.dm
@@ -179,5 +179,8 @@
 /obj/item/device/augment_implanter/engineering_toolset
 	augment = /obj/item/organ/internal/augment/active/polytool/engineer
 
+/obj/item/device/augment_implanter/engineering_toolset/advanced
+	augment = /obj/item/organ/internal/augment/active/polytool/engineer/advanced
+
 /obj/item/device/augment_implanter/powerfist
 	augment = /obj/item/organ/internal/augment/active/item/powerfist/prepared

--- a/code/modules/research/designs/designs_mechfab.dm
+++ b/code/modules/research/designs/designs_mechfab.dm
@@ -609,6 +609,13 @@
 	materials = list(MATERIAL_STEEL = 3000, MATERIAL_GLASS = 1000)
 	id = "augment_toolset_engineering"
 
+/datum/design/item/mechfab/augment/engineering/advanced
+	name = "Advanced engineering toolset"
+	build_path = /obj/item/organ/internal/augment/active/polytool/engineer/advanced
+	materials = list(MATERIAL_STEEL = 3000, MATERIAL_GLASS = 1000, MATERIAL_PHORON = 1000)
+	req_tech = list(TECH_ENGINEERING = 5, TECH_POWER = 4)
+	id = "augment_toolset_engineering_advanced"
+
 /datum/design/item/mechfab/augment/surgery
 	name = "Surgical toolset"
 	build_path = /obj/item/organ/internal/augment/active/polytool/surgical


### PR DESCRIPTION
adds an advanced engineering toolset augment for roboticists, dependent on the same material gate (phoron) and research gate (level 5 engineering, level 4 power manipulation) as constructing the tools individually. this is relevant for both qol (less clicky to swap heads on a drill than open that godsawful popup window every time) and mechanical concerns (robotic surgery has better success chances with the better tools)

the tools use the same icons as the basic engineering aug tools, based on which head is active (e.g. the hydraulic prytool's cutting head uses the digital splicer's icon), this is both because this one is not an artist and because it kinda just makes sense for consistency

:cl:
rscadd: added an advanced engineering toolset augment, which roboticists can print given research and materials
/:cl: