### PR TITLE
Fixes Species traits

### DIFF
--- a/code/datums/traits/traits.dm
+++ b/code/datums/traits/traits.dm
@@ -69,13 +69,8 @@
 	var/singleton/trait/T = GET_SINGLETON(trait_type)
 	if(!T.Validate(trait_level, additional_option))
 		return FALSE
-
-	if(!traits) // If traits haven't been setup before, check if we need to do so now
-		var/species_level = species.traits[trait_type]
-		if(species_level == trait_level) // Matched the default species trait level, ignore
-			return TRUE
-		traits = species.traits.Copy() // The setup is to simply copy the species list of traits
-
+	if (!traits) // If traits haven't been setup before, check if we need to do so now
+		traits = species.traits.Copy()
 	return ..(trait_type, trait_level, additional_option)
 
 /mob/living/proc/RemoveTrait(trait_type, additional_option)
@@ -164,7 +159,7 @@
 	var/addprompt = "Select a property to add."
 	var/remprompt = "Select a property to remove."
 
-	/// These trait types may not co-exist on the same mob/species
+	/// These trait types may not co-exist on the same mob/species. Should be set on both traits; not only one.
 	var/list/incompatible_traits
 	abstract_type = /singleton/trait
 

--- a/code/modules/client/preference_setup/general/02_body.dm
+++ b/code/modules/client/preference_setup/general/02_body.dm
@@ -716,6 +716,14 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 				remaining_budget -= existing_trait.GetCost()
 
 		var/list/possible_levels = selected.levels
+		if (selected.type in mob_species.traits)
+			var/minimum_level = mob_species.traits[selected.type]
+			var/cut = possible_levels.Find(minimum_level)
+			if (cut >= length(possible_levels)) //get_selectable_traits() already weeded out traits where Cut(1, cut + 1) returns an out of bound error. This is just for safety.
+				crash_with("Tried to cause an out of bounds error. ")
+				return
+			possible_levels.Cut(1, cut + 1)
+
 		var/selected_level
 		if (length(possible_levels) > 1)
 			var/list/letterized_levels
@@ -727,6 +735,7 @@ var/global/list/valid_bloodtypes = list("A+", "A-", "B+", "B-", "AB+", "AB-", "O
 			selected_level = letterized_levels[letterized_input]
 		else
 			selected_level = possible_levels[1]
+			to_chat(usr, SPAN_NOTICE ("The only level available for this trait is [LetterizeSeverity(selected_level)]."))
 
 		var/additional_data
 		if (length(selected.metaoptions))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -1221,6 +1221,9 @@
 	species = GLOB.species_by_name[new_species]
 	species.handle_pre_spawn(src)
 
+	if (length(species.traits))
+		traits = species.traits.Copy()
+
 	if(species.grab_type)
 		current_grab_type = all_grabobjects[species.grab_type]
 

--- a/code/modules/species/species.dm
+++ b/code/modules/species/species.dm
@@ -778,14 +778,21 @@ The slots that you can use are found in items_clothing.dm and are the inventory 
 	for (var/singleton/trait/allowed_trait in trait_list)
 		if (!allowed_trait.selectable)
 			continue
-		if (LAZYISIN(traits, allowed_trait.type))
-			continue
+		if (LAZYISIN(traits, allowed_trait.type)) //This allows you to select higher levels for selectable traits that species start with.
+			var/list/possible_levels = allowed_trait.levels
+			var/minimum_level = traits[allowed_trait.type]
+			var/cut = possible_levels.Find(minimum_level)
+			if (cut >= length(possible_levels))
+				continue
 		if (LAZYISIN(allowed_trait.forbidden_species, name))
 			continue
+		if (allowed_trait.incompatible_traits)
+			var/list/incompatibles = allowed_trait.incompatible_traits & traits
+			if (length(incompatibles))
+				continue
 		if (!allowed_trait.name)
 			continue
 		LAZYSET(allowed_traits, allowed_trait.name, allowed_trait)
-
 	return allowed_traits
 
 /singleton/species/proc/get_description(header, append, verbose = TRUE, skip_detail, skip_photo)


### PR DESCRIPTION
🆑 emmanuelbassil
bugfix: Fixed bug where non-humans would not spawn with their traits unless they had an allergy selected
/🆑 

Also added functionality where you could make selectable traits a higher level even if your species is born with them. No front-facing changes there; just laying ground work for the nausea PR where some human sub-species will be mildly prone to an upset stomach. Wanted to let players of said subspecies make it worse but not better.