### PR TITLE
Translator implant change

### DIFF
--- a/code/game/objects/items/weapons/implants/implants/translator.dm
+++ b/code/game/objects/items/weapons/implants/implants/translator.dm
@@ -8,6 +8,7 @@
 	var/list/languages = list()
 	var/learning_threshold = 20 //need to hear language spoken this many times to learn it
 	var/max_languages = 5
+	var/learned_languages = 0
 
 /obj/item/implant/translator/get_data()
 	return "WARNING: No match found in the database."
@@ -21,14 +22,20 @@
 		return
 	if(!imp_in)
 		return
-	if (length(languages) == max_languages)
+	if (learned_languages == max_languages)
 		return
+	if(imp_in.say_understands(M, speaking))
+		return
+
 	if(!languages[speaking.name])
 		languages[speaking.name] = 1
-	languages[speaking.name] = languages[speaking.name] + 1
-	if(!imp_in.say_understands(M, speaking) && languages[speaking.name] > learning_threshold)
+	else
+		languages[speaking.name] = languages[speaking.name] + 1
+
+	if(languages[speaking.name] > learning_threshold)
 		to_chat(imp_in, SPAN_NOTICE("You feel like you can understand [speaking.name] now..."))
 		imp_in.add_language(speaking.name)
+		learned_languages++
 
 /obj/item/implant/translator/implanted(mob/target)
 	return TRUE


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->

Slightly reworks how translator implant works. There is a limit for languages there, but it also accounts all the languages that the user can already understand. And another problem - someone might use an exotic language in front of the user once - and it also takes a slot in current translator implant, even though its user might never be able to hear it again.

With these changes, known languages are no longer accounted by this implant, and its limit is deduced from the number of actually learned languages.

:cl: Builder13
tweak: Translator implant now only accounts a number of learned languages as its limit, it no longer stores known languages.
/:cl: