### PR TITLE
[FIX] Remove Hypospray master object from ERT ship

### DIFF
--- a/maps/antag_spawn/ert/ert_ship.dm
+++ b/maps/antag_spawn/ert/ert_ship.dm
@@ -215,7 +215,7 @@
 	icon_vend = "med-vend"
 	base_type = /obj/machinery/vending/ert/medical
 	products = list(
-		/obj/item/reagent_containers/hypospray,
+		/obj/item/reagent_containers/hypospray/vial,
 		/obj/item/reagent_containers/syringe = 12,
 		/obj/item/device/scanner/health = 5,
 		/obj/item/reagent_containers/hypospray/autoinjector = 12,

--- a/maps/antag_spawn/ert/ert_ship.dmm
+++ b/maps/antag_spawn/ert/ert_ship.dmm
@@ -5569,10 +5569,10 @@
 /obj/item/gun/launcher/syringe/rapid,
 /obj/item/storage/box/syringes,
 /obj/item/storage/box/syringes,
-/obj/item/reagent_containers/hypospray,
-/obj/item/reagent_containers/hypospray,
-/obj/item/reagent_containers/hypospray,
-/obj/item/reagent_containers/hypospray,
+/obj/item/reagent_containers/hypospray/vial,
+/obj/item/reagent_containers/hypospray/vial,
+/obj/item/reagent_containers/hypospray/vial,
+/obj/item/reagent_containers/hypospray/vial,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/map_template/ert/ship/armory)
 "IG" = (


### PR DESCRIPTION
Replaced base hypos from ERT to vial ones because of:

`/obj/item/reagent_containers/hypospray //obsolete, use hypospray/vial for the actual hypospray item`
