### PR TITLE
Make it easier to use mindbreaker in food for imprinting

### DIFF
--- a/code/game/objects/items/weapons/implants/implants/imprinting.dm
+++ b/code/game/objects/items/weapons/implants/implants/imprinting.dm
@@ -43,7 +43,7 @@
 	var/mob/living/carbon/human/H = M
 	if(!istype(H))
 		return FALSE
-	if(H.reagents.has_reagent(/datum/reagent/drugs/mindbreaker))
+	if(H.metabolized.has_reagent(/datum/reagent/drugs/mindbreaker))
 		brainwashing = 1
 	var/msg = get_instructions()
 	to_chat(M, msg)

--- a/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
+++ b/code/modules/reagents/Chemistry-Reagents/Chemistry-Reagents-Toxins.dm
@@ -766,7 +766,7 @@
 	metabolism = REM * 0.5
 	overdose = REAGENTS_OVERDOSE
 
-/datum/reagent/drugs/affect_blood(mob/living/carbon/M, removed)
+/datum/reagent/drugs/affect_metabolites(mob/living/carbon/M, removed)
 	if (IS_METABOLICALLY_INERT(M))
 		return
 
@@ -878,6 +878,7 @@
 	reagent_state = LIQUID
 	color = "#b31008"
 	metabolism = REM * 0.25
+	bioavailability = 1
 	value = 0.6
 	should_admin_log = TRUE
 	high_message_list = list("You don't quite know what up or down is anymore...",
@@ -890,7 +891,7 @@
 	"Colors seem... flatter.",
 	"Everything feels a little dull, now.")
 
-/datum/reagent/drugs/mindbreaker/affect_blood(mob/living/carbon/M, removed)
+/datum/reagent/drugs/mindbreaker/affect_metabolites(mob/living/carbon/M, removed)
 	if (IS_METABOLICALLY_INERT(M))
 		return
 	M.add_chemical_effect(CE_MIND, -2)


### PR DESCRIPTION
* Move all base drug type + mindbreaker effects to metabolism instead of blood
* All drugs have 1.0 bioavailability

Fixes #35682

:cl: Banditoz
bugfix: It's now possible to use the mindbreaker implanting effect if the mindbreaker was in food.
balance: Mindbreaker effects last longer.
/:cl: