### PR TITLE
no more cloning knife hands

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -386,6 +386,11 @@
 	return neighbor == usr
 
 /obj/screen/inventory/MouseDrop_T(atom/dropped, mob/living/user)
+	// No more cloning knife hands by drag-dropping augs to the other hand slot
+	var/obj/item/droppeditem = dropped
+	if (istype(droppeditem) && !droppeditem.canremove)
+		return ..()
+
 	// Hands - Transfer items to between hands with drag+drop.
 	if (name == BP_R_HAND && user.l_hand == dropped)
 		return user.put_in_r_hand(dropped)


### PR DESCRIPTION
as much as it's funny, you should probably not be able to drag+drop the screwdriver integrated into your arm into your other hand and then extend another screwdriver from the hand to dual wield them or do surgery on a hand with the tool inside that hand. for example.

:cl:
bugfix: You can no longer drag augment items (among other things) out of the hand they're installed in to your other hand
/:cl: