### PR TITLE
Some changelog fixes

### DIFF
--- a/tools/changelog/generate_cl.py
+++ b/tools/changelog/generate_cl.py
@@ -28,7 +28,7 @@ from pathlib import Path
 from ruamel import yaml
 from github import Github, Auth, InputGitAuthor
 
-CL_BODY = re.compile(r"(:cl:|🆑)(.+)?\r\n((.|\n|\r)+?)\r\n\/(:cl:|🆑)", re.MULTILINE)
+CL_BODY = re.compile(r"(:cl:|🆑)\s*(.*)?\r\n((.|\n|\r)+?)\r\n\/(:cl:|🆑)", re.MULTILINE)
 CL_SPLIT = re.compile(r"(^\w+):\s+(\w.+)", re.MULTILINE)
 
 git_email = os.getenv("GIT_EMAIL")
@@ -63,8 +63,11 @@ except AttributeError:
     print("No CL found!")
     exit(0) # Change to '0' if you do not want the action to fail when no CL is provided
 
+if not cl or not cl_list:
+    print("No CL found!")
+    exit(0)
 
-if cl.group(2) is not None:
+if cl.group(2):
     write_cl['author'] = cl.group(2).lstrip()
 else:
     write_cl['author'] = pr_author


### PR DESCRIPTION
A changelog that looks like
```
cl<space>
rscadd: Adds glumpers
/cl
```
will break and have an author name with the space.

This change adjusts the regex to check for trailing space and corresponding py logic to fallback to GitHub PR author instead, if there are trailing spaces.
https://regex101.com/r/rPF3ZX/2 Note group 2 is now empty string, which `if not cl.group(2):` covers.

Also should cover PRs with empty changelog bodies.