### PR TITLE
Cutlery, empty snack bowls and boiled food to loadout.

### DIFF
--- a/code/modules/client/preference_setup/loadout/lists/misc.dm
+++ b/code/modules/client/preference_setup/loadout/lists/misc.dm
@@ -105,6 +105,26 @@
 	knives["lightweight utility knife"] = /obj/item/material/knife/utility/lightweight
 	gear_tweaks += new/datum/gear_tweak/path(knives)
 
+/datum/gear/utensil
+	display_name = "utensil selection"
+	description = "A selection of utensils."
+	path = /obj/item/material/utensil
+
+/datum/gear/utensil/New()
+	..()
+	var/utensil = list()
+	utensil["fork"] = /obj/item/material/utensil/fork
+	utensil["knife"] = /obj/item/material/utensil/knife
+	utensil["spork"] = /obj/item/material/utensil/spork
+	utensil["spoon"] = /obj/item/material/utensil/spoon
+	utensil["chopsticks"] = /obj/item/material/utensil/chopsticks
+	gear_tweaks += new/datum/gear_tweak/path(utensil)
+
+/datum/gear/serving_bowl
+	display_name = "serving bowl"
+	description = "An empty serving bowl, used to combine food together."
+	path = /obj/item/serving_bowl
+
 /datum/gear/kirpan
 	display_name = "kirpan"
 	description = "A ceremonial Sikh dagger."

--- a/code/modules/reagents/reagent_containers/food/lunch.dm
+++ b/code/modules/reagents/reagent_containers/food/lunch.dm
@@ -12,7 +12,11 @@ var/global/list/lunchables_lunches_ = list(
 									/obj/item/reagent_containers/food/snacks/jellysandwich,
 									/obj/item/reagent_containers/food/snacks/tossedsalad,
 									/obj/item/reagent_containers/food/snacks/vegetablesoup,
-									/obj/item/reagent_containers/food/snacks/plainsteak
+									/obj/item/reagent_containers/food/snacks/plainsteak,
+									/obj/item/reagent_containers/food/snacks/boiledrice,
+									/obj/item/reagent_containers/food/snacks/boiledspagetti,
+									/obj/item/reagent_containers/food/snacks/boiledegg,
+									/obj/item/reagent_containers/food/snacks/meatcube
 								  )
 
 var/global/list/lunchables_snacks_ = list(


### PR DESCRIPTION
You can now pick basic cutlery, empty snack bowls in the loadout, and lunchboxes now give you the selection of boiled food and meat cubes. 

Why? Because you can now spawn with chopsticks, a snack bowl and boiled rice and make a themed food. Still sucks compared to chef food. (Snack bowl is the thing you use to combine and serve food, ie rice with beef)
If someone ever adds asian-style noodles, these would be great for those.

:cl:
rcsadd: Cutlery and an empty snack bowl are now available in the loadout.
rcsadd: Lunch boxes can now let you pick various boiled food. 
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->