### PR TITLE
sulphuric acid dispensers are wallmounted and should not cause inviswalls

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -372,4 +372,5 @@
 	icon_state = "acidtank"
 	amount_per_transfer_from_this = 10
 	anchored = TRUE
+	density = FALSE
 	initial_reagent_types = list(/datum/reagent/acid = 1)


### PR DESCRIPTION
sulphuric acid dispensers currently count as solid and block you from moving into a tile, despite being visually wallmounted

:cl:
bugfix: sulphuric acid dispensers will no longer cause invisible walls
/:cl: