### PR TITLE
[FIX] Robots telekinesis removal and wired connection sprite fix

### DIFF
--- a/code/game/machinery/_machines_base/stock_parts/power/terminal.dm
+++ b/code/game/machinery/_machines_base/stock_parts/power/terminal.dm
@@ -4,7 +4,7 @@
 	name = "wired connection"
 	desc = "A power connection directly to the grid, via power cables."
 	icon = 'icons/obj/machines/apc.dmi'
-	icon_state = "terminal"
+	icon_state = "term"
 	priority = 2
 	var/obj/machinery/power/terminal/terminal
 	var/terminal_dir = 0

--- a/code/game/machinery/doors/simple.dm
+++ b/code/game/machinery/doors/simple.dm
@@ -103,10 +103,10 @@
 /obj/machinery/door/unpowered/simple/attack_ai(mob/user as mob) //those aren't machinery, they're just big fucking slabs of a mineral
 	if(isAI(user)) //so the AI can't open it
 		return
-	else if(isrobot(user)) //but cyborgs can
-		if(Adjacent(user)) //not remotely though
-			return attack_hand(user)
 
+/obj/machinery/door/unpowered/simple/attack_robot(mob/user as mob) //but cyborgs can
+	if(Adjacent(user)) //not remotely though
+		return attack_hand(user)
 
 /obj/machinery/door/unpowered/simple/use_tool(obj/item/I, mob/living/user, list/click_params)
 	if(istype(I, /obj/item/key) && lock)


### PR DESCRIPTION
Removed borgs ability to open and close unpowered doors remotely. Despite `attack_ai` block, they could still do this. So I just moved borg's part into their own interact

Minor spellcheck for wired connection icon
<img width="271" height="177" alt="image" src="https://github.com/user-attachments/assets/bf19d059-329b-45d4-b814-73312ed8612a" />