### PR TITLE
add supermatter shutdown feature

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -186,6 +186,8 @@
 
 #define SPAN_BAD(X) SPAN_CLASS("bad", "[X]")
 
+#define SPAN_AVERAGE(X) SPAN_CLASS("average", "[X]")
+
 #define SPAN_DANGER(X) SPAN_CLASS("danger", "[X]")
 
 #define SPAN_OCCULT(X) SPAN_CLASS("cult", "[X]")

--- a/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
+++ b/code/modules/modular_computers/file_system/programs/engineering/supermatter_monitor.dm
@@ -111,6 +111,12 @@
 		var/ambient_pressure = air.return_pressure()
 		var/epr = active.get_epr()
 
+		var/shutdown_phase = active.get_phase()
+		if (active.shutdown_aborted)
+			shutdown_phase = SPAN_BAD("ABORTING")
+		else if ((active.cooldown_time + active.last_shutdown_time) > world.time)
+			shutdown_phase = SPAN_BAD("COOLING DOWN")
+
 		data["active"] = TRUE
 		data["screen"] = screen
 		data["threshholds"] = active.threshholds
@@ -123,6 +129,7 @@
 		data["SM_ambientpressure_label"] = get_threshhold_color(SUPERMATTER_DATA_PRESSURE, ambient_pressure)
 		data["SM_EPR"] = process_data_output(engine_skill, epr)
 		data["SM_EPR_label"] = get_threshhold_color(SUPERMATTER_DATA_EPR, epr)
+		data["SM_shutdown_phase"] = shutdown_phase
 		if(air.total_moles)
 			data["SM_gas_O2"] = round(100*air.gas[GAS_OXYGEN]/air.total_moles,0.01)
 			data["SM_gas_CO2"] = round(100*air.gas[GAS_CO2]/air.total_moles,0.01)
@@ -181,6 +188,12 @@
 		var/new_value = input(usr, "Select a new threshhold, or set to -1 to disable:", "Threshhold", href_list["value"]) as null | num
 		if (!isnull(new_value))
 			set_threshhold_value(href_list["threshhold"], href_list["category"], new_value)
+		return TOPIC_HANDLED
+	if (href_list["set"])
+		var/obj/machinery/power/supermatter/supermatter = locate(href_list["set"])
+		if (!(supermatter in supermatters))
+			return TOPIC_NOACTION
+		active = supermatter
 		return TOPIC_HANDLED
 	if (href_list["set"])
 		var/obj/machinery/power/supermatter/supermatter = locate(href_list["set"])

--- a/code/modules/supermatter/supermatter.dm
+++ b/code/modules/supermatter/supermatter.dm
@@ -24,6 +24,13 @@
 
 #define WARNING_DELAY 20			//seconds between warnings.
 
+///SM Shutdown off. This is the phase during normal operation.
+#define SHUTDOWN_PHASE_OFF 0
+///Active SM shutdown, the SM is depowering rapidly and shedding lots of heat.
+#define SHUTDOWN_PHASE_ONE 1
+/// Final SM shutdown phase, it is holding in a non-reactive state where the setup can be safely modified.
+#define SHUTDOWN_PHASE_TWO 2
+
 /obj/machinery/power/supermatter
 	name = "supermatter core"
 	desc = "A strangely translucent and iridescent crystal. <span class='danger'>You get headaches just from looking at it.</span>"
@@ -63,6 +70,10 @@
 	var/emergency_point = 700
 	var/emergency_alert = "CRYSTAL DELAMINATION IMMINENT."
 	var/explosion_point = 1000
+	var/shutdown_alert = "Supermatter shutdown sequence engaged."
+	var/shutdown_phase_two_alert = "Shutdown sequence complete. Further reactions are now halted. Press shutdown button again to prepare for startup."
+	var/shutdown_complete_alert = "Supermatter shutdown sequence terminated."
+	var/shutdown_aborted_alert = "Supermatter shutdown sequence aborted. Hypermatrix integrity may be compromised."
 
 	light_color = "#927a10"
 	var/base_color = "#927a10"
@@ -105,12 +116,41 @@
 	var/aw_delam = FALSE
 	var/aw_EPR = FALSE
 
+	///Whether or not the shutdown process is currently active
+	var/shutdown_phase = SHUTDOWN_PHASE_OFF
+	/// The next time power/EER will tick down while the shutdown process is active
+	var/next_shutdown_process_time = 0
+	///Modifier to the amount of thermal energy added to the air around the SM during the shutdown phase. Higher = more energy, higher temperature
+	var/shutdown_thermal_modifier = 3.5
+	///Modifier to the rate of power decay during the shutdown phase. Higher = faster power loss
+	var/shutdown_power_modifier = 0.15
+	/// Set when the shutdown process starts. This is the power/EER at the moment the button is pressed, used to scale thermal energy release during shutdown.
+	var/power_at_shutdown_start
+	/// Time after which the shutdown can be aborted/terminated
+	var/cooldown_time = 5 MINUTES
+	///maximum temperature output during shutdown (kelvin)
+	var/max_temperature_shutdown = 15000
+	///How long the aborted phase will last when triggered
+	var/aborted_phase_length = 2 MINUTES
+	var/shutdown_aborted = FALSE
+	var/last_shutdown_time = 0
+
 	var/list/threshholds = list( // List of lists defining the amber/red labeling threshholds in readouts. Numbers are minminum red and amber and maximum amber and red, in that order
 		list("name" = SUPERMATTER_DATA_EER,         "min_h" = -1, "min_l" = -1,  "max_l" = 1100,  "max_h" = 1300),
 		list("name" = SUPERMATTER_DATA_TEMPERATURE, "min_h" = -1, "min_l" = -1,  "max_l" = 4000, "max_h" = 5000),
 		list("name" = SUPERMATTER_DATA_PRESSURE,    "min_h" = -1, "min_l" = -1,  "max_l" = 5000, "max_h" = 10000),
 		list("name" = SUPERMATTER_DATA_EPR,         "min_h" = -1, "min_l" = 1.0, "max_l" = 2.5,  "max_h" = 4.0)
 	)
+
+	uncreated_component_parts = list(
+		/obj/item/stock_parts/radio/receiver,
+		/obj/item/stock_parts/power/apc
+	)
+	public_methods = list(
+		/singleton/public_access/public_method/supermatter_shutdown
+	)
+	stock_part_presets = list(/singleton/stock_part_preset/radio/receiver/supermatter_shutdown = 1)
+
 
 /obj/machinery/power/supermatter/Destroy()
 	GLOB.supermatter_status.raise_event(src, FALSE) //If any alarm was still reporting on this, tell them to stop
@@ -365,8 +405,23 @@
 		env.remove(env.total_moles)
 	else
 		damage_archived = damage
+		damage = max(0, damage + clamp((removed.temperature - critical_temperature) / (shutdown_phase ? 50 : 150), -damage_rate_limit, damage_inc_limit))
 
-		damage = max(0, damage + clamp((removed.temperature - critical_temperature) / 150, -damage_rate_limit, damage_inc_limit))
+		if (shutdown_phase == SHUTDOWN_PHASE_ONE && (next_shutdown_process_time < world.time))
+			if (get_rads(loc) < ((power * 1.5) * radiation_release_modifier))
+				SSradiation.radiate(src, (power * 1.5) * radiation_release_modifier)
+			if (!(shutdown_phase == SHUTDOWN_PHASE_TWO))
+				power = power - shutdown_power_modifier * (power - (power * 0.025) ** 2 + 10)
+			if (power <= 0.05)
+				shutdown_phase = SHUTDOWN_PHASE_TWO
+				power = 0
+				charging_factor = 0.01
+				power_factor = 3
+				damage_rate_limit = 20
+				thermal_release_modifier = initial(thermal_release_modifier) * 5
+				radiation_release_modifier = radiation_release_modifier * 45
+				GLOB.global_announcer.autosay(shutdown_phase_two_alert, "Supermatter Monitor", "Engineering")
+			next_shutdown_process_time = world.time + 1 SECOND
 
 		//Ok, 100% oxygen atmosphere = best reaction
 		//Maxes out at 100% oxygen pressure
@@ -385,14 +440,15 @@
 			icon_state = base_icon_state
 
 		temp_factor = ( (equilibrium_power/decay_factor)**3 )/800
-		power = max( (removed.temperature * temp_factor) * oxygen + power, 0)
+		if (!(shutdown_phase == SHUTDOWN_PHASE_TWO))
+			power = max( (removed.temperature * temp_factor) * oxygen + power, 0)
 
 		var/device_energy = power * reaction_power_modifier
 
 		//Release reaction gasses
 		var/heat_capacity = removed.heat_capacity()
 		removed.adjust_multi(GAS_PHORON, max(device_energy / phoron_release_modifier, 0), \
-		                     GAS_OXYGEN, max((device_energy + removed.temperature - T0C) / oxygen_release_modifier, 0))
+							GAS_OXYGEN, max((device_energy + removed.temperature - T0C) / oxygen_release_modifier, 0))
 
 		var/thermal_power = thermal_release_modifier * device_energy
 		if (debug)
@@ -400,8 +456,11 @@
 			visible_message("[src]: Releasing [round(thermal_power)] W.")
 			visible_message("[src]: Releasing additional [round((heat_capacity_new - heat_capacity)*removed.temperature)] W with exhaust gasses.")
 
-		removed.add_thermal_energy(thermal_power)
-		removed.temperature = clamp(removed.temperature, 0, 10000)
+		var/current_thermal_modifier = shutdown_phase ? shutdown_thermal_modifier : 1
+		if (power_at_shutdown_start) //if we're above roughly 1600 eer then the reaction will build rapidly during shutdown and be catastrophic if not stopped
+			current_thermal_modifier = current_thermal_modifier * (power_at_shutdown_start / 500) + power
+		removed.add_thermal_energy(thermal_power * current_thermal_modifier)
+		removed.temperature = clamp(removed.temperature, 0, shutdown_phase ? max_temperature_shutdown : 10000)
 
 		env.merge(removed)
 
@@ -437,7 +496,8 @@
 	else if (damage < emergency_point)
 		filters = null
 
-	SSradiation.radiate(src, power * radiation_release_modifier) //Better close those shutters!
+	if (get_rads(loc) < (power * radiation_release_modifier))
+		SSradiation.radiate(src, power * radiation_release_modifier) //Better close those shutters!
 	power -= (power/decay_factor)**3		//energy losses due to radiation
 	handle_admin_warnings()
 
@@ -453,6 +513,8 @@
 
 	var/proj_damage = Proj.get_structure_damage()
 	if(istype(Proj, /obj/item/projectile/beam))
+		if (shutdown_phase >= SHUTDOWN_PHASE_ONE)
+			damage += 100
 		power += proj_damage * config_bullet_energy	* charging_factor / power_factor
 	else
 		damage += proj_damage * config_bullet_energy
@@ -514,6 +576,51 @@
 		damage = max(damage - 10, 0)
 		playsound(src, 'sound/effects/tape.ogg', 25)
 
+
+	if (istype(W, /obj/item/device/multitool))
+		if (!user.skill_check(SKILL_ENGINES, SKILL_EXPERIENCED) && !prob(5))
+			if (issilicon(user))
+				user.visible_message(
+					SPAN_DANGER("\The [user] fumbles \the [W], and it sparks against \the [src], causing it to flash into dust!"),
+					SPAN_DANGER("You fumble \the [W], and it sparks against \the [src]. Your vision floods with static as you flash into dust!")
+				)
+				Consume(user)
+				return TRUE
+			var/mob/living/carbon/human/victim = user
+			if (prob(25))
+				if (victim.gloves)
+					victim.visible_message(
+						SPAN_DANGER("\The [victim] fumbles \the [W], and their [victim.gloves.name] graze \the [src] and turn to dust!"),
+						SPAN_DANGER("You fumble \the [W], and your [victim.gloves.name] graze \the [src] - turning them to dust and burning your hands!")
+					)
+					qdel(victim.gloves)
+					victim.apply_damage(25, DAMAGE_BURN, BP_L_HAND)
+					victim.apply_damage(25, DAMAGE_BURN, BP_R_HAND)
+					return TRUE
+			if (prob(50) && !victim.gloves)
+				victim.visible_message(
+					SPAN_DANGER("\The [victim] makes one wrong move with \the [W], and their bare hands graze \the [src], turning them to ash!"),
+					SPAN_DANGER("You make one wrong move with \the [W], causing your bare hands to graze \the [src], and suddenly wish you had remembered your gloves as you turn to ash.")
+				)
+				Consume(victim)
+				return TRUE
+			user.visible_message(
+				SPAN_DANGER("\The [victim] slips with \the [W], but manages to avoid any contact with \the [src]."),
+				SPAN_DANGER("You slip with \the [W], just barely avoiding contact with \the [src]!")
+			)
+			return TRUE
+
+		var/tag = input(user, "Enter the tag to apply to the supermatter. This should match the tag on the shutdown button.", "Enter Tag", "supermatter_crystal") as null | text
+		if (!tag)
+			return TRUE
+		user.visible_message(
+			SPAN_NOTICE("\The [user] uses \the [W] to set the tag on \the [src]."),
+			SPAN_NOTICE("You set the tag on \the [src] with \the [W] to '[tag]'.")
+		)
+		playsound(src, 'sound/machines/click.ogg', 25)
+		id_tag = tag
+		return TRUE
+
 	user.visible_message(
 		SPAN_WARNING("\The [user] touches \a [W] to \the [src], then flinches away as it flashes instantly into dust. Silence blankets the air."),
 		SPAN_DANGER("You touch \the [W] to \the [src]. Everything suddenly goes silent as it flashes into dust, and you flinch away."),
@@ -524,6 +631,7 @@
 	if (user.drop_from_inventory(W))
 		Consume(W)
 		return TRUE
+
 	return ..()
 
 
@@ -563,7 +671,8 @@
 		else
 			to_chat(l, SPAN_WARNING("You hear a muffled, shrill ringing as an intense wave of heat washes over you."))
 	var/rads = 500
-	SSradiation.radiate(src, rads)
+	if (get_rads(loc) < rads) //prevent rads from being reduced if they're already above 500
+		SSradiation.radiate(src, rads)
 
 
 /proc/supermatter_pull(atom/target, pull_range = 255, pull_power = STAGE_FIVE)
@@ -698,3 +807,95 @@
 				set_on()
 			else if (!danger && on)
 				set_off()
+
+/obj/machinery/button/alternate/sm_shutdown
+	name = "Supermatter Shutdown"
+	desc = "A large red button labeled 'EMERGENCY SUPERMATTER SHUTDOWN'. You should probably read the accompanying instructions before pressing it."
+
+/singleton/public_access/public_method/supermatter_shutdown
+	call_proc = TYPE_PROC_REF(/obj/machinery/power/supermatter, shutdown_sm)
+
+/singleton/stock_part_preset/radio/receiver/supermatter_shutdown
+	frequency = BUTTON_FREQ
+	receive_and_call = list("button_active" = /singleton/public_access/public_method/supermatter_shutdown)
+
+/turf/simulated/floor/greengrid/sm
+	desc = "Extremely advanced circuitry embedded into the floor designed to interface with a supermatter crystal."
+
+/obj/machinery/power/supermatter/proc/shutdown_sm()
+	if ((cooldown_time + last_shutdown_time) > world.time)
+		return
+
+	//first stage shutdown
+	if (shutdown_phase == SHUTDOWN_PHASE_OFF && istype(get_turf(src), /turf/simulated/floor/greengrid/sm))
+		shutdown_phase = SHUTDOWN_PHASE_ONE
+		GLOB.global_announcer.autosay(shutdown_alert, "Supermatter Monitor", "Engineering")
+		if (get_rads(loc) < (power * 2 * radiation_release_modifier))
+			SSradiation.radiate(loc, power * 2 * radiation_release_modifier)
+		for(var/turf/simulated/floor/greengrid/sm/sm_turf in oview(2, src))
+			sm_turf.icon_state = "rcircuitanim"
+
+		radiation_release_modifier = (power / 10)
+		thermal_release_modifier = thermal_release_modifier * (power / 250)
+		power_at_shutdown_start = power
+		return
+
+	//shutdown aborted before second stage could start
+	if (shutdown_phase == SHUTDOWN_PHASE_ONE)
+		radiation_release_modifier = 50 * radiation_release_modifier
+		shutdown_phase = SHUTDOWN_PHASE_OFF
+		shutdown_aborted = TRUE
+		var/obj/effect/warp/small/warpeffect = new(get_turf(src))
+				//effect and sound
+		warpeffect.SetTransform(scale = 0)
+		warpeffect.alpha = 255
+		animate(
+			warpeffect,
+			transform = matrix(),
+			alpha = 0,
+			time = 1.25 SECONDS
+		)
+		addtimer(new Callback(GLOBAL_PROC, GLOBAL_PROC_REF(qdel), warpeffect), 1.25 SECONDS)
+		playsound(warpeffect, 'sound/effects/heavy_cannon_blast.ogg', 50, 1)
+
+		var/list/atoms = list()
+		if(isturf(src))
+			atoms = range(src, 6)
+		else
+			atoms = orange(src, 6)
+		for(var/atom/movable/A in atoms)
+			if(A.anchored || !A.simulated) continue
+			A.throw_at(get_edge_target_turf(A,get_dir(src, A)),10,5)
+		addtimer(new Callback(src, PROC_REF(end_abort_phase)), aborted_phase_length)
+		GLOB.global_announcer.autosay(shutdown_aborted_alert, "Supermatter Monitor", "Engineering")
+		for (var/turf/simulated/floor/greengrid/sm/T in oview(2, src))
+			T.icon_state = "gcircuit"
+
+	//end shutdown sequence after second stage, returns SM to normal
+	if (shutdown_phase == SHUTDOWN_PHASE_OFF)
+		if (power <= 0.01)
+			power = 0
+		shutdown_phase = SHUTDOWN_PHASE_OFF
+		GLOB.global_announcer.autosay(shutdown_complete_alert, "Supermatter Monitor", "Engineering")
+		for (var/turf/simulated/floor/greengrid/sm/T in oview(2, src))
+			T.icon_state = "gcircuit"
+
+	radiation_release_modifier = initial(radiation_release_modifier)
+	thermal_release_modifier = initial(thermal_release_modifier)
+	power_at_shutdown_start = 0
+	charging_factor = initial(charging_factor)
+	power_factor = initial(power_factor)
+	damage_rate_limit = initial(damage_rate_limit)
+	last_shutdown_time = world.time
+
+/obj/machinery/power/supermatter/proc/end_abort_phase()
+	radiation_release_modifier = initial(radiation_release_modifier)
+	shutdown_aborted = FALSE
+
+/obj/machinery/power/supermatter/proc/get_phase()
+	if (shutdown_phase == SHUTDOWN_PHASE_OFF)
+		return SPAN_GOOD("READY")
+	else if (shutdown_phase == SHUTDOWN_PHASE_ONE)
+		return SPAN_AVERAGE("SHUTTING DOWN")
+	else if (shutdown_phase == SHUTDOWN_PHASE_TWO)
+		return SPAN_AVERAGE("STANDBY")

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -239,7 +239,13 @@
 	desc = "A switch made to open the engine access hatch.";
 	id_tag = "EngineAccess";
 	name = "Engine Access Hatch";
-	pixel_x = -36
+	pixel_x = -36;
+	pixel_y = 9
+	},
+/obj/machinery/button/alternate/sm_shutdown{
+	id_tag = "supermatter_crystal";
+	pixel_x = -36;
+	pixel_y = -9
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/engine_monitoring)
@@ -653,10 +659,12 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftstarboard)
 "bo" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/visible/black{
-	dir = 4
+/obj/machinery/atmospherics/omni/filter{
+	tag_east = 6;
+	tag_west = 1;
+	tag_south = 2
 	},
+/obj/engine_setup/filter,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "bq" = (
@@ -4929,6 +4937,8 @@
 "kQ" = (
 /obj/structure/table/steel_reinforced,
 /obj/item/device/geiger,
+/obj/item/storage/firstaid/radiation,
+/obj/random_multi/single_item/memo_engineering,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_monitoring)
 "kR" = (
@@ -5038,15 +5048,17 @@
 	dir = 5
 	},
 /obj/floor_decal/industrial/outline/yellow,
-/obj/machinery/rotating_alarm/supermatter,
-/obj/machinery/power/apc/super/critical{
-	name = "north bump";
-	dir = 4;
-	pixel_x = 24
-	},
 /obj/structure/cable/cyan{
 	d2 = 2;
 	icon_state = "0-2"
+	},
+/obj/machinery/power/apc/super/critical{
+	dir = 1;
+	name = "north bump";
+	pixel_y = 24
+	},
+/obj/machinery/rotating_alarm/supermatter{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
@@ -5558,11 +5570,14 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/atmos)
 "mp" = (
-/obj/machinery/atmospherics/pipe/simple/visible/black,
-/obj/machinery/light{
-	dir = 8
-	},
 /obj/floor_decal/industrial/warning/corner,
+/obj/machinery/rotating_alarm/supermatter{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/black{
+	dir = 4
+	},
+/obj/machinery/light,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "mq" = (
@@ -5673,7 +5688,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/visible/cyan,
 /obj/floor_decal/industrial/warning/corner{
 	dir = 8;
 	icon_state = "warningcorner"
@@ -5683,21 +5697,23 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/manifold/visible/cyan{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "mL" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green{
 	dir = 5
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "mM" = (
 /obj/floor_decal/industrial/warning/corner{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/visible/green,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "mN" = (
@@ -5960,6 +5976,11 @@
 	master_tag = "engine_controller";
 	pixel_x = 23;
 	pixel_y = 23
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/simulated/floor/tiled/monotile,
 /area/engineering/engine_monitoring)
@@ -6310,15 +6331,19 @@
 /area/engineering/engine_room)
 "oA" = (
 /obj/floor_decal/industrial/warning/corner,
-/obj/machinery/atmospherics/pipe/simple/visible/black,
 /obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/visible/black{
+	dir = 8
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "oB" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
 /obj/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 4
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "oC" = (
@@ -6510,8 +6535,11 @@
 /obj/machinery/atmospherics/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/random_multi/single_item/memo_engineering,
-/obj/item/storage/firstaid/radiation,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_monitoring)
 "pq" = (
@@ -6797,6 +6825,11 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_monitoring)
 "pT" = (
@@ -6809,16 +6842,16 @@
 	sensor_name = "Engine Core";
 	sensor_tag = "engine_sensor"
 	},
-/obj/structure/cable/cyan{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 2;
+	d2 = 8;
+	icon_state = "2-8"
 	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_monitoring)
@@ -6835,11 +6868,6 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
 	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/hidden/supply{
 	dir = 4
 	},
@@ -6852,11 +6880,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers{
 	dir = 4
-	},
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
@@ -6948,7 +6971,8 @@
 "qf" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/binary/pump{
-	dir = 8
+	dir = 8;
+	name = "Secondary Shutdown Pump"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
@@ -7378,11 +7402,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/visible/cyan,
-/obj/structure/cable/cyan{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "rc" = (
@@ -7863,6 +7882,20 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
+"sp" = (
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/floor_decal/industrial/warning{
+	dir = 8;
+	icon_state = "warning"
+	},
+/obj/machinery/atmospherics/pipe/simple/visible/cyan,
+/obj/machinery/meter,
+/turf/simulated/floor/tiled/techfloor,
+/area/engineering/engine_room)
 "sq" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/pipe/simple/visible/cyan{
@@ -8098,7 +8131,8 @@
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/binary/passive_gate{
-	dir = 4
+	dir = 4;
+	name = "H2 to Secondary"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
@@ -9193,7 +9227,6 @@
 /obj/machinery/atmospherics/pipe/manifold/visible/green{
 	dir = 8
 	},
-/obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "wf" = (
@@ -9483,12 +9516,12 @@
 /turf/simulated/wall/r_wall/hull,
 /area/maintenance/seconddeck/aftport)
 "wW" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/green{
-	dir = 8
-	},
 /obj/item/device/radio/intercom{
 	dir = 4;
 	pixel_x = -21
+	},
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
@@ -9513,9 +9546,9 @@
 /obj/floor_decal/industrial/warning{
 	dir = 1
 	},
-/obj/machinery/atmospherics/binary/passive_gate{
+/obj/machinery/atmospherics/binary/pump{
 	dir = 8;
-	name = "Secondary to Waste"
+	name = "Secondary Shutdown Pump"
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
@@ -9526,6 +9559,7 @@
 /obj/floor_decal/industrial/warning{
 	dir = 1
 	},
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "xb" = (
@@ -9667,8 +9701,8 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "xB" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/visible/cyan{
+	dir = 10
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
@@ -11710,7 +11744,8 @@
 /area/maintenance/seconddeck/aftport)
 "Do" = (
 /obj/machinery/atmospherics/binary/pump{
-	dir = 8
+	dir = 8;
+	name = "Secondary Shutdown Pump"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/floor_decal/corner/orange{
@@ -13022,6 +13057,11 @@
 /obj/item/clothing/glasses/meson,
 /obj/item/clothing/glasses/meson,
 /obj/floor_decal/industrial/outline/yellow,
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engine_monitoring)
 "GM" = (
@@ -13334,6 +13374,17 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_bay)
+"HH" = (
+/obj/structure/bed/chair/padded/yellow{
+	dir = 4
+	},
+/obj/structure/cable/cyan{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/simulated/floor/tiled/steel_grid,
+/area/engineering/engine_monitoring)
 "HN" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -13866,7 +13917,8 @@
 /area/maintenance/seconddeck/aftport)
 "Jo" = (
 /obj/machinery/atmospherics/binary/pump{
-	dir = 8
+	dir = 8;
+	name = "Secondary Shutdown Pump"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/floor_decal/corner/white{
@@ -14268,7 +14320,8 @@
 	},
 /obj/machinery/light,
 /obj/machinery/atmospherics/binary/passive_gate{
-	dir = 1
+	dir = 1;
+	name = "H2 to Primary"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
@@ -14495,6 +14548,12 @@
 	},
 /turf/simulated/floor/tiled/dark,
 /area/engineering/bluespace)
+"LR" = (
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 5
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/engine_room)
 "LX" = (
 /obj/machinery/atmospherics/unary/outlet_injector{
 	dir = 4;
@@ -14768,7 +14827,7 @@
 /area/engineering/engineering_bay)
 "MP" = (
 /obj/machinery/atmospherics/binary/passive_gate{
-	name = "Primary to Waste"
+	name = "Secondary to Waste"
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
@@ -14829,11 +14888,10 @@
 /turf/simulated/floor/plating,
 /area/engineering/engine_smes)
 "Ne" = (
-/obj/engine_setup/pump_max,
-/obj/machinery/atmospherics/binary/pump/high_power/on{
-	dir = 8
-	},
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 9
+	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "Nf" = (
@@ -15144,7 +15202,8 @@
 "Oc" = (
 /obj/machinery/atmospherics/pipe/simple/visible/green,
 /obj/machinery/atmospherics/binary/pump{
-	dir = 8
+	dir = 8;
+	name = "Secondary Shutdown Pump"
 	},
 /obj/floor_decal/techfloor{
 	dir = 4
@@ -15563,11 +15622,6 @@
 "Pj" = (
 /obj/machinery/atmospherics/pipe/manifold/hidden/scrubbers,
 /obj/machinery/atmospherics/pipe/manifold/hidden/supply,
-/obj/structure/cable/cyan{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "Pk" = (
@@ -15887,12 +15941,11 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/prototype/control)
 "Qn" = (
-/obj/machinery/atmospherics/omni/filter{
-	tag_east = 2;
-	tag_south = 8;
-	tag_west = 1
+/obj/machinery/atmospherics/binary/pump{
+	dir = 4;
+	name = "Primary Shutdown Pump"
 	},
-/obj/engine_setup/filter,
+/obj/engine_setup/pump_max,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "Qo" = (
@@ -15956,6 +16009,14 @@
 "Qw" = (
 /turf/simulated/wall/ocp_wall,
 /area/engineering/wastetank)
+"Qy" = (
+/obj/floor_decal/industrial/warning,
+/obj/machinery/atmospherics/binary/passive_gate{
+	dir = 8;
+	name = "Primary to Waste"
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/engine_room)
 "Qz" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/power/apc{
@@ -16540,8 +16601,8 @@
 /area/shuttle/escape_pod10/station)
 "Sn" = (
 /obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 5
+/obj/machinery/atmospherics/pipe/manifold/visible/green{
+	dir = 8
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
@@ -16822,9 +16883,12 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
 "Tn" = (
-/obj/machinery/atmospherics/pipe/simple/visible/green{
-	dir = 9
+/obj/machinery/atmospherics/omni/filter{
+	tag_east = 2;
+	tag_south = 1;
+	tag_west = 8
 	},
+/obj/engine_setup/filter,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "To" = (
@@ -17095,9 +17159,8 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/maintenance/seconddeck/aftstarboard)
 "Un" = (
-/obj/machinery/atmospherics/tvalve/mirrored/digital{
-	name = "Phoron Bypass Valve"
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/visible/black,
+/obj/machinery/meter,
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "Uo" = (
@@ -17105,9 +17168,11 @@
 	dir = 4;
 	id_tag = "enginecore"
 	},
-/obj/machinery/power/supermatter,
+/obj/machinery/power/supermatter{
+	id_tag = "supermatter_crystal"
+	},
 /obj/engine_setup/core,
-/turf/simulated/floor/greengrid{
+/turf/simulated/floor/greengrid/sm{
 	map_airless = 1
 	},
 /area/engineering/engine_room)
@@ -17310,13 +17375,13 @@
 /turf/simulated/floor/plating,
 /area/maintenance/seconddeck/aftstarboard)
 "Vn" = (
-/obj/machinery/atmospherics/pipe/manifold/visible/black{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/visible/black{
+	dir = 4
 	},
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/engine_room)
 "Vo" = (
-/turf/simulated/floor/greengrid{
+/turf/simulated/floor/greengrid/sm{
 	map_airless = 1
 	},
 /area/engineering/engine_room)
@@ -17336,6 +17401,13 @@
 /obj/machinery/portable_atmospherics/powered/scrubber,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/maintenance/seconddeck/aftport)
+"VA" = (
+/obj/machinery/atmospherics/binary/pump/high_power/on{
+	dir = 4;
+	target_pressure = 15000
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/engine_room)
 "VB" = (
 /obj/floor_decal/techfloor/corner,
 /obj/floor_decal/techfloor{
@@ -17990,10 +18062,9 @@
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/storage/tech)
 "Xn" = (
-/obj/machinery/atmospherics/portables_connector{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/visible/green{
+	dir = 5
 	},
-/obj/machinery/portable_atmospherics/canister/empty/phoron,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
 "Xo" = (
@@ -18043,6 +18114,17 @@
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/atmos)
+"Xu" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/obj/machinery/portable_atmospherics/canister/empty/phoron,
+/obj/machinery/atmospherics/portables_connector{
+	dir = 8
+	},
+/turf/simulated/floor/tiled/techfloor/grid,
+/area/engineering/engine_room)
 "Xv" = (
 /obj/floor_decal/industrial/outline/yellow,
 /obj/structure/table/rack{
@@ -18250,7 +18332,8 @@
 /area/engineering/prototype/engine)
 "Yn" = (
 /obj/machinery/atmospherics/binary/pump{
-	dir = 8
+	dir = 8;
+	name = "Secondary Shutdown Pump"
 	},
 /obj/machinery/atmospherics/pipe/simple/hidden/black,
 /obj/floor_decal/corner/black{
@@ -18525,13 +18608,9 @@
 /turf/simulated/floor/tiled/techfloor,
 /area/engineering/shieldbay)
 "Zn" = (
-/obj/machinery/atmospherics/omni/filter{
-	tag_east = 2;
-	tag_north = 1;
-	tag_west = 6
-	},
-/obj/machinery/rotating_alarm/supermatter{
-	dir = 1
+/obj/machinery/atmospherics/tvalve/mirrored/digital{
+	name = "Phoron Bypass Valve";
+	state = 1
 	},
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engine_room)
@@ -42610,7 +42689,7 @@ kY
 nu
 GJ
 pp
-ov
+HH
 pS
 ov
 tz
@@ -43619,7 +43698,7 @@ kr
 Wb
 lT
 mK
-oz
+sp
 oz
 rb
 Ld
@@ -44024,7 +44103,7 @@ lf
 lV
 mM
 mL
-jL
+Qy
 pZ
 so
 KP
@@ -44642,7 +44721,7 @@ wg
 wY
 Un
 Zn
-dp
+LR
 gA
 dp
 dp
@@ -45045,7 +45124,7 @@ uJ
 uJ
 xa
 Wn
-yR
+VA
 jL
 PY
 gz
@@ -45247,7 +45326,7 @@ vs
 vs
 xb
 xT
-mS
+Xu
 jL
 PY
 gz

--- a/nano/templates/supermatter_monitor.tmpl
+++ b/nano/templates/supermatter_monitor.tmpl
@@ -33,6 +33,12 @@
 			<div class="itemContent">
 				<span class='{{:data.SM_EPR_label}}'>{{:data.SM_EPR}}</span>
 			</div>
+			<div class="itemLabel">
+				Shutdown Phase:
+			</div>
+			<div class="itemContent">
+				{{:data.SM_shutdown_phase}}</span>
+			</div>
 		</div>
 		<hr><br
 		<div class="item">


### PR DESCRIPTION
:cl: Mucker
rscadd: The supermatter can now be shut down.
/:cl:

How it works is pretty simple:
1. Hit the button to commence shutdown, which is behind the glass door in the monitoring room by the emergency buttons.
2. The SM will start shedding energy in the form of heat and radiation, much more than in normal operation, and EER will drop.
3. SM will go into a "standby" mode once EER hits 0, and it will hold there until the shutdown button is pressed again.

The process can also be aborted by hitting the button while shutdown is in progress, in which case the SM will eject a huge amount of radiation into its surroundings and send any nearby objects flying. I think this should be more destructive/consequential at some point, but I haven't thought up anything yet.

The process is not entirely safe. Shutting down at around 700-800 EER runs an increased risk of the temperature output damaging the crystal. Shutting down at over 1600 EER will cause a runaway reaction that rapidly increases EER instead of decreasing. Firing the emitter at the SM will also do 10% of its health every shot.

Right now, only supermatter(s) that are on top of the processing strata in the engine room can shut down.