### PR TITLE
make wire shocks more dangerous

### DIFF
--- a/code/modules/power/powernet.dm
+++ b/code/modules/power/powernet.dm
@@ -156,19 +156,11 @@
 		return clamp((avail / load) * 100, 0, 100)
 
 /datum/powernet/proc/get_electrocute_damage()
-	switch(avail)
-		if (1000000 to INFINITY)
-			return min(rand(50,160),rand(50,160))
-		if (200000 to 1000000)
-			return min(rand(25,80),rand(25,80))
-		if (100000 to 200000)//Ave powernet
-			return min(rand(20,60),rand(20,60))
-		if (50000 to 100000)
-			return min(rand(15,40),rand(15,40))
-		if (1000 to 50000)
-			return min(rand(10,20),rand(10,20))
-		else
-			return 0
+	var/damage = avail / 80000
+	if (damage < 1)
+		return 0
+
+	return damage
 
 // Proc: apcs_overload()
 // Parameters: 3 (failure_chance - chance to actually break the APC, overload_chance - Chance of breaking lights, reboot_chance - Chance of temporarily disabling the APC)


### PR DESCRIPTION
:cl: Mucker
tweak: Wire shocks now scale with wattage beyond 1MW, making them extremely dangerous at high loads.
/:cl:

Does roughly 30 burn damage at default round-start load, does about 100 at a little over 1MW.
yes this will gib half your body if you cut a high-powered wire with no gloves