### PR TITLE
Revert "roller beds now have wheels"

### DIFF
--- a/code/__defines/flags.dm
+++ b/code/__defines/flags.dm
@@ -53,7 +53,6 @@ GLOBAL_ALIST_INIT_STEP(flag_to_index, 0)
 
 /// Whether this object is offset onto a wall
 #define OBJ_FLAG_WALL_MOUNTED FLAG_07
-#define OBJ_FLAG_HAS_WHEELS FLAG_08
 
 //Flags for items (equipment)
 #define ITEM_FLAG_NO_BLUDGEON               FLAG_01  // When an item has this it produces no "X has been hit by Y with Z" message with the default handler.

--- a/code/game/objects/structures/roller_bed.dm
+++ b/code/game/objects/structures/roller_bed.dm
@@ -5,7 +5,6 @@
 	can_buckle = TRUE
 	buckle_dir = SOUTH
 	buckle_stance = BUCKLE_FORCE_PRONE
-	obj_flags = OBJ_FLAG_HAS_WHEELS
 
 	/// A shared list of pixel offsets for roller beds to move their buckled mobs by.
 	var/static/list/roller_bed_buckle_pixel_shift = list(0, 0, 6)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -228,7 +228,7 @@
 	if(pulling)
 		if(isobj(pulling))
 			var/obj/O = pulling
-			. += clamp(O.w_class, 0, ITEM_SIZE_GARGANTUAN) / ((O.obj_flags & OBJ_FLAG_HAS_WHEELS) ? 10 : 5)
+			. += clamp(O.w_class, 0, ITEM_SIZE_GARGANTUAN) / 5
 		else if(ismob(pulling))
 			var/mob/M = pulling
 			. += max(0, M.mob_size) / MOB_MEDIUM


### PR DESCRIPTION
:cl:
tweak: Roller beds slow pulling normally for their size again.
/:cl:

This reverts commit c96e71a6bed6a597e2fc1b584b24198d5325573c

Roller beds don't need special movement. Run speed exists and they have existing advantages (foldable, drips) over other buckle-move options.