### PR TITLE
allow the user to remove the integrated arc welder cell with empty hand

### DIFF
--- a/code/modules/augment/active/tool/engineering.dm
+++ b/code/modules/augment/active/tool/engineering.dm
@@ -136,3 +136,21 @@
 
 /obj/item/weldingtool/electric/finger/on_update_icon()
 	icon_state = welding ? "welder_finger_on" : "welder_finger"
+
+
+/obj/item/weldingtool/electric/finger/attack_hand(mob/living/user)
+	if (!cell || user.get_inactive_hand() != src)
+		return ..()
+
+	if (!welding)
+		user.visible_message(
+			SPAN_ITALIC("\The [user] removes \a [cell] from \a [src]."),
+			SPAN_ITALIC("You remove \the [cell] from \the [src].")
+		)
+		user.put_in_hands(cell)
+		cell = null
+		w_class = initial(w_class)
+		force = initial(force)
+		update_icon()
+	else
+		to_chat(user, SPAN_WARNING("Turn off the welder first!"))


### PR DESCRIPTION
as per https://github.com/Baystation12/Baystation12/pull/35554#pullrequestreview-3584151751

:cl:
tweak: the augment arc welder's cell can now be removed with an empty hand, so you don't need to carry a screwdriver around
/:cl: