### PR TITLE
Fixes null error reading trait save file

### DIFF
--- a/code/datums/traits/traits.dm
+++ b/code/datums/traits/traits.dm
@@ -123,6 +123,8 @@
 		var/trait_type = istext(trait) ? text2path(trait) : trait
 		var/singleton/trait/selected = GET_SINGLETON(trait_type)
 		var/severity
+		if (!selected)
+			continue
 
 		if (length(selected.metaoptions))
 			var/list/interim = preferences[trait]


### PR DESCRIPTION
Given my character's save file has straddled many different branches during the allergy project, caught this problem when trying to load a trait that no longer exists in the code.

Would call null.metaoptions which is problematic.