### PR TITLE
Adds Slate Sisters Engineering uniform

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/uniforms.dm
+++ b/code/modules/client/preference_setup/loadout/lists/uniforms.dm
@@ -177,6 +177,7 @@
 	corps += /obj/item/clothing/under/skinner
 	corps += /obj/item/clothing/under/dais
 	corps += /obj/item/clothing/under/rank/roboticist/bishop
+	corps += /obj/item/clothing/under/slate
 	gear_tweaks += new/datum/gear_tweak/path/specified_types_list(corps)
 
 /datum/gear/uniform/corp_exec

--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -727,3 +727,9 @@
 	icon_state = "kimono"
 	worn_state = "kimono"
 	body_parts_covered = UPPER_TORSO|LOWER_TORSO|LEGS|ARMS
+
+/obj/item/clothing/under/slate
+	name = "\improper Slate Engineering uniform"
+	desc = "A dress shirt and khakis belonging to Slate Sisters Engineering, a shipbuilding and asteroid excavation firm."
+	icon_state = "dispatch"
+	worn_state = "dispatch"


### PR DESCRIPTION
Just copies the under/dispatch uniform as a slate engineering one in the misc under file.
:cl:
rscadd: Adds a Slate Sisters Engineering uniform, under the corporate uniform loadout options.
/:cl: