### PR TITLE
Borer changes

### DIFF
--- a/code/modules/mob/living/carbon/carbon_powers.dm
+++ b/code/modules/mob/living/carbon/carbon_powers.dm
@@ -15,6 +15,7 @@
 		verbs -= /mob/living/carbon/proc/release_control
 		verbs -= /mob/living/carbon/proc/punish_host
 		verbs -= /mob/living/carbon/proc/spawn_larvae
+		verbs -= /mob/living/carbon/proc/borer_stun
 
 	else
 		to_chat(src, SPAN_DANGER("ERROR NO BORER OR BRAINMOB DETECTED IN THIS MOB, THIS IS A BUG !"))
@@ -60,6 +61,55 @@
 
 	else
 		to_chat(src, SPAN_WARNING("You do not have enough chemicals stored to reproduce."))
+		return
+
+/mob/living/carbon/proc/borer_stun()
+	set category = "Abilities"
+	set name = "Psi Stun (100)"
+	set desc = "Stun a visible target in your field of view."
+
+	var/mob/living/simple_animal/borer/B = has_brain_worms()
+
+	if(!B)
+		return
+
+	if(B.neutered)
+		return
+
+	var/attack_val = B.deep_link ? 3 : 1
+	var/stun_range = B.deep_link ? 6 : 3
+
+	var/list/victims = list()
+	for(var/mob/living/carbon/C in oview(stun_range))
+		victims += C
+
+	var/mob/living/M = input(src, "Select a mob to stun") as null|anything in victims
+
+	if(!M || !(M in view(stun_range)))
+		return
+
+	if(B.chemicals >= 100)
+		B.chemicals -= 100
+
+		if(M.deflect_psionic_attack())
+			return
+
+		sound_to(src, sound('sound/effects/psi/power_evoke.ogg'))
+		sound_to(M, sound('sound/effects/psi/power_evoke.ogg'))
+
+		if(do_psionics_check(5, src))
+			to_chat(src, SPAN_DANGER("You try to focus on [M], but you cannot expel any psionic power!"))
+			return
+
+		if(M.do_psionics_check(5, src))
+			to_chat(src, SPAN_DANGER("You focus on [M], but your psionic assault skates across them like glass."))
+			return
+		to_chat(M, SPAN_DANGER("You feel a sudden, sharp assault upon your mind that rattles your consciousness!"))
+		M.Weaken(attack_val)
+		visible_message(SPAN_DANGER("A wave of psychic energy emanates from [src], striking [M]!"), SPAN_DANGER("You focus on [M] and use your psionic energy to disorient them!"))
+		B.set_ability_cooldown(15 SECONDS)
+	else
+		to_chat(src, SPAN_WARNING("You do not have enough chemicals stored to psionically stun."))
 		return
 
 /**

--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -25,7 +25,8 @@
 
 	bleed_colour = "#816e12"
 
-	var/static/list/chemical_types = list(
+	var/list/chemical_types = list(
+		"adrenaline" = /datum/reagent/adrenaline,
 		"bicaridine" = /datum/reagent/bicaridine,
 		"hyperzine" =  /datum/reagent/hyperzine,
 		"tramadol" =   /datum/reagent/opiate/tramadol,
@@ -51,6 +52,18 @@
 	var/neutered                            // 'borer lite' mode - fewer powers, less hostile to the host.
 	var/mob/living/carbon/human/host        // Human host for the brain worm.
 	var/mob/living/captive_brain/host_brain // Used for swapping control of the body back and forth.
+
+	var/list/bonus_chemical_types = list(
+		"dexalin" = /datum/reagent/dexalin,
+		"hyronalin" = /datum/reagent/hyronalin,
+		"ryetalyn" = /datum/reagent/ryetalyn,
+		"rezadone" = /datum/reagent/rezadone,
+	)
+	var/deep_link = FALSE 					// Used to unlock stronger abilities
+	var/max_chemicals = 250					// Max amount of chemicals that borer can store, for deep_link
+	var/chem_gen_amount = 1					// Chemicals generation ratio, for deep_link
+	var/psi_boost = FALSE 					// Used to toggle psi boost
+	var/max_psi_rank = 5					// Max psi rank that host can recieve through psi boost
 
 /mob/living/simple_animal/borer/roundstart
 	roundstart = TRUE
@@ -165,9 +178,9 @@
 						to_chat(src, SPAN_NOTICE("You shake off your lethargy as the sugar leaves your host's blood."))
 					docile = 0
 
-			if(chemicals < 250 && host.nutrition >= (neutered ? 200 : 50))
+			if(chemicals < max_chemicals && host.nutrition >= (neutered ? 200 : 50))
 				host.nutrition--
-				chemicals++
+				chemicals += chem_gen_amount
 
 			if(controlling)
 
@@ -180,7 +193,7 @@
 					host.release_control()
 					return
 
-				if(prob(5))
+				if(!deep_link && prob(5))
 					host.adjustBrainLoss(0.1)
 
 				if(prob(host.getBrainLoss()/20))
@@ -202,17 +215,13 @@
 
 	if(!host || !controlling) return
 
-	if(istype(host,/mob/living/carbon/human))
-		var/mob/living/carbon/human/H = host
-		var/obj/item/organ/external/head = H.get_organ(BP_HEAD)
-		head.implants -= src
-
 	controlling = 0
 
 	host.remove_language(LANGUAGE_BORER_GLOBAL)
 	host.verbs -= /mob/living/carbon/proc/release_control
 	host.verbs -= /mob/living/carbon/proc/punish_host
 	host.verbs -= /mob/living/carbon/proc/spawn_larvae
+	host.verbs -= /mob/living/carbon/proc/borer_stun
 
 	if(host_brain)
 
@@ -249,6 +258,8 @@
 
 	qdel(host_brain)
 
+	set_ability_cooldown(15 SECONDS)
+
 #define COLOR_BORER_RED "#ff5555"
 /mob/living/simple_animal/borer/proc/set_ability_cooldown(amt)
 	last_special = world.time + amt
@@ -268,6 +279,11 @@
 	if(host.mind)
 		GLOB.borers.remove_antagonist(host.mind)
 
+	if(istype(host,/mob/living/carbon/human))
+		var/mob/living/carbon/human/H = host
+		var/obj/item/organ/external/head = H.get_organ(BP_HEAD)
+		head.implants -= src
+
 	dropInto(host.loc)
 
 	reset_view(null)
@@ -278,6 +294,14 @@
 
 	var/mob/living/H = host
 	H.status_flags &= ~PASSEMOTES
+
+	if(deep_link)
+		host.adjustBrainLoss(rand(80, 160))
+		host.visible_message(SPAN_WARNING("\The [host] twitches violently upon the removal of [src]. Seems like this procedure tore off a portion of their brain."))
+
+	weaken_connection()
+	reset_psi()
+
 	host = null
 	return
 

--- a/code/modules/mob/living/simple_animal/borer/borer_captive.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_captive.dm
@@ -55,6 +55,7 @@
 			verbs -= /mob/living/carbon/proc/release_control
 			verbs -= /mob/living/carbon/proc/punish_host
 			verbs -= /mob/living/carbon/proc/spawn_larvae
+			verbs -= /mob/living/carbon/proc/borer_stun
 
 		return
 

--- a/code/modules/mob/living/simple_animal/borer/borer_hud.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_hud.dm
@@ -44,7 +44,10 @@
 		return
 
 	to_chat(worm, SPAN_NOTICE("You begin delicately adjusting your connection to the host brain..."))
-	if(!do_after(worm, 100+(worm.host.getBrainLoss()*5), do_flags = DO_DEFAULT | DO_USER_UNIQUE_ACT) || !worm.host || !worm.can_use_borer_ability())
+
+	var/delay = (worm.deep_link ? 0 : 100) + worm.host.getBrainLoss() * 5
+
+	if(!do_after(worm, delay, do_flags = DO_DEFAULT | DO_USER_UNIQUE_ACT) || !worm.host || !worm.can_use_borer_ability())
 		return
 
 	to_chat(worm, SPAN_DANGER("You plunge your probosci deep into the cortex of the host brain, interfacing directly with their nervous system."))
@@ -79,6 +82,9 @@
 	worm.host.verbs += /mob/living/carbon/proc/release_control
 	worm.host.verbs += /mob/living/carbon/proc/punish_host
 	worm.host.verbs += /mob/living/carbon/proc/spawn_larvae
+
+	if(!worm.docile)
+		worm.host.verbs += /mob/living/carbon/proc/borer_stun
 
 	return TRUE
 
@@ -126,6 +132,10 @@
 	to_chat(worm, SPAN_NOTICE("You begin disconnecting from \the [worm.host]'s synapses and prodding at their internal ear canal."))
 	if(worm.host.stat == CONSCIOUS)
 		to_chat(worm.host, SPAN_WARNING("An odd, uncomfortable pressure begins to build inside your skull, behind your ear..."))
+
+	if(worm.deep_link)
+		to_chat(worm, SPAN_WARNING("Weaken your connection to the host first."))
+		return
 
 	if(!do_after(worm, 10 SECONDS, do_flags = DO_DEFAULT | DO_USER_UNIQUE_ACT) || !worm.can_use_borer_ability())
 		return

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -77,8 +77,8 @@
 
 /mob/living/carbon/human/proc/jumpstart()
 	set category = "Abilities"
-	set name = "Revive Host"
-	set desc = "Send a jolt of electricity through your host, reviving them."
+	set name = "Jumpstart body"
+	set desc = "Revive the dead body you are currently occupying."
 
 	if(stat != 2)
 		to_chat(usr, SPAN_WARNING("Your host is already alive."))
@@ -91,3 +91,233 @@
 	restore_blood()
 	fixblood()
 	UpdateLyingBuckledAndVerbStatus()
+
+	var/list/faculties = SSpsi.faculties_by_id
+
+	for(var/faculty in faculties)
+		set_psi_rank(faculty, 3, defer_update = TRUE)
+	psi.update()
+	resuscitate()
+
+/mob/living/simple_animal/borer/verb/assess_psi()
+	set category = "Abilities"
+	set name = "Assess Psi"
+	set desc = "Check psi potential of your host."
+
+	if(!can_use_borer_ability(requires_host_value = TRUE, usable_while_docile = TRUE, check_last_special = FALSE))
+		return
+
+	host.show_psi_assay(src)
+
+/mob/living/simple_animal/borer/verb/scan_health()
+	set category = "Abilities"
+	set name = "Scan Body"
+	set desc = "Scan body for damage."
+
+	if(!can_use_borer_ability(requires_host_value = TRUE, usable_while_docile = TRUE, check_last_special = FALSE))
+		return
+
+	if(deep_link)
+		var/scan_results = display_medical_data(host.get_raw_medical_data(), SKILL_MAX)
+		scan_results += "<A href='byond://?src=\ref[usr];mach_close=scanconsole'>Close</A>"
+		show_browser(usr, scan_results, "window=scanconsole;size=430x600")
+	else
+		var/scan_results = medical_scan_results(host, TRUE, SKILL_MASTER)
+		to_chat(src, "<br>[scan_results]<br>")
+
+/mob/living/simple_animal/borer/proc/weaken_connection()
+	deep_link = FALSE
+	max_chemicals = initial(max_chemicals)
+	chem_gen_amount = initial(chem_gen_amount)
+
+	chemical_types -= bonus_chemical_types
+
+	if(host)
+		to_chat(host, SPAN_NOTICE("The deep mental connection fades to a lighter presence."))
+
+/mob/living/simple_animal/borer/proc/strengthen_connection()
+	deep_link = TRUE
+	max_chemicals = 500
+	chem_gen_amount = 2
+
+	chemical_types += bonus_chemical_types
+
+	if(host)
+		to_chat(src, SPAN_NOTICE("Host agreed to integrate. Your abilities are strengthened."))
+		to_chat(host, SPAN_NOTICE("Something merges with your thoughts, and through a new two-way connection, you figure out a weakness of this entity, its sugar."))
+
+/mob/living/simple_animal/borer/verb/enforce_connection()
+	set category = "Abilities"
+	set name = "Toggle Integration"
+	set desc = "Strengthen or weaken neural connection with your host to improve your capabilities."
+
+	if(!can_use_borer_ability(requires_host_value = TRUE, usable_while_docile = TRUE, check_last_special = TRUE))
+		return
+
+	var/mob/original_host = host
+
+	if(deep_link)
+		if(alert("Do you wish to weaken established neural connection to the brain? It will take time.",,"Yes", "No") == "Yes")
+			set_ability_cooldown(120 SECONDS)
+			if(!do_after(src, 120 SECONDS, do_flags = DO_DEFAULT | DO_USER_UNIQUE_ACT))
+				return
+			weaken_connection()
+			to_chat(src, SPAN_NOTICE("You've successfully weakened your connection to host's brain."))
+	else
+		if(host.is_dead())
+			to_chat(src, SPAN_WARNING("The host's brain is non-functional."))
+			return
+		if(psi_boost)
+			to_chat(src, SPAN_WARNING("Stop applying psionic enhancements first."))
+			return
+
+		if(alert("Attempt to establish a deep neural connection with the host's brain? This can improve your abilities, but requires a consent from the host. Refusal might damage you.",,"Yes", "No") == "Yes")
+			if(!host.client)
+				to_chat(src, SPAN_WARNING("The host is not conscious enough for this."))
+				return
+			set_ability_cooldown(30 SECONDS)
+			if(!controlling && alert(host,"Something is trying to integrate more deeply with your consciousness, do you allow this?",,"Yes", "No") == "Yes")
+				if(host && original_host == host)
+					strengthen_connection()
+			else
+				apply_damage(5) // 25% of health
+				set_ability_cooldown(60 SECONDS)
+				to_chat(src, SPAN_DANGER("Host rejected your integration attempt! The neural backlash damages you."))
+
+/mob/living/simple_animal/borer/verb/revive_host()
+	set category = "Abilities"
+	set name = "Revive (250)"
+	set desc = "Perform a basic revival of your host from death."
+
+	if(!can_use_borer_ability(requires_host_value = TRUE, usable_while_docile = TRUE, check_last_special = TRUE))
+		return
+
+	if(!host.is_dead())
+		to_chat(src, SPAN_WARNING("Your host is already alive!"))
+		return TRUE
+	if(!deep_link && (world.time - host.timeofdeath) > 6000)
+		to_chat(src, SPAN_WARNING("\The [host] has been dead for too long to revive."))
+		return TRUE
+	if(chemicals >= 250)
+		chemicals -= 250
+
+		for(var/mob/observer/G in GLOB.dead_mobs)
+			if(G.mind && G.mind.current == host && G.client)
+				to_chat(G, SPAN_NOTICE(FONT_LARGE("<b>Your body has been revived, <b>Re-Enter Corpse</b> to return to it.</b>")))
+				break
+
+		host.visible_message(SPAN_NOTICE("\The [host] shudders violently!"))
+		host.adjustOxyLoss(-rand(30,45))
+		host.basic_revival()
+
+		if(deep_link)
+			host.adjustOxyLoss(-30)
+			host.adjustBrainLoss(-30)
+			host.resuscitate()
+
+		set_ability_cooldown(60 SECONDS)
+	else
+		to_chat(src, SPAN_WARNING("You do not have enough chemicals stored to revive."))
+		return
+
+/mob/living/simple_animal/borer/verb/rejuvenate_host()
+	set category = "Abilities"
+	set name = "Rejuvenate (500)"
+	set desc = "Fully heal your host at will."
+
+	if(!deep_link)
+		to_chat(src, SPAN_WARNING("This ability requires a deeper level of connection with the host."))
+		return
+
+	if(!can_use_borer_ability(requires_host_value = TRUE, usable_while_docile = TRUE, check_last_special = TRUE))
+		return
+
+	if(chemicals >= 500)
+		chemicals -= 500
+
+		to_chat(src, SPAN_NOTICE("You channel your stored chemicals into [host], flooding them with regenerative compounds."))
+
+		host.rejuvenate()
+		host.resuscitate()
+		host.visible_message(SPAN_WARNING("[host] suddenly convulses as their body rapidly regenerates!"), SPAN_WARNING("You feel a strange energy coursing through you."))
+		set_ability_cooldown(60 SECONDS)
+	else
+		to_chat(src, SPAN_WARNING("You do not have enough chemicals stored to rejuvenate."))
+		return
+
+/mob/living/simple_animal/borer/verb/clear_mind()
+	set category = "Abilities"
+	set name = "Clear Mind (50)"
+	set desc = "Purge host's hallucinations or reduce stun effects."
+
+	var/val = deep_link ? 100 : 50
+
+	if(!can_use_borer_ability(requires_host_value = TRUE, usable_while_docile = TRUE, check_last_special = TRUE))
+		return
+
+	if(host.is_dead())
+		return
+
+	if(chemicals >= 50)
+		chemicals -= 50
+
+		if(deep_link)
+			host.adjustBrainLoss(-10)
+
+		host.drowsyness = max(host.drowsyness - val, 0)
+		host.AdjustParalysis(-val)
+		host.AdjustStunned(-val)
+		host.AdjustWeakened(-val)
+		host.adjust_hallucination(-val)
+
+		set_ability_cooldown(5 SECONDS)
+		to_chat(src, SPAN_NOTICE("You channel your psychic energy to clear your host's mind, stabilizing their consciousness."))
+		to_chat(host, SPAN_NOTICE("A soothing psychic presence clears your mind, sharpening your focus and reducing mental fatigue."))
+	else
+		to_chat(src, SPAN_WARNING("You do not have enough chemicals stored to clear mind."))
+		return
+
+/mob/living/simple_animal/borer/proc/reset_psi()
+	if(psi_boost)
+		psi_boost = FALSE
+
+		if(host && host.psi)
+			host.psi.reset()
+			to_chat(host, SPAN_NOTICE("You feel like your mind narrows."))
+
+		to_chat(src, SPAN_NOTICE("You stopped enhancing psionic abilities."))
+
+/mob/living/simple_animal/borer/proc/boost_psi()
+	if(host)
+		var/boost_val = deep_link ? 2 : 1
+		var/boosted_psipower = deep_link ? 150 : 100
+
+		var/list/faculties = SSpsi.faculties_by_id
+		for(var/faculty in faculties)
+			var/boosted_rank = host.psi ? host.psi.get_rank(faculty) : 0
+			boosted_rank = min(max_psi_rank, boosted_rank + boost_val)
+
+			host.set_psi_rank(faculty, boosted_rank, take_larger = TRUE, temporary = TRUE)
+
+		host.psi.max_stamina = boosted_psipower
+		host.psi.update(force = TRUE)
+
+		psi_boost = TRUE
+
+		to_chat(src, SPAN_NOTICE("You start enhancing psionic abilities."))
+		to_chat(host, SPAN_NOTICE("You feel like your mind expands."))
+
+/mob/living/simple_animal/borer/verb/toggle_psi_boost()
+	set category = "Abilities"
+	set name = "Toggle Psi Boost"
+	set desc = "Toggle psionic enhancements for your host."
+
+	if(!can_use_borer_ability(requires_host_value = TRUE, usable_while_docile = TRUE, check_last_special = TRUE))
+		return
+
+	if(psi_boost)
+		reset_psi()
+	else
+		boost_psi()
+
+	set_ability_cooldown(15 SECONDS)

--- a/code/modules/organs/internal/species/borer.dm
+++ b/code/modules/organs/internal/species/borer.dm
@@ -12,10 +12,20 @@
 /obj/item/organ/internal/borer/Process()
 
 	// Borer husks regenerate health, feel no pain, and are resistant to stuns and brainloss.
-	for(var/chem_name in chemical_types)
-		var/chem = chemical_types[chem_name]
-		if(owner.reagents.get_reagent_amount(chem) < 3)
-			owner.reagents.add_reagent(chem, 5)
+	if(owner && world.time % 6)
+		owner.adjustBruteLoss(-1)
+		owner.adjustFireLoss(-1)
+		owner.adjustToxLoss(-1)
+		owner.adjustOxyLoss(-1)
+		owner.add_up_to_chemical_effect(CE_STABLE)
+		owner.add_up_to_chemical_effect(CE_PAINKILLER, 160)
+
+		for(var/obj/item/organ/internal/I in owner.internal_organs)
+			if(!BP_IS_ROBOTIC(I))
+				I.heal_damage(1)
+
+		if(prob(5))
+			owner.resuscitate()
 
 	// They're also super gross and ooze ichor.
 	if(prob(5))

--- a/code/modules/surgery/implant.dm
+++ b/code/modules/surgery/implant.dm
@@ -156,7 +156,7 @@
 /singleton/surgery_step/cavity/implant_removal/assess_bodypart(mob/living/user, mob/living/carbon/human/target, target_zone, obj/item/tool)
 	var/obj/item/organ/external/affected = ..()
 	if(affected)
-		for(var/obj/O in affected.implants)
+		for(var/atom/O in affected.implants)
 			if(!istype(O, /obj/item/organ/internal))
 				return affected
 	return FALSE


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Expands borer capabillities, turns them into natural psi amplifiers, of sorts. With addition of a few new abillities.

- Fixed borer-husk ressurection, by restarting their heart and by changing their chemical injection segment.
- Fixed borer removal surgery steps. Implant removal now accounts living mobs inside external organs and borers wouldn't disappear from implants upon releasing direct control of their host.
- Buffed borer-husk corpses by adding psionics to them. (instead of infinite hyperzine)
- Added adrenaline to basic chemicals, that borer can synthezise for their host.
- Added new abilities for borer.
- Adds a 15-seconds delay for the borer upon losing direct control. (both through release control verb and through host resisting)

Added the possibillity for borer to strengthen their connection to the host. By this, they can: 
- increase their chemicals limit and ratio of their generation (from 250 to 500 and from 1 to 2)
- unlock new abillity (Rejuvenate for 500 chemicals)
- unlock new chemicals for synthesis (dexalin, hyronaline, ryetalyn, rezadone)
- make some abillities more powerful (Psi stun, Clear mind, Scan body, Toggle Psi Boost)
- allows them to almost instantaneously take control over their host, while also removing a chance of brain damage upon control. (only brain damage delay would be accounted for this delay) 

This connection can be only estabilished voluntarily (with approval of the host). If the host refuses - borer gets damaged for 25% of their health and takes a 60 seconds cooldown. Borer must weaken this connection for 2 minutes, before they can leave host's body on their own, and force removal through surgery now causes brain damage upon strengthened connection.

Host also gains ingame message about borer's weakness to sugar upon this integration.

Added new abillities for borer.

**Inside host, but while not in direct control:**
- Assess Psi: displays psi abillities of the host to borer
- Scan body: displays health scan of the host as from health analyzer to borer. With strengthened connection - shows a full body scan to borer.
- Toggle Psi boost: adds extra 50 psi stamina and 1 psi level to each psi faculty of their host, 2 levels and 100 psi stamina - with strengthened connection. Only lasts, while its toggled active by borer and while borer is still inside the body. No chemical drain of any sort.
- Clear Mind (50) - uses 50 chemicals to remove hallucinations, dizziness and stun effects, stronger effects with strengthened connection.
- Revive (250) - performs a basic revive of the host. (Still needs a doctor in order not to die for the second time) Can be only used upon death. Has the same limitations as psionic revive - only usable for 10 minutes from the moment of the death, or indefinitely, if borer connection was strengthened before death.
- Rejuvenate (500) - only accessible with strengthened connection. Fully heals it's host.

**Inside host, while in direct control:**
- Psi stun (100) - uses 100 chemicals to weaken a victim in visible range. In a radius of 3 tiles. With strengthened connection - in 6 tiles.

:cl: Builder13
bugfix: Fixed borer-husk resurrection.
bugfix: Fixed borer removal surgery steps.
rscadd: Added psionics to borer-husk corpses.
rscadd: Added adrenaline to basic chemicals, that borer can synthesize for their host.
rscadd: Added new abilities to borer.
/:cl: