### PR TITLE
Reorganize how server logs are stored

### DIFF
--- a/code/_global_vars/logging.dm
+++ b/code/_global_vars/logging.dm
@@ -1,6 +1,11 @@
 var/global/datum/configuration/config
 var/global/diary
-
+var/global/game_id = randhex(8)
+var/global/datum/log_init/log_initializer = new
 
 GLOBAL_VAR(log_directory)
 GLOBAL_PROTECT(log_directory)
+
+/datum/log_init/New()
+	GLOB.log_directory = "data/logs/[time2text(world.realtime, "YYYY/MM/DD", 0)]/[time2text(world.timeofday, "hhmm", 0)]-[game_id]"
+	del(src)

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -66,7 +66,7 @@ var/global/datum/controller/master/Master = new
 
 /datum/controller/master/New()
 	if (!global.diary)
-		global.diary = file("data/logs/[time2text(world.timeofday, "YYYY/MM/DD", -world.timezone)].log")
+		global.diary = file("[GLOB.log_directory]/round-[game_id].log")
 	if (!config)
 		config = new
 	total_run_times = list()

--- a/code/controllers/subsystems/atoms.dm
+++ b/code/controllers/subsystems/atoms.dm
@@ -24,7 +24,7 @@ SUBSYSTEM_DEF(atoms)
 /datum/controller/subsystem/atoms/Shutdown()
 	var/initlog = InitLog()
 	if (initlog)
-		text2file(initlog, "[GLOB.log_directory]/initialize.log")
+		text2file(initlog, "[GLOB.log_directory]/initialize-[game_id].log")
 
 
 /datum/controller/subsystem/atoms/Initialize(start_uptime)

--- a/code/controllers/subsystems/garbage.dm
+++ b/code/controllers/subsystems/garbage.dm
@@ -65,7 +65,7 @@ SUBSYSTEM_DEF(garbage)
 			qdel_log += "\tSleeps: [details.slept_destroy]"
 		if (details.no_hint)
 			qdel_log += "\tNo hint: [details.no_hint] times"
-	var/log_file = file("[GLOB.log_directory]/qdel.log")
+	var/log_file = file("[GLOB.log_directory]/qdel-[game_id].log")
 	to_file(log_file, jointext(qdel_log, "\n"))
 
 

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -3,10 +3,6 @@
 #define THROTTLE_MAX_BURST 15 SECONDS
 #define SET_THROTTLE(TIME, REASON) throttle[1] = base_throttle + (TIME); throttle[2] = (REASON);
 
-
-
-var/global/game_id = randhex(8)
-
 GLOBAL_VAR(href_logfile)
 
 
@@ -79,7 +75,6 @@ GLOBAL_VAR(href_logfile)
 		call_ext(debug_server, "auxtools_init")()
 		enable_debugging()
 
-	SetupLogs()
 	var/date_string = time2text(world.realtime, "YYYY/MM/DD")
 	to_file(global.diary, "[log_end]\n[log_end]\nStarting up. (ID: [game_id]) [time2text(world.timeofday, "hh:mm.ss")][log_end]\n---------------------[log_end]")
 
@@ -87,7 +82,7 @@ GLOBAL_VAR(href_logfile)
 		if (config.server_name)
 			name = "[config.server_name]"
 		if (config.log_runtime)
-			var/runtime_log = file("data/logs/runtime/[date_string]_[time2text(world.timeofday, "hh:mm")]_[game_id].log")
+			var/runtime_log = file("[GLOB.log_directory]/runtime-[game_id].log")
 			to_file(runtime_log, "Game [game_id] starting up at [time2text(world.timeofday, "hh:mm.ss")]")
 			log = runtime_log
 		if (config.log_hrefs)
@@ -487,14 +482,6 @@ GLOBAL_VAR_AS(world_topic_last, world.timeofday)
 	if (!config?.hub_visible || !config.hub_entry)
 		return
 	status = config.generate_hub_entry()
-
-
-/world/proc/SetupLogs()
-	GLOB.log_directory = "data/logs/[time2text(world.realtime, "YYYY/MM/DD")]/round-"
-	if(game_id)
-		GLOB.log_directory += "[game_id]"
-	else
-		GLOB.log_directory += "[replacetext(time_stamp(), ":", ".")]"
 
 
 var/global/failed_db_connections = 0


### PR DESCRIPTION
<img width="295" height="599" alt="VSCodium_Z3D7OUwr8F" src="https://github.com/user-attachments/assets/f8f0afe0-1e3f-4c34-8e7d-6ab4b7377d54" />

Now is organized as:
data/logs/2026/04/18/1300-abcdefgh/round-abcdefgh.log ... qdel-abcdefgh.log, runtime-abcdefgh.log

Filename for hour and minute (1300) is UTC