### PR TITLE
fix IC sound circuit output

### DIFF
--- a/code/modules/integrated_electronics/subtypes/output.dm
+++ b/code/modules/integrated_electronics/subtypes/output.dm
@@ -159,12 +159,11 @@
 		if(isnull(text))
 			return
 		var/atom/movable/speaking = get_object()
-		var/sanitized_text = sanitize(text)
-		speaking.audible_message("\The [speaking][sanitized_text]")
+		speaking.audible_message("\The [speaking][text]")
 		if (assembly)
-			log_say("[assembly] \ref[assembly] : [sanitized_text]")
+			log_say("[assembly] \ref[assembly] : [text]")
 		else
-			log_say("[name] ([type]) : [sanitized_text]")
+			log_say("[name] ([type]) : [text]")
 
 /obj/item/integrated_circuit/output/sound/on_data_written()
 	power_draw_per_use =  get_pin_data(IC_INPUT, 2) * 15


### PR DESCRIPTION
we were sanitizing the (constant) text which strips leading spaces- leading to some interesting (bad) results

:cl:
bugfix: IC sound circuits no longer strip whitespace from constant values
/:cl: