### PR TITLE
Robot card fix

### DIFF
--- a/code/modules/mob/living/bot/bot.dm
+++ b/code/modules/mob/living/bot/bot.dm
@@ -94,12 +94,12 @@
 /mob/living/bot/use_tool(obj/item/tool, mob/user, list/click_params)
 	// ID Card - Toggle access panel lock
 	var/obj/item/card/id/id = tool.GetIdCard()
-	if (istype(id))
+	if (istype(id) || istype(tool, /obj/item/card/robot))
 		if (open)
 			USE_FEEDBACK_FAILURE("\The [src]'s access panel must be closed before you can lock it.")
 			return TRUE
 		var/id_name = GET_ID_NAME(id, tool)
-		if (!access_scanner.check_access(id))
+		if (!access_scanner.check_access(id) && !istype(tool, /obj/item/card/robot))
 			USE_FEEDBACK_ID_CARD_DENIED(src, id_name)
 			return TRUE
 		locked = !locked

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -672,14 +672,14 @@
 
 	// ID Card - Toggle panel lock
 	var/obj/item/card/id/id = tool.GetIdCard()
-	if (istype(id))
+	if (istype(id) || istype(tool, /obj/item/card/robot))
 		var/id_name = GET_ID_NAME(id, tool)
 		if (emagged)
 			to_chat(user, SPAN_WARNING("\The [src]'s panel lock seems slightly damaged."))
 		if (opened)
 			USE_FEEDBACK_FAILURE("\The [src]'s cover must be closed before you can lock it.")
 			return TRUE
-		if (!check_access(id))
+		if (!check_access(id) && !istype(tool, /obj/item/card/robot))
 			USE_FEEDBACK_ID_CARD_DENIED(src, id_name)
 			return TRUE
 		locked = !locked


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

Research robot module has an access code transmission device item, that is supposed to unlock covers of /mob/living/silicon/robot mobs, but currently it does nothing. 

https://github.com/Baystation12/Baystation12/blob/b2d2eb9b2d2f73a97025f93639ba7c19ac44a308/code/modules/mob/living/silicon/robot/robot_items.dm#L161-L166

This logic was erased by this PR https://github.com/Baystation12/Baystation12/pull/33108 in robot.dm

<img width="945" height="292" alt="image" src="https://github.com/user-attachments/assets/16b6d5d2-6b14-4824-99ed-457a324e3590" />

This changes bring this logic back, and also allows to unlock simple bot covers as well.

:cl: Builder13
bugfix: Access code transmission device of the research robot module is now functional and also works on simple bots
/:cl: