### PR TITLE
robotics lab remap

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -1016,7 +1016,7 @@
 /obj/item/reagent_containers/dropper{
 	pixel_y = -4
 	},
-/obj/structure/closet/crate/plastic,
+/obj/structure/closet,
 /obj/random/powercell,
 /obj/random/powercell,
 /obj/random/powercell,
@@ -1039,46 +1039,46 @@
 /obj/item/storage/belt/utility/full,
 /obj/item/storage/belt/utility/full,
 /obj/item/clothing/glasses/welding,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
 /obj/floor_decal/industrial/warning/corner{
 	dir = 8;
 	icon_state = "warningcorner"
 	},
-/obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "bZ" = (
-/obj/structure/closet/crate/plastic,
-/obj/floor_decal/industrial/outline/yellow,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/closet/crate,
+/obj/item/device/flash/synthetic,
+/obj/item/device/flash/synthetic,
+/obj/item/device/flash/synthetic,
+/obj/item/device/flash/synthetic,
 /obj/item/device/scanner/health,
-/obj/item/storage/firstaid/empty,
-/obj/item/device/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/device/assembly/prox_sensor{
-	pixel_x = -8;
-	pixel_y = 4
-	},
-/obj/item/device/flash/synthetic,
-/obj/item/device/flash/synthetic,
-/obj/item/device/flash/synthetic,
-/obj/item/device/flash/synthetic,
 /obj/item/device/flash,
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/device/assembly/prox_sensor{
+	pixel_x = -8;
+	pixel_y = 4
+	},
+/obj/item/storage/firstaid/empty,
 /obj/item/device/flash,
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/box/beakers,
-/obj/machinery/light{
-	dir = 1
-	},
+/turf/simulated/floor/tiled/dark/monotile,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "ca" = (
@@ -1254,7 +1254,6 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/disposal)
 "cr" = (
-/obj/floor_decal/industrial/outline/yellow,
 /obj/item/stack/material/glass{
 	amount = 20;
 	pixel_x = -3;
@@ -1292,7 +1291,7 @@
 	amount = 20
 	},
 /obj/item/stack/material/aluminium/fifty,
-/obj/structure/closet/crate/plastic,
+/obj/structure/table/rack,
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 24
 	},
@@ -1300,6 +1299,7 @@
 	pixel_x = 32
 	},
 /obj/item/stack/material/plastic/fifty,
+/turf/simulated/floor/tiled/dark/monotile,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "cs" = (
@@ -1338,15 +1338,16 @@
 /turf/simulated/floor/plating,
 /area/vacant/armory)
 "cv" = (
-/obj/floor_decal/industrial/warning{
-	dir = 8;
-	icon_state = "warning"
-	},
 /obj/machinery/light_switch{
 	pixel_x = -22;
 	pixel_y = 24
 	},
+/obj/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
 /turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "cw" = (
 /turf/simulated/wall/r_wall/prepainted,
@@ -1354,6 +1355,7 @@
 "cx" = (
 /obj/structure/ladder/up,
 /obj/floor_decal/industrial/hatch/yellow,
+/turf/simulated/floor/tiled/dark/monotile,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "cy" = (
@@ -1371,11 +1373,15 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/medical)
 "cz" = (
-/turf/simulated/floor/tiled/dark,
+/obj/machinery/fabricator,
+/obj/floor_decal/industrial/outline/yellow,
+/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "cA" = (
-/obj/machinery/robotics_fabricator,
 /obj/floor_decal/industrial/outline/yellow,
+/obj/machinery/mech_recharger,
+/turf/simulated/floor/tiled/dark/monotile,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "cB" = (
@@ -1711,6 +1717,7 @@
 	icon_state = "warning"
 	},
 /turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "dl" = (
 /obj/structure/cable/green{
@@ -1858,10 +1865,7 @@
 /area/storage/medical)
 "dF" = (
 /obj/structure/table/steel,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/device/paint_sprayer,
+/turf/simulated/floor/tiled/dark/monotile,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "dG" = (
@@ -1896,6 +1900,8 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 10
 	},
+/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
 "dL" = (
@@ -2117,6 +2123,7 @@
 "ee" = (
 /obj/structure/table/steel,
 /obj/machinery/cell_charger,
+/turf/simulated/floor/tiled/dark/monotile,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "ef" = (
@@ -2525,18 +2532,18 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/storage/medical)
 "eR" = (
-/obj/item/device/integrated_circuit_printer,
-/obj/item/device/integrated_electronics/analyzer,
-/obj/item/device/integrated_electronics/wirer,
-/obj/item/device/integrated_electronics/debugger,
-/obj/structure/table/steel,
+/obj/floor_decal/industrial/outline/yellow,
 /obj/floor_decal/industrial/warning/corner{
 	dir = 1
 	},
-/obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/vending/robotics{
+	dir = 4;
+	products = list(/obj/item/reagent_containers/food/drinks/bottle/oiljug=5,/obj/item/stack/cable_coil=6,/obj/item/device/flash/synthetic=4,/obj/item/cell/standard=4,/obj/item/device/scanner/health=2,/obj/item/scalpel/basic=1,/obj/item/circular_saw=1,/obj/item/tank/anesthetic=2,/obj/item/clothing/mask/breath/medical=5,/obj/item/screwdriver=2,/obj/item/crowbar=2)
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "eS" = (
@@ -2563,18 +2570,17 @@
 /area/maintenance/seconddeck/forestarboard)
 "eU" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
+	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
 "eV" = (
-/obj/machinery/fabricator,
-/obj/floor_decal/industrial/outline/yellow,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
 "eW" = (
 /obj/structure/disposalpipe/segment,
@@ -2751,7 +2757,6 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/forestarboard)
 "fy" = (
-/obj/structure/table/steel,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "west bump";
@@ -2761,6 +2766,8 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
+/obj/structure/table/steel,
+/turf/simulated/floor/tiled/dark/monotile,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "fz" = (
@@ -2770,6 +2777,8 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
 "fA" = (
@@ -2806,25 +2815,28 @@
 /area/maintenance/seconddeck/forestarboard)
 "fD" = (
 /obj/structure/table/steel,
+/obj/item/device/paint_sprayer,
+/turf/simulated/floor/tiled/dark/monotile,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "fE" = (
 /turf/simulated/wall/ocp_wall,
 /area/storage/research)
 "fF" = (
-/obj/structure/table/steel,
 /obj/machinery/light,
-/obj/machinery/photocopier/faxmachine{
-	department = "Torch - Robotics"
-	},
+/obj/floor_decal/industrial/outline/yellow,
+/obj/machinery/robotics_fabricator,
+/turf/simulated/floor/tiled/dark/monotile,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "fG" = (
-/obj/machinery/robotics_fabricator,
+/obj/machinery/mech_recharger,
 /obj/floor_decal/industrial/outline/yellow,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -32
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
+/turf/simulated/floor/tiled/dark/monotile,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "fH" = (
@@ -2869,11 +2881,14 @@
 /turf/simulated/floor/plating,
 /area/engineering/engineering_bay)
 "fK" = (
-/obj/item/device/radio/intercom{
-	dir = 1;
-	pixel_y = -28
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
-/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/tiled/dark,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "fL" = (
@@ -5853,6 +5868,8 @@
 	dir = 4
 	},
 /turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
 "nk" = (
 /obj/floor_decal/industrial/warning/corner{
@@ -5910,23 +5927,19 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "nq" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
 /obj/structure/cable/green{
-	d1 = 2;
+	d1 = 4;
 	d2 = 8;
-	icon_state = "2-8"
-	},
-/obj/structure/cable/green{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
-	dir = 8
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "nr" = (
 /obj/structure/closet/emcloset,
@@ -6126,6 +6139,8 @@
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 4
 	},
+/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
 "nY" = (
@@ -7004,12 +7019,11 @@
 /turf/simulated/floor/plating,
 /area/engineering/shieldbay)
 "qt" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/machinery/atmospherics/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
 "qu" = (
@@ -7722,6 +7736,27 @@
 	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck)
+"rX" = (
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers{
+	dir = 1
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
+	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
+/turf/simulated/floor/tiled/dark,
+/area/assembly/robotics)
 "rY" = (
 /obj/structure/table/steel,
 /obj/machinery/recharger,
@@ -7867,8 +7902,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftstarboard)
 "su" = (
-/obj/machinery/mech_recharger,
 /obj/floor_decal/industrial/outline/yellow,
+/obj/machinery/robotics_fabricator,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "sv" = (
@@ -12809,6 +12848,15 @@
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/prototype/engine)
+"Gk" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/floor_decal/industrial/outline/yellow,
+/obj/machinery/r_n_d/circuit_imprinter,
+/turf/simulated/floor/tiled/dark/monotile,
+/turf/simulated/floor/tiled/dark/monotile,
+/area/assembly/robotics)
 "Gl" = (
 /obj/structure/sign/warning/compressed_gas{
 	dir = 1
@@ -13790,12 +13838,7 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Jm" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
 /obj/floor_decal/corner/yellow{
 	dir = 5
 	},
@@ -13804,9 +13847,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/camera/network/second_deck{
-	c_tag = "Second Deck Hallway - Midships"
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck)
 "Jn" = (
@@ -14400,13 +14446,8 @@
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics/surgery)
 "LF" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "LJ" = (
 /obj/machinery/door/firedoor,
@@ -15930,17 +15971,14 @@
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/storage)
 "QA" = (
-/obj/machinery/vending/robotics{
-	dir = 4;
-	products = list(/obj/item/reagent_containers/food/drinks/bottle/oiljug=5,/obj/item/stack/cable_coil=6,/obj/item/device/flash/synthetic=4,/obj/item/cell/standard=4,/obj/item/device/scanner/health=2,/obj/item/scalpel/basic=1,/obj/item/circular_saw=1,/obj/item/tank/anesthetic=2,/obj/item/clothing/mask/breath/medical=5,/obj/item/screwdriver=2,/obj/item/crowbar=2)
-	},
-/obj/floor_decal/industrial/outline/yellow,
 /obj/machinery/requests_console{
 	department = "Robotics";
 	departmentType = 2;
 	name = "Robotics RC";
 	pixel_x = -31
 	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/simulated/floor/tiled/dark/monotile,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "QB" = (
@@ -16024,6 +16062,14 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
 "QT" = (
@@ -16278,10 +16324,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_bay)
 "RH" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/techfloor/grid,
 /turf/simulated/floor/tiled/dark,
 /area/assembly/robotics)
 "RI" = (
@@ -16403,13 +16451,6 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics/surgery)
-"Sa" = (
-/obj/machinery/atmospherics/unary/vent_pump/on{
-	dir = 4;
-	level = 2
-	},
-/turf/simulated/floor/tiled/dark,
-/area/assembly/robotics)
 "Sb" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/portables_connector{
@@ -16823,21 +16864,23 @@
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/foyer)
 "Tv" = (
-/obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
-/obj/floor_decal/corner/yellow{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/hidden/supply{
+	dir = 1
 	},
 /obj/structure/cable/green{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/hidden/supply,
+/obj/floor_decal/corner/yellow{
+	dir = 5
+	},
+/obj/machinery/camera/network/second_deck{
+	c_tag = "Second Deck Hallway - Midships"
+	},
 /turf/simulated/floor/tiled,
 /area/hallway/primary/seconddeck)
 "Tx" = (
@@ -16873,6 +16916,7 @@
 /obj/structure/reagent_dispensers/acid{
 	pixel_x = 32
 	},
+/turf/simulated/floor/tiled/dark/monotile,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "TG" = (
@@ -17842,14 +17886,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "WX" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/light,
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
 	},
 /turf/simulated/floor/tiled/dark,
+/turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "Xa" = (
 /obj/machinery/door/airlock/engineering{
@@ -18068,8 +18110,16 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/forestarboard)
 "XO" = (
-/obj/machinery/r_n_d/circuit_imprinter,
-/obj/floor_decal/industrial/outline/yellow,
+/obj/structure/table/steel,
+/obj/item/device/integrated_electronics/debugger,
+/obj/item/device/integrated_electronics/wirer,
+/obj/item/device/integrated_circuit_printer,
+/obj/item/device/integrated_electronics/analyzer,
+/obj/item/device/radio/intercom{
+	dir = 4;
+	pixel_x = -21
+	},
+/turf/simulated/floor/tiled/dark/monotile,
 /turf/simulated/floor/tiled/dark/monotile,
 /area/assembly/robotics)
 "XP" = (
@@ -35284,7 +35334,7 @@ dk
 dk
 eR
 QA
-su
+XO
 fy
 ee
 XP
@@ -35482,11 +35532,11 @@ bK
 XP
 bZ
 cx
-cz
+eV
 nW
-Sa
+eV
 nW
-Sa
+eV
 fz
 fF
 XP
@@ -35683,8 +35733,8 @@ eG
 bK
 XP
 cr
-cz
-cz
+LF
+eV
 dK
 eU
 ng
@@ -35886,14 +35936,14 @@ bK
 XP
 XP
 cA
-cz
-cz
 eV
-XO
+eV
 qt
-QQ
+eV
+qt
+rX
 fK
-XP
+KQ
 Jm
 gD
 Lp
@@ -36089,13 +36139,13 @@ bw
 XP
 su
 dm
-fD
-XP
+cz
+Gk
 TD
 LF
 nq
 WX
-KQ
+XP
 Tv
 xj
 PF

--- a/maps/torch/torch5_deck1.dmm
+++ b/maps/torch/torch5_deck1.dmm
@@ -6102,15 +6102,12 @@
 /turf/simulated/floor/tiled/steel_grid,
 /area/turbolift/robotics_lift)
 "aor" = (
-/obj/structure/ladder,
 /obj/floor_decal/corner/yellow{
 	dir = 5
 	},
-/obj/floor_decal/industrial/hatch/yellow,
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
+/obj/structure/ladder,
 /obj/catwalk_plated,
+/obj/floor_decal/industrial/hatch/yellow,
 /turf/simulated/floor/tiled/monotile,
 /area/assembly/robotics/office)
 "ape" = (
@@ -11420,21 +11417,20 @@
 /area/maintenance/firstdeck/centralport)
 "aPb" = (
 /obj/floor_decal/corner/yellow/mono,
-/obj/machinery/computer/modular{
-	dir = 8
-	},
 /obj/machinery/power/apc{
 	dir = 1;
 	name = "north bump";
 	pixel_y = 24
 	},
 /obj/structure/cable/green{
-	d2 = 2;
-	icon_state = "0-2"
+	d2 = 8;
+	icon_state = "0-8"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 32
 	},
+/obj/structure/table/steel,
+/obj/machinery/photocopier/faxmachine,
 /turf/simulated/floor/tiled/monotile,
 /area/assembly/robotics/office)
 "aPq" = (
@@ -11985,22 +11981,11 @@
 /area/maintenance/firstdeck/centralport)
 "aRb" = (
 /obj/floor_decal/corner/yellow/mono,
-/obj/structure/closet/wardrobe/robotics_black,
-/obj/item/clothing/under/rank/roboticist/skirt,
-/obj/item/clothing/under/rank/roboticist/skirt,
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 10
-	},
 /obj/machinery/light_switch{
 	pixel_x = 24
 	},
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
+/obj/machinery/computer/modular{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/assembly/robotics/office)
@@ -12466,16 +12451,12 @@
 /obj/floor_decal/corner/yellow{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
-/obj/structure/cable/green{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/closet/wardrobe/robotics_black,
+/obj/item/clothing/under/rank/roboticist/skirt,
+/obj/item/clothing/under/rank/roboticist/skirt,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
 "aSd" = (
@@ -14188,15 +14169,15 @@
 /turf/simulated/floor/plating,
 /area/maintenance/firstdeck/centralstarboard)
 "bkb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/floor_decal/corner/yellow{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/floor_decal/corner/yellow{
-	dir = 5
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics/laboratory)
@@ -16291,11 +16272,11 @@
 /obj/floor_decal/corner/yellow{
 	dir = 5
 	},
-/obj/machinery/disposal,
-/obj/floor_decal/industrial/hatch/yellow,
 /obj/machinery/alarm{
 	pixel_y = 24
 	},
+/obj/machinery/disposal,
+/obj/floor_decal/industrial/hatch/yellow,
 /obj/structure/disposalpipe/trunk,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
@@ -17154,7 +17135,7 @@
 /area/maintenance/firstdeck/aftport)
 "foK" = (
 /obj/wallframe_spawn/reinforced/no_grille,
-/turf/simulated/floor/plating,
+/turf/simulated/floor/tiled/steel_grid,
 /area/assembly/robotics/office)
 "foP" = (
 /obj/floor_decal/corner/research{
@@ -17307,6 +17288,19 @@
 	},
 /turf/simulated/floor/tiled/white,
 /area/medical/sleeper)
+"fGB" = (
+/obj/floor_decal/corner/yellow{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply,
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled,
+/area/assembly/robotics/office)
 "fHk" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
@@ -17679,6 +17673,10 @@
 /obj/floor_decal/techfloor{
 	dir = 8
 	},
+/obj/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
 /obj/structure/disposalpipe/segment{
 	dir = 4;
 	icon_state = "pipe-c"
@@ -17729,14 +17727,19 @@
 /turf/simulated/floor/tiled/monotile,
 /area/security/locker)
 "gos" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
-	dir = 4
+/obj/structure/cable/green{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
-	dir = 4
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 10
 	},
 /obj/structure/bed/chair/padded/yellow{
-	dir = 8
+	dir = 1
 	},
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
@@ -17989,9 +17992,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 8;
 	icon_state = "pipe-c"
-	},
-/obj/structure/bed/chair/padded/yellow{
-	dir = 4
 	},
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
@@ -19310,15 +19310,24 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/crew_quarters/safe_room/firstdeck)
 "iyb" = (
-/obj/structure/table/steel,
 /obj/floor_decal/corner/yellow{
 	dir = 5
 	},
 /obj/machinery/recharger/wallcharger{
 	pixel_y = 24
 	},
-/obj/item/book/manual/ripley_build_and_repair,
-/obj/item/book/manual/robotics_cyborgs,
+/obj/structure/filingcabinet/chestdrawer{
+	dir = 1
+	},
+/obj/item/material/folder/blue,
+/obj/item/material/folder/red,
+/obj/item/material/folder,
+/obj/item/material/folder/nt,
+/obj/item/material/folder/yellow,
+/obj/item/material/folder/white,
+/obj/item/material/folder/envelope,
+/obj/item/material/folder/yellow,
+/obj/item/material/folder/envelope,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
 "izd" = (
@@ -20668,11 +20677,6 @@
 /turf/simulated/floor/tiled/white/monotile,
 /area/assembly/robotics/laboratory)
 "kfb" = (
-/obj/structure/table/steel,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/item/material/folder/yellow,
-/obj/item/tape_roll,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 6
 	},
@@ -20717,6 +20721,16 @@
 /obj/floor_decal/corner/yellow{
 	dir = 5
 	},
+/obj/structure/cable/green{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
+/obj/structure/table/steel,
+/obj/item/pen,
+/obj/item/material/folder/yellow,
+/obj/item/tape_roll,
+/obj/item/paper_bin,
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
 "kiR" = (
@@ -21129,23 +21143,34 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/firstdeck/centralstarboard)
 "kNb" = (
-/obj/item/stool/padded,
 /obj/floor_decal/corner/yellow{
 	dir = 8
 	},
-/turf/simulated/floor/tiled/white,
-/area/assembly/robotics/laboratory)
-"kOb" = (
-/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 5
 	},
 /obj/structure/cable/green{
 	d1 = 1;
 	d2 = 4;
 	icon_state = "1-4"
+	},
+/obj/item/stool/padded,
+/turf/simulated/floor/tiled/white,
+/area/assembly/robotics/laboratory)
+"kOb" = (
+/obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/hidden/supply{
+	dir = 4
+	},
+/obj/structure/cable/green{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/white,
 /area/assembly/robotics/laboratory)
@@ -23817,16 +23842,6 @@
 /turf/simulated/floor/tiled,
 /area/rnd/entry)
 "ocG" = (
-/obj/structure/filingcabinet/chestdrawer{
-	dir = 1
-	},
-/obj/item/material/folder/blue,
-/obj/item/material/folder/red,
-/obj/item/material/folder,
-/obj/item/material/folder/nt,
-/obj/item/material/folder/yellow,
-/obj/item/material/folder/white,
-/obj/item/material/folder/yellow,
 /obj/floor_decal/corner/yellow{
 	dir = 5
 	},
@@ -23836,8 +23851,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/item/material/folder/envelope,
-/obj/item/material/folder/envelope,
+/obj/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
 "odb" = (
@@ -24300,6 +24317,10 @@
 	},
 /obj/machinery/atmospherics/unary/vent_scrubber/on{
 	dir = 1
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -24
 	},
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
@@ -30450,6 +30471,10 @@
 	},
 /obj/floor_decal/corner/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
 /turf/simulated/floor/tiled,
 /area/assembly/robotics/office)
 "xMx" = (
@@ -48110,9 +48135,9 @@ amA
 xcW
 kib
 gos
-knb
-kvb
-ohy
+fGB
+aTb
+bkb
 kNb
 kVb
 acE
@@ -48313,8 +48338,8 @@ xcW
 aPb
 aRb
 aSb
-aTb
-bkb
+kvb
+ohy
 kOb
 kWb
 ldb


### PR DESCRIPTION
The robotics workspace has long been a point of contention for several players; this PR is an attempt to resolve some of the major pain points, without making major gameplay changes. It is the result of many iterations based on feedback from other robotics players (and one dev) in the discord.

Highlights:
- the fax machine has been moved upstairs, since the lower lab isn't supposed to be an office
- the plastic crates have been replaced with more setting-appropriate variants
- the working area has been widened from 2 to 3 tiles, and the flooring has been slightly adjusted to demarcate the central space
- the welding tank is no longer directly next to the door
- both mech rechargers now have a direct path to the door, and are adjacent to exosuit fabricators. both are accessible from the stool that has access to their respective worktable, so you can build an entire mech- minus the control circuits- from your seat!
- the circuit imprinter is now much less awkward to access from the starboard workstation
- the upstairs table no longer juts out into a walkway
- simplified disposal piping
- the filing cabinet is now next to the table, so you can access it while doing paperwork
- added hazard markings to the lift (people will still fall down it, but at least it'll be more obvious where the boundary is)
- **zero changes to areas outside the robotics workshop- it all fits within the existing space**

Downstairs, before and after:
<img width="819" height="721" alt="image" src="https://github.com/user-attachments/assets/d52c265b-7626-419f-b2de-0d0faeb4feee" />
<img width="828" height="730" alt="image" src="https://github.com/user-attachments/assets/f9d054b8-9f6d-43ee-a53e-a83b43fe7ee2" />


Upstairs, before and after:
<img width="785" height="609" alt="image" src="https://github.com/user-attachments/assets/d0c6f013-c97b-489d-897e-4a7798532763" />
<img width="772" height="592" alt="image" src="https://github.com/user-attachments/assets/f0f4eea5-e697-4e59-b8e6-60e74284533b" />
