### PR TITLE
replace airlock circuits with braces in hard storage

### DIFF
--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -2189,9 +2189,9 @@
 "el" = (
 /obj/structure/table/rack,
 /obj/floor_decal/industrial/outline/yellow,
-/obj/item/airlock_electronics/brace,
-/obj/item/airlock_electronics/brace,
-/obj/item/airlock_electronics/brace,
+/obj/item/airlock_brace,
+/obj/item/airlock_brace,
+/obj/item/airlock_brace,
 /obj/item/airlock_brace,
 /obj/item/airlock_brace,
 /obj/item/airlock_brace,


### PR DESCRIPTION
:cl: Mucker
tweak: Replaced the airlock brace circuits in hard storage with actual braces.
/:cl:

Storing circuits is pointless when science can print the things directly.