### PR TITLE
add timestamps to tcom logs, fix corrupted logs

### DIFF
--- a/code/game/machinery/telecomms/logbrowser.dm
+++ b/code/game/machinery/telecomms/logbrowser.dm
@@ -69,9 +69,10 @@
 
 
 				// If the log is a speech file
-				if(C.input_type == "Speech File")
+				if(C.input_type == "Speech File" || C.input_type == "Corrupt File")
 
 					dat += "<li>[SPAN_COLOR("#008f00", C.name)]  <a href='byond://?src=\ref[src];delete=[i]'>[SPAN_COLOR("#ff0000", "\[X\]")]</a><br>"
+					dat += "<u>[SPAN_COLOR("#18743e", "Timestamp")]</u>: [C.timestamp]<br>"
 
 					// -- Determine race of orator --
 
@@ -84,9 +85,9 @@
 						dat += "<u>[SPAN_COLOR("#18743e", "Data type")]</u>: [C.input_type]<br>"
 						dat += "<u>[SPAN_COLOR("#18743e", "Source")]</u>: [C.parameters["name"]]<br>"
 						dat += "<u>[SPAN_COLOR("#18743e", "Class")]</u>: [race]<br>"
-						dat += "<u>[SPAN_COLOR("#18743e", "Contents")]</u>: \"[C.parameters["message"]]\"<br>"
 						if(language)
 							dat += "<u>[SPAN_COLOR("#18743e", "Language")]</u>: [language]<br/>"
+						dat += "<u>[SPAN_COLOR("#18743e", "Contents")]</u>: \"[C.parameters["message"]]\"<br>"
 
 					// -- Orator is not human and universal translate not active --
 

--- a/code/game/machinery/telecomms/telecomunications.dm
+++ b/code/game/machinery/telecomms/telecomunications.dm
@@ -511,6 +511,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 
 				var/datum/comm_log_entry/log = new
 				var/mob/M = signal.data["mob"]
+				log.timestamp = "[stationdate2text()], [time_stamp()]"
 
 				// Copy the signal.data entries we want
 				log.parameters["mobtype"] = signal.data["mobtype"]
@@ -585,6 +586,7 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	log.input_type = input
 	log.parameters["message"] = content
 	log_entries.Add(log)
+	log.timestamp = "[stationdate2text()], [time_stamp()]"
 	update_logs()
 
 /obj/machinery/telecomms/server/proc/get_channel_info(freq)
@@ -601,3 +603,4 @@ var/global/list/obj/machinery/telecomms/telecomms_list = list()
 	var/name = "data packet (#)"
 	var/garbage_collector = 1 // if set to 0, will not be garbage collected
 	var/input_type = "Speech File"
+	var/timestamp


### PR DESCRIPTION
:cl: Mucker
rscadd: Added timestamps to t-comms radio logs.
rscadd: T-comms now lists "corrupted" radio logs.
tweak: Tweaked the ordering of t-comm radio logs.
/:cl: