### PR TITLE
Streamline robot modules code & interactions

### DIFF
--- a/code/_onclick/cyborg.dm
+++ b/code/_onclick/cyborg.dm
@@ -63,7 +63,7 @@
 	var/obj/item/W = get_active_hand()
 
 	// Cyborgs have no range-checking unless there is item use
-	if(!W)
+	if(!W || istype(A.loc, /obj/item/robot_module))
 		A.add_hiddenprint(src)
 		A.attack_robot(src)
 		return

--- a/code/_onclick/hud/robot.dm
+++ b/code/_onclick/hud/robot.dm
@@ -28,7 +28,7 @@ var/global/obj/screen/robot_inventory
 	using.icon_state = "inv1"
 	using.screen_loc = ui_inv1
 	src.adding += using
-	mymob:inv1 = using
+	mymob:inv += using
 
 	using = new /obj/screen()
 	using.SetName("module2")
@@ -37,7 +37,7 @@ var/global/obj/screen/robot_inventory
 	using.icon_state = "inv2"
 	using.screen_loc = ui_inv2
 	src.adding += using
-	mymob:inv2 = using
+	mymob:inv += using
 
 	using = new /obj/screen()
 	using.SetName("module3")
@@ -46,7 +46,7 @@ var/global/obj/screen/robot_inventory
 	using.icon_state = "inv3"
 	using.screen_loc = ui_inv3
 	src.adding += using
-	mymob:inv3 = using
+	mymob:inv += using
 
 	//End of module select
 

--- a/code/modules/mob/living/silicon/robot/drone/drone_items.dm
+++ b/code/modules/mob/living/silicon/robot/drone/drone_items.dm
@@ -469,11 +469,11 @@
 		module = new /obj/item/robot_module/drone(src)
 
 	var/window = {"
-	<b>Activated Modules</b><br>
-	Module 1: [module_state_1 ? "<a href='byond://?src=\ref[src];mod=\ref[module_state_1]'>[module_state_1]</a>" : "No Module"]<br>
-	Module 2: [module_state_2 ? "<a href='byond://?src=\ref[src];mod=\ref[module_state_2]'>[module_state_2]</a>" : "No Module"]<br>
-	Module 3: [module_state_3 ? "<a href='byond://?src=\ref[src];mod=\ref[module_state_3]'>[module_state_3]</a>" : "No Module"]<br>
-	<br><b>Available Modules</b><br>"}
+	<b>Activated Modules</b><br>"}
+	for (var/index = 1; index <= length(module_states); index++)
+		var/obj/item/module_state = module_states[index]
+		window += {"Module [index]: [!isnull(module_state) ? "<a href='byond://?src=\ref[src];mod=\ref[module_state]'>[module_state]</a>" : "No Module"]<br>"}
+	window += {"<br><b>Available Modules</b><br>"}
 	for (var/O in module.equipment)
 		if (!O)
 			window += "<br><b>Depleted Resource</b>"

--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -1,9 +1,15 @@
 //These procs handle putting s tuff in your hand. It's probably best to use these rather than setting stuff manually
 //as they handle all relevant stuff like adding it to the player's screen and such
 
+/mob/living/silicon/robot/proc/get_active_module()
+	if (isnull(module_active_index))
+		return null
+
+	return module_states[module_active_index]
+
 //Returns the thing in our active hand (whatever is in our active module-slot, in this case)
 /mob/living/silicon/robot/get_active_hand()
-	return module_active
+	return get_active_module()
 
 
 /mob/living/silicon/robot/IsHolding(obj/item/item)
@@ -11,29 +17,33 @@
 		if (QDELING(item))
 			crash_with("Invalid instance supplied: The passed item has been QDEL'd.")
 			return
-		if (module_state_1 == item || module_state_2 == item || module_state_3 == item)
-			return item
+		for (var/obj/item/module_state in module_states)
+			if (module_state == item)
+				return item
 		return
 
 	if (ispath(item, /obj/item))
-		if (istype(module_state_1, item))
-			return module_state_1
-		if (istype(module_state_2, item))
-			return module_state_2
-		if (istype(module_state_3, item))
-			return module_state_3
+		for (var/obj/item/module_state in module_states)
+			if (istype(module_state, item))
+				return item
 		return
 
 	crash_with("Invalid instance or path supplied: Not a valid subtype of `/obj/item` or was `null`.")
 
 
 /mob/living/silicon/robot/HandsEmpty()
-	return isnull(module_state_1) && isnull(module_state_2) && isnull(module_state_3)
+	for (var/module_state in module_states)
+		if (!isnull(module_state))
+			return FALSE
 
+	return TRUE
 
 /mob/living/silicon/robot/HasFreeHand()
-	return isnull(module_state_1) || isnull(module_state_2) || isnull(module_state_3)
+	for (var/module_state in module_states)
+		if (isnull(module_state))
+			return TRUE
 
+	return FALSE
 
 /mob/living/silicon/robot/GetAllHeld(item_path)
 	. = list()
@@ -42,21 +52,15 @@
 		return
 
 	if (!item_path)
-		if (module_state_1)
-			. += module_state_1
-		if (module_state_2)
-			. += module_state_2
-		if (module_state_3)
-			. += module_state_3
+		for (var/obj/item/module_state in module_states)
+			if (!isnull(module_state))
+				. += module_state
 		return
 
 	if (ispath(item_path, /obj/item))
-		if (istype(module_state_1, item_path))
-			. += module_state_1
-		if (istype(module_state_2, item_path))
-			. += module_state_2
-		if (istype(module_state_3, item_path))
-			. += module_state_3
+		for (var/obj/item/module_state in module_states)
+			if (istype(module_state, item_path))
+				. += module_state
 		return
 
 	crash_with("Invalid path supplied: Not a valid subtype of `/obj/item`.")
@@ -82,70 +86,52 @@
 	uneq_active()
 	hud_used.update_robot_modules_display()
 
-/mob/living/silicon/robot/proc/uneq_active()
-	if(isnull(module_active))
+/mob/living/silicon/robot/proc/eq_module(index, obj/O)
+	if (isnull(index))
 		return
-	GLOB.module_deactivated_event.raise_event(src, module_active)
-	if(module_state_1 == module_active)
-		if(istype(module_state_1,/obj/item/borg/sight))
-			sight_mode &= ~module_state_1:sight_mode
-		if (client)
-			client.screen -= module_state_1
-		module_state_1.forceMove(module)
-		module_active = null
-		module_state_1 = null
-		inv1.icon_state = "inv1"
-	else if(module_state_2 == module_active)
-		if(istype(module_state_2,/obj/item/borg/sight))
-			sight_mode &= ~module_state_2:sight_mode
-		if (client)
-			client.screen -= module_state_2
-		module_state_2.forceMove(module)
-		module_active = null
-		module_state_2 = null
-		inv2.icon_state = "inv2"
-	else if(module_state_3 == module_active)
-		if(istype(module_state_3,/obj/item/borg/sight))
-			sight_mode &= ~module_state_3:sight_mode
-		if (client)
-			client.screen -= module_state_3
-		module_state_3.forceMove(module)
-		module_active = null
-		module_state_3 = null
-		inv3.icon_state = "inv3"
+
+	module_states[index] = O
+	O.hud_layerise()
+	O.screen_loc = inv[index].screen_loc
+	O.forceMove(src)
+	if (istype(module_states[index], /obj/item/borg/sight))
+		sight_mode |= module_states[index]:sight_mode
+
+	GLOB.module_activated_event.raise_event(src, O)
+
+/mob/living/silicon/robot/proc/uneq_module(index)
+	if (isnull(index))
+		return
+
+	var/obj/item/active_module = module_states[index]
+	if (isnull(active_module))
+		return
+
+	GLOB.module_deactivated_event.raise_event(src, active_module)
+
+	if(istype(active_module, /obj/item/borg/sight))
+		sight_mode &= ~active_module:sight_mode
+	if (client)
+		client.screen -= active_module
+	active_module.forceMove(module)
+	module_states[index] = null
+
+/mob/living/silicon/robot/proc/uneq_module_by_obj(obj/item/item)
+	var/index = 0
+	for (var/module_state in module_states)
+		index += 1
+		if (module_state == item)
+			uneq_module(index)
+
+/mob/living/silicon/robot/proc/uneq_active()
+	uneq_module(module_active_index)
 	update_icon()
 	hud_used.update_robot_modules_display()
 
 /mob/living/silicon/robot/proc/uneq_all()
-	module_active = null
+	for (var/index = 1; index <= length(module_states); index++)
+		uneq_module(index)
 
-	if(module_state_1)
-		GLOB.module_deactivated_event.raise_event(src, module_state_1)
-		if(istype(module_state_1,/obj/item/borg/sight))
-			sight_mode &= ~module_state_1:sight_mode
-		if (client)
-			client.screen -= module_state_1
-		module_state_1.forceMove(module)
-		module_state_1 = null
-		inv1.icon_state = "inv1"
-	if(module_state_2)
-		GLOB.module_deactivated_event.raise_event(src, module_state_2)
-		if(istype(module_state_2,/obj/item/borg/sight))
-			sight_mode &= ~module_state_2:sight_mode
-		if (client)
-			client.screen -= module_state_2
-		module_state_2.forceMove(module)
-		module_state_2 = null
-		inv2.icon_state = "inv2"
-	if(module_state_3)
-		GLOB.module_deactivated_event.raise_event(src, module_state_3)
-		if(istype(module_state_3,/obj/item/borg/sight))
-			sight_mode &= ~module_state_3:sight_mode
-		if (client)
-			client.screen -= module_state_3
-		module_state_3.forceMove(module)
-		module_state_3 = null
-		inv3.icon_state = "inv3"
 	update_icon()
 	hud_used.update_robot_modules_display()
 
@@ -154,81 +140,37 @@
 
 //module_selected(module) - Checks whether the module slot specified by "module" is currently selected.
 /mob/living/silicon/robot/proc/module_selected(module) //Module is 1-3
-	return module == get_selected_module()
+	return module == module_active_index
 
 //module_active(module) - Checks whether there is a module active in the slot specified by "module".
 /mob/living/silicon/robot/proc/module_active(module) //Module is 1-3
-	if(module < 1 || module > 3) return 0
-
-	switch(module)
-		if(1)
-			if(module_state_1)
-				return 1
-		if(2)
-			if(module_state_2)
-				return 1
-		if(3)
-			if(module_state_3)
-				return 1
-	return 0
-
-//get_selected_module() - Returns the slot number of the currently selected module.  Returns 0 if no modules are selected.
-/mob/living/silicon/robot/proc/get_selected_module()
-	if(module_state_1 && module_active == module_state_1)
-		return 1
-	else if(module_state_2 && module_active == module_state_2)
-		return 2
-	else if(module_state_3 && module_active == module_state_3)
-		return 3
-
-	return 0
+	return !isnull(module_states[module])
 
 //select_module(module) - Selects the module slot specified by "module"
 /mob/living/silicon/robot/proc/select_module(module) //Module is 1-3
-	if(module < 1 || module > 3) return
+	for (var/index = 1; index <= length(inv); index++)
+		if (index == module)
+			inv[index].icon_state = "inv[index] +a"
+		else
+			inv[index].icon_state = "inv[index]"
 
-	if(!module_active(module)) return
+	module_active_index = module
+	var/obj/item/active_module = module_states[module_active_index]
 
-	switch(module)
-		if(1)
-			if(module_active != module_state_1)
-				inv1.icon_state = "inv1 +a"
-				inv2.icon_state = "inv2"
-				inv3.icon_state = "inv3"
-				module_active = module_state_1
-		if(2)
-			if(module_active != module_state_2)
-				inv1.icon_state = "inv1"
-				inv2.icon_state = "inv2 +a"
-				inv3.icon_state = "inv3"
-				module_active = module_state_2
-		if(3)
-			if(module_active != module_state_3)
-				inv1.icon_state = "inv1"
-				inv2.icon_state = "inv2"
-				inv3.icon_state = "inv3 +a"
-				module_active = module_state_3
-	module_active.on_active_hand(src)
-	GLOB.module_selected_event.raise_event(src, module_active)
+	if (isnull(active_module))
+		return
+
+	active_module.on_active_hand(src)
+	GLOB.module_selected_event.raise_event(src, active_module)
 
 //deselect_module(module) - Deselects the module slot specified by "module"
 /mob/living/silicon/robot/proc/deselect_module(module) //Module is 1-3
-	if(module < 1 || module > 3) return
+	var/obj/item/active_module = module_states[module]
+	if (!isnull(active_module))
+		GLOB.module_deselected_event.raise_event(src, active_module)
 
-	GLOB.module_deselected_event.raise_event(src, module_active)
-	switch(module)
-		if(1)
-			if(module_active == module_state_1)
-				inv1.icon_state = "inv1"
-				module_active = null
-		if(2)
-			if(module_active == module_state_2)
-				inv2.icon_state = "inv2"
-				module_active = null
-		if(3)
-			if(module_active == module_state_3)
-				inv3.icon_state = "inv3"
-				module_active = null
+	module_active_index = null
+	inv[module].icon_state = "inv[module]"
 
 //toggle_module(module) - Toggles the selection of the module slot specified by "module".
 /mob/living/silicon/robot/proc/toggle_module(module) //Module is 1-3
@@ -237,15 +179,12 @@
 	if(module_selected(module))
 		deselect_module(module)
 	else
-		if(module_active(module))
-			select_module(module)
-		else
-			deselect_module(get_selected_module()) //If we can't do select anything, at least deselect the current module.
+		select_module(module)
 	return
 
 //cycle_modules() - Cycles through the list of selected modules.
 /mob/living/silicon/robot/proc/cycle_modules()
-	var/slot_start = get_selected_module()
+	var/slot_start = module_active_index
 	if(slot_start) deselect_module(slot_start) //Only deselect if we have a selected slot.
 
 	var/slot_num
@@ -267,34 +206,20 @@
 /mob/living/silicon/robot/proc/activate_module(obj/item/O)
 	if(!(locate(O) in module.equipment))
 		return
-	if (IsHolding(O))
-		to_chat(src, SPAN_NOTICE("Already activated"))
+
+	if (!isnull(module_active_index))
+		uneq_module(module_active_index)
+		eq_module(module_active_index, O)
 		return
+
 	if (!HasFreeHand())
 		to_chat(src, SPAN_NOTICE("You need to disable a module first!"))
 		return
-	if(!module_state_1)
-		module_state_1 = O
-		O.hud_layerise()
-		O.screen_loc = inv1.screen_loc
-		O.forceMove(src)
-		if(istype(module_state_1,/obj/item/borg/sight))
-			sight_mode |= module_state_1:sight_mode
-	else if(!module_state_2)
-		module_state_2 = O
-		O.hud_layerise()
-		O.screen_loc = inv2.screen_loc
-		O.forceMove(src)
-		if(istype(module_state_2,/obj/item/borg/sight))
-			sight_mode |= module_state_2:sight_mode
-	else if(!module_state_3)
-		module_state_3 = O
-		O.hud_layerise()
-		O.screen_loc = inv3.screen_loc
-		O.forceMove(src)
-		if(istype(module_state_3,/obj/item/borg/sight))
-			sight_mode |= module_state_3:sight_mode
-	GLOB.module_activated_event.raise_event(src, O)
+
+	for (var/index = 1; index <= length(module_states); index++)
+		if (isnull(module_states[index]))
+			eq_module(index, O)
+			return
 
 /mob/living/silicon/put_in_hands(obj/item/W) // No hands.
 	if(W.loc)

--- a/code/modules/mob/living/silicon/robot/life.dm
+++ b/code/modules/mob/living/silicon/robot/life.dm
@@ -276,12 +276,14 @@
 		for(var/obj/I in src.contents)
 			if(I && !(istype(I,/obj/item/cell) || istype(I,/obj/item/device/radio)  || istype(I,/obj/machinery/camera) || istype(I,/obj/item/device/mmi)))
 				src.client.screen += I
-	if(src.module_state_1)
-		src.module_state_1:screen_loc = ui_inv1
-	if(src.module_state_2)
-		src.module_state_2:screen_loc = ui_inv2
-	if(src.module_state_3)
-		src.module_state_3:screen_loc = ui_inv3
+
+	var/list/locations = list(ui_inv1, ui_inv2, ui_inv3)
+	var/index = 0
+	for (var/module_state in src.module_states)
+		index += 1
+		if (isnull(module_state))
+			continue
+		module_state:screen_loc = locations[index]
 	update_icon()
 
 /mob/living/silicon/robot/update_fire()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -38,19 +38,15 @@
 
 //Hud stuff
 
-	var/obj/screen/inv1 = null
-	var/obj/screen/inv2 = null
-	var/obj/screen/inv3 = null
+	var/obj/screen/inv = list()
 
 	var/shown_robot_modules = 0 //Used to determine whether they have the module menu shown or not
 	var/obj/screen/robot_modules_background
 
 //3 Modules can be activated at any one time.
 	var/obj/item/robot_module/module = null
-	var/obj/item/module_active
-	var/obj/item/module_state_1
-	var/obj/item/module_state_2
-	var/obj/item/module_state_3
+	var/module_active_index = null
+	var/obj/item/module_states = list(null, null, null)
 
 	silicon_camera = /obj/item/device/camera/siliconcam/robot_camera
 	silicon_radio = /obj/item/device/radio/borg
@@ -920,6 +916,7 @@
 		else
 			AddOverlays("[panelprefix]-openpanel -c")
 
+	var/obj/item/module_active = get_active_module()
 	if (module_active && istype(module_active,/obj/item/borg/combat/shield))
 		if (modtype == "Combat")
 			AddOverlays("[module_sprites[icontype]]-shield")
@@ -939,11 +936,11 @@
 	var/dat = "<HEAD><TITLE>Modules</TITLE></HEAD><BODY>\n"
 	dat += {"
 	<B>Activated Modules</B>
-	<BR>
-	Module 1: [module_state_1 ? "<A HREF='byond://?src=\ref[src];mod=\ref[module_state_1]'>[module_state_1]</A>" : "No Module"]<BR>
-	Module 2: [module_state_2 ? "<A HREF='byond://?src=\ref[src];mod=\ref[module_state_2]'>[module_state_2]</A>" : "No Module"]<BR>
-	Module 3: [module_state_3 ? "<A HREF='byond://?src=\ref[src];mod=\ref[module_state_3]'>[module_state_3]</A>" : "No Module"]<BR>
-	<BR>
+	<BR>"}
+	for (var/index = 1; index <= length(module_states); index++)
+		var/obj/item/module_state = module_states[index]
+		dat += {"Module [index]: [!isnull(module_state) ? "<A HREF='byond://?src=\ref[src];mod=\ref[module_state]'>[module_state]</A>" : "No Module"]<BR>"}
+	dat += {"<BR>
 	<B>Installed Modules</B><BR><BR>"}
 
 
@@ -975,50 +972,14 @@
 			if (!istype(O))
 				return TOPIC_HANDLED
 
-			if(!(O in module.equipment))
-				return TOPIC_HANDLED
-
-			if (IsHolding(O))
-				to_chat(src, "Already activated")
-				return TOPIC_HANDLED
-			if (!HasFreeHand())
-				to_chat(src, "You need to disable a module first!")
-				return TOPIC_HANDLED
-
-			if(!module_state_1)
-				module_state_1 = O
-				O.hud_layerise()
-				O.forceMove(src)
-				O.equipped_robot()
-				if(istype(module_state_1,/obj/item/borg/sight))
-					sight_mode |= module_state_1:sight_mode
-			else if(!module_state_2)
-				module_state_2 = O
-				O.hud_layerise()
-				O.forceMove(src)
-				O.equipped_robot()
-				if(istype(module_state_2,/obj/item/borg/sight))
-					sight_mode |= module_state_2:sight_mode
-			else if(!module_state_3)
-				module_state_3 = O
-				O.hud_layerise()
-				O.forceMove(src)
-				O.equipped_robot()
-				if(istype(module_state_3,/obj/item/borg/sight))
-					sight_mode |= module_state_3:sight_mode
+			activate_module(O)
 			installed_modules()
 			return TOPIC_HANDLED
 
 		if (href_list["deact"])
 			var/obj/item/O = locate(href_list["deact"])
 			if (IsHolding(O))
-				if(module_state_1 == O)
-					module_state_1 = null
-				else if(module_state_2 == O)
-					module_state_2 = null
-				else if(module_state_3 == O)
-					module_state_3 = null
-				O.forceMove(null)
+				uneq_module_by_obj(O)
 			else
 				to_chat(src, "Module isn't activated")
 			installed_modules()

--- a/code/modules/mob/living/silicon/robot/robot_damage.dm
+++ b/code/modules/mob/living/silicon/robot/robot_damage.dm
@@ -71,6 +71,7 @@
 	if (!length(components))
 		return
 
+	var/obj/item/module_active = get_active_module()
 	if (module_active && istype(module_active, /obj/item/borg/combat/shield))
 		var/obj/item/borg/combat/shield/shield = module_active
 		var/absorb_brute = brute * shield.shield_level
@@ -116,6 +117,7 @@
 	var/list/datum/robot_component/parts = get_damageable_components()
 
 	 //Combat shielding absorbs a percentage of damage directly into the cell.
+	var/obj/item/module_active = get_active_module()
 	if(module_active && istype(module_active,/obj/item/borg/combat/shield))
 		var/obj/item/borg/combat/shield/shield = module_active
 		//Shields absorb a certain percentage of damage based on their power setting.

--- a/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -28,6 +28,7 @@
 	if (vtec)
 		tally -= 1
 
+	var/obj/item/module_active = get_active_module()
 	if(module_active && istype(module_active,/obj/item/borg/combat/mobility))
 		tally -= 3
 

--- a/code/modules/xenoarcheaology/boulder.dm
+++ b/code/modules/xenoarcheaology/boulder.dm
@@ -99,5 +99,6 @@
 
 	else if(istype(AM,/mob/living/silicon/robot))
 		var/mob/living/silicon/robot/R = AM
-		if(istype(R.module_active,/obj/item/pickaxe))
-			use_tool(R.module_active,R)
+		var/obj/item/module_active = R.get_active_module()
+		if(istype(module_active,/obj/item/pickaxe))
+			use_tool(module_active,R)


### PR DESCRIPTION
Refactors robot module code to use lists instead of `if (index == 1) var1 else if (index == 2) var2 else if (index == 3) var3`-style statements.
The interactions are also streamlined, preserving the actively selected module slot even when a module is unequipped from that slot, as well as swapping out modules to the actively selected slot instead of giving up with an error message.

Before, to switch a module in a hand:
- unequip the module in the hand
- click the module you want to equip
- select the hand again

This is reduced to just:
- click the module you want to equip

:cl: sowelipililimute
tweak: Robots now preserve their selected slot when unequipping modules
tweak: Robot modules now load into/swap with the currently selected module slot
/:cl: