### PR TITLE
add a fridge with random fruits/veggies to the kitchen

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/fridge.dm
+++ b/code/game/objects/structures/crates_lockers/closets/fridge.dm
@@ -26,9 +26,18 @@
 
 /obj/structure/closet/fridge/meat/WillContain()
 	return list(
-		/obj/item/storage/fancy/bugmeat = 4,
-		/obj/item/reagent_containers/food/snacks/meat/chicken = 2,
-		/obj/item/reagent_containers/food/snacks/meat/beef = 2,
-		/obj/item/reagent_containers/food/snacks/cutlet/ham = 2,
-		/obj/random/fish = 4
+		/obj/item/storage/fancy/bugmeat = 8,
+		/obj/item/reagent_containers/food/snacks/meat/chicken = 4,
+		/obj/item/reagent_containers/food/snacks/meat/beef = 4,
+		/obj/item/reagent_containers/food/snacks/cutlet/ham = 4,
+		/obj/random/fish = 8
+	)
+
+/obj/structure/closet/fridge/extra/WillContain()
+	return list(
+		/obj/item/reagent_containers/food/snacks/grown/cabbage = rand(0, 4),
+		/obj/item/reagent_containers/food/snacks/grown/lettuce = rand(0, 4),
+		/obj/item/reagent_containers/food/snacks/grown/tomato = rand(0, 4),
+		/obj/item/reagent_containers/food/snacks/grown/potato = rand(0, 4),
+		/obj/item/reagent_containers/food/snacks/grown/carrots = rand(0, 4)
 	)

--- a/maps/torch/torch3_deck3.dmm
+++ b/maps/torch/torch3_deck3.dmm
@@ -2328,6 +2328,7 @@
 /obj/structure/window/basic{
 	dir = 1
 	},
+/obj/item/reagent_containers/food/condiment/enzyme,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/galleybackroom)
 "fz" = (
@@ -3129,11 +3130,10 @@
 /area/crew_quarters/gym)
 "hm" = (
 /obj/machinery/atmospherics/pipe/simple/hidden/supply,
-/obj/structure/closet/fridge/meat,
-/obj/item/reagent_containers/food/condiment/enzyme,
 /obj/structure/window/basic{
 	dir = 1
 	},
+/obj/structure/closet/fridge/extra,
 /turf/simulated/floor/tiled/freezer,
 /area/crew_quarters/galleybackroom)
 "hn" = (


### PR DESCRIPTION
:cl: Mucker
rscadd: Replaced the third fridge (from the left) in the kitchen freezer room with one that spawns with random fruits and veggies at round start.
tweak: Doubled the contents of the remaining meat fridge to replace the one that was removed.
/:cl:

goal here is to give some starter recipe items to cook with so cooks don't have to spend the first part of the round waiting for things to grow. It won't be enough to ignore botany completely (which isn't the goal), but it should give them a bit of a jumpstart.