### PR TITLE
pai no longer use you/yours pronouns, as funny as that was

### DIFF
--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -289,13 +289,14 @@ GLOBAL_LIST_AS(possible_say_verbs, list(
 /mob/living/silicon/pai/use_tool(obj/item/tool, mob/user, list/click_params)
 	// ID Card - Set pAI access
 	var/obj/item/card/id/id = tool.GetIdCard()
+	var/datum/pronouns/pronouns = choose_from_pronouns()
 	if (istype(id))
 		var/id_name = GET_ID_NAME(id, tool)
 		var/list/new_access = id.GetAccess()
 		idcard.access = new_access
 		user.visible_message(
-			SPAN_NOTICE("\The [user] scans \a [tool] over \the [src], updating its access."),
-			SPAN_NOTICE("You scan [id_name] over \the [src], updating its access.")
+			SPAN_NOTICE("\The [user] scans \a [tool] over \the [src], updating [pronouns.his] access."),
+			SPAN_NOTICE("You scan [id_name] over \the [src], updating [pronouns.his] access.")
 		)
 		return TRUE
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -289,14 +289,13 @@ GLOBAL_LIST_AS(possible_say_verbs, list(
 /mob/living/silicon/pai/use_tool(obj/item/tool, mob/user, list/click_params)
 	// ID Card - Set pAI access
 	var/obj/item/card/id/id = tool.GetIdCard()
-	var/datum/pronouns/pronouns = user.choose_from_pronouns()
 	if (istype(id))
 		var/id_name = GET_ID_NAME(id, tool)
 		var/list/new_access = id.GetAccess()
 		idcard.access = new_access
 		user.visible_message(
-			SPAN_NOTICE("\The [user] scans \a [tool] over \the [src], updating [pronouns.his] access."),
-			SPAN_NOTICE("You scan [id_name] over \the [src], updating [pronouns.his] access.")
+			SPAN_NOTICE("\The [user] scans \a [tool] over \the [src], updating its access."),
+			SPAN_NOTICE("You scan [id_name] over \the [src], updating its access.")
 		)
 		return TRUE
 


### PR DESCRIPTION
if this was intentional, feel free to close. currently, when you scan a pAI with your id card to update it, it uses the user's pronouns- i.e. not the pAI's- for the message. i.e. "(he/him player) scans the id card over Goki, updating his access". this just replaces that with it/its, since pAI don't actually store pronouns (they might, if the character setup part of them is ever fixed, but out of scope and all)

:cl:
bugfix: pAI no longer use you/yours pronouns
/:cl: