### PR TITLE
add maptext font preference

### DIFF
--- a/code/_macros.dm
+++ b/code/_macros.dm
@@ -198,9 +198,9 @@
 
 #define SPAN_INFO(X) SPAN_CLASS("info", "[X]")
 
-#define STYLE_SMALLFONTS(X, S, C1) SPAN_STYLE("font-family: 'Small Fonts'; color: [C1]; font-size: [S]px", "[X]")
+#define STYLE_SMALLFONTS(X, S, C1) SPAN_STYLE("color: [C1]; font-size: [S]px", "[X]")
 
-#define STYLE_SMALLFONTS_OUTLINE(X, S, C1, C2) SPAN_STYLE("font-family: 'Small Fonts'; color: [C1]; -dm-text-outline: 1 [C2]; font-size: [S]px", "[X]")
+#define STYLE_SMALLFONTS_OUTLINE(X, S, C1, C2) SPAN_STYLE("color: [C1]; -dm-text-outline: 1 [C2]; font-size: [S]px", "[X]")
 
 #define SPAN_DEBUG(X) SPAN_CLASS("debug", "[X]")
 

--- a/code/controllers/subsystems/jobs.dm
+++ b/code/controllers/subsystems/jobs.dm
@@ -621,7 +621,7 @@ SUBSYSTEM_DEF(jobs)
 	if(istype(V))
 		location_name = V.name
 
-	var/style = "font-family: 'Fixedsys'; -dm-text-outline: 1 black; font-size: 11px;"
+	var/style = "-dm-text-outline: 1 black; font-size: 11px;"
 	var/area/A = get_area(mob)
 	var/text = "Earthdate [stationdate2text()]\n[A.name], [location_name]\n[star_name] system"
 	text = uppertext(text)

--- a/code/game/movietitles.dm
+++ b/code/game/movietitles.dm
@@ -66,7 +66,7 @@ GLOBAL_LIST(end_titles)
 /obj/screen/credit/Initialize(mapload, credited, client/P)
 	. = ..()
 	parent = P
-	maptext = {"<div style="font:'Small Fonts'">[credited]</div>"}
+	maptext = "<div>[credited]</div>"
 	maptext_height = world.icon_size * 2
 	maptext_width = world.icon_size * 14
 

--- a/code/modules/client/preference_setup/global/01_ui.dm
+++ b/code/modules/client/preference_setup/global/01_ui.dm
@@ -7,8 +7,8 @@
 	var/outline_reachable = "#00ff00"
 	var/outline_unreachable = "#ff0000"
 	var/outline_alpha = 255
-
 	var/tooltip_style = "Midnight" //Style for popup tooltips
+	var/maptext_font = ""
 
 
 /datum/category_item/player_setup_item/player_global/ui
@@ -25,6 +25,7 @@
 	pref.outline_reachable = R.read("outline_reachable")
 	pref.outline_unreachable = R.read("outline_unreachable")
 	pref.outline_alpha = R.read("outline_alpha")
+	pref.maptext_font = R.read("maptext_font")
 
 
 /datum/category_item/player_setup_item/player_global/ui/save_preferences(datum/pref_record_writer/W)
@@ -36,6 +37,7 @@
 	W.write("outline_reachable", pref.outline_reachable)
 	W.write("outline_unreachable", pref.outline_unreachable)
 	W.write("outline_alpha", pref.outline_alpha)
+	W.write("maptext_font", pref.maptext_font)
 
 
 /datum/category_item/player_setup_item/player_global/ui/sanitize_preferences()
@@ -46,7 +48,15 @@
 	pref.outline_reachable = sanitize_hexcolor(pref.outline_reachable, initial(pref.outline_reachable))
 	pref.outline_unreachable = sanitize_hexcolor(pref.outline_unreachable, initial(pref.outline_unreachable))
 	pref.outline_alpha = sanitize_integer(pref.outline_alpha, 50, 255, initial(pref.outline_alpha))
+	pref.maptext_font = sanitize_text(pref.maptext_font, initial(pref.maptext_font))
 	sanitize_client_fps()
+
+
+/datum/category_item/player_setup_item/player_global/ui/sanitize_character()
+	if (pref.maptext_font)
+		winset(pref.client, ":map", "font-family='[pref.maptext_font]','Small Fonts',Fixedsys,sans-serif")
+	else
+		winset(pref.client, ":map", "font-family='Small Fonts',Fixedsys,sans-serif")
 
 
 /datum/category_item/player_setup_item/player_global/ui/content(mob/user)
@@ -56,6 +66,7 @@
 	. += "-Color: <a href='byond://?src=\ref[src];select_color=1'><b>[pref.UI_style_color]</b></a> <table style='display:inline;' bgcolor='[pref.UI_style_color]'><tr><td>__</td></tr></table> <a href='byond://?src=\ref[src];reset=ui'>reset</a><br>"
 	. += "-Alpha(transparency): <a href='byond://?src=\ref[src];select_alpha=1'><b>[pref.UI_style_alpha]</b></a> <a href='byond://?src=\ref[src];reset=alpha'>reset</a><br>"
 	. += "<b>Tooltip Style:</b> <a href='byond://?src=\ref[src];select_tooltip_style=1'><b>[pref.tooltip_style]</b></a><br>"
+	. += {"<b>Maptext Font:</b> <a href='byond://?src=\ref[src];select_maptext_font=1'><span style="font-weight: bold; font-family:[pref.maptext_font ? " '[pref.maptext_font]'," : ""] 'Small Fonts', Fixedsys, sans-serif; text-rendering: geometricPrecision;">[pref.maptext_font || "Default"]</span></a><br>"}
 	. += "<b>Atom Hover Outlines</b><br>"
 	var/outlines_enabled = user.get_preference_value(/datum/client_preference/atom_outlines) == GLOB.PREF_YES
 	. += "- Enabled: <a href='byond://?src=\ref[src];outline_toggle=1'>[outlines_enabled ? "Yes" : "No"]</a><br>"
@@ -144,6 +155,21 @@
 		if(!tooltip_style_new || !CanUseTopic(user))
 			return TOPIC_NOACTION
 		pref.tooltip_style = tooltip_style_new
+		return TOPIC_REFRESH
+
+	else if (href_list["select_maptext_font"])
+		var/response = input(user, "Maptext font name, or empty to reset:", "Global Preference", pref.maptext_font) as null | text
+		if (isnull(response))
+			return
+		if (response)
+			response = copytext_char(response, 1, 48)
+			response = replacetext_char(response, "\\", "")
+			response = replacetext_char(response, "'", "\\'")
+		pref.maptext_font = response
+		if (pref.maptext_font)
+			winset(pref.client, ":map", "font-family='[pref.maptext_font]','Small Fonts',Fixedsys,sans-serif")
+		else
+			winset(pref.client, ":map", "font-family='Small Fonts',Fixedsys,sans-serif")
 		return TOPIC_REFRESH
 
 	else if(href_list["reset"])

--- a/code/modules/holomap/ship_holomap.dm
+++ b/code/modules/holomap/ship_holomap.dm
@@ -187,7 +187,7 @@
 			if (prob(25))
 				set_broken()
 
-#define HOLOMAP_LEGEND_STYLING(X) SPAN_STYLE("font-family: 'Small Fonts'; font-size: 7px;", X)
+#define HOLOMAP_LEGEND_STYLING(X) SPAN_STYLE("font-size: 7px;", X)
 
 /obj/screen/levelselect
 	icon = 'icons/misc/mark.dmi'

--- a/code/modules/mechs/interface/screen_objects.dm
+++ b/code/modules/mechs/interface/screen_objects.dm
@@ -1,5 +1,5 @@
 // Screen objects hereon out.
-#define MECH_UI_STYLE(X) "<span style=\"font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: 5px;\">" + X + "</span>"
+#define MECH_UI_STYLE(X) {"<span style="-dm-text-outline: 1 black; font-size: 5px;">"} + X + "</span>"
 
 /obj/screen/exosuit
 	name = "hardpoint"
@@ -67,7 +67,7 @@
 		maptext = ""
 		return
 
-	maptext =  SPAN_STYLE("font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: 7px;", "[holding.get_hardpoint_maptext()]")
+	maptext =  SPAN_STYLE("-dm-text-outline: 1 black; font-size: 7px;", "[holding.get_hardpoint_maptext()]")
 
 	var/ui_damage = (!owner.body.diagnostics || !owner.body.diagnostics.is_functional() || ((owner.emp_damage>EMP_GUI_DISRUPT) && prob(owner.emp_damage)))
 
@@ -78,7 +78,7 @@
 
 	if(ui_damage)
 		value = -1
-		maptext = SPAN_STYLE("font-family: 'Small Fonts'; -dm-text-outline: 1 black; font-size: 7px;", "ERROR")
+		maptext = SPAN_STYLE("-dm-text-outline: 1 black; font-size: 7px;", "ERROR")
 	else
 		if((owner.emp_damage>EMP_GUI_DISRUPT) && prob(owner.emp_damage*2))
 			if(prob(10))

--- a/code/modules/mob/floating_message.dm
+++ b/code/modules/mob/floating_message.dm
@@ -81,7 +81,7 @@ var/global/list/floating_chat_colors = list()
 	I.pixel_w = -round(I.maptext_width/2) + 16 + holder.get_overhead_text_x_offset()
 	I.pixel_z = holder.get_overhead_text_y_offset()
 
-	style = "font-family: 'Small Fonts'; -dm-text-outline: 1px black; font-size: [size]px; line-height: 1.1; [style]"
+	style = "-dm-text-outline: 1px black; font-size: [size]px; line-height: 1.1; [style]"
 	I.maptext = "<center><span style=\"[style]\">[message]</span></center>"
 	animate(I, CHAT_MESSAGE_SPAWN_TIME, alpha = 255, pixel_z = 28)
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1043,7 +1043,7 @@ window "mapwindow"
 		size = 640x480
 		anchor1 = 0,0
 		anchor2 = 100,100
-		font-family = "Arial Rounded MT Bold,Arial Black,Arial,sans-serif"
+		font-family = "'Small Fonts',Fixedsys,sans-serif"
 		font-size = 7
 		is-default = true
 		saved-params = "icon-size"


### PR DESCRIPTION
:cl:
tweak: Adds a menu preference for the font to use for maptext (except status displays).
/:cl:
