### PR TITLE
Changes sensors from helm to shuttle helm access

### DIFF
--- a/code/modules/modular_computers/file_system/programs/ship/sensors.dm
+++ b/code/modules/modular_computers/file_system/programs/ship/sensors.dm
@@ -20,7 +20,7 @@
 	var/working_sound = 'sound/machines/sensors/sensorloop.ogg'
 	var/datum/sound_token/sound_token
 	var/sound_id
-	var/modify_access_req = access_bridge
+	var/modify_access_req = list(access_guppy_helm, access_aquila_helm, access_expedition_shuttle_helm, access_torch_helm)
 
 /datum/computer_file/program/ship/sensors/spacer
 	nanomodule_path = /datum/nano_module/program/ship/sensors/spacer


### PR DESCRIPTION
Sensors currently requires Torch helm, which shuttle pilots and prospectors lack. 
:cl:
tweak: Sensors on shuttles now require a shuttle access, not just Torch helm to modify.
/:cl:
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->