### PR TITLE
Fixes eyestab proc so it doesn't damage random organs

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -658,8 +658,6 @@ var/global/list/slot_flags_enumeration = list(
 
 		var/obj/item/organ/external/affecting = H.get_organ(eyes.parent_organ)
 		affecting.take_external_damage(7)
-	else
-		M.take_organ_damage(7, 0)
 
 	M.eye_blurry += rand(3,4)
 	return TRUE


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
:cl: Podszywacz
bugfix: Eyestab proc no longer damages random external organs
/:cl:

Axes the demented 'else damage random external organ' from the proc, which I don't think had any reason to exist in the way it functioned.