### PR TITLE
robotics fab console decon fix

### DIFF
--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -995,6 +995,13 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	name = "core fabricator console"
 	id = 1
 
+/obj/machinery/computer/rdconsole/dismantle(mob/user)
+	if(istype(src,/obj/machinery/computer/rdconsole/robotics))
+		for(var/obj/item/stock_parts/circuitboard/rdconsole/board in component_parts)
+			board.SetName("circuit board (RD Console - Robotics)")
+			board.build_path = /obj/machinery/computer/rdconsole/robotics
+	return ..()
+
 
 #undef CHECK_LATHE
 #undef CHECK_IMPRINTER


### PR DESCRIPTION
because the circuit boards for robotics and science fabrication consoles are the same object type, deconstructing one that's been placed in the map at roundstart (i.e. not constructed manually) will spawn the default state for that board, which then makes a _science_ fabrication console. this is a problem because most of the active roboticist playerbase rearranges the lab every round, and thus needs to fix the circuit board in-round every time; this fix makes it just spawn the correct board type instead

:cl:
bugfix: robotics fabrication consoles now give the correct circuit board on deconstruct
/:cl: