### PR TITLE
added an actual utility blade aug

### DIFF
--- a/code/modules/augment/active/armblades.dm
+++ b/code/modules/augment/active/armblades.dm
@@ -24,6 +24,7 @@
 	augment_slots = AUGMENT_ARM
 	item = /obj/item/material/armblade
 	augment_flags = AUGMENT_MECHANICAL | AUGMENT_SCANNABLE
+	origin_tech = list(TECH_COMBAT = 2, TECH_BIO = 3, TECH_MAGNET = 2, TECH_MATERIAL = 3)
 
 
 /obj/item/material/armblade/claws
@@ -42,7 +43,21 @@
 	augment_slots = AUGMENT_HAND
 	item = /obj/item/material/armblade/claws
 	augment_flags = AUGMENT_MECHANICAL | AUGMENT_SCANNABLE
+	origin_tech = list(TECH_MAGNET = 2, TECH_COMBAT = 4, TECH_MATERIAL = 3, TECH_BIO = 3)
 
+/obj/item/material/armblade/xsmall
+	name = "utility blade"
+	desc = "For non-combat use only"
+	base_parry_chance = 0
+	max_force = 10 // These values taken from the actual utility blade item. The one you can shove in your boot
+	force_multiplier = 0.2
+	w_class = ITEM_SIZE_SMALL
+
+/obj/item/organ/internal/augment/active/item/armblade/xsmall
+	name = "utility armblade"
+	desc = "An extra-small armblade, designed to be completely ineffective in combat. For those who really want to make sure they're within regulations."
+	item = /obj/item/material/armblade/xsmall
+	origin_tech = list()
 
 /// Traitor version - no parry chance but good damage, and compatible with organic limbs
 /obj/item/organ/internal/augment/active/item/wrist_blade

--- a/code/modules/research/designs/designs_mechfab.dm
+++ b/code/modules/research/designs/designs_mechfab.dm
@@ -539,6 +539,13 @@
 	req_tech = list(TECH_MAGNET = 3, TECH_COMBAT = 4, TECH_MATERIAL = 4, TECH_BIO = 3)
 	id = "augment_wolverine"
 
+/datum/design/item/mechfab/augment/armblade/xsmall
+	name = "Utility Armblade"
+	build_path = /obj/item/organ/internal/augment/active/item/armblade/xsmall
+	materials = list (MATERIAL_STEEL = 2000, MATERIAL_GLASS = 750) // It's a smaller blade, so it takes less steel.
+	id = "augment_blade_small"
+	req_tech = list() // Since it's not intended for combat, no tech lock either
+
 /datum/design/item/mechfab/augment/armblade/wrist_blade
 	name = "Wrist blade"
 	build_path = /obj/item/organ/internal/augment/active/item/wrist_blade


### PR DESCRIPTION
Since the armblade is, word of admins, not in fact weak enough to count as a utility blade for noncombat job purposes, here is one that is. Because sometimes you want to play a chef or botanist or something with a knife in their arm, but don't want to be constantly hassled for powergaming.
The stats of the item were copied directly over from the utility knife item you can spawn with at loadout + shove in your boot; this should mean it's ok to have semi concealed, especially since you need to get a roboticist to install it, but if it needs further nerfing to be acceptable please say so. The point is not the combat stats it's the 'having a knife so you can do your job'.

:cl:
rscadd: Added a utility blade augment, smaller and less combat-effective than armblades, for actual utility use. Works for plant sampling!
/:cl: