### PR TITLE
Fix fax machine GC failures

### DIFF
--- a/code/modules/paperwork/faxmachine.dm
+++ b/code/modules/paperwork/faxmachine.dm
@@ -48,6 +48,8 @@ GLOBAL_LIST_EMPTY(admin_departments)
 		for (var/obj/item/modular_computer/pda/pda as anything in linked_pdas)
 			unlink_pda(pda)
 		linked_pdas = null
+	GLOB.alldepartments -= src.department
+	GLOB.allfaxes -= src
 	. = ..()
 
 


### PR DESCRIPTION
:cl: Banditoz
bugfix: Fax machines are now removed as a possible destination when they're destroyed.
/:cl: