### PR TITLE
give roboticists medical comms from the start

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -64,7 +64,7 @@
 /obj/item/device/encryptionkey/headset_rob
 	name = "robotics radio encryption key"
 	icon_state = "rob_cypherkey"
-	channels = list("Engineering" = 1, "Science" = 1)
+	channels = list("Engineering" = 1, "Medical" = 1)
 
 /obj/item/device/encryptionkey/headset_med
 	name = "medical radio encryption key"

--- a/maps/torch/job/outfits/engineering_outfits.dm
+++ b/maps/torch/job/outfits/engineering_outfits.dm
@@ -43,6 +43,7 @@
 	name = OUTFIT_JOB_NAME("Roboticist - Contractor")
 	uniform = /obj/item/clothing/under/rank/roboticist
 	shoes = /obj/item/clothing/shoes/black
+	l_ear = /obj/item/device/radio/headset/headset_rob
 	id_types = list(/obj/item/card/id/torch/contractor/engineering/roboticist)
 	pda_type = /obj/item/modular_computer/pda/roboticist
 
@@ -50,12 +51,14 @@
 	name = OUTFIT_JOB_NAME("Roboticist - Torch")
 	uniform = /obj/item/clothing/under/solgov/utility/expeditionary/engineering
 	shoes = /obj/item/clothing/shoes/dutyboots
+	l_ear = /obj/item/device/radio/headset/headset_rob
 	id_types = list(/obj/item/card/id/torch/contractor/engineering/roboticist)
 	pda_type = /obj/item/modular_computer/pda/roboticist
 
 /singleton/hierarchy/outfit/job/torch/crew/engineering/roboticistfleet
 	name = OUTFIT_JOB_NAME("Roboticist - Fleet")
 	uniform = /obj/item/clothing/under/solgov/utility/fleet/engineering
+	l_ear = /obj/item/device/radio/headset/headset_rob
 	id_types = list(/obj/item/card/id/torch/contractor/engineering/roboticist)
 	shoes = /obj/item/clothing/shoes/dutyboots
 	pda_type = /obj/item/modular_computer/pda/roboticist

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -1028,8 +1028,8 @@
 /obj/item/aicard,
 /obj/item/clothing/gloves/insulated,
 /obj/item/clothing/gloves/insulated,
-/obj/item/device/radio/headset/headset_eng,
-/obj/item/device/radio/headset/headset_eng,
+/obj/item/device/radio/headset/headset_rob,
+/obj/item/device/radio/headset/headset_rob,
 /obj/item/device/multitool{
 	pixel_x = 3
 	},


### PR DESCRIPTION
because like every roboticist has to either hear "robotics, left comms on your desk" every shift or ask every shift and at this point why not just give them access from the start. also includes a mapping change that just replaces the 2 spare engineering headsets in the robotics lab with robotics headsets