### PR TITLE
vendor wires can't be pulsed while inoperable

### DIFF
--- a/code/game/machinery/vending/_wires.dm
+++ b/code/game/machinery/vending/_wires.dm
@@ -38,6 +38,8 @@
 
 /datum/wires/vending/UpdatePulsed(index)
 	var/obj/machinery/vending/vendor = holder
+	if (vendor.inoperable())
+		return
 	switch (index)
 		if (WIRE_THROW_PRODUCTS)
 			if (IsIndexCut(WIRE_THROW_PRODUCTS))


### PR DESCRIPTION
:cl:
bugfix: Vendor wires can't be pulsed while inoperable
/:cl:
