### PR TITLE
augment welding tools no longer perpetually glow as if actively welding

### DIFF
--- a/code/modules/augment/active/tool/engineering.dm
+++ b/code/modules/augment/active/tool/engineering.dm
@@ -21,7 +21,12 @@
 
 
 /obj/item/weldingtool/finger/on_update_icon()
-	icon_state = welding ? "welder_finger_on" : "welder_finger"
+	if(welding)
+		icon_state = "welder_finger_on"
+		set_light(2.5, 0.6, l_color =COLOR_PALE_ORANGE)
+	else
+		icon_state = "welder_finger"
+		set_light(0)
 
 
 /obj/item/wirecutters/finger
@@ -135,7 +140,12 @@
 
 
 /obj/item/weldingtool/electric/finger/on_update_icon()
-	icon_state = welding ? "welder_finger_on" : "welder_finger"
+	if(welding)
+		icon_state = "welder_finger_on"
+		set_light(0.6, 0.5, 2.5, l_color = COLOR_LIGHT_CYAN)
+	else
+		icon_state = "welder_finger"
+		set_light(0)
 
 
 /obj/item/weldingtool/electric/finger/attack_hand(mob/living/user)


### PR DESCRIPTION
because augment welders and arc welders override on_update_icon, they exclude the set_light(0) that normally resets a welder's lighting. this fixes that, and as a consequence also means they'll glow the correct colors (pale orange for t1 welders, cyan for arc welders)

:cl:
bugfix: Augment welders no longer perpetually glow as if actively welding
/:cl: