### PR TITLE
Stop GAS from accidentally shitting bricks of deuterium

### DIFF
--- a/code/modules/reagents/Chemistry-Recipes.dm
+++ b/code/modules/reagents/Chemistry-Recipes.dm
@@ -2357,7 +2357,9 @@
 /singleton/reaction/deuterium
 	name = "Deuterium"
 	result = null
-	required_reagents = list(/datum/reagent/water = 10, /datum/reagent/toxin/phoron/oxygen = 5)
+	required_reagents = list(/datum/reagent/drink/ice = 10, /datum/reagent/toxin/phoron/oxygen = 5)
+	minimum_temperature = (-25 CELSIUS) - 100
+	maximum_temperature = -25 CELSIUS
 	result_amount = 1
 	mix_message = "The solution makes a loud cracking sound as it crystalizes."
 


### PR DESCRIPTION
:cl: Podszywacz
tweak: Adds low temperature requirement for solid deuterium synthesis, so GAS will no longer accidentally produce solid deuterium when they are injected with or drink enough water
/:cl:

As per request by distraught janitors and user rochehendson's report.
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->