### PR TITLE
Additional programs for AI subsystem

### DIFF
--- a/code/modules/mob/skills/skill_ui.dm
+++ b/code/modules/mob/skills/skill_ui.dm
@@ -1,6 +1,7 @@
 //Holders/managers for nano_ui for the skill panel.
 
 /datum/nano_module/skill_ui
+	available_to_ai = FALSE
 	var/datum/skillset/skillset
 	var/template = "skill_ui.tmpl"
 	var/hide_unskilled = FALSE

--- a/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/atmos_control.dm
@@ -16,6 +16,7 @@
 
 /datum/nano_module/program/atmos_control
 	name = "Atmospherics Control"
+	available_to_ai = TRUE
 	var/obj/access = new()
 	var/emagged = FALSE
 	var/ui_ref

--- a/code/modules/modular_computers/file_system/programs/engineering/power_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/power_monitor.dm
@@ -32,6 +32,7 @@
 
 /datum/nano_module/program/power_monitor
 	name = "Power monitor"
+	available_to_ai = TRUE
 	var/list/grid_sensors
 	var/active_sensor = null	//name_tag of the currently selected sensor
 

--- a/code/modules/modular_computers/file_system/programs/engineering/rcon_console.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/rcon_console.dm
@@ -16,6 +16,7 @@
 
 /datum/nano_module/program/rcon
 	name = "Power RCON"
+	available_to_ai = TRUE
 	var/list/known_SMESs = null
 	var/list/known_breakers = null
 	// Allows you to hide specific parts of the UI

--- a/code/modules/modular_computers/file_system/programs/engineering/shields_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/shields_monitor.dm
@@ -14,6 +14,7 @@
 
 /datum/nano_module/program/shields_monitor
 	name = "Shields monitor"
+	available_to_ai = TRUE
 	var/obj/machinery/power/shield_generator/active = null
 
 /datum/nano_module/program/shields_monitor/Destroy()

--- a/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
@@ -30,6 +30,7 @@
 
 /datum/nano_module/program/supermatter_monitor
 	name = "Supermatter monitor"
+	available_to_ai = TRUE
 	var/list/supermatters
 	var/obj/machinery/power/supermatter/active = null		// Currently selected supermatter crystal.
 	var/screen = SM_MONITOR_SCREEN_MAIN // Which screen the monitor is currently on

--- a/code/modules/modular_computers/file_system/programs/generic/camera.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/camera.dm
@@ -40,6 +40,7 @@
 
 /datum/nano_module/program/camera_monitor
 	name = "Camera Monitoring program"
+	available_to_ai = TRUE
 	var/obj/machinery/camera/current_camera = null
 	var/current_network = null
 

--- a/code/modules/modular_computers/file_system/programs/generic/crew_manifest.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/crew_manifest.dm
@@ -13,6 +13,7 @@
 
 /datum/nano_module/program/crew_manifest
 	name = "Crew Manifest"
+	available_to_ai = TRUE
 
 /datum/nano_module/program/crew_manifest/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, state = GLOB.default_state)
 	var/list/data = host.initial_data(program)

--- a/code/modules/modular_computers/file_system/programs/generic/deck_management.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/deck_management.dm
@@ -18,6 +18,7 @@
 
 /datum/nano_module/program/deck_management
 	name = "Deck Management Program"
+	available_to_ai = TRUE
 	var/prog_state = DECK_HOME                       //Which menu we are in.
 	var/can_view_only = 0                            //Whether we are in view-only mode for the report viewer.
 	var/datum/shuttle/selected_shuttle               //Which shuttle is currently selected, if any.

--- a/code/modules/modular_computers/file_system/programs/generic/docks.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/docks.dm
@@ -21,6 +21,7 @@
 
 /datum/nano_module/program/docking
 	name = "Docking Control program"
+	available_to_ai = TRUE
 	var/list/docking_controllers = list() //list of tags
 
 /datum/nano_module/program/docking/New(datum/host, topic_manager)

--- a/code/modules/modular_computers/file_system/programs/generic/email_client.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/email_client.dm
@@ -60,6 +60,7 @@
 
 /datum/nano_module/program/email_client
 	name = "Email Client"
+	available_to_ai = TRUE
 	var/stored_login = ""
 	var/stored_password = ""
 	var/error = ""

--- a/code/modules/modular_computers/file_system/programs/generic/game.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/game.dm
@@ -46,6 +46,7 @@
 // and should generally not be used, as such nano modules are hard to use on other places.
 /datum/nano_module/program/arcade_classic
 	name = "Classic Arcade"
+	available_to_ai = TRUE
 	var/player_mana			// Various variables specific to the nano module. In this case, the nano module is a simple arcade game, so the variables store health and other stats.
 	var/player_health
 	var/enemy_mana

--- a/code/modules/modular_computers/file_system/programs/generic/library.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/library.dm
@@ -21,6 +21,7 @@ The answer was five and a half years -ZeroBits
 
 /datum/nano_module/program/library
 	name = "Library"
+	available_to_ai = TRUE
 	var/error_message = ""
 	var/current_book
 	var/obj/machinery/libraryscanner/scanner

--- a/code/modules/modular_computers/file_system/programs/generic/records.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/records.dm
@@ -13,6 +13,7 @@
 
 /datum/nano_module/program/records
 	name = "Crew Records"
+	available_to_ai = TRUE
 	var/datum/computer_file/report/crew_record/active_record
 	var/message = null
 

--- a/code/modules/modular_computers/file_system/programs/generic/supply.dm
+++ b/code/modules/modular_computers/file_system/programs/generic/supply.dm
@@ -33,6 +33,7 @@
 
 /datum/nano_module/program/supply
 	name = "Supply Management program"
+	available_to_ai = TRUE
 	var/screen = 1		// 1: Ordering menu, 2: Statistics, 3: Shuttle control, 4: Orders menu
 	var/selected_category
 	var/list/category_names = list()

--- a/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
+++ b/code/modules/modular_computers/file_system/programs/medical/suit_sensors.dm
@@ -38,6 +38,7 @@
 
 /datum/nano_module/program/crew_monitor
 	name = "Crew monitor"
+	available_to_ai = TRUE
 
 /datum/nano_module/program/crew_monitor/proc/has_alerts()
 	for(var/z_level in GLOB.using_map.map_levels)

--- a/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
+++ b/code/modules/modular_computers/file_system/programs/security/digitalwarrant.dm
@@ -18,6 +18,7 @@ LEGACY_RECORD_STRUCTURE(all_warrants, warrant)
 
 /datum/nano_module/program/digitalwarrant
 	name = "Warrant Assistant"
+	available_to_ai = TRUE
 	var/datum/computer_file/data/warrant/activewarrant
 
 /datum/nano_module/program/digitalwarrant/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/topic_state/state = GLOB.default_state)

--- a/code/modules/modular_computers/file_system/programs/security/forceauthorization.dm
+++ b/code/modules/modular_computers/file_system/programs/security/forceauthorization.dm
@@ -15,6 +15,7 @@
 
 /datum/nano_module/program/forceauthorization
 	name = "Use of Force Authorization Manager"
+	available_to_ai = TRUE
 
 /datum/nano_module/program/forceauthorization/ui_interact(mob/user, ui_key = "main", datum/nanoui/ui = null, force_open = 1, datum/topic_state/state = GLOB.default_state)
 	var/list/data = host.initial_data(program)


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Hides /datum/nano_module/skill_ui variations from subsystem tab, and removes blank spots from there that way. Adds back all the programs that AI had prior https://github.com/Baystation12/Baystation12/pull/35517

:cl: Builder13
bugfix: AI subsystem tab now contains all the programs, that it had before.
/:cl: