### PR TITLE
Negative solar panel generation value fix.dm

### DIFF
--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -103,7 +103,7 @@ var/global/solar_gen_rate = 1500
 		sunfrac = 0
 		return
 
-	sunfrac = (cos(p_angle) ** 2) - get_solar_distance_penalty(z)
+	sunfrac = max((cos(p_angle) ** 2) - get_solar_distance_penalty(z), 0)
 	//isn't the power received from the incoming light proportional to cos(p_angle) (Lambert's cosine law) rather than cos(p_angle)^2 ?
 
 /obj/machinery/power/solar/Process()


### PR DESCRIPTION
* Tiny bug fix,when solars panels generation go negative value depending on distance to closest star
* tested locally, sunfrac went zero as expected.
* No changelog
<img width="447" height="259" alt="image" src="https://github.com/user-attachments/assets/d232f9d7-b952-4aba-8b92-05a10a2b5e0d" />
<img width="1044" height="812" alt="image" src="https://github.com/user-attachments/assets/235e5a88-8e03-49eb-be59-c8b8e1a40259" />
<img width="280" height="501" alt="image" src="https://github.com/user-attachments/assets/2e18f242-bb28-418d-a2c0-fa1e5ced5f6e" />

