### PR TITLE
hover outlines

### DIFF
--- a/baystation12.dme
+++ b/baystation12.dme
@@ -1605,6 +1605,7 @@
 #include "code\modules\client\client_color.dm"
 #include "code\modules\client\client_defines.dm"
 #include "code\modules\client\client_helpers.dm"
+#include "code\modules\client\client_outline.dm"
 #include "code\modules\client\client_procs.dm"
 #include "code\modules\client\darkmode.dm"
 #include "code\modules\client\movement.dm"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -985,3 +985,19 @@ modules/mob/living/carbon/human/life.dm if you die, you will be zoomed out.
 	if (href_list["examine"])
 		examinate(usr, src)
 		return TOPIC_HANDLED
+
+
+/obj/item/MouseEntered()
+	if (usr.client?.outline_enabled)
+		usr.client.SetOutlineAtom(src)
+
+
+/obj/item/MouseExited()
+	if (usr.client?.outline_atom)
+		usr.client.SetOutlineAtom()
+
+
+/obj/item/MouseDrop()
+	. = ..()
+	if (usr.client?.outline_atom)
+		usr.client.SetOutlineAtom()

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -50,3 +50,15 @@
 
 	/// The current fullscreen state for /client/toggle_fullscreen()
 	var/fullscreen = FALSE
+
+	/// When the client has atom outlines enabled and hovers something applicable, that thing's outline
+	var/image/atom_outline
+
+	/// A resolvable to the current atom outline target, if any
+	var/weakref/outline_atom
+
+	/// True while an atom outline update is in-flight
+	var/outline_updating
+
+	/// Mirror of the truthiness of the atom_outlines preference
+	var/outline_enabled

--- a/code/modules/client/client_outline.dm
+++ b/code/modules/client/client_outline.dm
@@ -1,0 +1,56 @@
+/**
+* When atom is null, immediately clears the client's hover outline.
+* Otherwise, changes the next outline source and queues an update if
+* one is not already queued.
+*/
+/client/proc/SetOutlineAtom(atom/atom)
+	if (!atom)
+		if (atom_outline)
+			images -= atom_outline
+			atom_outline = null
+		outline_atom = null
+		return
+	outline_atom = weakref(atom)
+	if (outline_updating)
+		return
+	outline_updating = TRUE
+	addtimer(new Callback(src, PROC_REF(UpdateOutline)), 0)
+
+/**
+* Updates the client's hover outline to the most recent source if it
+* still exists, or otherwise clears the outline. Should not be called
+* directly - use SetOutlineAtom.
+*/
+/client/proc/UpdateOutline()
+	outline_updating = FALSE
+	if (atom_outline)
+		images -= atom_outline
+		atom_outline = null
+	var/atom/atom = outline_atom?.resolve()
+	if (!isloc(atom))
+		outline_atom = null
+		return
+	if (!mob)
+		return
+	atom_outline = image(atom, atom)
+	atom_outline.pixel_x = 0
+	atom_outline.pixel_y = 0
+	atom_outline.pixel_z = 0
+	atom_outline.alpha = prefs.outline_alpha
+	atom_outline.color = null
+	atom_outline.appearance_flags |= RESET_COLOR | RESET_ALPHA | NO_CLIENT_COLOR
+	var/outline_color = prefs.outline_unreachable
+	if (!mob.incapacitated() && mob.Adjacent(atom))
+		outline_color = prefs.outline_reachable
+	atom_outline.filters += filter(
+		type = "outline",
+		size = 1,
+		color = outline_color
+	)
+	atom.render_target = "slate-\ref[atom]"
+	atom_outline.filters += filter(
+		type = "alpha",
+		render_source = atom.render_target,
+		flags = MASK_INVERSE
+	)
+	images += atom_outline

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -250,6 +250,10 @@
 		if (T.status == TICKET_OPEN && T.owner.ckey == ckey)
 			message_staff("[key_name_admin(src)] has left the game with an open ticket. Status: [length(T.assigned_admins) ? "Assigned to: [english_list(T.assigned_admin_ckeys())]" : SPAN_DANGER("Unassigned.")]")
 			break
+	if (atom_outline)
+		images -= atom_outline
+		atom_outline = null
+	outline_atom = null
 	if (holder)
 		holder.owner = null
 		GLOB.admins -= src

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -4,6 +4,9 @@
 	var/UI_style = "Midnight"
 	var/UI_style_color = "#ffffff"
 	var/UI_style_alpha = 255
+	var/outline_reachable = "#00ff00"
+	var/outline_unreachable = "#ff0000"
+	var/outline_alpha = 255
 
 	var/tooltip_style = "Midnight" //Style for popup tooltips
 
@@ -19,6 +22,9 @@
 	pref.UI_style_alpha = R.read("UI_style_alpha")
 	pref.ooccolor = R.read("ooccolor")
 	pref.clientfps = R.read("clientfps")
+	pref.outline_reachable = R.read("outline_reachable")
+	pref.outline_unreachable = R.read("outline_unreachable")
+	pref.outline_alpha = R.read("outline_alpha")
 
 
 /datum/category_item/player_setup_item/player_global/ui/save_preferences(datum/pref_record_writer/W)
@@ -27,13 +33,19 @@
 	W.write("UI_style_alpha", pref.UI_style_alpha)
 	W.write("ooccolor", pref.ooccolor)
 	W.write("clientfps", pref.clientfps)
+	W.write("outline_reachable", pref.outline_reachable)
+	W.write("outline_unreachable", pref.outline_unreachable)
+	W.write("outline_alpha", pref.outline_alpha)
 
 
 /datum/category_item/player_setup_item/player_global/ui/sanitize_preferences()
 	pref.UI_style		= sanitize_inlist(pref.UI_style, all_ui_styles, initial(pref.UI_style))
 	pref.UI_style_color	= sanitize_hexcolor(pref.UI_style_color, initial(pref.UI_style_color))
-	pref.UI_style_alpha	= sanitize_integer(pref.UI_style_alpha, 0, 255, initial(pref.UI_style_alpha))
+	pref.UI_style_alpha	= sanitize_integer(pref.UI_style_alpha, 50, 255, initial(pref.UI_style_alpha))
 	pref.ooccolor		= sanitize_hexcolor(pref.ooccolor, initial(pref.ooccolor))
+	pref.outline_reachable = sanitize_hexcolor(pref.outline_reachable, initial(pref.outline_reachable))
+	pref.outline_unreachable = sanitize_hexcolor(pref.outline_unreachable, initial(pref.outline_unreachable))
+	pref.outline_alpha = sanitize_integer(pref.outline_alpha, 50, 255, initial(pref.outline_alpha))
 	sanitize_client_fps()
 
 
@@ -44,6 +56,12 @@
 	. += "-Color: <a href='byond://?src=\ref[src];select_color=1'><b>[pref.UI_style_color]</b></a> <table style='display:inline;' bgcolor='[pref.UI_style_color]'><tr><td>__</td></tr></table> <a href='byond://?src=\ref[src];reset=ui'>reset</a><br>"
 	. += "-Alpha(transparency): <a href='byond://?src=\ref[src];select_alpha=1'><b>[pref.UI_style_alpha]</b></a> <a href='byond://?src=\ref[src];reset=alpha'>reset</a><br>"
 	. += "<b>Tooltip Style:</b> <a href='byond://?src=\ref[src];select_tooltip_style=1'><b>[pref.tooltip_style]</b></a><br>"
+	. += "<b>Atom Hover Outlines</b><br>"
+	var/outlines_enabled = user.get_preference_value(/datum/client_preference/atom_outlines) == GLOB.PREF_YES
+	. += "- Enabled: <a href='byond://?src=\ref[src];outline_toggle=1'>[outlines_enabled ? "Yes" : "No"]</a><br>"
+	. += "- Reachable: <a href='byond://?src=\ref[src];outline_reachable=1' style='background:[pref.outline_reachable];color:transparent'>--</a><br>"
+	. += "- Unreachable: <a href='byond://?src=\ref[src];outline_unreachable=1' style='background:[pref.outline_unreachable];color:transparent'>--</a><br>"
+	. += "- Alpha: <a href='byond://?src=\ref[src];outline_alpha=1'>[pref.outline_alpha]</a><br>"
 	if(can_select_ooc_color(user))
 		. += "<b>OOC Color:</b> "
 		if(pref.ooccolor == initial(pref.ooccolor))
@@ -70,6 +88,39 @@
 		var/UI_style_alpha_new = input(user, "Select UI alpha (transparency) level, between 50 and 255.", "Global Preference", pref.UI_style_alpha) as num|null
 		if(isnull(UI_style_alpha_new) || (UI_style_alpha_new < 50 || UI_style_alpha_new > 255) || !CanUseTopic(user)) return TOPIC_NOACTION
 		pref.UI_style_alpha = UI_style_alpha_new
+		return TOPIC_REFRESH
+
+	else if (href_list["outline_toggle"])
+		user.cycle_preference(/datum/client_preference/atom_outlines)
+		return TOPIC_REFRESH
+
+	else if (href_list["outline_reachable"])
+		var/response = input(user, "Reachable atom outline color:", "Global Preference", pref.outline_reachable) as null | color
+		if (!response)
+			return TOPIC_NOACTION
+		if (!CanUseTopic(user))
+			return TOPIC_NOACTION
+		pref.outline_reachable = response
+		return TOPIC_REFRESH
+
+	else if (href_list["outline_unreachable"])
+		var/response = input(user, "Unreachable atom outline color:", "Global Preference", pref.outline_unreachable) as null | color
+		if (!response)
+			return TOPIC_NOACTION
+		if (!CanUseTopic(user))
+			return TOPIC_NOACTION
+		pref.outline_unreachable = response
+		return TOPIC_REFRESH
+
+	else if (href_list["outline_alpha"])
+		var/response = input(user, "Atom outline transparency, between 50 - 255:", "Global Preference", pref.outline_alpha) as null | num
+		if (!response)
+			return TOPIC_NOACTION
+		if (response < 50 || response > 255)
+			return TOPIC_NOACTION
+		if (!CanUseTopic(user))
+			return TOPIC_NOACTION
+		pref.outline_alpha = response
 		return TOPIC_REFRESH
 
 	else if(href_list["select_ooc_color"])

--- a/code/modules/client/preference_setup/global/05_settings.dm
+++ b/code/modules/client/preference_setup/global/05_settings.dm
@@ -38,14 +38,12 @@
 	var/list/client_preference_keys = list()
 	for(var/cp in get_client_preferences())
 		var/datum/client_preference/client_pref = cp
-
 		client_preference_keys |= client_pref.key
-
 		// if the preference has never been set, or if the player is no longer allowed to set the it, set it to default
-		preference_mob() // we don't care about the mob it returns, but it finds the correct client.
+		var/mob/mob = preference_mob()
 		if(!client_pref.may_set(pref.client) || !(client_pref.key in pref.preference_values))
 			pref.preference_values[client_pref.key] = client_pref.default_value
-
+		client_pref.started(mob, pref.preference_values[client_pref.key])
 
 	// Clean out preferences that no longer exist.
 	for(var/key in pref.preference_values)

--- a/code/modules/client/preference_setup/global/preferences.dm
+++ b/code/modules/client/preference_setup/global/preferences.dm
@@ -88,6 +88,10 @@ var/global/list/_client_preferences_by_type
 /datum/client_preference/proc/changed(mob/preference_mob, new_value)
 	return
 
+/// Called when a client's preferences are first set up
+/datum/client_preference/proc/started(mob/user, value)
+	return
+
 /*********************
 * Player Preferences *
 *********************/
@@ -345,6 +349,21 @@ GLOBAL_CONST(PREF_VA_HALF_POPUP, "Reminder Popup")
 			to_chat(mob, "[description]:When a vote starts, you will be notified.")
 		else
 			to_chat(mob, {"[description]: "[new_value]" is unexpected. Please report this."})
+
+
+/datum/client_preference/atom_outlines
+	description = "Show Atom Outlines"
+	key = "ATOM_OUTLINE"
+
+
+/datum/client_preference/atom_outlines/changed(mob/user, new_value)
+	var/client/client = user.client
+	client?.SetOutlineAtom()
+	client?.outline_enabled = new_value == GLOB.PREF_YES
+
+
+/datum/client_preference/atom_outlines/started(mob/user, value)
+	changed(user, value)
 
 
 /********************


### PR DESCRIPTION
:cl:
rscadd: Added optional mouse hover outlines for items, defaulting on and configurable through Setup → Global
/:cl:

Alt implementation for specifically the outlines part of #35595

This PR only applies the effect to items, but the behavior is trivially expanded to other interactables

Also adds a /started( hook for preferences that need to do things when first loaded