### PR TITLE
Cap SMES input/output when removing coils

### DIFF
--- a/code/modules/power/smes_construction.dm
+++ b/code/modules/power/smes_construction.dm
@@ -144,6 +144,8 @@
 		capacity *= 1.2
 		input_level_max *= 2
 		output_level_max *= 2
+	input_level = clamp(input_level, 0, input_level_max)
+	output_level = clamp(output_level, 0, output_level_max)
 	charge = clamp(charge, 0, capacity)
 
 // Proc: total_system_failure()


### PR DESCRIPTION
:cl: 
bugfix: SMES units now correctly cap their input and output wattage when parts are removed.
/:cl:

If you set the power input/output of a SMES high, then lower its maximum transmission by removing parts, the actual input/output stays high until someone changes it manually. Because of this bug, you can effectively duplicate transmission coils.