### PR TITLE
Un-crash the global deuterium market

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2357,8 +2357,7 @@
 /singleton/reaction/deuterium
 	name = "Deuterium"
 	result = null
-	required_reagents = list(/datum/reagent/water = 10)
-	catalysts = list(/datum/reagent/toxin/phoron/oxygen = 5)
+	required_reagents = list(/datum/reagent/water = 10, /datum/reagent/toxin/phoron/oxygen = 5)
 	result_amount = 1
 	mix_message = "The solution makes a loud cracking sound as it crystalizes."
 


### PR DESCRIPTION
:cl: Podszywacz 
bugfix: Changes the deuterium reaction by making oxyphoron into a substrate instead of a catalyst, so players cannot create infinite amount of deuterium
/:cl:

Also wiki no longer lies (in this instance)
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->