### PR TITLE
improve atmos danger behavior

### DIFF
--- a/code/__defines/atmos.dm
+++ b/code/__defines/atmos.dm
@@ -130,3 +130,11 @@
 #define GAS_BORON				"boron"
 #define GAS_HEAT                "heat" //Not a real gas, used for visual effects
 #define GAS_COLD                "cold" //Not a real gas, used for visual effects
+
+/** A get_atmosphere_issues mode. Used to indicate the proc
+	should return the count of all failed safeness conditions */
+#define ATMOS_ISSUE_COUNT 1
+
+/** A get_atmosphere_issues mode. Used to indicate the proc
+	should return the list of reasons for failed safeness conditions */
+#define ATMOS_ISSUE_DETAILED 2

--- a/code/_helpers/game.dm
+++ b/code/_helpers/game.dm
@@ -552,7 +552,6 @@
 		else if(istype(T, /turf/simulated))
 			rstats = null // Exclude zone (wall, door, etc).
 		else if(isturf(T))
-			// Should still work.  (/turf/return_air())
 			var/datum/gas_mixture/environment = T.return_air()
 			for(var/i=1;i<=length(stats);i++)
 				if(stats[i] == "pressure")

--- a/code/_helpers/turfs.dm
+++ b/code/_helpers/turfs.dm
@@ -107,26 +107,11 @@
 /proc/has_air(turf/T)
 	return !!T.return_air()
 
-/proc/IsTurfAtmosUnsafe(turf/T)
-	if (!T)
-		return "The spawn location doesn't seem to exist. Please contact an admin via adminhelp if this error persists."
+/proc/is_turf_human_safe(turf/turf)
+	return isturf(turf) && !istype(turf, /turf/space) && !get_atmosphere_issues(turf.return_air())
 
-	if(istype(T, /turf/space)) // Space tiles
-		return "Spawn location is open to space."
-	var/datum/gas_mixture/air = T.return_air()
-	if(!air)
-		return "Spawn location lacks atmosphere."
-	return get_atmosphere_issues(air, 1)
-
-/proc/IsTurfAtmosSafe(turf/T)
-	return !IsTurfAtmosUnsafe(T)
-
-/proc/is_below_sound_pressure(turf/T)
-	var/datum/gas_mixture/environment = T ? T.return_air() : null
-	var/pressure =  environment ? environment.return_pressure() : 0
-	if(pressure < SOUND_MINIMUM_PRESSURE)
-		return TRUE
-	return FALSE
+/proc/is_below_sound_pressure(turf/turf)
+	return turf?.return_air()?.return_pressure() < SOUND_MINIMUM_PRESSURE
 
 /*
 	Turf manipulation

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -163,7 +163,15 @@ SUBSYSTEM_DEF(jobs)
 
 /datum/controller/subsystem/jobs/proc/check_unsafe_spawn(mob/living/spawner, turf/spawn_turf)
 	var/radlevel = SSradiation.get_rads_at_turf(spawn_turf)
-	var/airstatus = IsTurfAtmosUnsafe(spawn_turf)
+	var/airstatus = ""
+	if (!isturf(spawn_turf))
+		airstatus = "The spawn location is not a turf."
+	else if (istype(spawn_turf, /turf/space))
+		airstatus = "The spawn location is open to space."
+	else
+		var/other_issues = get_atmosphere_issues(spawn_turf.return_air(), ATMOS_ISSUE_DETAILED)
+		if (length(other_issues))
+			airstatus = "The spawn location has an unsafe atmosphere: [jointext(other_issues, " ")]"
 	if(airstatus || radlevel > 0)
 		var/reply = alert(spawner, "Warning. Your selected spawn location seems to have unfavorable conditions. \
 		You may die shortly after spawning. \

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -66,7 +66,7 @@ GLOBAL_VAR_AS(minimum_safe_teleport_distance, 5)
 		list(GLOBAL_PROC_REF(is_not_space_area)),
 		list(
 			GLOBAL_PROC_REF(not_turf_contains_dense_objects),
-			GLOBAL_PROC_REF(IsTurfAtmosSafe)
+			GLOBAL_PROC_REF(is_turf_human_safe)
 		),
 		zlevels[1])
 	do_teleport(target, T)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -162,11 +162,8 @@
  *
  * Returns instance of `/datum/gas_mixture`.
  */
-/atom/proc/return_air()
-	if(loc)
-		return loc.return_air()
-	else
-		return null
+/atom/proc/return_air() as /datum/gas_mixture
+	return loc?.return_air()
 
 /**
  * Determines sight flags that should be added to user's sight var.

--- a/code/game/machinery/bluespace_drive.dm
+++ b/code/game/machinery/bluespace_drive.dm
@@ -227,7 +227,7 @@
 				list(GLOBAL_PROC_REF(is_not_space_area)),
 				list(
 					GLOBAL_PROC_REF(not_turf_contains_dense_objects),
-					GLOBAL_PROC_REF(IsTurfAtmosSafe)
+					GLOBAL_PROC_REF(is_turf_human_safe)
 				),
 				zlevels[1])
 			if (!T)

--- a/code/game/machinery/stasis_cage.dm
+++ b/code/game/machinery/stasis_cage.dm
@@ -236,12 +236,10 @@ var/global/const/STASISCAGE_WIRE_LOCK      = 4
 	return ..()
 
 
-/obj/machinery/stasis_cage/return_air() //Used to make stasis cage protect from vacuum.
-	if (!is_powered())
-		return
-	if(airtank)
+/obj/machinery/stasis_cage/return_air()
+	if (is_powered())
 		return airtank
-	..()
+	return ..()
 
 
 /obj/machinery/stasis_cage/RefreshParts()

--- a/code/game/objects/items/cryobag.dm
+++ b/code/game/objects/items/cryobag.dm
@@ -91,10 +91,8 @@
 	if(H.stasis_sources[STASIS_CRYOBAG] != stasis_power)
 		H.SetStasis(stasis_power, STASIS_CRYOBAG)
 
-/obj/structure/closet/body_bag/cryobag/return_air() //Used to make stasis bags protect from vacuum.
-	if(airtank)
-		return airtank
-	..()
+/obj/structure/closet/body_bag/cryobag/return_air()
+	return airtank
 
 /obj/structure/closet/body_bag/cryobag/examine(mob/user, distance, is_adjacent)
 	. = ..()

--- a/code/game/objects/items/rescuebag.dm
+++ b/code/game/objects/items/rescuebag.dm
@@ -145,7 +145,7 @@
 		var/transfer_moles = calculate_transfer_moles(airtank.air_contents, atmo, pressure_delta)
 		pump_gas_passive(airtank, airtank.air_contents, atmo, transfer_moles)
 
-/obj/structure/closet/body_bag/rescue/return_air() //Used to make stasis bags protect from vacuum.
+/obj/structure/closet/body_bag/rescue/return_air()
 	return atmo
 
 /obj/structure/closet/body_bag/rescue/examine(mob/user)

--- a/code/game/objects/objs.dm
+++ b/code/game/objects/objs.dm
@@ -99,12 +99,6 @@
 	else
 		return null
 
-/obj/return_air()
-	if(loc)
-		return loc.return_air()
-	else
-		return null
-
 /obj/proc/updateUsrDialog()
 	if(in_use)
 		var/is_in_use = 0

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -162,17 +162,14 @@
 	var/cooling_power = 40
 
 /obj/structure/closet/crate/freezer/return_air()
-	var/datum/gas_mixture/gas = (..())
-	if(!gas)	return null
-	var/datum/gas_mixture/newgas = new/datum/gas_mixture()
-	newgas.copy_from(gas)
-	if(newgas.temperature <= target_temp)	return
-
-	if((newgas.temperature - cooling_power) > target_temp)
-		newgas.temperature -= cooling_power
-	else
-		newgas.temperature = target_temp
-	return newgas
+	var/datum/gas_mixture/outside = ..()
+	if (!outside)
+		return null
+	var/datum/gas_mixture/inside = new /datum/gas_mixture
+	inside.copy_from(outside)
+	if (inside.temperature > target_temp)
+		inside.temperature = max(inside.temperature - cooling_power, target_temp)
+	return inside
 
 /obj/structure/closet/crate/freezer/ProcessAtomTemperature()
 	return PROCESS_KILL

--- a/code/game/objects/structures/pit.dm
+++ b/code/game/objects/structures/pit.dm
@@ -88,10 +88,9 @@
 	update_icon()
 
 /obj/structure/pit/return_air()
-	if(open && loc)
-		return loc.return_air()
-	else
+	if (!open)
 		return null
+	return ..()
 
 /obj/structure/pit/proc/digout(mob/escapee)
 	var/breakout_time = 1 //2 minutes by default

--- a/code/modules/ZAS/Turf.dm
+++ b/code/modules/ZAS/Turf.dm
@@ -266,15 +266,12 @@
 	return 0
 
 /turf/return_air()
-	//Create gas mixture to hold data for passing
-	var/datum/gas_mixture/GM = new
-
+	var/datum/gas_mixture/mix = new
 	if (initial_gas)
-		GM.gas = initial_gas.Copy()
-	GM.temperature = temperature
-	GM.update_values()
-
-	return GM
+		mix.gas = initial_gas.Copy()
+	mix.temperature = temperature
+	mix.update_values()
+	return mix
 
 /turf/remove_air(amount as num)
 	var/datum/gas_mixture/GM = return_air()
@@ -295,21 +292,18 @@
 	return 1
 
 /turf/simulated/return_air()
-	// ZAS participation
-	if (zone && !zone.invalid)
+	if (zone?.invalid == FALSE)
 		SSair.mark_zone_update(zone)
 		return zone.air
-
-	// Exterior turf global atmosphere
-	if ((!air && isnull(initial_gas)) || (external_atmosphere_participation && is_outside()))
-		. = get_external_air()
-
-	// Base behavior
-	if (!.)
-		. = air || make_air()
-		if (zone)
-			c_copy_air()
-			zone = null
+	if (!air && !initial_gas || external_atmosphere_participation && is_outside())
+		return get_external_air()
+	var/datum/gas_mixture/result = air
+	if (!result)
+		result = make_air()
+	if (zone)
+		c_copy_air()
+		zone = null
+	return result
 
 // Returns the external air if this turf is outside, modified by weather and heat sources. Outside checks do not occur in this proc!
 /turf/proc/get_external_air(include_heat_sources = TRUE)

--- a/code/modules/atmospherics/atmos_primitives.dm
+++ b/code/modules/atmospherics/atmos_primitives.dm
@@ -456,59 +456,56 @@
 
 	return (source_pressure - sink_pressure)/(R_IDEAL_GAS_EQUATION * (source.temperature/source_volume + sink.temperature/sink_volume))
 
-//Determines if the atmosphere is safe (for humans). Safe atmosphere:
-// - Is between 80 and 120kPa
-// - Has between 17% and 30% oxygen
-// - Has temperature between -10C and 50C
-// - Has no or only minimal phoron or N2O
-/proc/get_atmosphere_issues(datum/gas_mixture/atmosphere, returntext = 0)
-	var/list/status = list()
-	if(!atmosphere)
-		status.Add("No atmosphere present.")
 
-	// Temperature check
-	if((atmosphere.temperature > (T0C + 50)) || (atmosphere.temperature < (T0C - 10)))
-		status.Add("Temperature too [atmosphere.temperature > (T0C + 50) ? "high" : "low"].")
+/// Used to squash repetition in the following get_atmosphere_issues proc
+#define ATMOS_ISSUE_REASON(MESSAGE) switch (mode) { \
+	if (ATMOS_ISSUE_DETAILED) { issues += (MESSAGE); } \
+	if (ATMOS_ISSUE_COUNT) { ++issues; } \
+	else { return 1; } \
+}
 
-	// Pressure check
-	var/pressure = atmosphere.return_pressure()
-	if((pressure > 120) || (pressure < 80))
-		status.Add("Pressure too [pressure > 120 ? "high" : "low"].")
+/**
+* Determines if a gas mixture is human-safe according to the following conditions:
+* - It has pressure in the range 80 .. 120 kPa
+* - It has temperature in the range -10C .. 50C
+* - It has oxygen in the range 17 .. 30 %
+* - It has safe levels of phoron, co2, n2o, and hydrogen
+*
+* Has three modes:
+* - ATMOS_ISSUE_DETAILED returns a list of strings explaining each failed
+*   condition that is zero-length when the mixture is safe
+* - ATMOS_ISSUE_COUNT returns the number of failed conditions, 0 when safe
+* - Otherwise, returns 1 on the first failed condition, or 0 when safe
+*/
+/proc/get_atmosphere_issues(datum/gas_mixture/mix, mode)
+	var/issues = 0
+	if (mode == ATMOS_ISSUE_DETAILED)
+		issues = list()
+	var/moles = mix?.total_moles
+	if (!moles)
+		ATMOS_ISSUE_REASON("No gas present.")
+	var/temperature = mix.temperature
+	if (temperature < T0C - 10 || temperature > T0C + 50)
+		ATMOS_ISSUE_REASON("Temperature too [temperature > (T0C - 10) ? "low" : "high"].")
+	var/pressure = mix.return_pressure()
+	if (pressure < 80 || pressure > 120)
+		ATMOS_ISSUE_REASON("Pressure too [pressure < 80 ? "low" : "high"].")
+	var/list/gas = mix.gas
+	var/oxygen = gas[GAS_OXYGEN] / moles
+	if (oxygen < 0.17 || oxygen > 0.3)
+		ATMOS_ISSUE_REASON("Oxygen too [oxygen < 0.17 ? "low" : "high"].")
+	if (gas[GAS_PHORON] / moles > 0.001)
+		ATMOS_ISSUE_REASON("Phoron contamination.")
+	if (gas[GAS_CO2] / moles > 0.05)
+		ATMOS_ISSUE_REASON("CO2 concentration high.")
+	if (gas[GAS_N2O] / moles > 0.001)
+		ATMOS_ISSUE_REASON("Nitrous Oxide contamination")
+	if (gas[GAS_HYDROGEN] / moles > 0.025)
+		ATMOS_ISSUE_REASON("Hydrogen contamination.")
+	return issues
 
-	// Gas concentration checks
-	var/oxygen = 0
-	var/phoron = 0
-	var/carbondioxide = 0
-	var/nitrousoxide = 0
-	var/hydrogen = 0
-	if(atmosphere.total_moles) // Division by zero prevention
-		oxygen = (atmosphere.gas[GAS_OXYGEN] / atmosphere.total_moles) * 100 // Percentage of the gas
-		phoron = (atmosphere.gas[GAS_PHORON] / atmosphere.total_moles) * 100
-		carbondioxide = (atmosphere.gas[GAS_CO2] / atmosphere.total_moles) * 100
-		nitrousoxide = (atmosphere.gas[GAS_N2O] / atmosphere.total_moles) * 100
-		hydrogen = (atmosphere.gas[GAS_HYDROGEN] / atmosphere.total_moles) * 100
+#undef ATMOS_ISSUE_REASON
 
-	if(!oxygen)
-		status.Add("No oxygen.")
-	else if((oxygen > 30) || (oxygen < 17))
-		status.Add("Oxygen too [oxygen > 30 ? "high" : "low"].")
-
-
-
-	if(phoron > 0.1)		// Toxic even in small amounts.
-		status.Add("Phoron contamination.")
-	if(nitrousoxide > 0.1)	// Probably slightly less dangerous but still.
-		status.Add("N2O contamination.")
-	if(hydrogen > 2.5)	// Not too dangerous, but flammable.
-		status.Add("Hydrogen contamination.")
-	if(carbondioxide > 5)	// Not as dangerous until very large amount is present.
-		status.Add("CO2 concentration high.")
-
-
-	if(returntext)
-		return jointext(status, " ")
-	else
-		return length(status)
 
 /singleton/public_access/public_variable/power_draw
 	expected_type = /obj/machinery/atmospherics

--- a/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
+++ b/code/modules/atmospherics/components/binary_devices/binary_atmos_base.dm
@@ -124,8 +124,7 @@
 
 	. = ..()
 
-/obj/machinery/atmospherics/binary/return_air()			
-	if(air1.return_pressure() > air2.return_pressure())
+/obj/machinery/atmospherics/binary/return_air()
+	if (air1.return_pressure() > air2.return_pressure())
 		return air1
-	else
-		return air2
+	return air2

--- a/code/modules/atmospherics/pipes.dm
+++ b/code/modules/atmospherics/pipes.dm
@@ -76,8 +76,8 @@
 	return 1
 
 /obj/machinery/atmospherics/pipe/return_air()
-	if(!parent && !QDELING(src))
-		parent = new /datum/pipeline()
+	if (!parent && !QDELING(src))
+		parent = new /datum/pipeline
 		parent.build_pipeline(src)
 	return parent?.air
 

--- a/code/modules/butchery/butchery.dm
+++ b/code/modules/butchery/butchery.dm
@@ -69,11 +69,6 @@
 	var/secures_occupant = TRUE
 	var/busy =             FALSE
 
-/obj/structure/kitchenspike/return_air()
-	var/turf/T = get_turf(src)
-	if(istype(T))
-		return T.return_air()
-
 /obj/structure/kitchenspike/improvised
 	name = "truss"
 	icon_state = "improvised"

--- a/code/modules/events/infestation.dm
+++ b/code/modules/events/infestation.dm
@@ -80,7 +80,7 @@
 
 	var/list/vermin_turfs = get_area_turfs(location, list(
 		GLOBAL_PROC_REF(not_turf_contains_dense_objects),
-		GLOBAL_PROC_REF(IsTurfAtmosSafe)
+		GLOBAL_PROC_REF(is_turf_human_safe)
 	))
 	if(!length(vermin_turfs))
 		log_debug("Vermin infestation failed to find viable turfs in \the [location].")

--- a/code/modules/events/maint_drones.dm
+++ b/code/modules/events/maint_drones.dm
@@ -43,7 +43,7 @@
 
 	var/list/dron_turfs = get_area_turfs(location, list(
 		GLOBAL_PROC_REF(not_turf_contains_dense_objects),
-		GLOBAL_PROC_REF(IsTurfAtmosSafe)
+		GLOBAL_PROC_REF(is_turf_human_safe)
 	))
 	if(!length(dron_turfs))
 		log_debug("Drone infestation failed to find viable turfs in \the [location].")

--- a/code/modules/mechs/mech.dm
+++ b/code/modules/mechs/mech.dm
@@ -207,7 +207,9 @@
 	to_chat(user, "It menaces with reinforcements of [material].")
 
 /mob/living/exosuit/return_air()
-	return (body && body.pilot_coverage >= 100 && hatch_closed && body.cockpit) ? body.cockpit : loc.return_air()
+	if (hatch_closed && body?.cockpit && body.pilot_coverage >= 100)
+		return body.cockpit
+	return ..()
 
 /mob/living/exosuit/GetIdCard()
 	return access_card

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -161,8 +161,7 @@ var/global/list/rad_collectors = list()
 	update_icon()
 
 /obj/machinery/power/rad_collector/return_air()
-	if(P)
-		return P.return_air()
+	return P?.return_air()
 
 /obj/machinery/power/rad_collector/proc/eject()
 	locked = 0

--- a/maps/torch/torch_procs.dm
+++ b/maps/torch/torch_procs.dm
@@ -86,7 +86,7 @@
 /datum/map/torch/do_interlude_teleport(atom/movable/target, atom/destination, duration = 30 SECONDS, precision, type)
 	var/turf/T = pick_area_turf(/area/bluespace_interlude/platform, list(
 		GLOBAL_PROC_REF(not_turf_contains_dense_objects),
-		GLOBAL_PROC_REF(IsTurfAtmosSafe)
+		GLOBAL_PROC_REF(is_turf_human_safe)
 	))
 
 	if (!T && destination)

--- a/packs/deepmaint/generator/deepmaint_event.dm
+++ b/packs/deepmaint/generator/deepmaint_event.dm
@@ -47,7 +47,7 @@
 
 	var/list/ladder_turfs = get_area_turfs(location, list(
 		GLOBAL_PROC_REF(not_turf_contains_dense_objects),
-		GLOBAL_PROC_REF(IsTurfAtmosSafe)
+		GLOBAL_PROC_REF(is_turf_human_safe)
 	))
 	if(!length(ladder_turfs))
 		log_debug("Failed to find viable turfs to spawn ladders in \the [location].")


### PR DESCRIPTION
Wasn't a fan of how get_atmosphere_issues() builds a big string every run even when
most of its uses are boolean. It should probably be replaced with a
proc on /species for its original usage ("can I safely join the game
at this spawn point?"). This is a middle step that should help the
performance of other expensive behaviors that have been written to rely
on it in the mean time.

also as a consequence:
- inlines IsTurfAtmosUnsafe-ish behavior into its one real use
- replaces IsTurfAtmosSafe with is_turf_human_safe
- squishes is_below_sound_pressure since it was right there

----

making return_air slightly nicer was a tangent. adjusts the behavior of `stasis_cage/return_air` mechanically- this might be undesirable, but the prior behavior was nabbed from cryobags and itself an ancient misfire

nb. stasis_cage itself needs a good look, since it does some stuff that's entirely nonsensical (eg all of its cell behavior)