### PR TITLE
allow resetting IC access by passing falsy passkeys

### DIFF
--- a/code/modules/integrated_electronics/subtypes/access.dm
+++ b/code/modules/integrated_electronics/subtypes/access.dm
@@ -55,7 +55,11 @@
 	var/list/access
 
 /obj/item/integrated_circuit/output/access_displayer/do_work()
-	var/list/signature_and_data = splittext(get_pin_data(IC_INPUT, 1), ":")
+	var/pin_data = get_pin_data(IC_INPUT, 1)
+	if(!pin_data)
+		access = null // Allow revoking the circuit's access by passing something falsy
+		return
+	var/list/signature_and_data = splittext(pin_data, ":")
 	if(length(signature_and_data) < 2)
 		return
 


### PR DESCRIPTION
currently, there's no way to revoke an IC's access- if you pass anything other than a valid passkey, the function early-returns. this fixes that, allowing you to do things like remotely remove a drone's access or create a smart guest pass that turns itself off when you activate it

:cl:
tweak: IC access circuits now revoke their access when passed falsy values
/:cl: