### PR TITLE
added a macroable verb for using hud buttons

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -358,6 +358,28 @@
 
 	return
 
+/mob/living/verb/activate_action_button(button_select as text|num)
+	set name = "Activate Action Button"
+	set category = "Object"
+	if(!hud_used || !client || !client.screen) return
+	var/obj/screen/movable/action_button/chosen
+	if(isnum(button_select))
+		var/list/buttons=list()
+		for(var/obj/screen/movable/action_button/button in client.screen)
+			buttons.Add(button)
+		if(button_select <= length(buttons))
+			chosen = buttons[button_select]
+	else
+		for(var/obj/screen/movable/action_button/button in client.screen)
+			if(button.name == button_select)
+				chosen = button
+	if(!chosen || usr.next_move >= world.time) // Original code containing the latter check bore the comment "Is this needed ?"
+		return
+	if(istype(chosen,/obj/screen/movable/action_button/hide_toggle))
+		chosen.Click()
+	else
+		chosen.owner?.Trigger()
+
 /mob/living/update_action_buttons()
 	if(!hud_used) return
 	if(!client) return


### PR DESCRIPTION
currently, if you want to do something like flipping a welding mask, toggling an augment, or turning on your voidsuit light or magboots, you need to use the mouse. this PR adds a verb (Activate-Action-Button) and, at the suggestion of the discord, default macro binds for it (shift+1-9 in hotkey mode, ctrl+shift+1-9 in whatever the other mode is called). what this means is that, with either the default binds for numerical toggling or custom macros for specific buttons (i.e. assigning a specific key to use the engineering toolset augment no matter which order the buttons are in), you can 'click' these buttons with no mouse activity at all! very exciting efficiency boost

:cl:
rscadd: added a verb to trigger action buttons (the things at the top left of the screen, like the magboots or welding mask toggles)
/:cl: