### PR TITLE
roller beds now have wheels

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -53,6 +53,7 @@ GLOBAL_ALIST_INIT_STEP(flag_to_index, 0)
 
 /// Whether this object is offset onto a wall
 #define OBJ_FLAG_WALL_MOUNTED FLAG_07
+#define OBJ_FLAG_HAS_WHEELS FLAG_08
 
 //Flags for items (equipment)
 #define ITEM_FLAG_NO_BLUDGEON               FLAG_01  // When an item has this it produces no "X has been hit by Y with Z" message with the default handler.

--- a/code/game/objects/structures/roller_bed.dm
+++ b/code/game/objects/structures/roller_bed.dm
@@ -5,6 +5,7 @@
 	can_buckle = TRUE
 	buckle_dir = SOUTH
 	buckle_stance = BUCKLE_FORCE_PRONE
+	obj_flags = OBJ_FLAG_HAS_WHEELS
 
 	/// A shared list of pixel offsets for roller beds to move their buckled mobs by.
 	var/static/list/roller_bed_buckle_pixel_shift = list(0, 0, 6)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -228,7 +228,7 @@
 	if(pulling)
 		if(isobj(pulling))
 			var/obj/O = pulling
-			. += clamp(O.w_class, 0, ITEM_SIZE_GARGANTUAN) / 5
+			. += clamp(O.w_class, 0, ITEM_SIZE_GARGANTUAN) / ((O.obj_flags & OBJ_FLAG_HAS_WHEELS) ? 10 : 5)
 		else if(ismob(pulling))
 			var/mob/M = pulling
 			. += max(0, M.mob_size) / MOB_MEDIUM


### PR DESCRIPTION
by request from the discord; deployed roller beds now act like they have wheels, and won't slow you down the same as if you're dragging a bodybag around on the floor. implemented as a flag on objs, so it can be trivially extended to other wheeled objects (wheelchairs, maybe? unfamiliar with any other wheeled objects) if needed

implemented as a complete removal of the encumbrance penalty, currently, because frankly you can go really fast with wheeled objects irl; if for balance reasons it'd be better as a reduction to the penalty, that would also be trivial to implement

:cl:
tweak: rollerbeds no longer slow you down
/:cl: