### PR TITLE
Borer fix

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -313,3 +313,20 @@
 /mob/living/simple_animal/borer/flash_eyes(intensity, override_blindness_check, affect_silicon, visual, type)
 	intensity *= 1.5
 	. = ..()
+
+/mob/living/simple_animal/borer/handle_atmos(atmos_suitable = 1)
+	if(host)
+		return
+	. = ..()
+
+/mob/living/simple_animal/borer/attack_ghost(mob/observer/ghost/user)
+	if(!roundstart && !client && !key && user.client)
+		var/datum/ghosttrap/G = get_ghost_trap("cortical borer")
+
+		if (G.assess_candidate(user, src))
+			var/possess = alert(user, "Do you wish to become \the [src]?", "Become [src]?", "Yes", "No")
+			if (possess == "Yes")
+				G.transfer_personality(user, src)
+				return
+
+	. = ..()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Borer no longer takes environment damage, while inside host. (No longer takes damage and dies, once their host is in the space, or near the fire, even if the host has all the protective equipment)
Added the ability for ghosts to possess empty borers on click. (Allows to possess them outside of just a single request message on spawn)

:cl: Builder13
rscadd: Added the ability for ghosts to possess empty borers on click.
bugfix: Borer no longer takes environment damage, while inside host.
/:cl: