### PR TITLE
The PR where I got tired of pixel hunting again

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1605,6 +1605,7 @@
 #include "code\modules\client\client_color.dm"
 #include "code\modules\client\client_defines.dm"
 #include "code\modules\client\client_helpers.dm"
+#include "code\modules\client\client_outlines.dm"
 #include "code\modules\client\client_procs.dm"
 #include "code\modules\client\darkmode.dm"
 #include "code\modules\client\movement.dm"

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -63,6 +63,11 @@
 	if(world.time <= next_click) // Hard check, before anything else, to avoid crashing
 		return
 
+	if (istype(A, /obj/screen/item_relayed))
+		var/obj/screen/item_relayed/relay = A
+		if (!isnull(relay.hovered_on))
+			return ClickOn(relay.hovered_on, params, use_in_world)
+
 	next_click = world.time + 1
 
 	var/list/modifiers = params2list(params)
@@ -525,15 +530,15 @@ GLOBAL_LIST_INIT(click_catchers)
 
 /client/MouseDown(object, location, control, params)
 	var/datum/click_handler/click_handler = usr.GetClickHandler()
-	click_handler.OnMouseDown(object, location, params)
+	click_handler.OnMouseDown(object, location, control, params)
 
 /client/MouseUp(object, location, control, params)
 	var/datum/click_handler/click_handler = usr.GetClickHandler()
-	click_handler.OnMouseUp(object, location, params)
+	click_handler.OnMouseUp(object, location, control, params)
 
 /client/MouseDrag(src_object,atom/over_object,src_location,over_location,src_control,over_control,params)
 	var/datum/click_handler/click_handler = usr.GetClickHandler()
-	click_handler.OnMouseDrag(over_object, params)
+	click_handler.OnMouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params)
 
 /client/MouseEntered(object, location, control, params)
 	var/datum/click_handler/click_handler = usr.GetClickHandler()

--- a/code/_onclick/click_handling.dm
+++ b/code/_onclick/click_handling.dm
@@ -116,7 +116,7 @@ var/global/const/CLICK_HANDLER_REMOVE_IF_NOT_TOP    = FLAG_02
  *
  * Has no return value.
  */
-/datum/click_handler/proc/OnMouseDown(object, location, params)
+/datum/click_handler/proc/OnMouseDown(object, location, control, params)
 	return
 
 /**
@@ -129,7 +129,7 @@ var/global/const/CLICK_HANDLER_REMOVE_IF_NOT_TOP    = FLAG_02
  *
  * Has no return value.
  */
-/datum/click_handler/proc/OnMouseUp(object, location, params)
+/datum/click_handler/proc/OnMouseUp(object, location, control, params)
 	return
 
 /**
@@ -157,12 +157,17 @@ var/global/const/CLICK_HANDLER_REMOVE_IF_NOT_TOP    = FLAG_02
  * Called on MouseUp by `/client/MouseDrag()` when this is the mob's currently active click handler.
  *
  * **Parameters**:
+ * - `src_object` - The object being dragged.
  * - `over_object` - The new atom underneath mouse.
+ * - `src_location` - The source location of the drag
+ * - `over_location` - The source location of the dragged-over object
+ * - `src_control` - The source control of the dragged object
+ * - `over_control` - The source control of the dragged-over object
  * - `params` (list of strings) - List of click parameters. See BYOND's `CLick()` documentation.
  *
  * Has no return value.
  */
-/datum/click_handler/proc/OnMouseDrag(atom/over_object, params)
+/datum/click_handler/proc/OnMouseDrag(atom/src_object, atom/over_object, src_location, over_location, src_control, over_control, params)
 	return
 
 /datum/click_handler/proc/CanAutoClick(object, location, params)
@@ -178,7 +183,7 @@ var/global/const/CLICK_HANDLER_REMOVE_IF_NOT_TOP    = FLAG_02
 /datum/click_handler/default/OnDblClick(atom/A, params)
 	user.DblClickOn(A, params)
 
-/datum/click_handler/default/OnMouseDown(object, location, params)
+/datum/click_handler/default/OnMouseDown(atom/object, location, control, params)
 	var/delay = CanAutoClick(object, location, params)
 	if(delay)
 		selected_target[1] = object
@@ -186,14 +191,21 @@ var/global/const/CLICK_HANDLER_REMOVE_IF_NOT_TOP    = FLAG_02
 		while(selected_target[1])
 			OnClick(selected_target[1], selected_target[2])
 			sleep(delay)
+	else if (istype(object, /obj/screen))
+		object.MouseDown(location, control, params)
 
-/datum/click_handler/default/OnMouseUp(object, location, params)
+/datum/click_handler/default/OnMouseUp(atom/object, location, control, params)
 	selected_target[1] = null
 
-/datum/click_handler/default/OnMouseDrag(atom/over_object, params)
+	if (istype(object, /obj/screen))
+		object.MouseUp(location, control, params)
+
+/datum/click_handler/default/OnMouseDrag(src_object, atom/over_object, src_location, over_location, src_control, over_control, params)
 	if(selected_target[1] && over_object && over_object.IsAutoclickable()) //Over object could be null, for example if dragging over darkness
 		selected_target[1] = over_object
 		selected_target[2] = params
+	else if (istype(over_object, /obj/screen))
+		over_object.MouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params)
 
 /datum/click_handler/default/CanAutoClick(object, location, params)
 	return user.CanMobAutoclick(object, location, params)

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -17,7 +17,7 @@
 
 	var/list/hud_elements = list()
 	var/obj/screen/using
-	var/obj/screen/inventory/inv_box
+	var/obj/screen/item_relayed/inventory_slot/inv_box
 
 	stamina_bar = new
 	adding += stamina_bar
@@ -26,7 +26,7 @@
 	var/has_hidden_gear
 	for(var/gear_slot in hud_data.gear)
 
-		inv_box = new /obj/screen/inventory()
+		inv_box = new /obj/screen/item_relayed/inventory_slot()
 		inv_box.icon = ui_style
 		inv_box.color = ui_color
 		inv_box.alpha = ui_alpha
@@ -97,7 +97,7 @@
 		using.alpha = ui_alpha
 		src.adding += using
 
-		inv_box = new /obj/screen/inventory()
+		inv_box = new /obj/screen/item_relayed/inventory_slot()
 		inv_box.SetName("r_hand")
 		inv_box.icon = ui_style
 		inv_box.icon_state = "r_hand_inactive"
@@ -111,7 +111,7 @@
 		src.r_hand_hud_object = inv_box
 		src.adding += inv_box
 
-		inv_box = new /obj/screen/inventory()
+		inv_box = new /obj/screen/item_relayed/inventory_slot()
 		inv_box.SetName("l_hand")
 		inv_box.icon = ui_style
 		inv_box.icon_state = "l_hand_inactive"
@@ -124,7 +124,7 @@
 		src.l_hand_hud_object = inv_box
 		src.adding += inv_box
 
-		using = new /obj/screen/inventory()
+		using = new /obj/screen/item_relayed/inventory_slot()
 		using.SetName("hand")
 		using.icon = ui_style
 		using.icon_state = "hand1"
@@ -133,7 +133,7 @@
 		using.alpha = ui_alpha
 		src.adding += using
 
-		using = new /obj/screen/inventory()
+		using = new /obj/screen/item_relayed/inventory_slot()
 		using.SetName("hand")
 		using.icon = ui_style
 		using.icon_state = "hand2"

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -28,11 +28,6 @@
 	maptext_height = 480
 	maptext_width = 480
 
-
-/obj/screen/inventory
-	var/slot_id	//The indentifier for the slot. It has nothing to do with ID cards.
-
-
 /obj/screen/close
 	name = "close"
 
@@ -66,19 +61,139 @@
 	owner.ui_action_click(owner)
 	return 1
 
-/obj/screen/storage
+/// Base type for screen objects that relay to an /obj/item instance
+/obj/screen/item_relayed
+	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
+
+	var/obj/item/mouse_down_on = null
+	var/obj/item/hovered_on = null
+
+/// Finds the item for the given mouse parameters. Returns an /obj/item or null.
+/obj/screen/item_relayed/proc/find_item(params)
+	return null
+
+/// Called when the item relay is clicked, but not at a location with an item.
+/obj/screen/item_relayed/proc/empty_click(atom/location, control, params)
+
+/obj/screen/item_relayed/Click(atom/location, control, params)
+	if(!usr.canClick())
+		return
+	if(usr.stat || usr.paralysis || usr.stunned || usr.weakened)
+		return
+
+	var/obj/item/clicked_on = find_item(params)
+	if (!isnull(clicked_on))
+		usr.ClickOn(clicked_on, params)
+	else
+		empty_click(location, control, params)
+
+	return 1
+
+/obj/screen/item_relayed/MouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params)
+	var/obj/item/drag_on = find_item(params)
+
+	if (!isnull(drag_on))
+		var/datum/click_handler/click_handler = usr.GetClickHandler()
+		click_handler.OnMouseDrag(drag_on, params)
+
+/obj/screen/item_relayed/MouseUp(location, control, params)
+	var/obj/item/up_on = find_item(params)
+
+	if (!isnull(up_on))
+		var/datum/click_handler/click_handler = usr.GetClickHandler()
+		click_handler.OnMouseUp(up_on, location, control, params)
+
+/obj/screen/item_relayed/MouseDown(location, control, params)
+	var/obj/item/down_on = find_item(params)
+
+	if (!isnull(down_on))
+		var/datum/click_handler/click_handler = usr.GetClickHandler()
+		click_handler.OnMouseDown(down_on, location, control, params)
+		mouse_down_on = down_on
+
+/obj/screen/item_relayed/MouseDrop(atom/over_object, src_location, over_location, src_control, over_control, params)
+	if (!isnull(mouse_down_on))
+		mouse_down_on.MouseDrop(over_object, src_location, over_location, src_control, over_control, params)
+
+/obj/screen/item_relayed/MouseEntered(location, control, params)
+	hovered_on = find_item(params)
+	if (!isnull(hovered_on))
+		hovered_on.MouseEntered(location, control, params)
+
+/obj/screen/item_relayed/MouseMove(location, control, params)
+	var/obj/item/new_hovered_on = find_item(params)
+
+	if (hovered_on != new_hovered_on)
+		if (!isnull(hovered_on))
+			hovered_on.MouseExited(location, control, params)
+		if (!isnull(new_hovered_on))
+			new_hovered_on.MouseEntered(location, control, params)
+		hovered_on = new_hovered_on
+	else if (!isnull(hovered_on))
+		hovered_on.MouseMove(location, control, params)
+
+/obj/screen/item_relayed/MouseExited(location, control, params)
+	if (!isnull(hovered_on))
+		hovered_on.MouseExited(location, control, params)
+	hovered_on = null
+
+/// Item relay used by storage UIs - uses mouse position to determine which item in the storage is being pointed at
+/obj/screen/item_relayed/storage
 	name = "storage"
 
-/obj/screen/storage/Click()
-	if(!usr.canClick())
-		return 1
-	if(usr.stat || usr.paralysis || usr.stunned || usr.weakened)
-		return 1
-	if(master)
+	var/datum/storage_ui/default/containing_ui = null
+
+/obj/screen/item_relayed/storage/empty_click(atom/location, control, string_params)
+	if (master)
 		var/obj/item/I = usr.get_active_hand()
 		if(I)
 			usr.ClickOn(master)
+
 	return 1
+
+/obj/screen/item_relayed/storage/find_item(string_params)
+	if (isnull(master) || isnull(containing_ui))
+		return null
+
+	var/list/params = params2list(string_params)
+	var/list/clicked_loc = splittext(params[MOUSE_SCREEN_LOC], ",")
+	var/list/clicked_loc_X = splittext(clicked_loc[1],":")
+	var/list/clicked_loc_Y = splittext(clicked_loc[2],":")
+
+	if (!isnull(containing_ui.storage.storage_slots))
+		var/clicked_loc_tile_X = text2num(clicked_loc_X[1])
+		var/clicked_loc_pixel_X = text2num(clicked_loc_X[2])
+
+		if (clicked_loc_pixel_X <= 16)
+			clicked_loc_tile_X -= 1
+
+		var/clicked_loc_tile_Y = text2num(clicked_loc_Y[1])
+		var/clicked_loc_pixel_Y = text2num(clicked_loc_Y[2])
+
+		if (clicked_loc_pixel_Y <= 16)
+			clicked_loc_tile_Y -= 1
+
+		var/obj/item/O = containing_ui.slot_obj_locs["[clicked_loc_tile_X],[clicked_loc_tile_Y]"]
+
+		if (istype(O, /obj/item))
+			return O
+	else
+		var/clicked_loc_tile_X = text2num(clicked_loc_X[1])
+		var/clicked_loc_pixel_X = text2num(clicked_loc_X[2])
+
+		var/clicked_loc_x = clicked_loc_tile_X * WORLD_ICON_SIZE + clicked_loc_pixel_X 
+
+		for (var/i in 1 to length(containing_ui.space_obj_x_start))
+			var/obj/item/O = master.contents[i]
+			if (!istype(O, /obj/item))
+				continue
+
+			if (!(containing_ui.space_obj_x_start[i] <= clicked_loc_x && clicked_loc_x <= containing_ui.space_obj_x_end[i]))
+				continue
+
+			return O
+
+	return null
 
 /obj/screen/zone_sel
 	name = "damage zone"
@@ -350,13 +465,18 @@
 			return 0
 	return 1
 
-/obj/screen/inventory/Click()
-	// At this point in client Click() code we have passed the 1/10 sec check and little else
-	// We don't even know if it's a middle click
-	if(!usr.canClick())
-		return 1
-	if(usr.incapacitated())
-		return 1
+// An item relay that represents an inventory slot for some mob
+/obj/screen/item_relayed/inventory_slot
+	var/slot_id
+
+/obj/screen/item_relayed/inventory_slot/find_item(params)
+	if (!ismob(usr))
+		return null
+
+	var/mob/C = usr
+	return C.get_equipped_item(slot_id)
+
+/obj/screen/item_relayed/inventory_slot/empty_click(atom/location, control, params)
 	switch(name)
 		if("r_hand")
 			if(iscarbon(usr))
@@ -380,12 +500,11 @@
 			if(usr.attack_ui(slot_id))
 				usr.update_inv_l_hand(0)
 				usr.update_inv_r_hand(0)
-	return 1
 
-/obj/screen/inventory/Adjacent(atom/neighbor)
+/obj/screen/item_relayed/inventory_slot/Adjacent(atom/neighbor)
 	return neighbor == usr
 
-/obj/screen/inventory/MouseDrop_T(atom/dropped, mob/living/user)
+/obj/screen/item_relayed/inventory_slot/MouseDrop_T(atom/dropped, mob/living/user)
 	// No more cloning knife hands by drag-dropping augs to the other hand slot
 	var/obj/item/droppeditem = dropped
 	if (istype(droppeditem) && !droppeditem.canremove)

--- a/code/controllers/subsystems/timer.dm
+++ b/code/controllers/subsystems/timer.dm
@@ -100,8 +100,8 @@ SUBSYSTEM_DEF(timer)
 				if (match)
 					if (!(flags & TIMER_OVERRIDE))
 						return
-					subsystem.timers_by_hash[hash] = timer
 					subsystem.queue -= match
+				subsystem.timers_by_hash[hash] = timer
 			timer.hash = hash
 	timer.fire_time = timer.wait + world.time
 	BINARY_INSERT(timer, subsystem.queue, /datum/timer, timer, fire_time, COMPARE_KEY)

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -100,7 +100,6 @@
 
 	var/attack_ignore_harm_check = FALSE
 
-
 /obj/item/Initialize()
 	. = ..()
 	if(randpixel && (!pixel_x && !pixel_y) && isturf(loc))
@@ -985,3 +984,23 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	if (href_list["examine"])
 		examinate(usr, src)
 		return TOPIC_HANDLED
+
+/obj/item/MouseEntered(location, control, params)
+	if (!usr.client)
+		return
+
+	usr.client.set_hover_outline(src, Adjacent(usr))
+
+/obj/item/MouseExited(location, control, params)
+	if (!usr.client)
+		return
+
+	usr.client.clear_hover_outline(src)
+
+/obj/item/MouseDrop(over_atom, source_loc, over_loc, src_control, over_control, params)
+	. = ..()
+
+	if (!usr.client)
+		return
+
+	usr.client.clear_hover_outline(src)

--- a/code/game/objects/items/weapons/storage/storage_ui/default.dm
+++ b/code/game/objects/items/weapons/storage/storage_ui/default.dm
@@ -1,42 +1,53 @@
 /datum/storage_ui/default
 	var/list/is_seeing = list() //List of mobs which are currently seeing the contents of this item's storage
 
-	var/obj/screen/storage/boxes
-	var/obj/screen/storage/storage_start //storage UI
-	var/obj/screen/storage/storage_continue
-	var/obj/screen/storage/storage_end
-	var/obj/screen/storage/stored_start
-	var/obj/screen/storage/stored_continue
-	var/obj/screen/storage/stored_end
+	// mapping of screen locations to items in slots
+	var/list/slot_obj_locs = alist()
+
+	// arrays containing the start-x and end-x for items in a space storage. each index corresponds to the item of the same one in storage.contents
+	var/list/space_obj_x_start = list()
+	var/list/space_obj_x_end = list()
+
+	var/obj/screen/item_relayed/storage/boxes
+	var/obj/screen/item_relayed/storage/storage_start //storage UI
+	var/obj/screen/item_relayed/storage/storage_continue
+	var/obj/screen/item_relayed/storage/storage_end
+	var/obj/screen/item_relayed/storage/stored_start
+	var/obj/screen/item_relayed/storage/stored_continue
+	var/obj/screen/item_relayed/storage/stored_end
 	var/obj/screen/close/closer
 
 /datum/storage_ui/default/New(storage)
 	..()
-	boxes = new /obj/screen/storage(  )
+	boxes = new /obj/screen/item_relayed/storage(  )
 	boxes.SetName("storage")
 	boxes.master = storage
 	boxes.icon_state = "block"
 	boxes.screen_loc = "7,7 to 10,8"
 	boxes.layer = HUD_BASE_LAYER
+	boxes.containing_ui = src
 
-	storage_start = new /obj/screen/storage(  )
+	storage_start = new /obj/screen/item_relayed/storage(  )
 	storage_start.SetName("storage")
 	storage_start.master = storage
 	storage_start.icon_state = "storage_start"
 	storage_start.screen_loc = "7,7 to 10,8"
 	storage_start.layer = HUD_BASE_LAYER
-	storage_continue = new /obj/screen/storage(  )
+	storage_start.containing_ui = src
+	storage_continue = new /obj/screen/item_relayed/storage(  )
 	storage_continue.SetName("storage")
 	storage_continue.master = storage
 	storage_continue.icon_state = "storage_continue"
 	storage_continue.screen_loc = "7,7 to 10,8"
 	storage_continue.layer = HUD_BASE_LAYER
-	storage_end = new /obj/screen/storage(  )
+	storage_continue.containing_ui = src
+	storage_end = new /obj/screen/item_relayed/storage(  )
 	storage_end.SetName("storage")
 	storage_end.master = storage
 	storage_end.icon_state = "storage_end"
 	storage_end.screen_loc = "7,7 to 10,8"
 	storage_end.layer = HUD_BASE_LAYER
+	storage_end.containing_ui = src
 
 	stored_start = new /obj //we just need these to hold the icon
 	stored_start.icon_state = "stored_start"
@@ -151,22 +162,6 @@
 			is_seeing -= M
 	return cansee
 
-//This proc draws out the inventory and places the items on it. tx and ty are the upper left tile and mx, my are the bottm right.
-//The numbers are calculated from the bottom-left The bottom-left slot being 1,1.
-/datum/storage_ui/default/proc/orient_objs(tx, ty, mx, my)
-	var/cx = tx
-	var/cy = ty
-	boxes.screen_loc = "[tx]:,[ty] to [mx],[my]"
-	for(var/obj/O in storage.contents)
-		O.screen_loc = "[cx],[cy]"
-		O.hud_layerise()
-		cx++
-		if (cx > mx)
-			cx = tx
-			cy--
-	closer.screen_loc = "[mx+1],[my]"
-	return
-
 //This proc determins the size of the inventory to be displayed. Please touch it only if you know what you're doing.
 /datum/storage_ui/default/proc/slot_orient_objs()
 	var/adjusted_contents = length(storage.contents)
@@ -181,9 +176,11 @@
 	var/cx = 4
 	var/cy = 2+rows
 	boxes.screen_loc = "4:16,2:16 to [4+cols]:16,[2+rows]:16"
+	slot_obj_locs.Cut()
 
 	for(var/obj/O in storage.contents)
 		O.screen_loc = "[cx]:16,[cy]:16"
+		slot_obj_locs["[cx],[cy]"] = O
 		O.maptext = ""
 		O.hud_layerise()
 		cx++
@@ -211,6 +208,9 @@
 	var/startpoint = 0
 	var/endpoint = 1
 
+	space_obj_x_start.Cut()
+	space_obj_x_end.Cut()
+
 	for(var/obj/item/O in storage.contents)
 		startpoint = endpoint + 1
 		endpoint += storage_width * O.get_storage_cost()/storage.max_storage_space
@@ -229,6 +229,11 @@
 		O.screen_loc = "4:[round((startpoint+endpoint)/2)+2],2:16"
 		O.maptext = ""
 		O.hud_layerise()
+
+		var/base = 4 * WORLD_ICON_SIZE + 2 + (WORLD_ICON_SIZE/2)
+
+		space_obj_x_start.Add(base + startpoint)
+		space_obj_x_end.Add(base + endpoint)
 
 	closer.screen_loc = "4:[storage_width+19],2:16"
 

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -98,7 +98,7 @@
 
 /obj/item/tray/use_before(atom/target, mob/living/user, click_parameters)
 	var/intent_check = ishuman(user) ? I_GRAB : I_HELP
-	if (user.a_intent != intent_check || istype(target, /obj/item/storage) || istype(target, /obj/screen/storage))
+	if (user.a_intent != intent_check || istype(target, /obj/item/storage) || istype(target, /obj/screen/item_relayed/storage))
 		return ..()
 
 	var/turf/turf = get_turf(target)

--- a/code/modules/client/client_outlines.dm
+++ b/code/modules/client/client_outlines.dm
@@ -1,10 +1,18 @@
 /client
 	var/image/active_outline = null
-	var/atom/active_outline_target = null
+	var/weakref/active_outline_target = null
+	var/active_outline_timer_id = null
 
 /client/proc/set_hover_outline(atom/target, accessible)
+	if (!isnull(active_outline_target) && !isnull(active_outline_target.resolve()) && !isnull(target) && active_outline_target.resolve() == target)
+		return
+
 	if (active_outline)
 		images -= active_outline
+
+	if (!isnull(active_outline_timer_id))
+		deltimer(active_outline_timer_id)
+		active_outline_timer_id = null
 
 	active_outline = null
 	active_outline_target = null
@@ -12,12 +20,29 @@
 	if (!istype(target))
 		return
 
+	active_outline_target = weakref(target)
+
+	if (prefs.UI_outline_fast)
+		commit_hover_outline(weakref(target), accessible)
+	else
+		var/datum/callback/active_outline_callback = new Callback(src, TYPE_PROC_REF(/client, commit_hover_outline), weakref(target), accessible)
+		active_outline_timer_id = addtimer(active_outline_callback, 0.7 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE | TIMER_STOPPABLE) // funny magic delay taken from Qt if anyone cares
+
+/client/proc/commit_hover_outline(weakref/target_weakref, accessible)
+	var/atom/target = target_weakref.resolve()
+
+	active_outline_timer_id = null
+	if (!istype(target))
+		return
+
+	if (active_outline)
+		images -= active_outline
+
 	var/render_target_id = "outline-[any2ref(target)]"
 	target.render_target = render_target_id
 
 	active_outline = image(icon = target, loc = target)
 	active_outline.appearance_flags |= RESET_COLOR | RESET_ALPHA
-	active_outline_target = target
 
 	if (accessible)
 		active_outline.filters += filter(type = "outline", size = 1, color = prefs.UI_outline_accessible_color)
@@ -35,11 +60,15 @@
 	images += active_outline
 
 /client/proc/clear_hover_outline(atom/target)
-	if (isnull(active_outline) || isnull(target))
+	if (isnull(active_outline_target) || isnull(active_outline_target.resolve()) || isnull(target))
 		return
 
-	if (active_outline_target != target)
-		return
+	if (active_outline_target.resolve() != target)
+		return	
+
+	if (!isnull(active_outline_timer_id))
+		deltimer(active_outline_timer_id)
+		active_outline_timer_id = null
 
 	images -= active_outline
 	active_outline = null

--- a/code/modules/client/client_outlines.dm
+++ b/code/modules/client/client_outlines.dm
@@ -1,0 +1,51 @@
+/client
+	var/image/active_outline = null
+	var/atom/active_outline_target = null
+
+/client/proc/set_hover_outline(atom/target, accessible)
+	if (active_outline)
+		images -= active_outline
+
+	active_outline = null
+	active_outline_target = null
+
+	if (!istype(target))
+		return
+
+	var/render_target_id = "outline-[any2ref(target)]"
+	target.render_target = render_target_id
+
+	active_outline = image(icon = target, loc = target)
+	active_outline.appearance_flags |= RESET_COLOR | RESET_ALPHA
+	active_outline_target = target
+
+	if (accessible)
+		active_outline.filters += filter(type = "outline", size = 1, color = prefs.UI_outline_accessible_color)
+		active_outline.alpha = prefs.UI_outline_accessible_alpha
+	else
+		active_outline.filters += filter(type = "outline", size = 1, color = prefs.UI_outline_inaccessible_color)
+		active_outline.alpha = prefs.UI_outline_inaccessible_alpha
+
+	active_outline.filters += filter(type = "alpha", render_source = render_target_id, flags = MASK_INVERSE)
+	active_outline.pixel_x = 0
+	active_outline.pixel_y = 0
+	active_outline.pixel_z = 0
+	active_outline.color = null
+
+	images += active_outline
+
+/client/proc/clear_hover_outline(atom/target)
+	if (isnull(active_outline) || isnull(target))
+		return
+
+	if (active_outline_target != target)
+		return
+
+	images -= active_outline
+	active_outline = null
+	active_outline_target = null
+
+/client/Destroy()
+	images -= active_outline
+	active_outline = null
+	return ..()

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -8,6 +8,7 @@
 	var/UI_outline_accessible_alpha = 255
 	var/UI_outline_inaccessible_color = "#99002e"
 	var/UI_outline_inaccessible_alpha = 255
+	var/UI_outline_fast = TRUE
 
 	var/tooltip_style = "Midnight" //Style for popup tooltips
 
@@ -27,6 +28,7 @@
 	pref.UI_outline_accessible_alpha = R.read("UI_outline_accessible_alpha")
 	pref.UI_outline_inaccessible_color = R.read("UI_outline_inaccessible_color")
 	pref.UI_outline_inaccessible_alpha = R.read("UI_outline_inaccessible_alpha")
+	pref.UI_outline_fast = R.read("UI_outline_fast")
 
 /datum/category_item/player_setup_item/player_global/ui/save_preferences(datum/pref_record_writer/W)
 	W.write("UI_style", pref.UI_style)
@@ -38,6 +40,7 @@
 	W.write("UI_outline_accessible_alpha", pref.UI_outline_accessible_alpha)
 	W.write("UI_outline_inaccessible_color", pref.UI_outline_inaccessible_color)
 	W.write("UI_outline_inaccessible_alpha", pref.UI_outline_inaccessible_alpha)
+	W.write("UI_outline_fast", pref.UI_outline_fast)
 
 
 /datum/category_item/player_setup_item/player_global/ui/sanitize_preferences()
@@ -48,6 +51,7 @@
 	pref.UI_outline_accessible_alpha = sanitize_integer(pref.UI_outline_accessible_alpha, 50, 255, initial(pref.UI_outline_accessible_alpha))
 	pref.UI_outline_inaccessible_color = sanitize_hexcolor(pref.UI_outline_inaccessible_color, initial(pref.UI_outline_inaccessible_color))
 	pref.UI_outline_inaccessible_alpha = sanitize_integer(pref.UI_outline_inaccessible_alpha, 50, 255, initial(pref.UI_outline_inaccessible_alpha))
+	pref.UI_outline_fast = sanitize_bool(pref.UI_outline_fast, initial(pref.UI_outline_fast))
 	pref.ooccolor		= sanitize_hexcolor(pref.ooccolor, initial(pref.ooccolor))
 	sanitize_client_fps()
 
@@ -62,7 +66,8 @@
 	. += "- Accessible color: <a href='byond://?src=\ref[src];select_accessible_color=1'><b>[pref.UI_outline_accessible_color]</b></a> <table style='display:inline;' bgcolor='[pref.UI_outline_accessible_color]'><tr><td>__</td></tr></table> <a href='byond://?src=\ref[src];reset=accessible_color'>reset</a><br>"
 	. += "- Accessible alpha: <a href='byond://?src=\ref[src];select_accessible_alpha=1'><b>[pref.UI_outline_accessible_alpha]</b></a> <a href='byond://?src=\ref[src];reset=accessible_alpha'>reset</a><br>"
 	. += "- Inaccessible color: <a href='byond://?src=\ref[src];select_inaccessible_color=1'><b>[pref.UI_outline_inaccessible_color]</b></a> <table style='display:inline;' bgcolor='[pref.UI_outline_inaccessible_color]'><tr><td>__</td></tr></table> <a href='byond://?src=\ref[src];reset=inaccessible_color'>reset</a><br>"
-	. += "- Inaccessible alpha: <a href='byond://?src=\ref[src];select_inaccessible_alpha=1'><b>[pref.UI_outline_inaccessible_alpha]</b></a> <a href='byond://?src=\ref[src];reset=inaccessible_alpha'>reset</a><br>"
+	. += "- Inaccessible alpha: <a href='byond://?src=\ref[src];select_inaccessible_alpha=1'><b>[pref.UI_outline_inaccessible_alpha]</b></a> <a href='byond://?src=\ref[src];reset=inaccessible_alpha'>reset</a><br><br>"
+	. += "- Speed: <a href='byond://?src=\ref[src];select_outline_speed=1'><b>[pref.UI_outline_fast ? "Fast" : "Delayed"]</b></a><br>"
 	. += "<br><b>Tooltip Style:</b> <a href='byond://?src=\ref[src];select_tooltip_style=1'><b>[pref.tooltip_style]</b></a><br>"
 	if(can_select_ooc_color(user))
 		. += "<b>OOC Color:</b> "
@@ -108,6 +113,13 @@
 		var/UI_inaccessible_alpha_new = input(user, "Select outline alpha (transparency) level, between 50 and 255.", "Global Preference", pref.UI_outline_inaccessible_alpha) as num|null
 		if (isnull(UI_inaccessible_alpha_new) || (UI_inaccessible_alpha_new < 50 || UI_inaccessible_alpha_new > 255) || !CanUseTopic(user)) return TOPIC_NOACTION
 		pref.UI_outline_inaccessible_alpha = UI_inaccessible_alpha_new
+		return TOPIC_REFRESH
+
+	else if (href_list["select_outline_speed"])
+		var/speed_new = input(user, "Choose outline speed on hover.", "Global Preference", ui_outline_speeds[pref.UI_outline_fast ? 1 : 2]) as null|anything in ui_outline_speeds
+		if (isnull(speed_new) || !CanUseTopic(user))
+			return TOPIC_NOACTION
+		pref.UI_outline_fast = speed_new == ui_outline_speeds[1]
 		return TOPIC_REFRESH
 
 	else if(href_list["select_alpha"])

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -4,6 +4,10 @@
 	var/UI_style = "Midnight"
 	var/UI_style_color = "#ffffff"
 	var/UI_style_alpha = 255
+	var/UI_outline_accessible_color = "#00d485"
+	var/UI_outline_accessible_alpha = 255
+	var/UI_outline_inaccessible_color = "#99002e"
+	var/UI_outline_inaccessible_alpha = 255
 
 	var/tooltip_style = "Midnight" //Style for popup tooltips
 
@@ -19,7 +23,10 @@
 	pref.UI_style_alpha = R.read("UI_style_alpha")
 	pref.ooccolor = R.read("ooccolor")
 	pref.clientfps = R.read("clientfps")
-
+	pref.UI_outline_accessible_color = R.read("UI_outline_accessible_color")
+	pref.UI_outline_accessible_alpha = R.read("UI_outline_accessible_alpha")
+	pref.UI_outline_inaccessible_color = R.read("UI_outline_inaccessible_color")
+	pref.UI_outline_inaccessible_alpha = R.read("UI_outline_inaccessible_alpha")
 
 /datum/category_item/player_setup_item/player_global/ui/save_preferences(datum/pref_record_writer/W)
 	W.write("UI_style", pref.UI_style)
@@ -27,12 +34,20 @@
 	W.write("UI_style_alpha", pref.UI_style_alpha)
 	W.write("ooccolor", pref.ooccolor)
 	W.write("clientfps", pref.clientfps)
+	W.write("UI_outline_accessible_color", pref.UI_outline_accessible_color)
+	W.write("UI_outline_accessible_alpha", pref.UI_outline_accessible_alpha)
+	W.write("UI_outline_inaccessible_color", pref.UI_outline_inaccessible_color)
+	W.write("UI_outline_inaccessible_alpha", pref.UI_outline_inaccessible_alpha)
 
 
 /datum/category_item/player_setup_item/player_global/ui/sanitize_preferences()
 	pref.UI_style		= sanitize_inlist(pref.UI_style, all_ui_styles, initial(pref.UI_style))
 	pref.UI_style_color	= sanitize_hexcolor(pref.UI_style_color, initial(pref.UI_style_color))
 	pref.UI_style_alpha	= sanitize_integer(pref.UI_style_alpha, 0, 255, initial(pref.UI_style_alpha))
+	pref.UI_outline_accessible_color = sanitize_hexcolor(pref.UI_outline_accessible_color, initial(pref.UI_outline_accessible_color))
+	pref.UI_outline_accessible_alpha = sanitize_integer(pref.UI_outline_accessible_alpha, 50, 255, initial(pref.UI_outline_accessible_alpha))
+	pref.UI_outline_inaccessible_color = sanitize_hexcolor(pref.UI_outline_inaccessible_color, initial(pref.UI_outline_inaccessible_color))
+	pref.UI_outline_inaccessible_alpha = sanitize_integer(pref.UI_outline_inaccessible_alpha, 50, 255, initial(pref.UI_outline_inaccessible_alpha))
 	pref.ooccolor		= sanitize_hexcolor(pref.ooccolor, initial(pref.ooccolor))
 	sanitize_client_fps()
 
@@ -43,7 +58,12 @@
 	. += "<b>Custom UI</b> (recommended for White UI):<br>"
 	. += "-Color: <a href='byond://?src=\ref[src];select_color=1'><b>[pref.UI_style_color]</b></a> <table style='display:inline;' bgcolor='[pref.UI_style_color]'><tr><td>__</td></tr></table> <a href='byond://?src=\ref[src];reset=ui'>reset</a><br>"
 	. += "-Alpha(transparency): <a href='byond://?src=\ref[src];select_alpha=1'><b>[pref.UI_style_alpha]</b></a> <a href='byond://?src=\ref[src];reset=alpha'>reset</a><br>"
-	. += "<b>Tooltip Style:</b> <a href='byond://?src=\ref[src];select_tooltip_style=1'><b>[pref.tooltip_style]</b></a><br>"
+	. += "<br><b>Targeting outlines</b>:<br>"
+	. += "- Accessible color: <a href='byond://?src=\ref[src];select_accessible_color=1'><b>[pref.UI_outline_accessible_color]</b></a> <table style='display:inline;' bgcolor='[pref.UI_outline_accessible_color]'><tr><td>__</td></tr></table> <a href='byond://?src=\ref[src];reset=accessible_color'>reset</a><br>"
+	. += "- Accessible alpha: <a href='byond://?src=\ref[src];select_accessible_alpha=1'><b>[pref.UI_outline_accessible_alpha]</b></a> <a href='byond://?src=\ref[src];reset=accessible_alpha'>reset</a><br>"
+	. += "- Inaccessible color: <a href='byond://?src=\ref[src];select_inaccessible_color=1'><b>[pref.UI_outline_inaccessible_color]</b></a> <table style='display:inline;' bgcolor='[pref.UI_outline_inaccessible_color]'><tr><td>__</td></tr></table> <a href='byond://?src=\ref[src];reset=inaccessible_color'>reset</a><br>"
+	. += "- Inaccessible alpha: <a href='byond://?src=\ref[src];select_inaccessible_alpha=1'><b>[pref.UI_outline_inaccessible_alpha]</b></a> <a href='byond://?src=\ref[src];reset=inaccessible_alpha'>reset</a><br>"
+	. += "<br><b>Tooltip Style:</b> <a href='byond://?src=\ref[src];select_tooltip_style=1'><b>[pref.tooltip_style]</b></a><br>"
 	if(can_select_ooc_color(user))
 		. += "<b>OOC Color:</b> "
 		if(pref.ooccolor == initial(pref.ooccolor))
@@ -64,6 +84,30 @@
 		var/UI_style_color_new = input(user, "Choose UI color, dark colors are not recommended!", "Global Preference", pref.UI_style_color) as color|null
 		if(isnull(UI_style_color_new) || !CanUseTopic(user)) return TOPIC_NOACTION
 		pref.UI_style_color = UI_style_color_new
+		return TOPIC_REFRESH
+
+	else if (href_list["select_accessible_color"])
+		var/UI_accessible_color_new = input(user, "Choose outline color:", "Global Preference") as color|null
+		if(UI_accessible_color_new && CanUseTopic(user))
+			pref.UI_outline_accessible_color = UI_accessible_color_new
+			return TOPIC_REFRESH
+
+	else if (href_list["select_inaccessible_color"])
+		var/UI_inaccessible_color_new = input(user, "Choose outline color:", "Global Preference") as color|null
+		if(UI_inaccessible_color_new && CanUseTopic(user))
+			pref.UI_outline_inaccessible_color = UI_inaccessible_color_new
+			return TOPIC_REFRESH
+
+	else if (href_list["select_accessible_alpha"])
+		var/UI_accessible_alpha_new = input(user, "Select outline alpha (transparency) level, between 50 and 255.", "Global Preference", pref.UI_outline_accessible_alpha) as num|null
+		if (isnull(UI_accessible_alpha_new) || (UI_accessible_alpha_new < 50 || UI_accessible_alpha_new > 255) || !CanUseTopic(user)) return TOPIC_NOACTION
+		pref.UI_outline_accessible_alpha = UI_accessible_alpha_new
+		return TOPIC_REFRESH
+
+	else if (href_list["select_inaccessible_alpha"])
+		var/UI_inaccessible_alpha_new = input(user, "Select outline alpha (transparency) level, between 50 and 255.", "Global Preference", pref.UI_outline_inaccessible_alpha) as num|null
+		if (isnull(UI_inaccessible_alpha_new) || (UI_inaccessible_alpha_new < 50 || UI_inaccessible_alpha_new > 255) || !CanUseTopic(user)) return TOPIC_NOACTION
+		pref.UI_outline_inaccessible_alpha = UI_inaccessible_alpha_new
 		return TOPIC_REFRESH
 
 	else if(href_list["select_alpha"])
@@ -103,6 +147,14 @@
 				pref.UI_style_alpha = initial(pref.UI_style_alpha)
 			if("ooc")
 				pref.ooccolor = initial(pref.ooccolor)
+			if ("accessible_color")
+				pref.UI_outline_accessible_color = initial(pref.UI_outline_accessible_color)
+			if ("accessible_alpha")
+				pref.UI_outline_accessible_alpha = initial(pref.UI_outline_accessible_alpha)
+			if ("inaccessible_color")
+				pref.UI_outline_inaccessible_color = initial(pref.UI_outline_inaccessible_color)
+			if ("inaccessible_alpha")
+				pref.UI_outline_inaccessible_alpha = initial(pref.UI_outline_inaccessible_alpha)
 		return TOPIC_REFRESH
 
 	return ..()

--- a/code/modules/client/ui_style.dm
+++ b/code/modules/client/ui_style.dm
@@ -18,6 +18,11 @@ var/global/all_tooltip_styles = list(
 	"Clockwork"
 	)
 
+var/global/ui_outline_speeds = list(
+	"As soon as pointer enters item",
+	"When pointer is held over item",
+	)
+
 /proc/ui_style2icon(ui_style)
 	if(ui_style in all_ui_styles)
 		return all_ui_styles[ui_style]

--- a/code/modules/cooking/container.dm
+++ b/code/modules/cooking/container.dm
@@ -99,7 +99,7 @@
 
 /obj/item/reagent_containers/cooking_container/use_before(atom/target, mob/living/user, click_parameters)
 	var/intent_check = ishuman(user) ? I_GRAB : I_HELP
-	if (user.a_intent != intent_check || istype(target, /obj/item/storage) || istype(target, /obj/screen/storage))
+	if (user.a_intent != intent_check || istype(target, /obj/item/storage) || istype(target, /obj/screen/item_relayed/storage))
 		return ..()
 
 	var/turf/turf = get_turf(target)


### PR DESCRIPTION
The PR where I got tired of pixel hunting but this time there's an option to turn on a delay which addresses the accessibility and network lag concerns concerns of a fast-moving bright outline across a line of objects on the screen out of sync with the mouse cursor and also I fixed timer cancellation being broken which probably has more wide-reaching implications but y'know 

<img width="567" height="115" alt="Bildschirmfoto 2025-12-15 um 7 31 22 PM" src="https://github.com/user-attachments/assets/e34cce34-bf08-4282-97dd-864a89f0231a" />

(nested inventories) why isn't this item coming out of the inventory when I click it- oh it's red that means this is intentional and not a bug

<img width="567" height="115" alt="Bildschirmfoto 2025-12-15 um 7 32 45 PM" src="https://github.com/user-attachments/assets/1a612425-f814-4eed-befe-f7bd98cc5abb" />

(item reachability) ugh i don't know if it's lagging or is just barely out of reach

<img width="258" height="233" alt="Bildschirmfoto 2025-12-15 um 7 34 37 PM" src="https://github.com/user-attachments/assets/f206c8a6-dec6-49e7-bc46-e46b49d0da35" />

<img width="258" height="233" alt="Bildschirmfoto 2025-12-15 um 7 35 14 PM" src="https://github.com/user-attachments/assets/ce5f052f-33ca-4f1c-a5dc-4a7760ec776b" />

(distinguishing items) so uhhh idk which one i'm pointing at unless they have different names and im staring at the bottom left corner of the screen where the thing i'm trying to aim isn't

<img width="258" height="233" alt="Bildschirmfoto 2025-12-15 um 7 37 25 PM" src="https://github.com/user-attachments/assets/c781bbbb-658b-4ebf-ad5f-e89ff72a7295" />

:cl: sowelipililimute
rscadd: You can now click items anywhere in your inventory or in open storages, not just the exact pixels of the sprite.
rscadd: Items now have an outline that indicates reachability, as well as making it easier to tell which item in a cluster you're aiming at.
/:cl: