### PR TITLE
De/readmining tweaks

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -351,7 +351,8 @@ var/global/list/admin_verbs_mod = list(
 		admin_verbs_rejuv,
 		admin_verbs_sounds,
 		admin_verbs_spawn,
-		debug_verbs
+		debug_verbs,
+		admin_verbs_mod
 		)
 
 /client/proc/hide_most_verbs()//Allows you to keep some functionality while hiding some verbs
@@ -588,8 +589,7 @@ var/global/list/admin_verbs_mod = list(
 
 	if(deadmin_holder)
 		deadmin_holder.reassociate()
-		log_admin("[src] re-admined themself.")
-		message_admins("[src] re-admined themself.", 1)
+		log_and_message_staff("re-admined themself.")
 		to_chat(src, SPAN_CLASS("interface", "You now have the keys to control the planet, or at least [GLOB.using_map.full_name]."))
 		verbs -= /client/proc/readmin_self
 
@@ -599,8 +599,7 @@ var/global/list/admin_verbs_mod = list(
 
 	if(holder)
 		if(alert("Confirm self-deadmin for the round? You can re-admin yourself at any time.",,"Yes","No") == "Yes")
-			log_admin("[src] deadmined themself.")
-			message_admins("[src] deadmined themself.", 1)
+			log_and_message_staff("deadmined themself.")
 			deadmin()
 			to_chat(src, SPAN_CLASS("interface", "You are now a normal player."))
 			verbs |= /client/proc/readmin_self


### PR DESCRIPTION
* Deadmining/readmining is now a staff log (goes to all staff, not just admins)
* Properly removes all staff verbs upon deadmining