### PR TITLE
Ending message in " or ' won't append period

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -179,7 +179,8 @@ var/global/list/channel_to_radio_key = new
 	message = html_decode(message)
 
 	var/end_char = copytext_char(message, -1)
-	if(!(end_char in list(".", "?", "!", "-", "~", ":")))
+	var/static/list/end_char_puncuation = list(".", "?", "!", "-", "~", ":", "\"", "'")
+	if(!(end_char in end_char_puncuation))
 		message += "."
 
 	return html_encode(message)


### PR DESCRIPTION
:cl: Banditoz
tweak: Ending your message in a single or double quote (', ") won't append a period at the end.
/:cl:

<img width="324" height="35" alt="dreamseeker_fW1TtaCdS5" src="https://github.com/user-attachments/assets/d0c05c7a-43d5-46bd-a1e8-95ac7c0e1c1d" />
