### PR TITLE
Adds blast door control toggle outside Petrov cockpit

### DIFF
--- a/maps/torch/torch1_deck5.dmm
+++ b/maps/torch/torch1_deck5.dmm
@@ -11806,6 +11806,12 @@
 	pixel_x = -5;
 	pixel_y = -3
 	},
+/obj/machinery/button/blast_door{
+	id_tag = "PetrovShield";
+	name = "Blast Shutter Control";
+	pixel_x = 5;
+	pixel_y = -3
+	},
 /turf/simulated/wall/titanium,
 /area/shuttle/petrov/rd)
 "DN" = (


### PR DESCRIPTION
adds a blast shutter control *outside* the Petrov's cockpit, because that button not being there has literally cost this one an entire several-times-extended round's worth of gameplay because the carp that got in took hours for security and engineering to deal with

:cl:
maptweak: The Petrov's external shutters can now be closed from its hallway.
/:cl: