### PR TITLE
[BUGFIX] Zippo object heating

### DIFF
--- a/code/game/objects/items/weapons/lighter.dm
+++ b/code/game/objects/items/weapons/lighter.dm
@@ -174,6 +174,8 @@
 		playsound(src.loc, 'sound/effects/refill.ogg', 50, 1, -6)
 		return TRUE
 
+	return ..()
+
 /obj/item/flame/lighter/zippo/black
 	color = COLOR_DARK_GRAY
 	name = "black zippo"


### PR DESCRIPTION
Seems like heating objects by Zippo was missing. Bringing that tiny bugfix to upsteram

🆑AttHawk
bugfix: Zippo now can heat objects once again
/🆑