### PR TITLE
Allow nonhumans to insert cooking containers into appliances

### DIFF
--- a/code/modules/cooking/container.dm
+++ b/code/modules/cooking/container.dm
@@ -99,7 +99,7 @@
 	return TRUE
 
 /obj/item/reagent_containers/cooking_container/use_before(atom/target, mob/living/user, click_parameters)
-	var/intent_check = ishuman(user) ? I_GRAB : I_HELP
+	var/intent_check = ishuman(user) ? I_GRAB : I_HURT
 	if (user.a_intent != intent_check || istype(target, /obj/item/storage) || istype(target, /obj/screen/item_relayed/storage))
 		return ..()
 


### PR DESCRIPTION
Resolves https://github.com/Baystation12/Baystation12/issues/35712.
As it is, the interaction code prioritises "dump onto target" over other interactions, such as "insert into appliance." This inverts that so "insert into appliance" is prioritised over "dump onto target", as the latter can be worked around, but the former has no replacement.

:cl: sowelipililimute
bugfix: Robots can now cook again.
/:cl: