### PR TITLE
tag out sticky notes for engineering

### DIFF
--- a/code/modules/paperwork/paper_sticky.dm
+++ b/code/modules/paperwork/paper_sticky.dm
@@ -135,3 +135,22 @@
 				else if(dir_offset & SOUTH)
 					pixel_y -= 32
 		return TRUE
+
+//Custom pad that has persistent text on it on all notes taken from it
+/obj/item/sticky_pad/tag_out
+	var/template_text =  "\
+	\[table\]\[cell\]\[center\]\[table\]\[cell\]<pre>SYSTEM / COMPONENT / IDENTIFICATION</pre>\[field\]\[cell\]<pre>DATE</pre>\[field\]\[row\]\[cell\]<pre>POSITION OR CONDITION OF ITEM TAGGED</pre>\[field\]\[cell\]<pre>TIME</pre>\[field\]\
+	\[/table\]\[row\]\[cell\]\[center\]\[h1\]DANGER\[/h1\]\[h2\]DO NOT OPERATE\[/h2\]\[h3\]OPERATION OF THIS EQUIPMENT WILL ENDANGER PERSONNEL OR HARM THE EQUIPMENT. THIS EQUIPMENT SHALL NOT BE OPERATED UNTIL THIS TAG HAS BEEN REMOVED BY AN AUTHORIZED PERSON.\
+	\[/h3\]\[row\]\[cell\]\[center\]\[table\]\[cell\]<pre>SIGNATURE OF PERSON ATTACHING TAG</pre>\[field\]\[cell\]<pre>SIGNATURES OF PERSONS CHECKING TAG</pre>\[field\]\[row\]\[cell\]<pre>SIGNATURE OF AUTHORIZING PERSONNEL</pre>\[field\]\[cell\]\
+	<pre>SIGNATURE OF VENDOR REPRESENTATIVE</pre>\[field\]\[/table\]\[/center\]\[/table\]\
+	"
+
+/obj/item/sticky_pad/tag_out/Initialize()
+	. = ..()
+	color = COLOR_RED
+	written_text = template_text
+
+
+/obj/item/sticky_pad/tag_out/attack_hand(mob/user)
+	. = ..()
+	written_text = template_text

--- a/maps/torch/torch4_deck2.dmm
+++ b/maps/torch/torch4_deck2.dmm
@@ -11419,6 +11419,7 @@
 /obj/machinery/atmospherics/pipe/simple/hidden/cyan{
 	dir = 4
 	},
+/obj/item/sticky_pad/tag_out,
 /turf/simulated/floor/tiled/steel_grid,
 /area/engineering/engineering_bay)
 "CD" = (
@@ -15728,6 +15729,7 @@
 /obj/floor_decal/techfloor{
 	dir = 6
 	},
+/obj/item/sticky_pad/tag_out,
 /turf/simulated/floor/tiled/techfloor/grid,
 /area/engineering/engineering_bay)
 "PM" = (


### PR DESCRIPTION
:cl: Mucker
rscadd: Added 'tag out' sticky notes for Engineering, placed by the lobby window.
/:cl:

https://www.ccohs.ca/oshanswers/hsprograms/lockout.html

usually this would accompany a physical lock as well, but that can be done later

<img width="714" height="682" alt="image" src="https://github.com/user-attachments/assets/053e2411-54e2-44a9-bd46-363468f6d217" />
