### PR TITLE
vox gun capacity fix and tweak

### DIFF
--- a/code/modules/projectiles/guns/energy/vox.dm
+++ b/code/modules/projectiles/guns/energy/vox.dm
@@ -38,7 +38,7 @@
 			"burst_accuracy" = list(30),
 			"dispersion" = null,
 			"projectile_type" = /obj/item/projectile/beam/stun/darkmatter,
-			"charge_cost" = 50
+			"charge_cost" = 20
 		),
 		list(
 			"mode_name" = "focused",
@@ -48,7 +48,7 @@
 			"burst_accuracy" = list(30),
 			"dispersion" = null,
 			"projectile_type" = /obj/item/projectile/beam/darkmatter,
-			"charge_cost" = 75
+			"charge_cost" = 30
 		),
 		list(
 			"mode_name" = "scatter burst",
@@ -85,7 +85,7 @@
 		list(
 			"mode_name" = "normal",
 			"projectile_type" = /obj/item/projectile/energy/plasmastun/sonic/weak,
-			"charge_cost" = 50
+			"charge_cost" = 20
 		),
 		list(
 			"mode_name" = "overcharge",


### PR DESCRIPTION
🆑 10sc
bugfix: Soundcannon and flux cannon now keep their capacity of 10 shots on the base fire mode.
tweak: Flux cannon focused fire mode now has capacity of 6 shots compared to 2.667.
/:cl:

Resolves and closes #35495. Little ggorginjak can use vox guns fairly again! My logic regarding the focused capacity:

1. Stun had cost of 50.
2. Focused had cost of 75.
3. 75 ÷ 50 = 1.5
4. Stun needs 10 shots so lower to 20.
5. 20 × 1.5 = 30