### PR TITLE
Force initial firemode for guns on init

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -140,6 +140,10 @@
 	if(scope_zoom)
 		verbs += /obj/item/gun/proc/scope
 
+	if (length(firemodes))
+		var/datum/firemode/mode = firemodes[sel_mode]
+		mode.apply_to(src)
+
 /obj/item/gun/on_update_icon()
 	var/mob/living/M = loc
 	ClearOverlays()


### PR DESCRIPTION
Fixes #35495
Alternative to #35621

:cl: Banditoz
bugfix: Guns now properly use everything their first firemode specifies on init.
/:cl: