### PR TITLE
Remove pixelhunting from storage

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -63,6 +63,11 @@
 	if(world.time <= next_click) // Hard check, before anything else, to avoid crashing
 		return
 
+	if (istype(A, /obj/screen/item_relayed))
+		var/obj/screen/item_relayed/relay = A
+		if (!isnull(relay.hovered_on))
+			return ClickOn(relay.hovered_on, params, use_in_world)
+
 	next_click = world.time + 1
 
 	var/list/modifiers = params2list(params)
@@ -525,15 +530,15 @@ GLOBAL_LIST_INIT(click_catchers)
 
 /client/MouseDown(object, location, control, params)
 	var/datum/click_handler/click_handler = usr.GetClickHandler()
-	click_handler.OnMouseDown(object, location, params)
+	click_handler.OnMouseDown(object, location, control, params)
 
 /client/MouseUp(object, location, control, params)
 	var/datum/click_handler/click_handler = usr.GetClickHandler()
-	click_handler.OnMouseUp(object, location, params)
+	click_handler.OnMouseUp(object, location, control, params)
 
 /client/MouseDrag(src_object,atom/over_object,src_location,over_location,src_control,over_control,params)
 	var/datum/click_handler/click_handler = usr.GetClickHandler()
-	click_handler.OnMouseDrag(over_object, params)
+	click_handler.OnMouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params)
 
 /client/MouseEntered(object, location, control, params)
 	var/datum/click_handler/click_handler = usr.GetClickHandler()

--- a/code/_onclick/click_handling.dm
+++ b/code/_onclick/click_handling.dm
@@ -116,7 +116,7 @@ var/global/const/CLICK_HANDLER_REMOVE_IF_NOT_TOP    = FLAG_02
  *
  * Has no return value.
  */
-/datum/click_handler/proc/OnMouseDown(object, location, params)
+/datum/click_handler/proc/OnMouseDown(object, location, control, params)
 	return
 
 /**
@@ -129,7 +129,7 @@ var/global/const/CLICK_HANDLER_REMOVE_IF_NOT_TOP    = FLAG_02
  *
  * Has no return value.
  */
-/datum/click_handler/proc/OnMouseUp(object, location, params)
+/datum/click_handler/proc/OnMouseUp(object, location, control, params)
 	return
 
 /**
@@ -157,12 +157,17 @@ var/global/const/CLICK_HANDLER_REMOVE_IF_NOT_TOP    = FLAG_02
  * Called on MouseUp by `/client/MouseDrag()` when this is the mob's currently active click handler.
  *
  * **Parameters**:
+ * - `src_object` - The object being dragged.
  * - `over_object` - The new atom underneath mouse.
+ * - `src_location` - The source location of the drag
+ * - `over_location` - The source location of the dragged-over object
+ * - `src_control` - The source control of the dragged object
+ * - `over_control` - The source control of the dragged-over object
  * - `params` (list of strings) - List of click parameters. See BYOND's `CLick()` documentation.
  *
  * Has no return value.
  */
-/datum/click_handler/proc/OnMouseDrag(atom/over_object, params)
+/datum/click_handler/proc/OnMouseDrag(atom/src_object, atom/over_object, src_location, over_location, src_control, over_control, params)
 	return
 
 /datum/click_handler/proc/CanAutoClick(object, location, params)
@@ -178,7 +183,7 @@ var/global/const/CLICK_HANDLER_REMOVE_IF_NOT_TOP    = FLAG_02
 /datum/click_handler/default/OnDblClick(atom/A, params)
 	user.DblClickOn(A, params)
 
-/datum/click_handler/default/OnMouseDown(object, location, params)
+/datum/click_handler/default/OnMouseDown(atom/object, location, control, params)
 	var/delay = CanAutoClick(object, location, params)
 	if(delay)
 		selected_target[1] = object
@@ -186,14 +191,21 @@ var/global/const/CLICK_HANDLER_REMOVE_IF_NOT_TOP    = FLAG_02
 		while(selected_target[1])
 			OnClick(selected_target[1], selected_target[2])
 			sleep(delay)
+	else if (istype(object, /obj/screen))
+		object.MouseDown(location, control, params)
 
-/datum/click_handler/default/OnMouseUp(object, location, params)
+/datum/click_handler/default/OnMouseUp(atom/object, location, control, params)
 	selected_target[1] = null
 
-/datum/click_handler/default/OnMouseDrag(atom/over_object, params)
+	if (istype(object, /obj/screen))
+		object.MouseUp(location, control, params)
+
+/datum/click_handler/default/OnMouseDrag(src_object, atom/over_object, src_location, over_location, src_control, over_control, params)
 	if(selected_target[1] && over_object && over_object.IsAutoclickable()) //Over object could be null, for example if dragging over darkness
 		selected_target[1] = over_object
 		selected_target[2] = params
+	else if (istype(over_object, /obj/screen))
+		over_object.MouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params)
 
 /datum/click_handler/default/CanAutoClick(object, location, params)
 	return user.CanMobAutoclick(object, location, params)

--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -17,7 +17,7 @@
 
 	var/list/hud_elements = list()
 	var/obj/screen/using
-	var/obj/screen/inventory/inv_box
+	var/obj/screen/item_relayed/inventory_slot/inv_box
 
 	stamina_bar = new
 	adding += stamina_bar
@@ -26,7 +26,7 @@
 	var/has_hidden_gear
 	for(var/gear_slot in hud_data.gear)
 
-		inv_box = new /obj/screen/inventory()
+		inv_box = new /obj/screen/item_relayed/inventory_slot
 		inv_box.icon = ui_style
 		inv_box.color = ui_color
 		inv_box.alpha = ui_alpha
@@ -97,7 +97,7 @@
 		using.alpha = ui_alpha
 		src.adding += using
 
-		inv_box = new /obj/screen/inventory()
+		inv_box = new /obj/screen/item_relayed/inventory_slot
 		inv_box.SetName("r_hand")
 		inv_box.icon = ui_style
 		inv_box.icon_state = "r_hand_inactive"
@@ -111,7 +111,7 @@
 		src.r_hand_hud_object = inv_box
 		src.adding += inv_box
 
-		inv_box = new /obj/screen/inventory()
+		inv_box = new /obj/screen/item_relayed/inventory_slot
 		inv_box.SetName("l_hand")
 		inv_box.icon = ui_style
 		inv_box.icon_state = "l_hand_inactive"
@@ -124,7 +124,7 @@
 		src.l_hand_hud_object = inv_box
 		src.adding += inv_box
 
-		using = new /obj/screen/inventory()
+		using = new /obj/screen/item_relayed/inventory_slot
 		using.SetName("hand")
 		using.icon = ui_style
 		using.icon_state = "hand1"
@@ -133,7 +133,7 @@
 		using.alpha = ui_alpha
 		src.adding += using
 
-		using = new /obj/screen/inventory()
+		using = new /obj/screen/item_relayed/inventory_slot
 		using.SetName("hand")
 		using.icon = ui_style
 		using.icon_state = "hand2"

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -28,11 +28,6 @@
 	maptext_height = 480
 	maptext_width = 480
 
-
-/obj/screen/inventory
-	var/slot_id	//The indentifier for the slot. It has nothing to do with ID cards.
-
-
 /obj/screen/close
 	name = "close"
 
@@ -66,19 +61,142 @@
 	owner.ui_action_click(owner)
 	return 1
 
-/obj/screen/storage
+/// Base type for screen objects that relay to an /obj/item instance
+/obj/screen/item_relayed
+	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
+
+	var/obj/item/mouse_down_on = null
+	var/obj/item/hovered_on = null
+
+/// Finds the item for the given mouse parameters. Returns an /obj/item or null.
+/obj/screen/item_relayed/proc/find_item(params)
+	return null
+
+/// Called when the item relay is clicked, but not at a location with an item.
+/obj/screen/item_relayed/proc/empty_click(atom/location, control, params)
+
+/obj/screen/item_relayed/Click(atom/location, control, params)
+	if(!usr.canClick())
+		return
+	if(usr.stat || usr.paralysis || usr.stunned || usr.weakened)
+		return
+
+	var/obj/item/clicked_on = find_item(params)
+	if (!isnull(clicked_on))
+		usr.ClickOn(clicked_on, params)
+	else
+		empty_click(location, control, params)
+
+	return 1
+
+/obj/screen/item_relayed/MouseDrag(src_object, over_object, src_location, over_location, src_control, over_control, params)
+	var/obj/item/drag_on = find_item(params)
+
+	if (!isnull(drag_on))
+		var/datum/click_handler/click_handler = usr.GetClickHandler()
+		click_handler.OnMouseDrag(drag_on, params)
+
+/obj/screen/item_relayed/MouseUp(location, control, params)
+	var/obj/item/up_on = find_item(params)
+
+	if (!isnull(up_on))
+		var/datum/click_handler/click_handler = usr.GetClickHandler()
+		click_handler.OnMouseUp(up_on, location, control, params)
+
+/obj/screen/item_relayed/MouseDown(location, control, params)
+	var/obj/item/down_on = find_item(params)
+
+	if (!isnull(down_on))
+		var/datum/click_handler/click_handler = usr.GetClickHandler()
+		click_handler.OnMouseDown(down_on, location, control, params)
+		mouse_down_on = down_on
+
+/obj/screen/item_relayed/MouseDrop(atom/over_object, src_location, over_location, src_control, over_control, params)
+	if (!isnull(mouse_down_on))
+		mouse_down_on.MouseDrop(over_object, src_location, over_location, src_control, over_control, params)
+
+/obj/screen/item_relayed/MouseEntered(location, control, params)
+	hovered_on = find_item(params)
+	if (!isnull(hovered_on))
+		hovered_on.MouseEntered(location, control, params)
+
+/obj/screen/item_relayed/MouseMove(location, control, params)
+	var/obj/item/new_hovered_on = find_item(params)
+
+	if (hovered_on != new_hovered_on)
+		if (!isnull(hovered_on))
+			hovered_on.MouseExited(location, control, params)
+		if (!isnull(new_hovered_on))
+			new_hovered_on.MouseEntered(location, control, params)
+		hovered_on = new_hovered_on
+	else if (!isnull(hovered_on))
+		hovered_on.MouseMove(location, control, params)
+
+/obj/screen/item_relayed/MouseExited(location, control, params)
+	if (!isnull(hovered_on))
+		hovered_on.MouseExited(location, control, params)
+	hovered_on = null
+
+/// Item relay used by storage UIs - uses mouse position to determine which item in the storage is being pointed at
+/obj/screen/item_relayed/storage
 	name = "storage"
 
-/obj/screen/storage/Click()
-	if(!usr.canClick())
-		return 1
-	if(usr.stat || usr.paralysis || usr.stunned || usr.weakened)
-		return 1
-	if(master)
+	var/datum/storage_ui/default/containing_ui = null
+
+/obj/screen/item_relayed/storage/empty_click(atom/location, control, string_params)
+	if (master)
 		var/obj/item/I = usr.get_active_hand()
 		if(I)
 			usr.ClickOn(master)
+
 	return 1
+
+/obj/screen/item_relayed/storage/find_item(string_params)
+	if (isnull(master) || isnull(containing_ui))
+		return null
+
+	var/list/params = params2list(string_params)
+	// the screen location format is "tileX:pixelX,tileY:pixelY"
+	var/list/clicked_loc = splittext(params[MOUSE_SCREEN_LOC], ",")
+	// so this is "tileX:pixelX"
+	var/list/clicked_loc_X = splittext(clicked_loc[1],":")
+	// and "tileY:pixelY"
+	var/list/clicked_loc_Y = splittext(clicked_loc[2],":")
+
+	if (!isnull(containing_ui.storage.storage_slots))
+		var/clicked_loc_tile_X = text2num(clicked_loc_X[1])
+		var/clicked_loc_pixel_X = text2num(clicked_loc_X[2])
+
+		if (clicked_loc_pixel_X <= 16)
+			clicked_loc_tile_X -= 1
+
+		var/clicked_loc_tile_Y = text2num(clicked_loc_Y[1])
+		var/clicked_loc_pixel_Y = text2num(clicked_loc_Y[2])
+
+		if (clicked_loc_pixel_Y <= 16)
+			clicked_loc_tile_Y -= 1
+
+		var/obj/item/stored = containing_ui.slot_obj_locs["[clicked_loc_tile_X],[clicked_loc_tile_Y]"]
+
+		if (istype(stored, /obj/item))
+			return stored
+	else
+		var/clicked_loc_tile_X = text2num(clicked_loc_X[1])
+		var/clicked_loc_pixel_X = text2num(clicked_loc_X[2])
+
+		var/clicked_loc_x = clicked_loc_tile_X * WORLD_ICON_SIZE + clicked_loc_pixel_X 
+
+		for (var/i in 1 to length(containing_ui.space_obj_x_start))
+			var/obj/item/stored = master.contents[i]
+			if (!istype(stored, /obj/item))
+				continue
+
+			if (!(containing_ui.space_obj_x_start[i] <= clicked_loc_x && clicked_loc_x <= containing_ui.space_obj_x_end[i]))
+				continue
+
+			return stored
+
+	return null
 
 /obj/screen/zone_sel
 	name = "damage zone"
@@ -350,13 +468,18 @@
 			return 0
 	return 1
 
-/obj/screen/inventory/Click()
-	// At this point in client Click() code we have passed the 1/10 sec check and little else
-	// We don't even know if it's a middle click
-	if(!usr.canClick())
-		return 1
-	if(usr.incapacitated())
-		return 1
+// An item relay that represents an inventory slot for some mob
+/obj/screen/item_relayed/inventory_slot
+	var/slot_id
+
+/obj/screen/item_relayed/inventory_slot/find_item(params)
+	if (!ismob(usr))
+		return null
+
+	var/mob/mob = usr
+	return mob.get_equipped_item(slot_id)
+
+/obj/screen/item_relayed/inventory_slot/empty_click(atom/location, control, params)
 	switch(name)
 		if("r_hand")
 			if(iscarbon(usr))
@@ -380,12 +503,11 @@
 			if(usr.attack_ui(slot_id))
 				usr.update_inv_l_hand(0)
 				usr.update_inv_r_hand(0)
-	return 1
 
-/obj/screen/inventory/Adjacent(atom/neighbor)
+/obj/screen/item_relayed/inventory_slot/Adjacent(atom/neighbor)
 	return neighbor == usr
 
-/obj/screen/inventory/MouseDrop_T(atom/dropped, mob/living/user)
+/obj/screen/item_relayed/inventory_slot/MouseDrop_T(atom/dropped, mob/living/user)
 	// No more cloning knife hands by drag-dropping augs to the other hand slot
 	var/obj/item/droppeditem = dropped
 	if (istype(droppeditem) && !droppeditem.canremove)

--- a/code/game/objects/items/weapons/trays.dm
+++ b/code/game/objects/items/weapons/trays.dm
@@ -98,7 +98,7 @@
 
 /obj/item/tray/use_before(atom/target, mob/living/user, click_parameters)
 	var/intent_check = ishuman(user) ? I_GRAB : I_HELP
-	if (user.a_intent != intent_check || istype(target, /obj/item/storage) || istype(target, /obj/screen/storage))
+	if (user.a_intent != intent_check || istype(target, /obj/item/storage) || istype(target, /obj/screen/item_relayed/storage))
 		return ..()
 
 	var/turf/turf = get_turf(target)

--- a/code/modules/cooking/container.dm
+++ b/code/modules/cooking/container.dm
@@ -99,7 +99,7 @@
 
 /obj/item/reagent_containers/cooking_container/use_before(atom/target, mob/living/user, click_parameters)
 	var/intent_check = ishuman(user) ? I_GRAB : I_HELP
-	if (user.a_intent != intent_check || istype(target, /obj/item/storage) || istype(target, /obj/screen/storage))
+	if (user.a_intent != intent_check || istype(target, /obj/item/storage) || istype(target, /obj/screen/item_relayed/storage))
 		return ..()
 
 	var/turf/turf = get_turf(target)


### PR DESCRIPTION
<img width="274" height="152" alt="Bildschirmfoto 2025-12-23 um 5 58 13 PM" src="https://github.com/user-attachments/assets/901d832f-5e65-4762-924d-e633250480f9" />
<img width="309" height="165" alt="Bildschirmfoto 2025-12-23 um 5 58 29 PM" src="https://github.com/user-attachments/assets/732ba472-baf2-4a7f-b3ca-94e0dc1396db" />

:cl: sowelipililimute
rscadd: You can now click items anywhere in your inventory or in open storages, not just the exact pixels of the sprite.
/:cl: