### PR TITLE
Fix for turfs on the shuttle

### DIFF
--- a/code/game/turfs/turf_changing.dm
+++ b/code/game/turfs/turf_changing.dm
@@ -195,6 +195,16 @@
 		other.zone.remove(other)
 	return 1
 
+/turf/simulated/floor/transport_properties_from(turf/simulated/floor/other)
+	if(other)
+		ClearOverlays()
+		if(other.flooring)
+			flooring = new other.flooring.type
+		else
+			flooring = null
+
+	. = ..()
+
 /turf/simulated/wall/transport_properties_from(turf/simulated/wall/other)
 	if(!..())
 		return 0


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Makes the transitions of the turfs less noticeable, by also clearing initial overlays and by applying the right flooring.

Otherwise, it is possible to dublicate turf tiles, and the turfs on the shuttle are always the same, even if you replace them.

Steps to reproduce the issue:
1. Spawn two /turf/simulated/floor/carpet on any shuttle.
2. Use crowbar to remove the tiles of these two turfs, apply a steel tile to any of these turfs.
3. Launch the shuttle.
4. Both turfs - the one that is supposed to be without tiling and the one with a steel tiling are getting replaced by carpet tiles.

:cl: Builder13
bugfix: Fixed the transition of tiles upon shuttle launching.
/:cl: