### PR TITLE
Adds Chairs to Aluminum Recipes (Addresses #35432)

### DIFF
--- a/code/modules/materials/material_recipes.dm
+++ b/code/modules/materials/material_recipes.dm
@@ -181,8 +181,15 @@
 	. = ..()
 	if(reinforce_material)	//recipes below don't support composite materials
 		return
+	. += new/datum/stack_recipe_list("office chairs",list(
+		new/datum/stack_recipe/furniture/chair/office/dark(src),
+		new/datum/stack_recipe/furniture/chair/office/light(src)
+		))
 	. += new/datum/stack_recipe/grenade(src)
 	. += new/datum/stack_recipe/missile_frame(src)
+	. += new/datum/stack_recipe_list("comfy office chairs", create_recipe_list(/datum/stack_recipe/furniture/chair/office/comfy))
+	. += new/datum/stack_recipe_list("comfy chairs", create_recipe_list(/datum/stack_recipe/furniture/chair/comfy))
+	. += new/datum/stack_recipe_list("armchairs", create_recipe_list(/datum/stack_recipe/furniture/chair/arm))
 
 /material/leather/generate_recipes(reinforce_material)
 	. = ..()


### PR DESCRIPTION
Adds comfy chairs, comfy office chairs, and armchairs to the aluminium recipes list. This addresses issue #35432 and will ensure that deconstructing aluminium chairs no longer leaves you sad and unable to rebuild them.

:cl: 
tweak: Adds comfy chairs, comfy office chairs, and armchairs to the aluminium material recipes list.
/:cl: