### PR TITLE
Removes modify access reqs from off-ship sensors

### DIFF
--- a/code/modules/modular_computers/file_system/programs/ship/sensors.dm
+++ b/code/modules/modular_computers/file_system/programs/ship/sensors.dm
@@ -34,6 +34,7 @@
 
 /datum/nano_module/program/ship/sensors/spacer
 	print_language = LANGUAGE_SPACER
+	modify_access_req = null
 
 /datum/nano_module/program/ship/sensors/proc/get_sensors()
 	var/obj/machinery/shipsensors/sensors = sensor_ref?.resolve()

--- a/maps/away/voxship/voxship_machines.dm
+++ b/maps/away/voxship/voxship_machines.dm
@@ -4,6 +4,7 @@
 
 /datum/nano_module/program/ship/sensors/vox
 	print_language = LANGUAGE_VOX
+	modify_access_req = null
 
 /obj/machinery/computer/modular/preset/sensors/vox
 	default_software = list(


### PR DESCRIPTION
🆑 Cakey
bugfix: Non-Torch off-ship sensors consoles no longer require bridge access.
/🆑